### PR TITLE
fix: match DROP at line start in iptables output

### DIFF
--- a/src/server/routers/system.ts
+++ b/src/server/routers/system.ts
@@ -26,7 +26,7 @@ function withIptablesLock<T>(fn: () => Promise<T>): Promise<T> {
 async function isWanBlocked(): Promise<boolean> {
   try {
     const { stdout } = await execFileAsync(IPTABLES, ['-L', 'OUTPUT', '-n'])
-    return /\bDROP\s*$/m.test(stdout)
+    return /^DROP\b/m.test(stdout)
   }
   catch {
     return false


### PR DESCRIPTION
## Summary
- Fix `isWanBlocked()` regex: `\bDROP\s*$` → `^DROP\b`
- `iptables -L OUTPUT -n` puts `DROP` in the target column (start of line), not end
- This caused `setInternetAccess` to always report `{ blocked: false }`

Closes #169

## Test plan
- [x] 396 tests pass
- [x] Regex matches real `iptables -L OUTPUT -n` output format