### PR TITLE
fix: replace z-score movement scoring with sample-to-sample delta (PIM)

### DIFF
--- a/.claude/docs/trpc-api-architecture.md
+++ b/.claude/docs/trpc-api-architecture.md
@@ -189,11 +189,11 @@ Query sleep and health data from Pod sensors.
 - Heart rate: Beats per minute (SHS autocorrelation, 0.8-8.5 Hz band)
 - HRV: RMSSD in ms (sub-window autocorrelation IBI, 5-200 ms range)
 - Breathing rate: Breaths per minute (Hilbert envelope of cardiac band)
-- Movement: Integer 0-1000 (0=still, 50-200=restless, 200+=major movement)
+- Movement: Integer 0-1000 (0-50=still, 50-200=fidgeting, 200-500=repositioning, 500+=major)
 - Fields may be null if sensor couldn't get reliable reading
 
 **Performance:**
-- Historical data only (5-minute lag)
+- Historical data only (60-second lag for vitals and movement)
 - Large date ranges can be slow (consider caching)
 - Default limits sized for typical use cases (30 sleep records = ~1 month, 288 vitals = 24 hours)
 

--- a/docs/sleep-detector.md
+++ b/docs/sleep-detector.md
@@ -53,12 +53,12 @@ The delta approach removes the DC presence offset entirely. A person's body shif
 
 | Score | State | Expected frequency during sleep |
 |-------|-------|---------------------------------|
-| 0-50 | Still (deep sleep, stable N2) | 70-80% of epochs |
+| 0-50 | Still (deep sleep, stable N2) — capSense2 | 70-80% of epochs |
 | 50-200 | Minor fidgeting, twitches | 10-15% |
 | 200-500 | Limb repositioning, partial turn | 5-10% |
 | 500+ | Major position change, rolling over | 1-3% (~1-2/hour) |
 
-Score is capped at 1000 to prevent outliers from sensor glitches.
+Score is capped at 1000. The scale factor is sensor-type-dependent: capSense2 (Pod 5) uses `×10`, capSense (Pod 3) uses `×0.5` to normalize the different ADC ranges to the same 0-1000 scale. Boundaries are empirical and may need per-pod tuning.
 
 Normal healthy sleep averages ~10 major position changes per night (De Koninck et al. 1992).
 
@@ -93,7 +93,8 @@ Session records include:
 | `MOVEMENT_INTERVAL_S` | 60 s | One movement score per minute; matches AASM epoch length |
 | `PRESENCE_THRESHOLD` | 1500 | Fallback for uncalibrated capSense (Pod 3) |
 | `CALIBRATION_RELOAD_S` | 60 s | Poll calibration_profiles for updates |
-| Movement scale factor | 10x | `score = min(1000, sum(deltas) * 10)` |
+| Movement scale (capSense2) | 10x | Pod 5 float channels, deltas ~0.05-5.0 |
+| Movement scale (capSense) | 0.5x | Pod 3 int ADC channels, deltas ~1-50 |
 | Movement cap | 1000 | Prevents outlier scores from sensor glitches |
 | Sentinel value | -1.0 | capSense2 firmware error indicator |
 | Reference nominal | 1.16 | Expected reference channel value |

--- a/modules/sleep-detector/main.py
+++ b/modules/sleep-detector/main.py
@@ -54,7 +54,6 @@ from common.calibration import (
     is_present_capsense_calibrated,
     is_present_capsense2_calibrated,
 )
-import numpy as np
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -166,8 +165,6 @@ def report_health(status: str, message: str) -> None:
 # Calibration-aware presence and movement
 # ---------------------------------------------------------------------------
 
-CHANNELS = ("out", "cen", "in")
-
 # Sentinel value emitted by capSense2 firmware on read errors
 CAPSENSE2_SENTINEL = -1.0
 
@@ -213,7 +210,8 @@ def _extract_channel_values(record: dict, side: str,
             c -= ref_delta
         return [a, b, c], rtype
 
-    # capSense (Pod 3): named int channels
+    # capSense (Pod 3): named int channels — baselines param unused
+    # (Pod 3 has no reference channel for common-mode rejection)
     a = int(data.get("out", 0))
     b = int(data.get("cen", 0))
     c = int(data.get("in", 0))
@@ -281,6 +279,7 @@ class SessionTracker:
     _movement_buf: list = field(default_factory=list)
     _last_movement_write: float = field(default_factory=time.time)
     _prev_values: Optional[list] = None  # previous sample's channel values
+    _scale_factor: float = 10.0  # default for capSense2; updated on first record
 
     def process(self, ts: float, record: dict) -> None:
         baselines = self.calibration.get_baselines(self.side)
@@ -297,6 +296,12 @@ class SessionTracker:
             present = is_present_capsense_calibrated(
                 record, self.side, cal, fallback_threshold=PRESENCE_THRESHOLD,
             )
+
+        # Set scale factor based on sensor type (Pod 3 int vs Pod 5 float)
+        if rtype == "capSense" and self._scale_factor != 0.5:
+            self._scale_factor = 0.5
+        elif rtype == "capSense2" and self._scale_factor != 10.0:
+            self._scale_factor = 10.0
 
         # Movement: sample-to-sample delta (PIM)
         current_values, _ = _extract_channel_values(record, self.side, baselines)
@@ -381,18 +386,26 @@ class SessionTracker:
         self._interval_start = None
         self._was_present = False
         self._exit_count = 0
+        self._prev_values = None  # avoid stale delta on next session start
+        self._movement_buf = []   # discard leftover deltas from session end
 
     def _flush_movement(self, ts: float) -> None:
         if ts - self._last_movement_write < MOVEMENT_INTERVAL_S:
             return
-        if self._movement_buf:
-            # Sum of absolute deltas over the epoch (PIM analog)
-            # Scale: multiply by 10 and cap at 1000 for integer storage
-            raw_sum = sum(self._movement_buf)
-            total = min(1000, int(raw_sum * 10))
-            write_movement(self.db, self.side,
-                           datetime.fromtimestamp(ts, tz=timezone.utc), total)
+        if not self._movement_buf or self._session_start is None:
+            # Only write movement during active sessions (O-2 fix)
             self._movement_buf = []
+            self._last_movement_write = ts
+            return
+        # Sum of absolute deltas over the epoch (PIM analog)
+        # Scale factor depends on sensor type:
+        #   capSense2 (Pod 5): float channels, deltas ~0.05-5.0 → ×10
+        #   capSense  (Pod 3): int ADC channels, deltas ~1-50 → ×0.5
+        raw_sum = sum(self._movement_buf)
+        total = min(1000, int(raw_sum * self._scale_factor))
+        write_movement(self.db, self.side,
+                       datetime.fromtimestamp(ts, tz=timezone.utc), total)
+        self._movement_buf = []
         self._last_movement_write = ts
 
 


### PR DESCRIPTION
## Summary
- Replace `movement_score_calibrated()` z-score-from-baseline with sample-to-sample delta (Proportional Integration Mode)
- Add sentinel value filtering (-1.0 from firmware → zero-order hold)
- Add reference channel common-mode rejection for capSense2
- Change epoch aggregation from `np.mean(z_scores)` to `sum(deltas) * 10`
- Store previous sample values per side for delta computation

## The problem

Old scoring measured **how present** someone was (z-score deviation from empty-bed baseline), not **how much they moved**. A person lying perfectly still scored 28,000-75,000 because the presence shift (5-20 units) divided by the tiny calibrated std (0.05) produced hundreds of sigma per channel.

## The fix (literature-backed)

Sum of absolute sample-to-sample deltas per epoch — the bed sensor analog of wrist actigraphy's Proportional Integration Mode (Kortelainen et al. 2010; Cole-Kripke 1992). First differences act as a high-pass filter that removes the DC presence offset.

## Pod validation (2026-03-16)

| State | Old score | New score |
|-------|-----------|-----------|
| Left (empty, still) | 27,583-28,706 | 35-77 |
| Right (occupied, still) | 73,578-75,547 | 57-74 |
| Right (minor movement) | ~75,000 (indistinguishable) | 100-500 |
| Right (major movement) | ~75,000 (indistinguishable) | 650-1000 |

Closes #217

## Test plan
- [x] Live pod deployment producing meaningful scores
- [ ] Overnight validation comparing movement density with sleep quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movement scoring now uses a standardized 0–1000 scale with clear interpretation thresholds (still, restless, major movement).
  * Vital sign measurements enhanced with refined heart rate, HRV, and breathing rate calculations.

* **Documentation**
  * Added comprehensive documentation for sleep detection and movement analysis systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->