### PR TITLE
fix: validate DAC socket path against writable paths

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -48,7 +48,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release delete dev --yes --cleanup-tag 2>/dev/null || true
+          gh release delete dev --yes 2>/dev/null || true
+          git push -d origin refs/tags/dev 2>/dev/null || true
           git tag -f dev
           git push -f origin refs/tags/dev
           gh release create dev sleepypod-core.tar.gz \

--- a/scripts/install
+++ b/scripts/install
@@ -203,18 +203,31 @@ if [ "$DISK_AVAIL" -lt 500 ]; then
   exit 1
 fi
 
-# Detect dac.sock path (skip if .env already has it)
+# Detect dac.sock path — must be within a writable path (ProtectSystem=strict)
+ALLOWED_DAC_PREFIXES="/persistent/deviceinfo/ /run/dac/"
 DAC_SOCK_PATH=""
 
+is_allowed_dac_path() {
+  for prefix in $ALLOWED_DAC_PREFIXES; do
+    case "$1" in "$prefix"*) return 0 ;; esac
+  done
+  return 1
+}
+
+# Check .env but validate the path is still writable
 if [ -f "$INSTALL_DIR/.env" ]; then
-  DAC_SOCK_PATH=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
+  EXISTING_PATH=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
+  if [ -n "$EXISTING_PATH" ] && is_allowed_dac_path "$EXISTING_PATH"; then
+    DAC_SOCK_PATH="$EXISTING_PATH"
+  elif [ -n "$EXISTING_PATH" ]; then
+    echo "Warning: Existing DAC_SOCK_PATH=$EXISTING_PATH is outside writable paths, re-detecting..."
+  fi
 fi
 
 if [ -z "$DAC_SOCK_PATH" ]; then
   echo "Detecting dac.sock path..."
   for sock_path in \
-    /run/dac.sock \
-    /var/run/dac.sock \
+    /run/dac/dac.sock \
     /persistent/deviceinfo/dac.sock \
   ; do
     if [ -S "$sock_path" ]; then
@@ -225,11 +238,7 @@ if [ -z "$DAC_SOCK_PATH" ]; then
 fi
 
 if [ -z "$DAC_SOCK_PATH" ]; then
-  DAC_SOCK_PATH=$(find / -name 'dac.sock' -type s 2>/dev/null | head -1)
-fi
-
-if [ -z "$DAC_SOCK_PATH" ]; then
-  # Default to known path even if socket isn't present yet (daemon may not be running)
+  # Default to known writable path even if socket isn't present yet
   DAC_SOCK_PATH="/persistent/deviceinfo/dac.sock"
   echo "Warning: dac.sock not found as active socket, using default: $DAC_SOCK_PATH"
 else
@@ -548,12 +557,19 @@ fi
 
 systemctl restart sleepypod.service
 
-# Restart frankenfirmware so it discovers our dac.sock server.
-# frankenfirmware connects to dac.sock on startup — it won't retry if the
-# socket didn't exist when it started.
+# Wait for sleepypod to create dac.sock before killing frankenfirmware.
+# frankenfirmware connects on startup and won't retry — if it restarts
+# before the socket exists, it silently fails to connect.
+echo "Waiting for dac.sock..."
+for i in $(seq 1 10); do
+  [ -S "$DAC_SOCK_PATH" ] && break
+  sleep 1
+done
+
+# Kill frankenfirmware so its supervisor restarts it against the new dac.sock
 FRANKEN_PID=$(pgrep frankenfirmware 2>/dev/null || true)
 if [ -n "$FRANKEN_PID" ]; then
-  echo "Restarting frankenfirmware (PID $FRANKEN_PID) to discover dac.sock..."
+  echo "Killing frankenfirmware (PID $FRANKEN_PID) so supervisor reconnects to dac.sock..."
   kill "$FRANKEN_PID" 2>/dev/null || true
 fi
 
@@ -643,10 +659,21 @@ cat > /usr/local/bin/sp-status << 'EOF'
 systemctl status sleepypod.service
 EOF
 
-cat > /usr/local/bin/sp-restart << 'EOF'
+cat > /usr/local/bin/sp-restart << 'RESTARTEOF'
 #!/bin/bash
+set -euo pipefail
 systemctl restart sleepypod.service
-EOF
+# Wait for sleepypod to create dac.sock before killing frankenfirmware
+DAC_SOCK=$(grep '^DAC_SOCK_PATH=' /home/dac/sleepypod-core/.env 2>/dev/null | cut -d= -f2- || echo "")
+if [ -n "$DAC_SOCK" ]; then
+  for i in $(seq 1 10); do
+    [ -S "$DAC_SOCK" ] && break
+    sleep 1
+  done
+fi
+# Kill frankenfirmware so its supervisor restarts it against the new dac.sock
+pkill frankenfirmware 2>/dev/null || true
+RESTARTEOF
 
 cat > /usr/local/bin/sp-logs << 'EOF'
 #!/bin/bash

--- a/src/server/routers/health.ts
+++ b/src/server/routers/health.ts
@@ -13,7 +13,7 @@ import { eq } from 'drizzle-orm'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 
-const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/run/dac.sock'
+const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
 
 /**
  * Health router — exposes system observability endpoints.


### PR DESCRIPTION
## Summary
- Existing `.env` values and detected paths are now validated against `ReadWritePaths` prefixes
- Removes `find /` fallback that could discover stale sockets at paths like `/deviceinfo/dac.sock` from old free-sleep installs
- Prevents EROFS errors under `ProtectSystem=strict`

## Test plan
- [ ] Fresh install on pod with old free-sleep → DAC_SOCK_PATH set to `/persistent/deviceinfo/dac.sock`, not `/deviceinfo/dac.sock`
- [ ] Reinstall on pod with valid .env path → path preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflow updated to produce and move deployment artifacts via a temporary path for more reliable releases.
  * Release creation adjusted to reference the current commit and ensure tags/cleanup are handled correctly.

* **Bug Fixes / Installation**
  * Installer now validates socket paths, emits warnings for invalid values, and falls back to secure defaults.
  * System service setup ensures required runtime directories exist and applies stricter protections.
  * Restart helper now reliably restarts dependent firmware processes to reconnect to the selected socket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->