### PR TITLE
fix: DAC socket detection from frank.sh for pod3/4/5 compat

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
 
+concurrency:
+  group: dev-release
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -48,6 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # --cleanup-tag removed: it can delete a branch named 'dev' on older gh versions
           gh release delete dev --yes 2>/dev/null || true
           git push -d origin refs/tags/dev 2>/dev/null || true
           git tag -f dev

--- a/scripts/install
+++ b/scripts/install
@@ -203,46 +203,59 @@ if [ "$DISK_AVAIL" -lt 500 ]; then
   exit 1
 fi
 
-# Detect dac.sock path — must be within a writable path (ProtectSystem=strict)
-ALLOWED_DAC_PREFIXES="/persistent/deviceinfo/ /run/dac/"
+# Detect dac.sock path — read from frank.sh (the firmware launcher) to match
+# whatever path frankenfirmware actually connects to. Different pod hardware
+# versions use different paths:
+#   Pod 3/4: /deviceinfo/dac.sock (tmpfs)
+#   Pod 5:   /persistent/deviceinfo/dac.sock (ext4)
 DAC_SOCK_PATH=""
 
-is_allowed_dac_path() {
-  for prefix in $ALLOWED_DAC_PREFIXES; do
-    case "$1" in "$prefix"*) return 0 ;; esac
-  done
-  return 1
+# Only accept known firmware-supported socket locations
+is_supported_dac_path() {
+  case "$1" in
+    /deviceinfo/dac.sock|/persistent/deviceinfo/dac.sock) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-# Check .env but validate the path is still writable
+# Priority 1: Read from existing .env (validate against known paths)
 if [ -f "$INSTALL_DIR/.env" ]; then
   EXISTING_PATH=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
-  if [ -n "$EXISTING_PATH" ] && is_allowed_dac_path "$EXISTING_PATH"; then
+  if [ -n "$EXISTING_PATH" ] && is_supported_dac_path "$EXISTING_PATH"; then
     DAC_SOCK_PATH="$EXISTING_PATH"
   elif [ -n "$EXISTING_PATH" ]; then
-    echo "Warning: Existing DAC_SOCK_PATH=$EXISTING_PATH is outside writable paths, re-detecting..."
+    echo "Warning: Ignoring unsupported DAC_SOCK_PATH from .env: $EXISTING_PATH"
   fi
 fi
 
+# Priority 2: Extract from frank.sh (what frankenfirmware actually uses)
+if [ -z "$DAC_SOCK_PATH" ] && [ -f /opt/eight/bin/frank.sh ]; then
+  FRANK_PATH=$(grep 'DAC_SOCKET=' /opt/eight/bin/frank.sh 2>/dev/null \
+    | grep -o '[^ ]*dac\.sock' | head -1 || true)
+  if [ -n "$FRANK_PATH" ]; then
+    DAC_SOCK_PATH="$FRANK_PATH"
+    echo "Detected dac.sock path from frank.sh: $DAC_SOCK_PATH"
+  fi
+fi
+
+# Priority 3: Check known socket locations
 if [ -z "$DAC_SOCK_PATH" ]; then
-  echo "Detecting dac.sock path..."
   for sock_path in \
-    /run/dac/dac.sock \
     /persistent/deviceinfo/dac.sock \
+    /deviceinfo/dac.sock \
   ; do
     if [ -S "$sock_path" ]; then
       DAC_SOCK_PATH="$sock_path"
+      echo "Found active dac.sock at: $DAC_SOCK_PATH"
       break
     fi
   done
 fi
 
+# Priority 4: Default to /persistent/deviceinfo/dac.sock
 if [ -z "$DAC_SOCK_PATH" ]; then
-  # Default to known writable path even if socket isn't present yet
   DAC_SOCK_PATH="/persistent/deviceinfo/dac.sock"
-  echo "Warning: dac.sock not found as active socket, using default: $DAC_SOCK_PATH"
-else
-  echo "Using dac.sock at: $DAC_SOCK_PATH"
+  echo "Warning: dac.sock not found, using default: $DAC_SOCK_PATH"
 fi
 
 # Create data directory with shared group for multi-user SQLite access.
@@ -252,10 +265,12 @@ fi
 # group-write bits are preserved (including SQLite WAL/SHM files).
 DATA_DIR="/persistent/sleepypod-data"
 echo "Creating data directory at $DATA_DIR..."
-# Ensure /persistent/deviceinfo exists — systemd's ProtectSystem=strict
-# requires all ReadWritePaths to exist or the namespace setup fails.
+# Ensure ReadWritePaths directories exist — systemd's ProtectSystem=strict
+# requires all listed paths to exist or the namespace setup fails.
 # /run/dac is handled by RuntimeDirectory=dac in the service unit.
 mkdir -p /persistent/deviceinfo
+mkdir -p /deviceinfo
+mkdir -p "$(dirname "$DAC_SOCK_PATH")"
 groupadd --force sleepypod
 if id dac &>/dev/null; then
   usermod -aG sleepypod dac
@@ -510,6 +525,7 @@ WorkingDirectory=$INSTALL_DIR
 Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
+ExecStartPre=/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
 ExecStart=/usr/local/bin/pnpm start
 Restart=always
 RestartSec=10
@@ -517,7 +533,7 @@ RestartSec=10
 # Hardening (optional, doesn't interfere with dac.sock)
 NoNewPrivileges=true
 RuntimeDirectory=dac
-ReadWritePaths=$DATA_DIR /persistent/deviceinfo /run/dac
+ReadWritePaths=$DATA_DIR /persistent/deviceinfo /deviceinfo /run/dac
 ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectKernelModules=true
@@ -565,12 +581,15 @@ for i in $(seq 1 10); do
   [ -S "$DAC_SOCK_PATH" ] && break
   sleep 1
 done
-
-# Kill frankenfirmware so its supervisor restarts it against the new dac.sock
-FRANKEN_PID=$(pgrep frankenfirmware 2>/dev/null || true)
-if [ -n "$FRANKEN_PID" ]; then
-  echo "Killing frankenfirmware (PID $FRANKEN_PID) so supervisor reconnects to dac.sock..."
-  kill "$FRANKEN_PID" 2>/dev/null || true
+if [ -S "$DAC_SOCK_PATH" ]; then
+  # Kill frankenfirmware so its supervisor restarts it against the new dac.sock
+  FRANKEN_PID=$(pgrep frankenfirmware 2>/dev/null || true)
+  if [ -n "$FRANKEN_PID" ]; then
+    echo "Killing frankenfirmware (PID $FRANKEN_PID) so supervisor reconnects to dac.sock..."
+    kill "$FRANKEN_PID" 2>/dev/null || true
+  fi
+else
+  echo "Warning: dac.sock not found after 10s — skipping frankenfirmware restart" >&2
 fi
 
 # ============================================================================
@@ -659,20 +678,23 @@ cat > /usr/local/bin/sp-status << 'EOF'
 systemctl status sleepypod.service
 EOF
 
-cat > /usr/local/bin/sp-restart << 'RESTARTEOF'
+cat > /usr/local/bin/sp-restart << RESTARTEOF
 #!/bin/bash
 set -euo pipefail
 systemctl restart sleepypod.service
 # Wait for sleepypod to create dac.sock before killing frankenfirmware
-DAC_SOCK=$(grep '^DAC_SOCK_PATH=' /home/dac/sleepypod-core/.env 2>/dev/null | cut -d= -f2- || echo "")
-if [ -n "$DAC_SOCK" ]; then
-  for i in $(seq 1 10); do
-    [ -S "$DAC_SOCK" ] && break
-    sleep 1
-  done
+DAC_SOCK=\$(grep '^DAC_SOCK_PATH=' $INSTALL_DIR/.env 2>/dev/null | cut -d= -f2- || echo "")
+[ -z "\$DAC_SOCK" ] && DAC_SOCK="$DAC_SOCK_PATH"
+for i in \$(seq 1 10); do
+  [ -S "\$DAC_SOCK" ] && break
+  sleep 1
+done
+if [ -S "\$DAC_SOCK" ]; then
+  # Kill frankenfirmware so its supervisor restarts it against the new dac.sock
+  pkill frankenfirmware 2>/dev/null || true
+else
+  echo "Warning: dac.sock not found after 10s — skipping frankenfirmware restart" >&2
 fi
-# Kill frankenfirmware so its supervisor restarts it against the new dac.sock
-pkill frankenfirmware 2>/dev/null || true
 RESTARTEOF
 
 cat > /usr/local/bin/sp-logs << 'EOF'


### PR DESCRIPTION
## Summary
- Read DAC socket path from frank.sh (pod3/4: /deviceinfo, pod5: /persistent/deviceinfo)
- Create /deviceinfo unconditionally for ReadWritePaths
- Portable grep, socket-wait with guarded kill, .env path validation
- Concurrency block on dev-release workflow

## Test plan
- [ ] Pod 3/4 install → frankenfirmware connects
- [ ] Pod 5 install → symlink created, frankenfirmware connects