### PR TITLE
Fix DAC socket path parsing and Avahi EROFS on device startup

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -231,10 +231,12 @@ fi
 # Priority 2: Extract from frank.sh (what frankenfirmware actually uses)
 if [ -z "$DAC_SOCK_PATH" ] && [ -f /opt/eight/bin/frank.sh ]; then
   FRANK_PATH=$(grep 'DAC_SOCKET=' /opt/eight/bin/frank.sh 2>/dev/null \
-    | grep -o '[^ ]*dac\.sock' | head -1 || true)
-  if [ -n "$FRANK_PATH" ]; then
+    | sed -n 's/.*DAC_SOCKET=\([^ ]*dac\.sock\).*/\1/p' | head -1 || true)
+  if [ -n "$FRANK_PATH" ] && is_supported_dac_path "$FRANK_PATH"; then
     DAC_SOCK_PATH="$FRANK_PATH"
     echo "Detected dac.sock path from frank.sh: $DAC_SOCK_PATH"
+  elif [ -n "$FRANK_PATH" ]; then
+    echo "Warning: Ignoring unsupported DAC_SOCK_PATH from frank.sh: $FRANK_PATH"
   fi
 fi
 
@@ -569,6 +571,30 @@ if command -v fuser &>/dev/null; then
     kill "$PORT_PID" 2>/dev/null || true
     sleep 1
   fi
+fi
+
+# Install Avahi mDNS service file (must happen here, not at runtime,
+# because ProtectSystem=strict makes /etc read-only for the service process)
+if [ -d /etc/avahi ]; then
+  mkdir -p /etc/avahi/services
+  TRPC_PORT=${PORT:-3000}
+  WS_PORT=${PIEZO_WS_PORT:-3001}
+  cat > /etc/avahi/services/sleepypod.service << AVAHI_EOF
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name>sleepypod</name>
+  <service>
+    <type>_sleepypod._tcp</type>
+    <port>$TRPC_PORT</port>
+    <txt-record>wsPort=$WS_PORT</txt-record>
+    <txt-record>version=1.0.0</txt-record>
+  </service>
+</service-group>
+AVAHI_EOF
+  # Reload avahi to pick up the new service file
+  kill -HUP "$(pidof avahi-daemon 2>/dev/null)" 2>/dev/null || true
+  echo "Avahi mDNS service installed (_sleepypod._tcp on port $TRPC_PORT)"
 fi
 
 systemctl restart sleepypod.service

--- a/scripts/install
+++ b/scripts/install
@@ -574,7 +574,8 @@ if command -v fuser &>/dev/null; then
 fi
 
 # Install Avahi mDNS service file (must happen here, not at runtime,
-# because ProtectSystem=strict makes /etc read-only for the service process)
+# because ProtectSystem=strict makes /etc read-only for the service process).
+# Port values are baked in at install time; sp-update re-runs this to refresh.
 if [ -d /etc/avahi ]; then
   mkdir -p /etc/avahi/services
   TRPC_PORT=${PORT:-3000}

--- a/src/streaming/bonjourAnnounce.ts
+++ b/src/streaming/bonjourAnnounce.ts
@@ -47,8 +47,22 @@ export function startBonjourAnnouncement(): void {
       return
     }
 
-    mkdirSync('/etc/avahi/services', { recursive: true })
-    writeFileSync(SERVICE_FILE, SERVICE_XML)
+    // The service file is installed by scripts/install (which runs as root
+    // before ProtectSystem=strict makes /etc read-only). If it's already
+    // there, just reload Avahi. Only attempt to write as a fallback.
+    if (!existsSync(SERVICE_FILE)) {
+      try {
+        mkdirSync('/etc/avahi/services', { recursive: true })
+        writeFileSync(SERVICE_FILE, SERVICE_XML)
+      }
+      catch {
+        // ProtectSystem=strict or read-only rootfs — can't write to /etc.
+        // The install script should have placed the file already.
+        console.log('[bonjour] Service file not found and /etc is read-only — mDNS unavailable')
+        console.log('[bonjour] Re-run the installer to create /etc/avahi/services/sleepypod.service')
+        return
+      }
+    }
 
     // Reload avahi to pick up the service file
     try {

--- a/src/streaming/bonjourAnnounce.ts
+++ b/src/streaming/bonjourAnnounce.ts
@@ -14,7 +14,7 @@
  * TXT records include the WebSocket port and protocol version.
  */
 
-import { writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 
 const TRPC_PORT = Number(process.env.PORT ?? 3000)
@@ -90,13 +90,15 @@ export function startBonjourAnnouncement(): void {
 export function stopBonjourAnnouncement(): void {
   try {
     if (existsSync(SERVICE_FILE)) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { unlinkSync } = require('node:fs')
-      unlinkSync(SERVICE_FILE)
       try {
+        unlinkSync(SERVICE_FILE)
         execSync('kill -HUP $(pidof avahi-daemon) 2>/dev/null', { stdio: 'ignore' })
       }
-      catch { /* ok */ }
+      catch {
+        // ProtectSystem=strict makes /etc read-only — the service file
+        // persists until the next install run. Avahi keeps advertising,
+        // which is acceptable (the iOS app handles offline pods gracefully).
+      }
     }
     console.log('[bonjour] mDNS announcement stopped')
   }


### PR DESCRIPTION
## Summary

- **DAC_SOCK_PATH** was being set to `DAC_SOCKET=/deviceinfo/dac.sock` instead of just the path, because the grep pattern captured the variable assignment prefix from `frank.sh`. Switched to `sed` extraction and added path validation.
- **Avahi service file** write fails at runtime because `ProtectSystem=strict` makes `/etc` read-only. Moved the write to `scripts/install` (runs as root before systemd sandboxing) and made the runtime code a graceful fallback.

## Test plan

- [x] Verified on-device: DAC connects successfully after fix
- [x] Verified on-device: Avahi error resolved (service file installed by installer)
- [x] `sp-logs` shows clean startup with DAC connection and sensor stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic network service advertisement during installation, enabling system discoverability with version and connectivity information.

* **Bug Fixes**
  * Improved socket path detection with validation to gracefully handle unsupported configurations.
  * Enhanced error handling for read-only filesystem environments with clear recovery instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->