### PR TITLE
feat: 24/7 temperature mode with keepalive and stale display fix

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -20,6 +20,7 @@ import { closeDatabase, closeBiometricsDatabase } from '@/src/db'
 import { getDacMonitor, shutdownDacMonitor } from '@/src/hardware/dacMonitor.instance'
 import { startPiezoStreamServer, shutdownPiezoStreamServer } from '@/src/streaming/piezoStream'
 import { startBonjourAnnouncement, stopBonjourAnnouncement } from '@/src/streaming/bonjourAnnounce'
+import { initializeKeepalives, shutdownKeepalives } from '@/src/services/temperatureKeepalive'
 
 let isInitialized = false
 let isShuttingDown = false
@@ -41,6 +42,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
     process.exit(1)
   }, 10_000)
   forceExitTimer.unref()
+
+  // Step 0: Stop keepalive timers
+  try {
+    shutdownKeepalives()
+  }
+  catch (error) {
+    console.error('Error shutting down keepalives:', error)
+  }
 
   // Step 1: Shutdown scheduler (waits for in-flight jobs internally)
   try {
@@ -251,6 +260,9 @@ export async function initializeScheduler(): Promise<void> {
 
     // Start DAC monitor (non-blocking — waits for frankenfirmware to connect)
     initializeDacMonitor()
+
+    // Initialize temperature keepalive timers for sides with alwaysOn enabled
+    initializeKeepalives()
 
     // Start piezo WebSocket stream server (non-blocking)
     try {

--- a/src/db/migrations/0004_shallow_tomorrow_man.sql
+++ b/src/db/migrations/0004_shallow_tomorrow_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `side_settings` ADD `always_on` integer DEFAULT false NOT NULL;

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,781 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "48a5ab38-529c-496f-8052-b8760da45bf8",
+  "prevId": "a578bda9-6bb5-48fe-be74-65002e304ccd",
+  "tables": {
+    "alarm_schedules": {
+      "name": "alarm_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_intensity": {
+          "name": "vibration_intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_pattern": {
+          "name": "vibration_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rise'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alarm_temperature": {
+          "name": "alarm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_alarm_schedules_side_day": {
+          "name": "idx_alarm_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_settings": {
+      "name": "device_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'F'"
+        },
+        "reboot_daily": {
+          "name": "reboot_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reboot_time": {
+          "name": "reboot_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'03:00'"
+        },
+        "prime_pod_daily": {
+          "name": "prime_pod_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prime_pod_time": {
+          "name": "prime_pod_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'14:00'"
+        },
+        "led_night_mode_enabled": {
+          "name": "led_night_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "led_day_brightness": {
+          "name": "led_day_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "led_night_brightness": {
+          "name": "led_night_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "led_night_start_time": {
+          "name": "led_night_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'22:00'"
+        },
+        "led_night_end_time": {
+          "name": "led_night_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'07:00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_state": {
+      "name": "device_state",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_temperature": {
+          "name": "current_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_temperature": {
+          "name": "target_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_powered": {
+          "name": "is_powered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_alarm_vibrating": {
+          "name": "is_alarm_vibrating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "water_level": {
+          "name": "water_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "powered_on_at": {
+          "name": "powered_on_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "power_schedules": {
+      "name": "power_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_time": {
+          "name": "on_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "off_time": {
+          "name": "off_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_temperature": {
+          "name": "on_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_power_schedules_side_day": {
+          "name": "idx_power_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_once_sessions": {
+      "name": "run_once_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_points": {
+          "name": "set_points",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_run_once_side_status": {
+          "name": "idx_run_once_side_status",
+          "columns": [
+            "side",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "side_settings": {
+      "name": "side_settings",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "away_mode": {
+          "name": "away_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_on": {
+          "name": "always_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_enabled": {
+          "name": "auto_off_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_minutes": {
+          "name": "auto_off_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "away_start": {
+          "name": "away_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "away_return": {
+          "name": "away_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_health": {
+      "name": "system_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "component": {
+          "name": "component",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "system_health_component_unique": {
+          "name": "system_health_component_unique",
+          "columns": [
+            "component"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tap_gestures": {
+      "name": "tap_gestures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tap_type": {
+          "name": "tap_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature_change": {
+          "name": "temperature_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_amount": {
+          "name": "temperature_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_behavior": {
+          "name": "alarm_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_snooze_duration": {
+          "name": "alarm_snooze_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_inactive_behavior": {
+          "name": "alarm_inactive_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temperature_schedules": {
+      "name": "temperature_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_temp_schedules_side_day_time": {
+          "name": "idx_temp_schedules_side_day_time",
+          "columns": [
+            "side",
+            "day_of_week",
+            "time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774835533223,
       "tag": "0003_previous_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1774935266497,
+      "tag": "0004_shallow_tomorrow_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,6 +38,7 @@ export const sideSettings = sqliteTable('side_settings', {
   side: text('side', { enum: ['left', 'right'] }).primaryKey(),
   name: text('name').notNull(), // Must be provided explicitly during insert
   awayMode: integer('away_mode', { mode: 'boolean' }).notNull().default(false),
+  alwaysOn: integer('always_on', { mode: 'boolean' }).notNull().default(false),
   autoOffEnabled: integer('auto_off_enabled', { mode: 'boolean' }).notNull().default(false),
   autoOffMinutes: integer('auto_off_minutes').notNull().default(30),
   awayStart: text('away_start'), // ISO datetime when away mode activates

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -58,7 +58,13 @@ export class DeviceStateSync {
   private upsertSide = async (side: 'left' | 'right', status: DeviceStatus): Promise<void> => {
     const sideStatus = side === 'left' ? status.leftSide : status.rightSide
     const now = new Date()
-    const isNowPowered = sideStatus.currentLevel !== 0
+
+    // Stale display fix: if firmware reports targetLevel=0 AND heatingDuration=0,
+    // the pod has returned to neutral after its duration expired. Force isPowered
+    // to false regardless of currentLevel (which may still be non-zero while the
+    // water temperature equalizes back to ambient).
+    const durationExpired = sideStatus.targetLevel === 0 && sideStatus.heatingDuration === 0
+    const isNowPowered = durationExpired ? false : sideStatus.currentLevel !== 0
 
     db.transaction((tx) => {
       const [prev] = tx
@@ -78,12 +84,16 @@ export class DeviceStateSync {
         poweredOnAt = null
       }
 
+      // When duration has expired, clear the target temperature so the UI
+      // doesn't show a stale "warming to X°F" when the pod is actually neutral.
+      const targetTemp = durationExpired ? null : sideStatus.targetTemperature
+
       tx
         .insert(deviceState)
         .values({
           side,
           currentTemperature: sideStatus.currentTemperature,
-          targetTemperature: sideStatus.targetTemperature,
+          targetTemperature: targetTemp,
           isPowered: isNowPowered,
           waterLevel: status.waterLevel,
           poweredOnAt,
@@ -93,7 +103,7 @@ export class DeviceStateSync {
           target: deviceState.side,
           set: {
             currentTemperature: sideStatus.currentTemperature,
-            targetTemperature: sideStatus.targetTemperature,
+            targetTemperature: targetTemp,
             isPowered: isNowPowered,
             waterLevel: status.waterLevel,
             poweredOnAt,

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -12,6 +12,7 @@ import {
   timeStringSchema,
 } from '@/src/server/validation-schemas'
 import { getJobManager } from '@/src/scheduler'
+import { startKeepalive, stopKeepalive } from '@/src/services/temperatureKeepalive'
 
 /**
  * Reload schedules in the job manager after settings changes
@@ -68,8 +69,8 @@ export const settingsRouter = router({
             updatedAt: new Date(),
           },
           sides: {
-            left: sides.find(s => s.side === 'left') ?? { side: 'left' as const, name: 'Left', awayMode: false, autoOffEnabled: false, autoOffMinutes: 30, createdAt: new Date(), updatedAt: new Date() },
-            right: sides.find(s => s.side === 'right') ?? { side: 'right' as const, name: 'Right', awayMode: false, autoOffEnabled: false, autoOffMinutes: 30, createdAt: new Date(), updatedAt: new Date() },
+            left: sides.find(s => s.side === 'left') ?? { side: 'left' as const, name: 'Left', alwaysOn: false, awayMode: false, autoOffEnabled: false, autoOffMinutes: 30, createdAt: new Date(), updatedAt: new Date() },
+            right: sides.find(s => s.side === 'right') ?? { side: 'right' as const, name: 'Right', alwaysOn: false, awayMode: false, autoOffEnabled: false, autoOffMinutes: 30, createdAt: new Date(), updatedAt: new Date() },
           },
           gestures: {
             left: gestures.filter(g => g.side === 'left'),
@@ -195,6 +196,7 @@ export const settingsRouter = router({
         .object({
           side: sideSchema,
           name: z.string().min(1).max(20).optional(),
+          alwaysOn: z.boolean().optional(),
           awayMode: z.boolean().optional(),
           autoOffEnabled: z.boolean().optional(),
           autoOffMinutes: z.number().int().min(5).max(120).optional(),
@@ -268,6 +270,16 @@ export const settingsRouter = router({
           }
         }
 
+        // Start/stop keepalive if alwaysOn changed
+        if ('alwaysOn' in input) {
+          if (input.alwaysOn) {
+            startKeepalive(input.side)
+          }
+          else {
+            stopKeepalive(input.side)
+          }
+        }
+
         return updated
       }
       catch (error) {
@@ -276,6 +288,58 @@ export const settingsRouter = router({
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to update side settings: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          cause: error,
+        })
+      }
+    }),
+
+  /**
+   * Set alwaysOn mode for a side.
+   * When enabled, the keepalive service periodically re-sends the current
+   * target temperature to prevent the firmware's 8-hour duration timeout.
+   */
+  setAlwaysOn: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/settings/always-on', protect: false, tags: ['Settings'] } })
+    .input(
+      z
+        .object({
+          side: sideSchema,
+          alwaysOn: z.boolean(),
+        })
+        .strict()
+    )
+    .output(z.any())
+    .mutation(async ({ input }) => {
+      try {
+        const [updated] = db
+          .update(sideSettings)
+          .set({ alwaysOn: input.alwaysOn, updatedAt: new Date() })
+          .where(eq(sideSettings.side, input.side))
+          .returning()
+          .all()
+
+        if (!updated) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: `Side settings for ${input.side} not found`,
+          })
+        }
+
+        if (input.alwaysOn) {
+          startKeepalive(input.side)
+        }
+        else {
+          stopKeepalive(input.side)
+        }
+
+        return updated
+      }
+      catch (error) {
+        if (error instanceof TRPCError) throw error
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to set alwaysOn: ${error instanceof Error ? error.message : 'Unknown error'}`,
           cause: error,
         })
       }

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -311,19 +311,23 @@ export const settingsRouter = router({
     .output(z.any())
     .mutation(async ({ input }) => {
       try {
-        const [updated] = db
-          .update(sideSettings)
-          .set({ alwaysOn: input.alwaysOn, updatedAt: new Date() })
-          .where(eq(sideSettings.side, input.side))
-          .returning()
-          .all()
+        const updated = db.transaction((tx) => {
+          const [row] = tx
+            .update(sideSettings)
+            .set({ alwaysOn: input.alwaysOn, updatedAt: new Date() })
+            .where(eq(sideSettings.side, input.side))
+            .returning()
+            .all()
 
-        if (!updated) {
-          throw new TRPCError({
-            code: 'NOT_FOUND',
-            message: `Side settings for ${input.side} not found`,
-          })
-        }
+          if (!row) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: `Side settings for ${input.side} not found`,
+            })
+          }
+
+          return row
+        })
 
         if (input.alwaysOn) {
           startKeepalive(input.side)

--- a/src/services/temperatureKeepalive.ts
+++ b/src/services/temperatureKeepalive.ts
@@ -29,7 +29,7 @@ const timers = new Map<Side, ReturnType<typeof setInterval>>()
 export function startKeepalive(side: Side): void {
   stopKeepalive(side)
 
-  const interval = setInterval(async () => {
+  const tick = async () => {
     try {
       // Read current device state to get target temperature
       const [state] = db
@@ -68,7 +68,12 @@ export function startKeepalive(side: Side): void {
         error instanceof Error ? error.message : error,
       )
     }
-  }, KEEPALIVE_INTERVAL_MS)
+  }
+
+  // Fire immediately to reset firmware duration timer right away
+  tick()
+
+  const interval = setInterval(tick, KEEPALIVE_INTERVAL_MS)
 
   // Allow Node process to exit even if timer is running
   interval.unref()
@@ -91,8 +96,8 @@ export function stopKeepalive(side: Side): void {
 }
 
 /**
- * Initialize keepalive timers for all sides that have alwaysOn enabled
- * and are currently powered on. Called once at startup.
+ * Initialize keepalive timers for all sides that have alwaysOn enabled.
+ * Called once at startup.
  */
 export function initializeKeepalives(): void {
   const sides: Side[] = ['left', 'right']
@@ -106,16 +111,7 @@ export function initializeKeepalives(): void {
         .limit(1)
         .all()
 
-      if (!settings?.alwaysOn) continue
-
-      const [state] = db
-        .select()
-        .from(deviceState)
-        .where(eq(deviceState.side, side))
-        .limit(1)
-        .all()
-
-      if (state?.isPowered && state.targetTemperature != null) {
+      if (settings?.alwaysOn) {
         startKeepalive(side)
       }
     }

--- a/src/services/temperatureKeepalive.ts
+++ b/src/services/temperatureKeepalive.ts
@@ -1,0 +1,138 @@
+/**
+ * Temperature Keepalive Service
+ *
+ * The pod firmware requires a `duration` parameter with every temperature command.
+ * After the duration expires (~8 hours / 28800s), the pod returns to neutral (82.5F).
+ * This service periodically re-sends the current target temperature to reset the
+ * firmware's duration timer, enabling 24/7 temperature control.
+ *
+ * Keepalive interval: 6 hours (21600s) — well within the 8-hour firmware limit.
+ */
+
+import { eq } from 'drizzle-orm'
+import { db } from '@/src/db'
+import { deviceState, sideSettings } from '@/src/db/schema'
+import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+import type { Side } from '@/src/hardware/types'
+
+const KEEPALIVE_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6 hours in milliseconds
+
+const timers = new Map<Side, ReturnType<typeof setInterval>>()
+
+/**
+ * Start the keepalive timer for a side. If the side is powered on and has
+ * a target temperature, periodically re-sends setTemperature to reset the
+ * firmware's duration counter.
+ *
+ * Idempotent — stops any existing timer for the side before starting a new one.
+ */
+export function startKeepalive(side: Side): void {
+  stopKeepalive(side)
+
+  const interval = setInterval(async () => {
+    try {
+      // Read current device state to get target temperature
+      const [state] = db
+        .select()
+        .from(deviceState)
+        .where(eq(deviceState.side, side))
+        .limit(1)
+        .all()
+
+      if (!state || !state.isPowered || state.targetTemperature == null) {
+        // Side is off or has no target — nothing to keepalive
+        return
+      }
+
+      // Verify alwaysOn is still enabled (may have been toggled off between ticks)
+      const [settings] = db
+        .select()
+        .from(sideSettings)
+        .where(eq(sideSettings.side, side))
+        .limit(1)
+        .all()
+
+      if (!settings?.alwaysOn) {
+        stopKeepalive(side)
+        return
+      }
+
+      const client = getSharedHardwareClient()
+      await client.connect()
+      await client.setTemperature(side, state.targetTemperature)
+      console.log(`[keepalive] Re-sent temperature ${state.targetTemperature}°F for ${side}`)
+    }
+    catch (error) {
+      console.error(
+        `[keepalive] Failed to re-send temperature for ${side}:`,
+        error instanceof Error ? error.message : error,
+      )
+    }
+  }, KEEPALIVE_INTERVAL_MS)
+
+  // Allow Node process to exit even if timer is running
+  interval.unref()
+
+  timers.set(side, interval)
+  console.log(`[keepalive] Started for ${side} (interval: 6h)`)
+}
+
+/**
+ * Stop the keepalive timer for a side.
+ * No-op if no timer is active.
+ */
+export function stopKeepalive(side: Side): void {
+  const timer = timers.get(side)
+  if (timer) {
+    clearInterval(timer)
+    timers.delete(side)
+    console.log(`[keepalive] Stopped for ${side}`)
+  }
+}
+
+/**
+ * Initialize keepalive timers for all sides that have alwaysOn enabled
+ * and are currently powered on. Called once at startup.
+ */
+export function initializeKeepalives(): void {
+  const sides: Side[] = ['left', 'right']
+
+  for (const side of sides) {
+    try {
+      const [settings] = db
+        .select()
+        .from(sideSettings)
+        .where(eq(sideSettings.side, side))
+        .limit(1)
+        .all()
+
+      if (!settings?.alwaysOn) continue
+
+      const [state] = db
+        .select()
+        .from(deviceState)
+        .where(eq(deviceState.side, side))
+        .limit(1)
+        .all()
+
+      if (state?.isPowered && state.targetTemperature != null) {
+        startKeepalive(side)
+      }
+    }
+    catch (error) {
+      console.error(
+        `[keepalive] Failed to initialize for ${side}:`,
+        error instanceof Error ? error.message : error,
+      )
+    }
+  }
+}
+
+/**
+ * Stop all keepalive timers. Called during graceful shutdown.
+ */
+export function shutdownKeepalives(): void {
+  for (const side of timers.keys()) {
+    stopKeepalive(side)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `alwaysOn` field to side settings with a keepalive service that re-sends temperature every 6 hours to prevent firmware's 8-hour auto-off
- Fixes stale temperature display when firmware duration expires — auto-corrects DB state when `targetLevel=0` and `heatingDuration=0`
- New `setAlwaysOn` mutation and startup/shutdown wiring

Closes #297

## Test plan
- [ ] Enable always-on for a side — verify keepalive timer starts
- [ ] Disable always-on — verify timer stops
- [ ] Verify stale display fix: when firmware returns to neutral, DB updates to `isPowered: false`
- [ ] Run migration on fresh DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Always On" temperature mode: devices stay powered and have target temperatures re-sent periodically to maintain settings.
  * New API to enable/disable "Always On" per side.

* **Chores**
  * Database schema updated to persist the "Always On" setting.

* **Stability**
  * Keepalive lifecycle now starts/shuts reliably during startup and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->