### PR TITLE
fix: create /usr/local/bin before symlinking node binaries

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -277,6 +277,7 @@ if [ "$CURRENT_NODE_MAJOR" -lt "$NODE_WANTED" ]; then
   curl -fSL "$NODE_URL" | tar -xz -C "$NODE_DIR"
 
   # Symlink binaries into /usr/local/bin
+  mkdir -p /usr/local/bin
   NODE_BIN="$NODE_DIR/node-v${NODE_FULL}-linux-${NODE_ARCH}/bin"
   for bin in node npm npx; do
     ln -sf "$NODE_BIN/$bin" "/usr/local/bin/$bin"


### PR DESCRIPTION
## Summary
- Yocto images don't have `/usr/local/bin/` — the `ln -sf` for node/npm/npx fails, leaving the old system node (v16) on PATH
- One-line fix: `mkdir -p /usr/local/bin` before the symlink loop

Reported by user during first install attempt after #253.

## Test plan
- [ ] Fresh install on Pod 4 via `curl ... | sudo bash` — node symlinks succeed, v22 is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation script to ensure required system directories are created before setting up Node.js tools, preventing potential installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->