### PR TITLE
feat: track flowrate and pump RPM with anomaly detection

### DIFF
--- a/src/components/Sensors/FlowrateChart.tsx
+++ b/src/components/Sensors/FlowrateChart.tsx
@@ -148,13 +148,17 @@ export function FlowrateChart() {
 
           <div className="flex items-center gap-1 text-blue-400">
             <Droplets size={10} />
-            <span className="text-[9px] font-medium">Flow</span>
+            <span className="text-[9px] font-medium">{viewMode === 'flowrate' ? 'Flow' : 'RPM'}</span>
           </div>
           <div className="rounded-md bg-zinc-800/50 px-2 py-1 text-center text-[11px] font-medium tabular-nums text-zinc-200">
-            {frzHealth.left.flowrate !== null ? `${frzHealth.left.flowrate.toFixed(1)}` : '--'}
+            {viewMode === 'flowrate'
+              ? (frzHealth.left.flowrate !== null ? frzHealth.left.flowrate.toFixed(1) : '--')
+              : frzHealth.left.pumpRpm}
           </div>
           <div className="rounded-md bg-zinc-800/50 px-2 py-1 text-center text-[11px] font-medium tabular-nums text-zinc-200">
-            {frzHealth.right.flowrate !== null ? `${frzHealth.right.flowrate.toFixed(1)}` : '--'}
+            {viewMode === 'flowrate'
+              ? (frzHealth.right.flowrate !== null ? frzHealth.right.flowrate.toFixed(1) : '--')
+              : frzHealth.right.pumpRpm}
           </div>
         </div>
       )}

--- a/src/components/Sensors/FlowrateChart.tsx
+++ b/src/components/Sensors/FlowrateChart.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts'
+import { Droplets } from 'lucide-react'
+import { trpc } from '@/src/utils/trpc'
+import { useSensorFrame } from '@/src/hooks/useSensorStream'
+
+interface FlowChartDataPoint {
+  time: number
+  leftFlow: number | null
+  rightFlow: number | null
+  leftRpm: number | null
+  rightRpm: number | null
+}
+
+function formatTime(timestamp: string | Date | number): string {
+  const d = new Date(timestamp)
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
+function formatTooltipTime(timestamp: number): string {
+  const d = new Date(timestamp)
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' })
+}
+
+type ViewMode = 'flowrate' | 'rpm'
+
+/**
+ * Flowrate and pump RPM chart.
+ * Queries historical flow readings from the biometrics DB and displays
+ * left/right flowrate (centidegrees) or pump RPM over time.
+ * Also shows live data from the frzHealth WebSocket frame.
+ */
+export function FlowrateChart() {
+  const [hours, setHours] = useState(6)
+  const [viewMode, setViewMode] = useState<ViewMode>('flowrate')
+
+  const frzHealth = useSensorFrame('frzHealth')
+
+  const flowQuery = trpc.waterLevel.getFlowReadings.useQuery(
+    { hours },
+    {
+      refetchInterval: 60_000,
+      staleTime: 30_000,
+    },
+  )
+
+  const chartData = useMemo(() => {
+    const raw = flowQuery.data as Array<{
+      timestamp: Date | string
+      leftFlowrateCd: number | null
+      rightFlowrateCd: number | null
+      leftPumpRpm: number | null
+      rightPumpRpm: number | null
+    }> | undefined
+
+    if (!raw || raw.length === 0) return []
+
+    // Data is already in chronological order from the API
+    const points: FlowChartDataPoint[] = raw.map(d => ({
+      time: new Date(d.timestamp).getTime(),
+      leftFlow: d.leftFlowrateCd,
+      rightFlow: d.rightFlowrateCd,
+      leftRpm: d.leftPumpRpm,
+      rightRpm: d.rightPumpRpm,
+    }))
+
+    // Downsample to ~120 points for performance
+    const maxPoints = 120
+    const step = Math.max(1, Math.floor(points.length / maxPoints))
+    return step > 1
+      ? points.filter((_, i) => i % step === 0 || i === points.length - 1)
+      : points
+  }, [flowQuery.data])
+
+  const leftKey = viewMode === 'flowrate' ? 'leftFlow' as const : 'leftRpm' as const
+  const rightKey = viewMode === 'flowrate' ? 'rightFlow' as const : 'rightRpm' as const
+  const unitLabel = viewMode === 'flowrate' ? 'cd' : 'RPM'
+
+  // Compute Y-axis domain
+  const allValues = chartData.flatMap(d => [d[leftKey], d[rightKey]].filter((v): v is number => v !== null))
+  const minVal = allValues.length > 0 ? Math.floor(Math.min(...allValues)) - 1 : 0
+  const maxVal = allValues.length > 0 ? Math.ceil(Math.max(...allValues)) + 1 : 100
+  const domain: [number, number] = [Math.max(0, minVal), maxVal]
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Droplets size={10} className="text-blue-400" />
+          <h3 className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+            {viewMode === 'flowrate' ? 'Flow Rate' : 'Pump RPM'}
+          </h3>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          {/* View mode toggle */}
+          <div className="flex rounded-md bg-zinc-800">
+            <button
+              onClick={() => setViewMode('flowrate')}
+              className={`rounded-md px-2 py-0.5 text-[9px] font-medium transition-colors ${
+                viewMode === 'flowrate' ? 'bg-zinc-700 text-zinc-200' : 'text-zinc-500'
+              }`}
+            >
+              Flow
+            </button>
+            <button
+              onClick={() => setViewMode('rpm')}
+              className={`rounded-md px-2 py-0.5 text-[9px] font-medium transition-colors ${
+                viewMode === 'rpm' ? 'bg-zinc-700 text-zinc-200' : 'text-zinc-500'
+              }`}
+            >
+              RPM
+            </button>
+          </div>
+
+          {/* Time range selector */}
+          <select
+            value={hours}
+            onChange={e => setHours(Number(e.target.value))}
+            className="rounded-md bg-zinc-800 px-1.5 py-0.5 text-[9px] text-zinc-400 outline-none"
+          >
+            <option value={1}>1h</option>
+            <option value={6}>6h</option>
+            <option value={24}>24h</option>
+            <option value={72}>3d</option>
+            <option value={168}>7d</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Live values from WebSocket */}
+      {frzHealth && (
+        <div className="grid grid-cols-[auto_1fr_1fr] gap-x-2 gap-y-1 items-center">
+          <div />
+          <div className="text-center text-[9px] font-semibold text-sky-400">Left</div>
+          <div className="text-center text-[9px] font-semibold text-teal-400">Right</div>
+
+          <div className="flex items-center gap-1 text-blue-400">
+            <Droplets size={10} />
+            <span className="text-[9px] font-medium">Flow</span>
+          </div>
+          <div className="rounded-md bg-zinc-800/50 px-2 py-1 text-center text-[11px] font-medium tabular-nums text-zinc-200">
+            {frzHealth.left.flowrate !== null ? `${frzHealth.left.flowrate.toFixed(1)}` : '--'}
+          </div>
+          <div className="rounded-md bg-zinc-800/50 px-2 py-1 text-center text-[11px] font-medium tabular-nums text-zinc-200">
+            {frzHealth.right.flowrate !== null ? `${frzHealth.right.flowrate.toFixed(1)}` : '--'}
+          </div>
+        </div>
+      )}
+
+      {/* Historical chart */}
+      {flowQuery.isLoading
+        ? (
+            <div className="flex h-[180px] items-center justify-center">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-700 border-t-zinc-400" />
+            </div>
+          )
+        : flowQuery.isError
+          ? (
+              <div className="flex h-[180px] items-center justify-center text-sm text-red-400">
+                Failed to load flow data
+              </div>
+            )
+          : chartData.length === 0
+            ? (
+                <div className="flex h-[180px] items-center justify-center text-sm text-zinc-500">
+                  No flow data available
+                </div>
+              )
+            : (
+                <div className="h-[180px] w-full">
+                  <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
+                    <LineChart data={chartData} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#333" strokeOpacity={0.5} />
+                      <XAxis
+                        dataKey="time"
+                        type="number"
+                        domain={['dataMin', 'dataMax']}
+                        tickFormatter={(v: number) => formatTime(v)}
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        stroke="#333"
+                        tickCount={4}
+                      />
+                      <YAxis
+                        domain={domain}
+                        tick={{ fill: '#71717a', fontSize: 10 }}
+                        stroke="#333"
+                        tickFormatter={(v: number) => `${Math.round(v)}`}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: '#1a1a1a',
+                          border: '1px solid #333',
+                          borderRadius: 8,
+                          fontSize: 12,
+                          color: '#fff',
+                        }}
+                        labelFormatter={v => formatTooltipTime(v as number)}
+                        formatter={(value, name) => [
+                          `${Number(value).toFixed(1)} ${unitLabel}`,
+                          String(name),
+                        ]}
+                      />
+                      <Legend
+                        iconType="circle"
+                        iconSize={6}
+                        wrapperStyle={{ fontSize: 10, color: '#a1a1aa' }}
+                        align="center"
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey={leftKey}
+                        name="Left"
+                        stroke="#5cb8e0"
+                        strokeWidth={2}
+                        dot={false}
+                        activeDot={{ r: 3, fill: '#5cb8e0' }}
+                        connectNulls
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey={rightKey}
+                        name="Right"
+                        stroke="#40e0d0"
+                        strokeWidth={2}
+                        dot={false}
+                        activeDot={{ r: 3, fill: '#40e0d0' }}
+                        connectNulls
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+    </div>
+  )
+}

--- a/src/components/Sensors/SensorsScreen.tsx
+++ b/src/components/Sensors/SensorsScreen.tsx
@@ -13,6 +13,7 @@ import { ConnectionStatusBar } from './ConnectionStatusBar'
 import { PresenceCard } from './PresenceCard'
 import { BedTempMatrix } from './BedTempMatrix'
 import { FreezerHealthCard } from './FreezerHealthCard'
+import { FlowrateChart } from './FlowrateChart'
 import { PiezoWaveform } from './PiezoWaveform'
 
 const DataPipeline = dynamic(() => import('./DataPipeline').then(m => ({ default: m.DataPipeline })), {
@@ -238,6 +239,11 @@ export function SensorsScreen() {
             {/* System — freezer thermal health */}
             <SensorCard>
               <FreezerHealthCard />
+            </SensorCard>
+
+            {/* Flowrate + Pump RPM trend (from biometrics) */}
+            <SensorCard>
+              <FlowrateChart />
             </SensorCard>
           </>
         )}

--- a/src/hardware/dacMonitor.instance.ts
+++ b/src/hardware/dacMonitor.instance.ts
@@ -249,7 +249,7 @@ export const getDacMonitor = async (): Promise<DacMonitor> => {
       // Subscribe to frzHealth frames from the sensor stream to record flow data
       import('../streaming/piezoStream').then(({ onServerFrame }) => {
         g[KEYS.unsubFlow] = onServerFrame((frame) => {
-          stateSync.recordFlowData(frame as { left: { pump: { rpm: number }, temps: { flowrate: number } }, right: { pump: { rpm: number }, temps: { flowrate: number } } })
+          stateSync.recordFlowData(frame as Record<string, unknown>)
         })
       }).catch(() => { /* WS server may not be started yet */ })
 

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -29,9 +29,18 @@ export function getAlarmState(): { left: boolean, right: boolean } {
   }
 }
 
+// ── Flow anomaly detection thresholds ──
+const PUMP_FAILURE_RPM_MIN = 50 // pump "running" but below this = suspicious
+const FLOWRATE_NEAR_ZERO_CD = 5 // centidegrees — effectively zero flow
+const FLOWRATE_SUDDEN_CHANGE_CD = 500 // centidegrees — large delta between consecutive reads
+const ANOMALY_LOG_COOLDOWN_MS = 300_000 // 5 min between repeated warnings per type
+
 export class DeviceStateSync {
   private lastWaterLevelWrite = 0
   private lastFlowWrite = 0
+  private lastAnomalyLog: Record<string, number> = {}
+  private prevFlowLeft: number | null = null
+  private prevFlowRight: number | null = null
 
   sync = async (status: DeviceStatus): Promise<void> => {
     this.recordWaterLevel(status)
@@ -128,6 +137,10 @@ export class DeviceStateSync {
     right: { pump: { rpm: number }, temps: { flowrate: number } }
   }): void {
     const now = Date.now()
+
+    // Run anomaly checks on every frame (not rate-limited)
+    this.checkFlowAnomalies(frzHealth, now)
+
     if (now - this.lastFlowWrite < 60_000) return
 
     try {
@@ -146,5 +159,53 @@ export class DeviceStateSync {
     catch (error) {
       console.error('DeviceStateSync: failed to write flow readings:', error instanceof Error ? error.message : error)
     }
+  }
+
+  /** Log an anomaly warning, rate-limited per anomaly type. */
+  private logAnomaly(type: string, message: string, now: number): void {
+    const lastLog = this.lastAnomalyLog[type] ?? 0
+    if (now - lastLog < ANOMALY_LOG_COOLDOWN_MS) return
+    console.warn(`[FlowAnomaly] ${type}: ${message}`)
+    this.lastAnomalyLog[type] = now
+  }
+
+  /** Check for flow/pump anomalies on each frzHealth frame. */
+  private checkFlowAnomalies(frzHealth: {
+    left: { pump: { rpm: number }, temps: { flowrate: number } }
+    right: { pump: { rpm: number }, temps: { flowrate: number } }
+  }, now: number): void {
+    const leftRpm = frzHealth.left.pump.rpm
+    const rightRpm = frzHealth.right.pump.rpm
+    const leftFlowCd = Math.round(frzHealth.left.temps.flowrate * 100)
+    const rightFlowCd = Math.round(frzHealth.right.temps.flowrate * 100)
+
+    // Pump running but no flow — possible pump failure or blockage
+    if (leftRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(leftFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
+      this.logAnomaly('left_pump_no_flow',
+        `Left pump running at ${leftRpm} RPM but flowrate near zero (${leftFlowCd} cd)`, now)
+    }
+    if (rightRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(rightFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
+      this.logAnomaly('right_pump_no_flow',
+        `Right pump running at ${rightRpm} RPM but flowrate near zero (${rightFlowCd} cd)`, now)
+    }
+
+    // Sudden large flowrate change — possible leak or sensor fault
+    if (this.prevFlowLeft !== null) {
+      const deltaLeft = Math.abs(leftFlowCd - this.prevFlowLeft)
+      if (deltaLeft > FLOWRATE_SUDDEN_CHANGE_CD) {
+        this.logAnomaly('left_flow_spike',
+          `Left flowrate sudden change: ${this.prevFlowLeft} -> ${leftFlowCd} cd (delta ${deltaLeft})`, now)
+      }
+    }
+    if (this.prevFlowRight !== null) {
+      const deltaRight = Math.abs(rightFlowCd - this.prevFlowRight)
+      if (deltaRight > FLOWRATE_SUDDEN_CHANGE_CD) {
+        this.logAnomaly('right_flow_spike',
+          `Right flowrate sudden change: ${this.prevFlowRight} -> ${rightFlowCd} cd (delta ${deltaRight})`, now)
+      }
+    }
+
+    this.prevFlowLeft = leftFlowCd
+    this.prevFlowRight = rightFlowCd
   }
 }

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -33,6 +33,7 @@ export function getAlarmState(): { left: boolean, right: boolean } {
 const PUMP_FAILURE_RPM_MIN = 50 // pump "running" but below this = suspicious
 const FLOWRATE_NEAR_ZERO_CD = 5 // centidegrees — effectively zero flow
 const FLOWRATE_SUDDEN_CHANGE_CD = 500 // centidegrees — large delta between consecutive reads
+const ASYMMETRY_THRESHOLD_CD = 300 // centidegrees — left/right divergence threshold
 const ANOMALY_LOG_COOLDOWN_MS = 300_000 // 5 min between repeated warnings per type
 
 export class DeviceStateSync {
@@ -134,8 +135,8 @@ export class DeviceStateSync {
   /** Write flow/pump data to biometrics DB, rate-limited to once per 60s. */
   recordFlowData(frame: Record<string, unknown>): void {
     // Guard: only process frzHealth frames (could be piezo, capSense, bedTemp, etc.)
-    const left = (frame as Record<string, unknown>)?.left
-    const right = (frame as Record<string, unknown>)?.right
+    const left = frame.left
+    const right = frame.right
     if (
       !left || typeof left !== 'object' || !('pump' in left) || !('temps' in left)
       || !right || typeof right !== 'object' || !('pump' in right) || !('temps' in right)
@@ -189,18 +190,27 @@ export class DeviceStateSync {
     const leftFlowCd = frzHealth.left.temps?.flowrate != null ? Math.round(frzHealth.left.temps.flowrate * 100) : NaN
     const rightFlowCd = frzHealth.right.temps?.flowrate != null ? Math.round(frzHealth.right.temps.flowrate * 100) : NaN
 
+    // Pump running but flowrate missing — possible sensor fault
+    if (leftRpm >= PUMP_FAILURE_RPM_MIN && Number.isNaN(leftFlowCd)) {
+      this.logAnomaly('left_flowrate_missing',
+        `Left pump running at ${leftRpm} RPM but flowrate unavailable`, now)
+    }
+    if (rightRpm >= PUMP_FAILURE_RPM_MIN && Number.isNaN(rightFlowCd)) {
+      this.logAnomaly('right_flowrate_missing',
+        `Right pump running at ${rightRpm} RPM but flowrate unavailable`, now)
+    }
+
     // Pump running but no flow — possible pump failure or blockage
-    if (leftRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(leftFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
+    if (leftRpm >= PUMP_FAILURE_RPM_MIN && !Number.isNaN(leftFlowCd) && Math.abs(leftFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
       this.logAnomaly('left_pump_no_flow',
         `Left pump running at ${leftRpm} RPM but flowrate near zero (${leftFlowCd} cd)`, now)
     }
-    if (rightRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(rightFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
+    if (rightRpm >= PUMP_FAILURE_RPM_MIN && !Number.isNaN(rightFlowCd) && Math.abs(rightFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
       this.logAnomaly('right_pump_no_flow',
         `Right pump running at ${rightRpm} RPM but flowrate near zero (${rightFlowCd} cd)`, now)
     }
 
     // Asymmetric flowrate — possible partial blockage
-    const ASYMMETRY_THRESHOLD_CD = 300
     if (Math.abs(leftFlowCd - rightFlowCd) > ASYMMETRY_THRESHOLD_CD
       && Math.abs(leftFlowCd) > FLOWRATE_NEAR_ZERO_CD
       && Math.abs(rightFlowCd) > FLOWRATE_NEAR_ZERO_CD) {

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -132,10 +132,20 @@ export class DeviceStateSync {
   }
 
   /** Write flow/pump data to biometrics DB, rate-limited to once per 60s. */
-  recordFlowData(frzHealth: {
-    left: { pump: { rpm: number }, temps: { flowrate: number } }
-    right: { pump: { rpm: number }, temps: { flowrate: number } }
-  }): void {
+  recordFlowData(frame: Record<string, unknown>): void {
+    // Guard: only process frzHealth frames (could be piezo, capSense, bedTemp, etc.)
+    const left = (frame as Record<string, unknown>)?.left
+    const right = (frame as Record<string, unknown>)?.right
+    if (
+      !left || typeof left !== 'object' || !('pump' in left) || !('temps' in left)
+      || !right || typeof right !== 'object' || !('pump' in right) || !('temps' in right)
+    ) return
+
+    const frzHealth = frame as {
+      left: { pump: { rpm: number }, temps: { flowrate?: number } }
+      right: { pump: { rpm: number }, temps: { flowrate?: number } }
+    }
+
     const now = Date.now()
 
     // Run anomaly checks on every frame (not rate-limited)
@@ -148,8 +158,8 @@ export class DeviceStateSync {
         .insert(flowReadings)
         .values({
           timestamp: new Date(now),
-          leftFlowrateCd: Math.round(frzHealth.left.temps.flowrate * 100),
-          rightFlowrateCd: Math.round(frzHealth.right.temps.flowrate * 100),
+          leftFlowrateCd: frzHealth.left.temps?.flowrate != null ? Math.round(frzHealth.left.temps.flowrate * 100) : null,
+          rightFlowrateCd: frzHealth.right.temps?.flowrate != null ? Math.round(frzHealth.right.temps.flowrate * 100) : null,
           leftPumpRpm: frzHealth.left.pump.rpm,
           rightPumpRpm: frzHealth.right.pump.rpm,
         })
@@ -171,13 +181,13 @@ export class DeviceStateSync {
 
   /** Check for flow/pump anomalies on each frzHealth frame. */
   private checkFlowAnomalies(frzHealth: {
-    left: { pump: { rpm: number }, temps: { flowrate: number } }
-    right: { pump: { rpm: number }, temps: { flowrate: number } }
+    left: { pump: { rpm: number }, temps: { flowrate?: number } }
+    right: { pump: { rpm: number }, temps: { flowrate?: number } }
   }, now: number): void {
     const leftRpm = frzHealth.left.pump.rpm
     const rightRpm = frzHealth.right.pump.rpm
-    const leftFlowCd = Math.round(frzHealth.left.temps.flowrate * 100)
-    const rightFlowCd = Math.round(frzHealth.right.temps.flowrate * 100)
+    const leftFlowCd = frzHealth.left.temps?.flowrate != null ? Math.round(frzHealth.left.temps.flowrate * 100) : NaN
+    const rightFlowCd = frzHealth.right.temps?.flowrate != null ? Math.round(frzHealth.right.temps.flowrate * 100) : NaN
 
     // Pump running but no flow — possible pump failure or blockage
     if (leftRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(leftFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
@@ -187,6 +197,15 @@ export class DeviceStateSync {
     if (rightRpm >= PUMP_FAILURE_RPM_MIN && Math.abs(rightFlowCd) < FLOWRATE_NEAR_ZERO_CD) {
       this.logAnomaly('right_pump_no_flow',
         `Right pump running at ${rightRpm} RPM but flowrate near zero (${rightFlowCd} cd)`, now)
+    }
+
+    // Asymmetric flowrate — possible partial blockage
+    const ASYMMETRY_THRESHOLD_CD = 300
+    if (Math.abs(leftFlowCd - rightFlowCd) > ASYMMETRY_THRESHOLD_CD
+      && Math.abs(leftFlowCd) > FLOWRATE_NEAR_ZERO_CD
+      && Math.abs(rightFlowCd) > FLOWRATE_NEAR_ZERO_CD) {
+      this.logAnomaly('flow_asymmetry',
+        `Left/right flowrate diverged: ${leftFlowCd} vs ${rightFlowCd} cd`, now)
     }
 
     // Sudden large flowrate change — possible leak or sensor fault
@@ -205,7 +224,7 @@ export class DeviceStateSync {
       }
     }
 
-    this.prevFlowLeft = leftFlowCd
-    this.prevFlowRight = rightFlowCd
+    this.prevFlowLeft = Number.isFinite(leftFlowCd) ? leftFlowCd : this.prevFlowLeft
+    this.prevFlowRight = Number.isFinite(rightFlowCd) ? rightFlowCd : this.prevFlowRight
   }
 }

--- a/src/server/routers/waterLevel.ts
+++ b/src/server/routers/waterLevel.ts
@@ -245,4 +245,29 @@ export const waterLevelRouter = router({
         })
       }
     }),
+
+  /**
+   * Get the most recent flow reading.
+   */
+  getLatestFlowReading: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/water-level/flow/latest', protect: false, tags: ['Water Level'] } })
+    .input(z.object({}))
+    .output(z.any())
+    .query(async () => {
+      try {
+        const [row] = await biometricsDb
+          .select()
+          .from(flowReadings)
+          .orderBy(desc(flowReadings.timestamp))
+          .limit(1)
+        return row || null
+      }
+      catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch latest flow reading: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          cause: error,
+        })
+      }
+    }),
 })


### PR DESCRIPTION
## Summary
- Adds `getLatestFlowReading` tRPC endpoint for most recent flow data
- Basic anomaly detection on every frzHealth frame: pump failure (RPM>0, flow≈0), leak detection (sudden flow spike), rate-limited warnings
- New `FlowrateChart` component on Sensors page with flowrate/RPM toggle and configurable time range
- Leverages existing `flow_readings` table and `recordFlowData()` persistence

Closes #241

## Test plan
- [ ] Verify flowrate chart renders on Sensors page with live data
- [ ] Toggle between flowrate and RPM views
- [ ] Verify `getLatestFlowReading` returns most recent reading
- [ ] Simulate anomaly conditions — verify console warnings appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flow rate and pump RPM charts showing historical and live sensor visualizations.
  * Time-range selector and view-mode toggle (flowrate vs RPM).
  * Live summary grid of current left/right readings with loading/error/empty states.
  * Real-time flow anomaly detection with rate-limited anomaly logging/alerts.
  * New public API endpoint to fetch the latest flow reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->