### PR TITLE
fix: biometrics DB migrations + common module deploy

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -493,6 +493,12 @@ else
     fi
   }
 
+  # Copy shared common package (used by all modules via sys.path)
+  if [ -d "$MODULES_SRC/common" ]; then
+    mkdir -p "$MODULES_DEST/common"
+    cp -r "$MODULES_SRC/common/." "$MODULES_DEST/common/"
+  fi
+
   install_module "piezo-processor"
   install_module "sleep-detector"
 fi

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -2,11 +2,12 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { db, sqlite } from './index'
+import { biometricsDb, closeBiometricsDatabase } from './biometrics'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /**
- * Run pending database migrations.
+ * Run pending database migrations for all databases.
  * This should be called on server startup.
  */
 export async function runMigrations() {
@@ -15,6 +16,10 @@ export async function runMigrations() {
 
     migrate(db, {
       migrationsFolder: path.resolve(__dirname, 'migrations'),
+    })
+
+    migrate(biometricsDb, {
+      migrationsFolder: path.resolve(__dirname, 'biometrics-migrations'),
     })
 
     console.log('✓ Database migrations completed successfully')
@@ -86,11 +91,13 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     .then(() => seedDefaultData())
     .then(() => {
       console.log('✓ Database setup complete')
+      closeBiometricsDatabase()
       sqlite.close()
       process.exit(0)
     })
     .catch((error) => {
       console.error('✗ Database setup failed:', error)
+      closeBiometricsDatabase()
       sqlite.close()
       process.exit(1)
     })


### PR DESCRIPTION
## Summary
- **Biometrics migrations**: `runMigrations()` now runs drizzle migrations for both the main DB and biometrics DB on every startup. Previously only the main DB was migrated, leaving biometrics tables (vitals, movement, sleep_records) missing.
- **Common module deploy**: Install script now copies `modules/common/` to `/opt/sleepypod/modules/common/` so piezo-processor and sleep-detector can import shared code via `sys.path`.

Both issues caused the biometrics Python modules to crash-loop on every deploy (3600+ restarts overnight).

## Test plan
- [x] Dev server starts cleanly, biometrics.dev.db has all tables + `__drizzle_migrations`
- [ ] Deploy to pod, verify modules start without `ModuleNotFoundError` or `no such table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)