### PR TITLE
fix: systemd namespace fix and dev-release workflow

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -243,6 +243,10 @@ fi
 # group-write bits are preserved (including SQLite WAL/SHM files).
 DATA_DIR="/persistent/sleepypod-data"
 echo "Creating data directory at $DATA_DIR..."
+# Ensure /persistent/deviceinfo exists — systemd's ProtectSystem=strict
+# requires all ReadWritePaths to exist or the namespace setup fails.
+# /run/dac is handled by RuntimeDirectory=dac in the service unit.
+mkdir -p /persistent/deviceinfo
 groupadd --force sleepypod
 if id dac &>/dev/null; then
   usermod -aG sleepypod dac
@@ -503,6 +507,7 @@ RestartSec=10
 
 # Hardening (optional, doesn't interfere with dac.sock)
 NoNewPrivileges=true
+RuntimeDirectory=dac
 ReadWritePaths=$DATA_DIR /persistent/deviceinfo /run/dac
 ProtectSystem=strict
 ProtectKernelTunables=true


### PR DESCRIPTION
## Summary
- Create `/persistent/deviceinfo` before service start — `ProtectSystem=strict` requires all `ReadWritePaths` to exist
- Use `RuntimeDirectory=dac` so systemd creates `/run/dac` at service start (survives reboots)
- Fix dev-release tarball (write to `/tmp`, disambiguate `dev` tag from branch)

## Test plan
- [ ] Fresh pod install → service starts without NAMESPACE error
- [ ] Service survives reboot