### PR TITLE
refactor: remove stub sleep records from DeviceStateSync

### DIFF
--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -1,13 +1,15 @@
 import { eq } from 'drizzle-orm'
-import { db, biometricsDb } from '@/src/db'
+import { db } from '@/src/db'
 import { deviceState } from '@/src/db/schema'
-import { sleepRecords } from '@/src/db/biometrics-schema'
 import type { DeviceStatus } from './types'
 
 /**
  * Consumes status:updated events and writes current device state to the DB.
- * Also detects power transitions to create stub sleep records.
- * No hardware access. No business logic beyond power-transition tracking.
+ * Tracks power transitions (OFF→ON stamps poweredOnAt, ON→OFF clears it).
+ *
+ * Sleep records are handled exclusively by the sleep-detector module, which
+ * uses capacitance sensor data for accurate presence detection rather than
+ * power-cycle heuristics.
  */
 export class DeviceStateSync {
   sync = async (status: DeviceStatus): Promise<void> => {
@@ -29,19 +31,14 @@ export class DeviceStateSync {
    * Upsert one side of device_state from a fresh DeviceStatus.
    * Detects OFF→ON and ON→OFF transitions:
    *   OFF→ON: stamps poweredOnAt
-   *   ON→OFF: creates a stub sleep record and clears poweredOnAt
-   *
-   * The SELECT and UPSERT run inside a single transaction so concurrent
-   * sync() calls cannot both observe the same ON→OFF transition and
-   * double-create a sleep record.
+   *   ON→OFF: clears poweredOnAt
    */
   private upsertSide = async (side: 'left' | 'right', status: DeviceStatus): Promise<void> => {
     const sideStatus = side === 'left' ? status.leftSide : status.rightSide
     const now = new Date()
     const isNowPowered = sideStatus.currentLevel !== 0
 
-    // Note: better-sqlite3 transactions are synchronous — cannot use async/await
-    const sleepInfo = db.transaction((tx) => {
+    db.transaction((tx) => {
       const [prev] = tx
         .select({ isPowered: deviceState.isPowered, poweredOnAt: deviceState.poweredOnAt })
         .from(deviceState)
@@ -51,13 +48,11 @@ export class DeviceStateSync {
 
       const wasPowered = prev?.isPowered ?? false
       let poweredOnAt = prev?.poweredOnAt ?? null
-      let sessionToRecord: { enteredBedAt: Date, leftBedAt: Date } | null = null
 
       if (!wasPowered && isNowPowered) {
         poweredOnAt = now
       }
-      else if (wasPowered && !isNowPowered && poweredOnAt) {
-        sessionToRecord = { enteredBedAt: poweredOnAt, leftBedAt: now }
+      else if (wasPowered && !isNowPowered) {
         poweredOnAt = null
       }
 
@@ -84,49 +79,6 @@ export class DeviceStateSync {
           },
         })
         .run()
-
-      return sessionToRecord
     })
-
-    // Write to biometricsDb after the main transaction commits — it's a
-    // separate SQLite file so it cannot share the transaction, but the
-    // deviceState row is already updated so a retry would not re-trigger this.
-    if (sleepInfo) {
-      await this.createSleepRecord(side, sleepInfo.enteredBedAt, sleepInfo.leftBedAt)
-    }
-  }
-
-  /**
-   * Create a stub sleep record from power on/off timestamps.
-   * presentIntervals and timesExitedBed are left empty — a future biometrics
-   * module will backfill these with accurate presence data.
-   */
-  private createSleepRecord = async (
-    side: 'left' | 'right',
-    enteredBedAt: Date,
-    leftBedAt: Date
-  ): Promise<void> => {
-    const sleepDurationSeconds = Math.round((leftBedAt.getTime() - enteredBedAt.getTime()) / 1000)
-    // Ignore sessions shorter than 5 minutes (noise / accidental power cycles)
-    if (sleepDurationSeconds < 300) return
-
-    try {
-      await biometricsDb.insert(sleepRecords).values({
-        side,
-        enteredBedAt,
-        leftBedAt,
-        sleepDurationSeconds,
-        timesExitedBed: 0,
-        presentIntervals: null,
-        notPresentIntervals: null,
-      })
-      console.log(`Sleep record created for ${side}: ${Math.round(sleepDurationSeconds / 60)} min`)
-    }
-    catch (error) {
-      console.error(
-        'DeviceStateSync: failed to create sleep record:',
-        error instanceof Error ? error.message : error
-      )
-    }
   }
 }


### PR DESCRIPTION
## Summary

- Remove stub sleep record creation from `DeviceStateSync` — `sleep-detector` module is the sole authority for `sleep_records`
- Eliminates duplicate record risk between power-cycle heuristics and capacitance-based presence detection
- `DeviceStateSync` still tracks power transitions (`poweredOnAt`) for device state; only the `biometricsDb` write path is removed

Follows calibration landing (#174) — `sleep-detector` now has adaptive thresholds, making it the reliable single writer.

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] 394 tests pass (2 pre-existing socket flakes unrelated)
- [ ] Deploy to pod, verify sleep-detector still creates sleep records normally
- [ ] Verify no duplicate records in `sleep_records` table after power cycling a side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined device state synchronization logic to improve code maintainability and reduce redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->