### PR TITLE
feat: auto-unblock internet during update check

### DIFF
--- a/src/components/status/UpdateCard.tsx
+++ b/src/components/status/UpdateCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { trpc } from '@/src/utils/trpc'
-import { CheckCircle, Download, Loader2, RefreshCw, AlertTriangle } from 'lucide-react'
+import { CheckCircle, Download, Loader2, RefreshCw, AlertTriangle, Globe } from 'lucide-react'
 
 /**
  * UpdateCard — shows current version and provides a trigger to update the pod software.
@@ -10,16 +10,28 @@ import { CheckCircle, Download, Loader2, RefreshCw, AlertTriangle } from 'lucide
  * Wires into:
  * - system.getVersion → shows running version/branch
  * - system.triggerUpdate → kicks off sp-update (service will restart)
+ * - system.internetStatus → checks if WAN is blocked
+ * - system.setInternetAccess → temporarily unblocks WAN for updates
  *
  * After triggering an update the service restarts, so the UI shows a
  * "reconnecting" state and polls until the server comes back.
+ *
+ * If internet is blocked when the user initiates an update, the card
+ * prompts to temporarily allow internet. After the update completes
+ * (or fails), internet is re-blocked automatically.
  */
 export function UpdateCard() {
+  const utils = trpc.useUtils()
   const version = trpc.system.getVersion.useQuery({})
   const triggerUpdate = trpc.system.triggerUpdate.useMutation()
+  const setInternetAccess = trpc.system.setInternetAccess.useMutation()
 
-  const [updateState, setUpdateState] = useState<'idle' | 'confirming' | 'updating' | 'reconnecting' | 'error'>('idle')
+  const [updateState, setUpdateState] = useState<
+    'idle' | 'confirming' | 'internet-prompt' | 'unblocking' | 'updating' | 'reconnecting' | 'error'
+  >('idle')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  /** Tracks whether we temporarily unblocked internet and need to re-block */
+  const didUnblockRef = useRef(false)
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cancelledRef = useRef(false)
 
@@ -33,6 +45,22 @@ export function UpdateCard() {
 
   const versionData = version.data
 
+  /**
+   * Re-block internet if we temporarily unblocked it.
+   * Called after update completes, fails, or is cancelled.
+   */
+  const reblockIfNeeded = async () => {
+    if (!didUnblockRef.current) return
+    didUnblockRef.current = false
+    try {
+      await setInternetAccess.mutateAsync({ blocked: true })
+      utils.system.internetStatus.invalidate()
+    }
+    catch {
+      // Best effort — don't let re-block failure obscure the update result
+    }
+  }
+
   const handleUpdate = async () => {
     if (updateState === 'idle') {
       setUpdateState('confirming')
@@ -40,24 +68,57 @@ export function UpdateCard() {
     }
 
     if (updateState === 'confirming') {
-      setUpdateState('updating')
       setErrorMessage(null)
 
+      // Check if internet is blocked before proceeding
       try {
-        await triggerUpdate.mutateAsync({
-          branch: versionData?.branch !== 'unknown' ? versionData?.branch : undefined,
-        })
-        setUpdateState('reconnecting')
-
-        // Poll for reconnection — the service restarts after update
-        pollForReconnection()
+        const status = await utils.system.internetStatus.fetch({})
+        if (status.blocked) {
+          setUpdateState('internet-prompt')
+          return
+        }
       }
       catch {
-        // If the request fails immediately it might be because the service
-        // already restarted (which is actually success)
-        setUpdateState('reconnecting')
-        pollForReconnection()
+        // If we can't check, proceed anyway — the update script handles its own connectivity
       }
+
+      await startUpdate()
+    }
+  }
+
+  /** Unblock internet then proceed with the update */
+  const handleAllowInternet = async () => {
+    setUpdateState('unblocking')
+    setErrorMessage(null)
+
+    try {
+      await setInternetAccess.mutateAsync({ blocked: false })
+      didUnblockRef.current = true
+      utils.system.internetStatus.invalidate()
+      await startUpdate()
+    }
+    catch {
+      setUpdateState('error')
+      setErrorMessage('Failed to enable internet access. Try again or enable internet manually.')
+    }
+  }
+
+  /** Trigger the actual update */
+  const startUpdate = async () => {
+    setUpdateState('updating')
+
+    try {
+      await triggerUpdate.mutateAsync({
+        branch: versionData?.branch !== 'unknown' ? versionData?.branch : undefined,
+      })
+      setUpdateState('reconnecting')
+      pollForReconnection()
+    }
+    catch {
+      // If the request fails immediately it might be because the service
+      // already restarted (which is actually success)
+      setUpdateState('reconnecting')
+      pollForReconnection()
     }
   }
 
@@ -71,6 +132,7 @@ export function UpdateCard() {
       try {
         await version.refetch()
         // Success — service is back
+        await reblockIfNeeded()
         setUpdateState('idle')
       }
       catch {
@@ -78,6 +140,7 @@ export function UpdateCard() {
           pollTimerRef.current = setTimeout(check, 2000)
         }
         else if (!cancelledRef.current) {
+          await reblockIfNeeded()
           setUpdateState('error')
           setErrorMessage('Service did not come back after update. Check pod manually.')
         }
@@ -97,7 +160,7 @@ export function UpdateCard() {
     <div className="rounded-2xl bg-zinc-900/80 p-3 sm:p-4">
       {/* Header */}
       <div className="mb-2 flex items-center gap-2 sm:mb-3">
-        {updateState === 'idle' || updateState === 'confirming'
+        {updateState === 'idle' || updateState === 'confirming' || updateState === 'internet-prompt'
           ? (
               <>
                 <CheckCircle size={16} className="text-emerald-400" />
@@ -115,7 +178,11 @@ export function UpdateCard() {
                 <>
                   <Loader2 size={16} className="animate-spin text-sky-400" />
                   <span className="text-sm font-medium text-white">
-                    {updateState === 'updating' ? 'Updating...' : 'Reconnecting...'}
+                    {updateState === 'unblocking'
+                      ? 'Enabling internet...'
+                      : updateState === 'updating'
+                        ? 'Updating...'
+                        : 'Reconnecting...'}
                   </span>
                 </>
               )}
@@ -155,37 +222,64 @@ export function UpdateCard() {
         </p>
       )}
 
-      {/* Action buttons */}
-      {(updateState === 'idle' || updateState === 'confirming' || updateState === 'error') && (
-        <div className="flex gap-2">
-          <button
-            onClick={handleUpdate}
-            disabled={version.isLoading}
-            className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-sky-400 transition-colors active:bg-zinc-700 disabled:opacity-50"
-          >
-            {updateState === 'confirming'
-              ? (
-                  <>
-                    <Download size={14} />
-                    Confirm Update
-                  </>
-                )
-              : updateState === 'error'
-                ? (
-                    <>
-                      <RefreshCw size={14} />
-                      Retry Update
-                    </>
-                  )
-                : (
-                    <>
-                      <RefreshCw size={14} />
-                      Check for Updates
-                    </>
-                  )}
-          </button>
+      {/* Internet blocked prompt */}
+      {updateState === 'internet-prompt' && (
+        <div className="mb-3">
+          <div className="flex items-center gap-2 mb-2">
+            <Globe size={14} className="text-amber-400" />
+            <p className="text-xs text-amber-400">
+              Internet is currently blocked. Temporarily allow internet to check for updates?
+            </p>
+          </div>
+          <p className="text-[10px] text-zinc-500">
+            Internet will be re-blocked automatically after the update completes.
+          </p>
+        </div>
+      )}
 
-          {updateState === 'confirming' && (
+      {/* Action buttons */}
+      {(updateState === 'idle' || updateState === 'confirming' || updateState === 'error' || updateState === 'internet-prompt') && (
+        <div className="flex gap-2">
+          {updateState === 'internet-prompt'
+            ? (
+                <button
+                  onClick={handleAllowInternet}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-amber-400 transition-colors active:bg-zinc-700"
+                >
+                  <Globe size={14} />
+                  Allow &amp; Update
+                </button>
+              )
+            : (
+                <button
+                  onClick={handleUpdate}
+                  disabled={version.isLoading}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-sky-400 transition-colors active:bg-zinc-700 disabled:opacity-50"
+                >
+                  {updateState === 'confirming'
+                    ? (
+                        <>
+                          <Download size={14} />
+                          Confirm Update
+                        </>
+                      )
+                    : updateState === 'error'
+                      ? (
+                          <>
+                            <RefreshCw size={14} />
+                            Retry Update
+                          </>
+                        )
+                      : (
+                          <>
+                            <RefreshCw size={14} />
+                            Check for Updates
+                          </>
+                        )}
+                </button>
+              )}
+
+          {(updateState === 'confirming' || updateState === 'internet-prompt') && (
             <button
               onClick={handleCancel}
               className="rounded-lg border border-zinc-800 px-4 py-2.5 text-xs font-medium text-zinc-400 transition-colors active:bg-zinc-800"
@@ -196,14 +290,16 @@ export function UpdateCard() {
         </div>
       )}
 
-      {/* Updating/reconnecting state */}
-      {(updateState === 'updating' || updateState === 'reconnecting') && (
+      {/* Unblocking/updating/reconnecting state */}
+      {(updateState === 'unblocking' || updateState === 'updating' || updateState === 'reconnecting') && (
         <div className="flex items-center gap-2 rounded-lg bg-zinc-800/50 px-4 py-3">
           <Loader2 size={14} className="animate-spin text-sky-400" />
           <span className="text-xs text-zinc-400">
-            {updateState === 'updating'
-              ? 'Triggering update...'
-              : 'Waiting for service to restart...'}
+            {updateState === 'unblocking'
+              ? 'Enabling internet access...'
+              : updateState === 'updating'
+                ? 'Triggering update...'
+                : 'Waiting for service to restart...'}
           </span>
         </div>
       )}

--- a/src/components/status/UpdateCard.tsx
+++ b/src/components/status/UpdateCard.tsx
@@ -35,12 +35,18 @@ export function UpdateCard() {
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cancelledRef = useRef(false)
 
-  // Clean up poll timer on unmount
+  // Clean up poll timer on unmount and re-block internet if needed
   useEffect(() => {
     return () => {
       cancelledRef.current = true
       if (pollTimerRef.current) clearTimeout(pollTimerRef.current)
+      // Fire-and-forget re-block if we unblocked internet and the user navigates away
+      if (didUnblockRef.current) {
+        didUnblockRef.current = false
+        setInternetAccess.mutate({ blocked: true })
+      }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup-only ref, stable mutation object
   }, [])
 
   const versionData = version.data


### PR DESCRIPTION
## Summary
- When user initiates update check with internet blocked, shows prompt to temporarily allow internet
- On allow: unblocks internet, proceeds with update, re-blocks automatically after completion/failure
- Uses `system.internetStatus` and `system.setInternetAccess` APIs
- Internet re-blocked in both success and failure paths via ref tracking

Closes #306

## Test plan
- [ ] With internet blocked: press update → verify prompt appears
- [ ] Press "Allow & Update" → verify internet unblocks, update proceeds, internet re-blocks
- [ ] Press Cancel → verify no changes
- [ ] With internet already allowed: press update → verify normal flow (no prompt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Update process now detects when internet access is blocked before proceeding
* Displays a prompt asking users to allow internet access when needed
* Added "Allow & Update" button for users to grant temporary internet access
* Automatically re-restricts internet access after the update completes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->