### PR TITLE
feat: auto-off when no bed presence detected

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -76,9 +76,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
     console.error('Error stopping Bonjour:', error)
   }
 
-  // Step 4: Stop auto-off watcher
+  // Step 4: Stop auto-off watcher (await in-flight power-off calls)
   try {
-    stopAutoOffWatcher()
+    await stopAutoOffWatcher()
   }
   catch (error) {
     console.error('Error stopping auto-off watcher:', error)

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -21,6 +21,7 @@ import { getDacMonitor, shutdownDacMonitor } from '@/src/hardware/dacMonitor.ins
 import { startPiezoStreamServer, shutdownPiezoStreamServer } from '@/src/streaming/piezoStream'
 import { startBonjourAnnouncement, stopBonjourAnnouncement } from '@/src/streaming/bonjourAnnounce'
 import { initializeKeepalives, shutdownKeepalives } from '@/src/services/temperatureKeepalive'
+import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
 
 let isInitialized = false
 let isShuttingDown = false
@@ -75,7 +76,15 @@ async function gracefulShutdown(signal: string): Promise<void> {
     console.error('Error stopping Bonjour:', error)
   }
 
-  // Step 4: Shutdown DAC monitor
+  // Step 4: Stop auto-off watcher
+  try {
+    stopAutoOffWatcher()
+  }
+  catch (error) {
+    console.error('Error stopping auto-off watcher:', error)
+  }
+
+  // Step 5: Shutdown DAC monitor
   try {
     await shutdownDacMonitor()
   }
@@ -83,7 +92,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     console.error('Error shutting down DacMonitor:', error)
   }
 
-  // Step 5: Close database connections
+  // Step 6: Close database connections
   try {
     closeDatabase()
     closeBiometricsDatabase()
@@ -274,6 +283,9 @@ export async function initializeScheduler(): Promise<void> {
         error instanceof Error ? error.message : error
       )
     }
+
+    // Start auto-off watcher (polls biometrics DB for bed-exit events)
+    startAutoOffWatcher()
 
     // Start Bonjour/mDNS announcement (non-blocking)
     startBonjourAnnouncement()

--- a/src/components/Settings/SideSettingsForm.tsx
+++ b/src/components/Settings/SideSettingsForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { User, Plane } from 'lucide-react'
+import { User, Plane, Timer } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { Toggle } from './Toggle'
 
@@ -9,6 +9,8 @@ interface SideData {
   side: 'left' | 'right'
   name: string
   awayMode: boolean
+  autoOffEnabled: boolean
+  autoOffMinutes: number
 }
 
 interface SideSettingsFormProps {
@@ -16,23 +18,39 @@ interface SideSettingsFormProps {
   sideData: SideData
 }
 
+const AUTO_OFF_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90, 120] as const
+
 /**
- * Per-side settings: name and away mode for a single side.
+ * Per-side settings: name, away mode, and auto-off for a single side.
  */
 export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
-  return <SideCard data={sideData ?? { side, name: side === 'left' ? 'Left' : 'Right', awayMode: false }} />
+  return (
+    <SideCard
+      data={sideData ?? {
+        side,
+        name: side === 'left' ? 'Left' : 'Right',
+        awayMode: false,
+        autoOffEnabled: false,
+        autoOffMinutes: 30,
+      }}
+    />
+  )
 }
 
 function SideCard({ data }: { data: SideData }) {
   const utils = trpc.useUtils()
   const [name, setName] = useState(data.name)
   const [awayMode, setAwayMode] = useState(data.awayMode)
+  const [autoOffEnabled, setAutoOffEnabled] = useState(data.autoOffEnabled)
+  const [autoOffMinutes, setAutoOffMinutes] = useState(data.autoOffMinutes)
 
   // Sync from server
   useEffect(() => {
     setName(data.name)
     setAwayMode(data.awayMode)
-  }, [data.name, data.awayMode])
+    setAutoOffEnabled(data.autoOffEnabled)
+    setAutoOffMinutes(data.autoOffMinutes)
+  }, [data.name, data.awayMode, data.autoOffEnabled, data.autoOffMinutes])
 
   const mutation = trpc.settings.updateSide.useMutation({
     onSuccess: () => utils.settings.getAll.invalidate(),
@@ -61,6 +79,17 @@ function SideCard({ data }: { data: SideData }) {
     const newVal = !awayMode
     setAwayMode(newVal)
     mutation.mutate({ side: data.side, awayMode: newVal })
+  }
+
+  function handleAutoOffToggle() {
+    const newVal = !autoOffEnabled
+    setAutoOffEnabled(newVal)
+    mutation.mutate({ side: data.side, autoOffEnabled: newVal })
+  }
+
+  function handleAutoOffMinutesChange(minutes: number) {
+    setAutoOffMinutes(minutes)
+    mutation.mutate({ side: data.side, autoOffMinutes: minutes })
   }
 
   return (
@@ -103,6 +132,45 @@ function SideCard({ data }: { data: SideData }) {
           label={`Toggle away mode for ${sideLabel} side`}
         />
       </div>
+
+      {/* Auto-off toggle */}
+      <div className="mt-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Timer size={14} className={autoOffEnabled ? 'text-sky-400' : 'text-zinc-500'} />
+          <span className="text-sm text-zinc-300">Auto-off when empty</span>
+        </div>
+        <Toggle
+          enabled={autoOffEnabled}
+          onToggle={handleAutoOffToggle}
+          disabled={isPending}
+          label={`Toggle auto-off for ${sideLabel} side`}
+        />
+      </div>
+
+      {/* Auto-off duration picker (shown when enabled) */}
+      {autoOffEnabled && (
+        <div className="mt-3">
+          <label className="mb-1.5 block text-xs font-medium text-zinc-400">
+            Auto-off after
+          </label>
+          <div className="flex flex-wrap gap-1.5">
+            {AUTO_OFF_DURATION_OPTIONS.map(mins => (
+              <button
+                key={mins}
+                onClick={() => handleAutoOffMinutesChange(mins)}
+                disabled={isPending}
+                className={`rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${
+                  autoOffMinutes === mins
+                    ? 'bg-sky-500/20 text-sky-400 ring-1 ring-sky-500/40'
+                    : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+                }`}
+              >
+                {mins < 60 ? `${mins}m` : `${mins / 60}h${mins % 60 ? ` ${mins % 60}m` : ''}`}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {mutation.error && (
         <p className="mt-2 text-xs text-red-400">{mutation.error.message}</p>

--- a/src/components/Settings/SideSettingsForm.tsx
+++ b/src/components/Settings/SideSettingsForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { User, Plane, Timer } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { Toggle } from './Toggle'
@@ -24,15 +24,19 @@ const AUTO_OFF_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90, 120] as const
  * Per-side settings: name, away mode, and auto-off for a single side.
  */
 export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
+  const d = sideData ?? {
+    side,
+    name: side === 'left' ? 'Left' : 'Right',
+    awayMode: false,
+    autoOffEnabled: false,
+    autoOffMinutes: 30,
+  }
+
+  // key forces remount when server data changes, replacing the useEffect sync pattern
   return (
     <SideCard
-      data={sideData ?? {
-        side,
-        name: side === 'left' ? 'Left' : 'Right',
-        awayMode: false,
-        autoOffEnabled: false,
-        autoOffMinutes: 30,
-      }}
+      key={`${d.name}-${d.awayMode}-${d.autoOffEnabled}-${d.autoOffMinutes}`}
+      data={d}
     />
   )
 }
@@ -43,14 +47,6 @@ function SideCard({ data }: { data: SideData }) {
   const [awayMode, setAwayMode] = useState(data.awayMode)
   const [autoOffEnabled, setAutoOffEnabled] = useState(data.autoOffEnabled)
   const [autoOffMinutes, setAutoOffMinutes] = useState(data.autoOffMinutes)
-
-  // Sync from server
-  useEffect(() => {
-    setName(data.name)
-    setAwayMode(data.awayMode)
-    setAutoOffEnabled(data.autoOffEnabled)
-    setAutoOffMinutes(data.autoOffMinutes)
-  }, [data.name, data.awayMode, data.autoOffEnabled, data.autoOffMinutes])
 
   const mutation = trpc.settings.updateSide.useMutation({
     onSuccess: () => utils.settings.getAll.invalidate(),

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -15,6 +15,7 @@ import { sendCommand } from '@/src/hardware/dacTransport'
 import { encode as cborEncode } from 'cbor-x'
 import { fahrenheitToLevel, HardwareCommand } from '@/src/hardware/types'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
+import { cancelAutoOffTimer } from '@/src/services/autoOffWatcher'
 import { timeToDate } from './timeUtils'
 
 /**
@@ -206,6 +207,7 @@ export class JobManager {
         await client.connect()
         try {
           await client.setPower(sched.side, true, sched.onTemperature)
+          cancelAutoOffTimer(sched.side)
           const onTemp = sched.onTemperature ?? 75
           broadcastMutationStatus(sched.side, {
             targetTemperature: onTemp,
@@ -440,6 +442,7 @@ export class JobManager {
               const client = getSharedHardwareClient()
               await client.connect()
               await client.setPower(side, true)
+              cancelAutoOffTimer(side)
               broadcastMutationStatus(side, {})
             }
             catch (e) {

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -13,6 +13,7 @@ import {
 } from '@/src/server/validation-schemas'
 import { getJobManager } from '@/src/scheduler'
 import { startKeepalive, stopKeepalive } from '@/src/services/temperatureKeepalive'
+import { restartAutoOffTimers } from '@/src/services/autoOffWatcher'
 
 /**
  * Reload schedules in the job manager after settings changes
@@ -277,6 +278,16 @@ export const settingsRouter = router({
           }
           else {
             stopKeepalive(input.side)
+          }
+        }
+
+        // Restart auto-off timers if auto-off settings changed
+        if ('autoOffEnabled' in input || 'autoOffMinutes' in input) {
+          try {
+            restartAutoOffTimers()
+          }
+          catch (e) {
+            console.error('Auto-off timer restart failed:', e)
           }
         }
 

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -1,0 +1,314 @@
+/**
+ * Auto-Off Watcher Service
+ *
+ * Polls the biometrics DB `sleep_records` table for bed-exit events.
+ * When a side has no presence for longer than `autoOffMinutes`, powers
+ * off that side via the shared hardware client.
+ *
+ * Per-side countdown timers reset on bed re-entry and cancel if the side
+ * is already off or a run-once session is active.
+ */
+
+import { eq, and, desc } from 'drizzle-orm'
+import { db, biometricsDb } from '@/src/db'
+import { sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
+import { sleepRecords } from '@/src/db/biometrics-schema'
+import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 30_000 // 30 seconds
+const SIDES = ['left', 'right'] as const
+type Side = (typeof SIDES)[number]
+
+// ---------------------------------------------------------------------------
+// Per-side timer state
+// ---------------------------------------------------------------------------
+
+interface SideTimer {
+  /** setTimeout handle for the pending auto-off */
+  timer: ReturnType<typeof setTimeout> | null
+  /** Unix-ms when the timer was started (bed-exit time) */
+  startedAt: number | null
+  /** The configured timeout in ms when the timer was created */
+  timeoutMs: number | null
+}
+
+const timers: Record<Side, SideTimer> = {
+  left: { timer: null, startedAt: null, timeoutMs: null },
+  right: { timer: null, startedAt: null, timeoutMs: null },
+}
+
+let pollHandle: ReturnType<typeof setInterval> | null = null
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clearSideTimer(side: Side): void {
+  const t = timers[side]
+  if (t.timer) {
+    clearTimeout(t.timer)
+    t.timer = null
+    t.startedAt = null
+    t.timeoutMs = null
+  }
+}
+
+/** Check whether the side currently has power. */
+function isSidePowered(side: Side): boolean {
+  try {
+    const [row] = db
+      .select({ isPowered: deviceState.isPowered })
+      .from(deviceState)
+      .where(eq(deviceState.side, side))
+      .limit(1)
+      .all()
+    return row?.isPowered ?? false
+  }
+  catch {
+    return false
+  }
+}
+
+/** Check whether a run-once session is active for this side. */
+function hasActiveRunOnce(side: Side): boolean {
+  try {
+    const [row] = db
+      .select({ id: runOnceSessions.id })
+      .from(runOnceSessions)
+      .where(
+        and(
+          eq(runOnceSessions.side, side),
+          eq(runOnceSessions.status, 'active'),
+        ),
+      )
+      .limit(1)
+      .all()
+    return !!row
+  }
+  catch {
+    return false
+  }
+}
+
+/** Read auto-off config for both sides. */
+function getAutoOffConfig(): Record<Side, { enabled: boolean; minutes: number }> {
+  const defaults = { enabled: false, minutes: 30 }
+  try {
+    const rows = db.select().from(sideSettings).all()
+    const left = rows.find(r => r.side === 'left')
+    const right = rows.find(r => r.side === 'right')
+    return {
+      left: {
+        enabled: left?.autoOffEnabled ?? defaults.enabled,
+        minutes: left?.autoOffMinutes ?? defaults.minutes,
+      },
+      right: {
+        enabled: right?.autoOffEnabled ?? defaults.enabled,
+        minutes: right?.autoOffMinutes ?? defaults.minutes,
+      },
+    }
+  }
+  catch {
+    return { left: defaults, right: defaults }
+  }
+}
+
+/**
+ * Get the most recent sleep record for a side.
+ * Returns the record or null if none exists.
+ */
+function getLatestSleepRecord(side: Side) {
+  try {
+    const [row] = biometricsDb
+      .select()
+      .from(sleepRecords)
+      .where(eq(sleepRecords.side, side))
+      .orderBy(desc(sleepRecords.leftBedAt))
+      .limit(1)
+      .all()
+    return row ?? null
+  }
+  catch {
+    return null
+  }
+}
+
+/** Power off a side via the shared hardware client. */
+async function powerOffSide(side: Side): Promise<void> {
+  try {
+    const client = getSharedHardwareClient()
+    await client.setPower(side, false)
+
+    // Best-effort DB sync
+    try {
+      db.update(deviceState)
+        .set({ isPowered: false, lastUpdated: new Date() })
+        .where(eq(deviceState.side, side))
+        .run()
+    }
+    catch {
+      // next status poll will re-sync
+    }
+
+    console.log(`[auto-off] Powered off ${side} side (no presence detected)`)
+  }
+  catch (error) {
+    console.error(
+      `[auto-off] Failed to power off ${side}:`,
+      error instanceof Error ? error.message : error,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core poll logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a side currently has bed presence.
+ *
+ * The sleep-detector writes a `sleep_records` row when a session ends
+ * (i.e. the person has left the bed). If the most recent record's
+ * `leftBedAt` is recent (within the poll window), we consider
+ * presence lost. If there is no record or the most recent exit was
+ * long ago and the side is still powered, we assume they are in bed
+ * (the session hasn't closed yet).
+ */
+function evaluateSide(side: Side): void {
+  const config = getAutoOffConfig()
+  const cfg = config[side]
+
+  // Feature disabled for this side
+  if (!cfg.enabled) {
+    clearSideTimer(side)
+    return
+  }
+
+  // Side already off -- nothing to do
+  if (!isSidePowered(side)) {
+    clearSideTimer(side)
+    return
+  }
+
+  // Suppress if a run-once session is active
+  if (hasActiveRunOnce(side)) {
+    clearSideTimer(side)
+    return
+  }
+
+  const record = getLatestSleepRecord(side)
+  if (!record) {
+    // No sleep records yet -- cannot determine presence
+    clearSideTimer(side)
+    return
+  }
+
+  const leftBedAtMs = record.leftBedAt instanceof Date
+    ? record.leftBedAt.getTime()
+    : (record.leftBedAt as number) * 1000
+  const nowMs = Date.now()
+  const timeoutMs = cfg.minutes * 60_000
+
+  // If the most recent bed exit is in the future or very recent
+  // and we don't have a timer yet, start one.
+  const msSinceBedExit = nowMs - leftBedAtMs
+
+  // Check: has the person re-entered bed since this exit?
+  // If the sleep_records entry has been superseded by a newer entry with
+  // enteredBedAt > leftBedAt of the previous record, the person is back in bed.
+  // The sleep-detector only writes a record when a session ENDS, so if the side
+  // is powered and the most recent record's leftBedAt was long ago, a new session
+  // may be in progress (person is currently in bed).
+  // Heuristic: if leftBedAt is older than the timeout, the timer should have
+  // already fired. If the side is still on, either it was manually turned on
+  // or a new session is in progress -- don't start a new timer.
+  if (msSinceBedExit > timeoutMs) {
+    clearSideTimer(side)
+    return
+  }
+
+  // Bed exit is recent -- check if we need to start or update a timer
+  const existing = timers[side]
+
+  if (existing.timer) {
+    // Timer already running. If it targets the same bed-exit event, keep it.
+    // If the config (minutes) changed, restart with the new timeout.
+    if (existing.startedAt === leftBedAtMs && existing.timeoutMs === timeoutMs) {
+      return // timer is correct
+    }
+    // Config changed or different exit event -- restart
+    clearSideTimer(side)
+  }
+
+  // Start countdown timer
+  const remainingMs = Math.max(0, timeoutMs - msSinceBedExit)
+  console.log(
+    `[auto-off] ${side}: bed exit detected, auto-off in ${Math.round(remainingMs / 1000)}s`,
+  )
+
+  timers[side] = {
+    timer: setTimeout(() => {
+      timers[side] = { timer: null, startedAt: null, timeoutMs: null }
+      // Re-check conditions before actually powering off
+      if (!isSidePowered(side)) return
+      if (hasActiveRunOnce(side)) return
+      const freshConfig = getAutoOffConfig()
+      if (!freshConfig[side].enabled) return
+
+      powerOffSide(side)
+    }, remainingMs),
+    startedAt: leftBedAtMs,
+    timeoutMs,
+  }
+}
+
+function poll(): void {
+  for (const side of SIDES) {
+    try {
+      evaluateSide(side)
+    }
+    catch (error) {
+      console.error(
+        `[auto-off] Error evaluating ${side}:`,
+        error instanceof Error ? error.message : error,
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Start the auto-off watcher polling loop. */
+export function startAutoOffWatcher(): void {
+  if (pollHandle) return // already running
+  console.log('[auto-off] Watcher started (poll every 30s)')
+  poll() // initial evaluation
+  pollHandle = setInterval(poll, POLL_INTERVAL_MS)
+}
+
+/** Stop the watcher and clear all pending timers. */
+export function stopAutoOffWatcher(): void {
+  if (pollHandle) {
+    clearInterval(pollHandle)
+    pollHandle = null
+  }
+  clearSideTimer('left')
+  clearSideTimer('right')
+  console.log('[auto-off] Watcher stopped')
+}
+
+/**
+ * Restart timers after settings change.
+ * Called when autoOffEnabled or autoOffMinutes is updated via the API.
+ */
+export function restartAutoOffTimers(): void {
+  clearSideTimer('left')
+  clearSideTimer('right')
+  poll()
+}

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -44,6 +44,9 @@ const timers: Record<Side, SideTimer> = {
 
 let pollHandle: ReturnType<typeof setInterval> | null = null
 
+/** Track in-flight powerOffSide() calls so shutdown can await them. */
+const pendingPowerOffs = new Set<Promise<void>>()
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -138,6 +141,25 @@ function getLatestSleepRecord(side: Side) {
   }
 }
 
+/**
+ * Check whether the user is currently in bed by comparing enteredBedAt
+ * and leftBedAt from the latest sleep record. If `enteredBedAt > leftBedAt`,
+ * a new session started after the last exit — the user is back in bed.
+ */
+function isUserInBed(side: Side): boolean {
+  const record = getLatestSleepRecord(side)
+  if (!record) return false
+
+  const enteredMs = record.enteredBedAt instanceof Date
+    ? record.enteredBedAt.getTime()
+    : (record.enteredBedAt as number) * 1000
+  const leftMs = record.leftBedAt instanceof Date
+    ? record.leftBedAt.getTime()
+    : (record.leftBedAt as number) * 1000
+
+  return enteredMs > leftMs
+}
+
 /** Power off a side via the shared hardware client. */
 async function powerOffSide(side: Side): Promise<void> {
   try {
@@ -165,6 +187,16 @@ async function powerOffSide(side: Side): Promise<void> {
       error instanceof Error ? error.message : error,
     )
   }
+}
+
+/**
+ * Fire powerOffSide and track the promise so shutdown can await it.
+ */
+function firePowerOff(side: Side): void {
+  const p = powerOffSide(side).finally(() => {
+    pendingPowerOffs.delete(p)
+  })
+  pendingPowerOffs.add(p)
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +241,13 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
     return
   }
 
+  // Fix 1: Don't arm if the user has returned to bed
+  // (enteredBedAt > leftBedAt means a new session started after the exit)
+  if (isUserInBed(side)) {
+    clearSideTimer(side)
+    return
+  }
+
   const leftBedAtMs = record.leftBedAt instanceof Date
     ? record.leftBedAt.getTime()
     : (record.leftBedAt as number) * 1000
@@ -228,8 +267,27 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
   // Heuristic: if leftBedAt is older than the timeout, the timer should have
   // already fired. If the side is still on, either it was manually turned on
   // or a new session is in progress -- don't start a new timer.
+  // Fix 5: Add grace window for server restarts during countdown.
+  // If msSinceBedExit is within timeoutMs + 2 * POLL_INTERVAL_MS, the timer
+  // may have been lost during a restart — fire immediately rather than skip.
+  const graceMs = timeoutMs + 2 * POLL_INTERVAL_MS
+  if (msSinceBedExit > graceMs) {
+    clearSideTimer(side)
+    return
+  }
+
+  // Fix 5: If past the timeout but within the grace window, fire immediately
   if (msSinceBedExit > timeoutMs) {
     clearSideTimer(side)
+    // Re-check conditions before actually powering off
+    if (!isSidePowered(side)) return
+    if (hasActiveRunOnce(side)) return
+    if (isUserInBed(side)) return
+    const freshConfig = getAutoOffConfig()
+    if (!freshConfig[side].enabled) return
+
+    console.log(`[auto-off] ${side}: bed exit was ${Math.round(msSinceBedExit / 1000)}s ago (within grace window), firing immediately`)
+    firePowerOff(side)
     return
   }
 
@@ -270,7 +328,13 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
         if (latestLeftBedMs !== leftBedAtMs) return // newer event; evaluateSide will re-arm
       }
 
-      powerOffSide(side)
+      // Fix 1: Check live presence before firing — user may have returned
+      if (isUserInBed(side)) {
+        console.log(`[auto-off] ${side}: user returned to bed, skipping power-off`)
+        return
+      }
+
+      firePowerOff(side)
     }, remainingMs),
     startedAt: leftBedAtMs,
     timeoutMs,
@@ -304,14 +368,21 @@ export function startAutoOffWatcher(): void {
   pollHandle = setInterval(poll, POLL_INTERVAL_MS)
 }
 
-/** Stop the watcher and clear all pending timers. */
-export function stopAutoOffWatcher(): void {
+/** Stop the watcher, clear all pending timers, and await in-flight power-offs. */
+export async function stopAutoOffWatcher(): Promise<void> {
   if (pollHandle) {
     clearInterval(pollHandle)
     pollHandle = null
   }
   clearSideTimer('left')
   clearSideTimer('right')
+
+  // Await any in-flight powerOffSide() calls
+  if (pendingPowerOffs.size > 0) {
+    console.log(`[auto-off] Waiting for ${pendingPowerOffs.size} in-flight power-off(s)...`)
+    await Promise.allSettled([...pendingPowerOffs])
+  }
+
   console.log('[auto-off] Watcher stopped')
 }
 
@@ -320,7 +391,22 @@ export function stopAutoOffWatcher(): void {
  * Called when autoOffEnabled or autoOffMinutes is updated via the API.
  */
 export function restartAutoOffTimers(): void {
+  // Fix 3: Don't poll if watcher is not running (e.g. in CI)
+  if (!pollHandle) return
+
   clearSideTimer('left')
   clearSideTimer('right')
   poll()
+}
+
+/**
+ * Cancel the auto-off timer for a specific side without re-evaluating.
+ * Called when a scheduled power-on fires — the side is being turned on
+ * intentionally, so any pending auto-off countdown should be aborted.
+ */
+export function cancelAutoOffTimer(side: Side): void {
+  if (timers[side].timer) {
+    console.log(`[auto-off] ${side}: timer cancelled (scheduled power-on)`)
+    clearSideTimer(side)
+  }
 }

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -14,6 +14,7 @@ import { db, biometricsDb } from '@/src/db'
 import { sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
 import { sleepRecords } from '@/src/db/biometrics-schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -154,6 +155,7 @@ async function powerOffSide(side: Side): Promise<void> {
       // next status poll will re-sync
     }
 
+    broadcastMutationStatus(side, { isPowered: false, targetLevel: 0 })
     console.log(`[auto-off] Powered off ${side} side (no presence detected)`)
   }
   catch (error) {
@@ -178,8 +180,7 @@ async function powerOffSide(side: Side): Promise<void> {
  * long ago and the side is still powered, we assume they are in bed
  * (the session hasn't closed yet).
  */
-function evaluateSide(side: Side): void {
-  const config = getAutoOffConfig()
+function evaluateSide(side: Side, config: Record<Side, { enabled: boolean; minutes: number }>): void {
   const cfg = config[side]
 
   // Feature disabled for this side
@@ -259,6 +260,15 @@ function evaluateSide(side: Side): void {
       const freshConfig = getAutoOffConfig()
       if (!freshConfig[side].enabled) return
 
+      // Verify the bed-exit that armed this timer is still the latest
+      const latestRecord = getLatestSleepRecord(side)
+      if (latestRecord) {
+        const latestLeftBedMs = latestRecord.leftBedAt instanceof Date
+          ? latestRecord.leftBedAt.getTime()
+          : (latestRecord.leftBedAt as number) * 1000
+        if (latestLeftBedMs !== leftBedAtMs) return // newer event; evaluateSide will re-arm
+      }
+
       powerOffSide(side)
     }, remainingMs),
     startedAt: leftBedAtMs,
@@ -267,9 +277,10 @@ function evaluateSide(side: Side): void {
 }
 
 function poll(): void {
+  const config = getAutoOffConfig()
   for (const side of SIDES) {
     try {
-      evaluateSide(side)
+      evaluateSide(side, config)
     }
     catch (error) {
       console.error(

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -142,6 +142,7 @@ function getLatestSleepRecord(side: Side) {
 async function powerOffSide(side: Side): Promise<void> {
   try {
     const client = getSharedHardwareClient()
+    await client.connect()
     await client.setPower(side, false)
 
     // Best-effort DB sync
@@ -155,7 +156,7 @@ async function powerOffSide(side: Side): Promise<void> {
       // next status poll will re-sync
     }
 
-    broadcastMutationStatus(side, { isPowered: false, targetLevel: 0 })
+    broadcastMutationStatus(side, { targetLevel: 0 })
     console.log(`[auto-off] Powered off ${side} side (no presence detected)`)
   }
   catch (error) {

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -96,7 +96,7 @@ function hasActiveRunOnce(side: Side): boolean {
 }
 
 /** Read auto-off config for both sides. */
-function getAutoOffConfig(): Record<Side, { enabled: boolean; minutes: number }> {
+function getAutoOffConfig(): Record<Side, { enabled: boolean, minutes: number }> {
   const defaults = { enabled: false, minutes: 30 }
   try {
     const rows = db.select().from(sideSettings).all()
@@ -180,7 +180,7 @@ async function powerOffSide(side: Side): Promise<void> {
  * long ago and the side is still powered, we assume they are in bed
  * (the session hasn't closed yet).
  */
-function evaluateSide(side: Side, config: Record<Side, { enabled: boolean; minutes: number }>): void {
+function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minutes: number }>): void {
   const cfg = config[side]
 
   // Feature disabled for this side


### PR DESCRIPTION
## Summary
- New auto-off watcher service that monitors sleep_records for bed-exit events and powers off after configurable timeout
- Per-side countdown timers with reset on re-entry, suppression during run-once sessions
- Web UI: toggle + duration picker (5–120 min) in side settings form
- Wired into server startup/shutdown lifecycle

Closes #257

## Test plan
- [ ] Enable auto-off with 5 min timeout — verify side powers off after no presence
- [ ] Verify timer resets on bed re-entry
- [ ] Verify auto-off suppressed during active run-once session
- [ ] Verify duration picker UI renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-side automatic power-off: enable/disable auto-off per side with configurable timeout in Settings (toggle + duration picker).
  * Settings apply immediately: changes to auto-off or timeout take effect without needing a restart.
  * Auto-off respects active use: timers pause/cancel when a side is powered on or detects return to bed, reducing unwanted shutdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->