### PR TITLE
feat: OpenAPI REST handler for iOS API access

### DIFF
--- a/app/api/[...rest]/route.ts
+++ b/app/api/[...rest]/route.ts
@@ -1,0 +1,12 @@
+import { appRouter } from '@/src/server/routers/app'
+import { createOpenApiFetchHandler } from 'trpc-to-openapi'
+
+const handler = (req: Request) =>
+  createOpenApiFetchHandler({
+    endpoint: '/api',
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+  })
+
+export { handler as GET, handler as POST, handler as PUT, handler as PATCH, handler as DELETE }


### PR DESCRIPTION
## Summary

- Add catch-all route at `app/api/[...rest]/route.ts` using `trpc-to-openapi`'s fetch adapter
- Enables plain REST access (standard JSON bodies) to all endpoints with OpenAPI metadata
- iOS can now call e.g. `POST /api/calibration/trigger` with `{"side":"left","sensorType":"piezo"}` directly
- Existing routes (`/api/trpc/*`, `/api/openapi.json`, `/api/docs`, `/api/raw/*`) unaffected — Next.js route specificity gives them precedence

Before this change, the OpenAPI `.meta()` annotations were only used for spec generation. Now they actually serve REST traffic.

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] 396 tests pass
- [ ] `curl -X POST http://<pod>:3000/api/calibration/trigger -H 'Content-Type: application/json' -d '{"side":"left","sensorType":"piezo"}'` returns `{"triggered":true,...}`
- [ ] `curl http://<pod>:3000/api/system/internet-status` returns JSON
- [ ] tRPC calls at `/api/trpc/*` still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added OpenAPI-compatible API endpoints with full support for GET, POST, PUT, PATCH, and DELETE HTTP methods, enabling standardized API interactions across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->