### PR TITLE
fix: bug sweep — settings 500, null defaults, optional side/dates

### DIFF
--- a/src/server/routers/biometrics.ts
+++ b/src/server/routers/biometrics.ts
@@ -52,7 +52,7 @@ export const biometricsRouter = router({
     .input(
       z
         .object({
-          side: sideSchema,
+          side: sideSchema.optional(),
           startDate: z.date().optional(),
           endDate: z.date().optional(),
           limit: z.number().int().min(1).max(100).default(30),
@@ -74,7 +74,10 @@ export const biometricsRouter = router({
     )
     .query(async ({ input }) => {
       try {
-        const conditions = [eq(sleepRecords.side, input.side)]
+        const conditions = []
+        if (input.side) {
+          conditions.push(eq(sleepRecords.side, input.side))
+        }
 
         if (input.startDate) {
           conditions.push(gte(sleepRecords.enteredBedAt, input.startDate))
@@ -133,7 +136,7 @@ export const biometricsRouter = router({
     .input(
       z
         .object({
-          side: sideSchema,
+          side: sideSchema.optional(),
           startDate: z.date().optional(),
           endDate: z.date().optional(),
           limit: z.number().int().min(1).max(1000).default(288), // Default: 24 hours of 5-min intervals
@@ -155,7 +158,10 @@ export const biometricsRouter = router({
     )
     .query(async ({ input }) => {
       try {
-        const conditions = [eq(vitals.side, input.side)]
+        const conditions = []
+        if (input.side) {
+          conditions.push(eq(vitals.side, input.side))
+        }
 
         if (input.startDate) {
           conditions.push(gte(vitals.timestamp, input.startDate))
@@ -213,7 +219,7 @@ export const biometricsRouter = router({
     .input(
       z
         .object({
-          side: sideSchema,
+          side: sideSchema.optional(),
           startDate: z.date().optional(),
           endDate: z.date().optional(),
           limit: z.number().int().min(1).max(1000).default(288),
@@ -235,7 +241,10 @@ export const biometricsRouter = router({
     )
     .query(async ({ input }) => {
       try {
-        const conditions = [eq(movement.side, input.side)]
+        const conditions = []
+        if (input.side) {
+          conditions.push(eq(movement.side, input.side))
+        }
 
         if (input.startDate) {
           conditions.push(gte(movement.timestamp, input.startDate))
@@ -337,12 +346,17 @@ export const biometricsRouter = router({
       z
         .object({
           side: sideSchema,
-          startDate: z.date(),
-          endDate: z.date(),
+          startDate: z.date().optional(),
+          endDate: z.date().optional(),
         })
         .strict()
         .refine(
-          data => validateDateRange(data.startDate, data.endDate),
+          (data) => {
+            if (data.startDate && data.endDate) {
+              return validateDateRange(data.startDate, data.endDate)
+            }
+            return true
+          },
           {
             message: 'startDate must be before or equal to endDate',
             path: ['endDate'],
@@ -351,6 +365,10 @@ export const biometricsRouter = router({
     )
     .query(async ({ input }) => {
       try {
+        const now = new Date()
+        const effectiveStart = input.startDate ?? new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+        const effectiveEnd = input.endDate ?? now
+
         const [summary] = await biometricsDb
           .select({
             avgHeartRate: avg(vitals.heartRate),
@@ -364,8 +382,8 @@ export const biometricsRouter = router({
           .where(
             and(
               eq(vitals.side, input.side),
-              gte(vitals.timestamp, input.startDate),
-              lte(vitals.timestamp, input.endDate)
+              gte(vitals.timestamp, effectiveStart),
+              lte(vitals.timestamp, effectiveEnd)
             )
           )
 

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -51,10 +51,20 @@ export const settingsRouter = router({
         const gestures = await db.select().from(tapGestures)
 
         return {
-          device: device || null,
+          device: device ?? {
+            id: 1,
+            timezone: 'America/New_York',
+            temperatureUnit: 'f',
+            rebootDaily: false,
+            rebootTime: null,
+            primePodDaily: false,
+            primePodTime: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
           sides: {
-            left: sides.find(s => s.side === 'left') || null,
-            right: sides.find(s => s.side === 'right') || null,
+            left: sides.find(s => s.side === 'left') ?? { side: 'left' as const, name: 'Left', awayMode: false, createdAt: new Date(), updatedAt: new Date() },
+            right: sides.find(s => s.side === 'right') ?? { side: 'right' as const, name: 'Right', awayMode: false, createdAt: new Date(), updatedAt: new Date() },
           },
           gestures: {
             left: gestures.filter(g => g.side === 'left'),
@@ -187,6 +197,7 @@ export const settingsRouter = router({
           })
           .where(eq(sideSettings.side, side))
           .returning()
+          .all()
 
         if (!updated) {
           throw new TRPCError({
@@ -252,6 +263,7 @@ export const settingsRouter = router({
             )
           )
           .limit(1)
+          .all()
 
         if (existing.length > 0) {
           // Update existing
@@ -263,6 +275,7 @@ export const settingsRouter = router({
             })
             .where(eq(tapGestures.id, existing[0].id))
             .returning()
+            .all()
 
           if (!updated) {
             throw new TRPCError({
@@ -281,6 +294,7 @@ export const settingsRouter = router({
               ...input,
             })
             .returning()
+            .all()
 
           if (!created) {
             throw new TRPCError({
@@ -328,6 +342,7 @@ export const settingsRouter = router({
             )
           )
           .returning()
+          .all()
 
         if (!deleted) {
           throw new TRPCError({


### PR DESCRIPTION
## Summary

Fixes 5 bugs in one sweep:

| # | Bug | Fix |
|---|-----|-----|
| #224 | `settings.updateSide` returns 500 | Add `.all()` after `.returning()` for better-sqlite3 |
| #204 | Inconsistent await pattern in settings | Same `.all()` fix across all settings mutations |
| #142 | `settings.getAll` returns null | Provide defaults (timezone, side names, etc.) |
| #141 | `getVitalsSummary` requires dates | Make optional, default to last 7 days |
| #140 | `side` required in biometrics queries | Make optional, return both sides when omitted |

Also closes #172 (unreliable biometrics) — already fixed by piezo processor v2.

## Pod validation
- `settings.updateSide` → 200 with updated name (was 500)
- `biometrics.getVitals` without side → returns both sides
- `biometrics.getVitalsSummary` without dates → defaults to 7 days

Closes #224, #204, #142, #141, #140, #172

## Test plan
- [x] TypeScript compilation clean
- [x] 219 tests pass
- [x] Pod: updateSide returns 200
- [x] Pod: getVitals without side returns both
- [x] Pod: getVitalsSummary without dates returns 7-day default

🤖 Generated with [Claude Code](https://claude.com/claude-code)