### PR TITLE
fix: tar file-changed error in release workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create deploy tarball
         run: |
-          tar czf sleepypod-core.tar.gz \
+          tar czf /tmp/sleepypod-core.tar.gz \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.env*' \
@@ -42,6 +42,7 @@ jobs:
             --exclude='.serena' \
             --exclude='.claude' \
             .
+          mv /tmp/sleepypod-core.tar.gz .
 
       - name: Update dev release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create deploy tarball
         run: |
-          tar czf sleepypod-core.tar.gz \
+          tar czf /tmp/sleepypod-core.tar.gz \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.env*' \
@@ -51,6 +51,7 @@ jobs:
             --exclude='.serena' \
             --exclude='.claude' \
             .
+          mv /tmp/sleepypod-core.tar.gz .
 
       - name: Semantic Release
         env:


### PR DESCRIPTION
## Summary
- Write tarball to `/tmp` before moving it into the working directory
- GNU tar fails with "file changed as we read it" when output is inside the archived directory
- Fixes dev-release workflow failure from #272

## Test plan
- [ ] Dev release workflow succeeds and `dev` release has tarball attached