### PR TITLE
ci: build and upload artifact on all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create deploy tarball
         run: |
           # Package source + .next build (no node_modules — installed on target)
-          tar czf sleepypod-core.tar.gz \
+          tar czf /tmp/sleepypod-core.tar.gz \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='*.db' \
@@ -43,8 +43,8 @@ jobs:
             --exclude='test-results' \
             --exclude='.serena' \
             --exclude='.claude' \
-            --exclude='sleepypod-core.tar.gz' \
             .
+          mv /tmp/sleepypod-core.tar.gz .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Expands the Build & Package workflow push trigger from `main`-only to all branches (`'**'`), so CI validates builds on every feature branch push
- Adds `dev` to the pull_request trigger branches
- Build artifacts are uploaded on every run, making them available for manual deploys from any branch

`sp-update` still only auto-deploys from `main`/`dev` — this change only affects CI build validation and artifact availability.