### PR TITLE
feat: add Always On toggle to side settings UI

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/src/components/Settings/SideSettingsForm.tsx
+++ b/src/components/Settings/SideSettingsForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { User, Plane, Timer } from 'lucide-react'
+import { User, Plane, Timer, Infinity as InfinityIcon } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { Toggle } from './Toggle'
 
@@ -9,6 +9,7 @@ interface SideData {
   side: 'left' | 'right'
   name: string
   awayMode: boolean
+  alwaysOn: boolean
   autoOffEnabled: boolean
   autoOffMinutes: number
 }
@@ -21,13 +22,14 @@ interface SideSettingsFormProps {
 const AUTO_OFF_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90, 120] as const
 
 /**
- * Per-side settings: name, away mode, and auto-off for a single side.
+ * Per-side settings: name, away mode, always on, and auto-off for a single side.
  */
 export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
   const d = sideData ?? {
     side,
     name: side === 'left' ? 'Left' : 'Right',
     awayMode: false,
+    alwaysOn: false,
     autoOffEnabled: false,
     autoOffMinutes: 30,
   }
@@ -35,7 +37,7 @@ export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
   // key forces remount when server data changes, replacing the useEffect sync pattern
   return (
     <SideCard
-      key={`${d.name}-${d.awayMode}-${d.autoOffEnabled}-${d.autoOffMinutes}`}
+      key={`${d.name}-${d.awayMode}-${d.alwaysOn}-${d.autoOffEnabled}-${d.autoOffMinutes}`}
       data={d}
     />
   )
@@ -45,6 +47,7 @@ function SideCard({ data }: { data: SideData }) {
   const utils = trpc.useUtils()
   const [name, setName] = useState(data.name)
   const [awayMode, setAwayMode] = useState(data.awayMode)
+  const [alwaysOn, setAlwaysOn] = useState(data.alwaysOn)
   const [autoOffEnabled, setAutoOffEnabled] = useState(data.autoOffEnabled)
   const [autoOffMinutes, setAutoOffMinutes] = useState(data.autoOffMinutes)
 
@@ -77,10 +80,31 @@ function SideCard({ data }: { data: SideData }) {
     mutation.mutate({ side: data.side, awayMode: newVal })
   }
 
+  function handleAlwaysOnToggle() {
+    const newVal = !alwaysOn
+    setAlwaysOn(newVal)
+    // Always On and Auto-off are mutually exclusive — turning on Always On
+    // disables Auto-off so the firmware never powers down mid-session.
+    if (newVal && autoOffEnabled) {
+      setAutoOffEnabled(false)
+      mutation.mutate({ side: data.side, alwaysOn: true, autoOffEnabled: false })
+    }
+    else {
+      mutation.mutate({ side: data.side, alwaysOn: newVal })
+    }
+  }
+
   function handleAutoOffToggle() {
     const newVal = !autoOffEnabled
     setAutoOffEnabled(newVal)
-    mutation.mutate({ side: data.side, autoOffEnabled: newVal })
+    // Mirror image of the Always On rule above.
+    if (newVal && alwaysOn) {
+      setAlwaysOn(false)
+      mutation.mutate({ side: data.side, autoOffEnabled: true, alwaysOn: false })
+    }
+    else {
+      mutation.mutate({ side: data.side, autoOffEnabled: newVal })
+    }
   }
 
   function handleAutoOffMinutesChange(minutes: number) {
@@ -127,6 +151,25 @@ function SideCard({ data }: { data: SideData }) {
           disabled={isPending}
           label={`Toggle away mode for ${sideLabel} side`}
         />
+      </div>
+
+      {/* Always On toggle */}
+      <div className="mt-3 border-t border-zinc-800 pt-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <InfinityIcon size={14} className={alwaysOn ? 'text-sky-400' : 'text-zinc-500'} />
+            <div>
+              <span className="text-sm text-zinc-300">Always On</span>
+              <p className="text-xs text-zinc-500">Prevents firmware&apos;s 8-hour auto-off</p>
+            </div>
+          </div>
+          <Toggle
+            enabled={alwaysOn}
+            onToggle={handleAlwaysOnToggle}
+            disabled={isPending}
+            label={`Toggle always on for ${sideLabel} side`}
+          />
+        </div>
       </div>
 
       {/* Auto-off toggle */}

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -331,6 +331,19 @@ export const settingsRouter = router({
             })
           }
 
+          // alwaysOn and autoOffEnabled are mutually exclusive — the UI
+          // already enforces this but a direct API call could land both as
+          // true. Reject so the autoOffWatcher's "alwaysOn wins" tiebreak
+          // never has to paper over an inconsistent persisted state.
+          const finalAlwaysOn = updates.alwaysOn !== undefined ? updates.alwaysOn : current.alwaysOn
+          const finalAutoOff = updates.autoOffEnabled !== undefined ? updates.autoOffEnabled : current.autoOffEnabled
+          if (finalAlwaysOn && finalAutoOff) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'alwaysOn and autoOffEnabled are mutually exclusive — set the other to false in the same call',
+            })
+          }
+
           // Validate merged away window — reject reversed ranges
           if ('awayStart' in updates || 'awayReturn' in updates) {
             const finalStart = updates.awayStart !== undefined ? updates.awayStart : current.awayStart


### PR DESCRIPTION
## Summary
- Adds Always On toggle to per-side settings form with Infinity icon
- Mutual exclusion: enabling Always On auto-disables Auto-off (and vice versa)
- Wires into existing `settings.updateSide({ alwaysOn })` mutation

Closes #305

## Test plan
- [ ] Toggle Always On — verify keepalive starts
- [ ] Toggle Always On while Auto-off is enabled — verify Auto-off is disabled
- [ ] Toggle Auto-off while Always On is enabled — verify Always On is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Always On" toggle setting that works as a mutually exclusive option with "Auto-off" for improved control.

* **Chores**
  * Added Git LFS integration hooks for post-checkout, post-commit, and post-merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->