### PR TITLE
Fix Python venv creation on Pod 3/4 Yocto images

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -628,16 +628,10 @@ else
     mkdir -p "$dest"
     cp -r "$src/." "$dest/"
 
-    # Check if python3 venv is available (built-in on most distros, separate package on Debian)
-    if ! python3 -m venv --help >/dev/null 2>&1; then
-      echo "Warning: python3-venv not available, skipping module $name"
-      echo "On Debian/Ubuntu: apt-get install -y python3-venv"
+    # Create Python virtualenv (handles Pod 3/4 Yocto quirks — see scripts/setup-python-venv)
+    if ! "$INSTALL_DIR/scripts/setup-python-venv" "$dest"; then
+      echo "Warning: python3 venv creation failed, skipping module $name"
       return
-    fi
-
-    # Create Python virtualenv and install deps
-    if [ ! -d "$dest/venv" ]; then
-      python3 -m venv "$dest/venv"
     fi
     "$dest/venv/bin/pip" install --quiet --upgrade pip
     "$dest/venv/bin/pip" install --quiet -r "$dest/requirements.txt"
@@ -882,7 +876,7 @@ if pnpm install --frozen-lockfile --prod; then
         mkdir -p "$MODULES_DEST/$mod"
         cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
         if [ ! -d "$MODULES_DEST/$mod/venv" ] && command -v python3 &>/dev/null; then
-          python3 -m venv "$MODULES_DEST/$mod/venv" 2>/dev/null || true
+          "$INSTALL_DIR/scripts/setup-python-venv" "$MODULES_DEST/$mod" 2>/dev/null || true
         fi
         if [ -d "$MODULES_DEST/$mod/venv" ] && [ -f "$MODULES_DEST/$mod/requirements.txt" ]; then
           "$MODULES_DEST/$mod/venv/bin/pip" install --quiet -r "$MODULES_DEST/$mod/requirements.txt" 2>/dev/null || true

--- a/scripts/setup-python-venv
+++ b/scripts/setup-python-venv
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Create a Python virtual environment with pip, handling Yocto image quirks.
+#
+# Pod 3 (Python 3.9): venv module may be entirely missing
+# Pod 4 (Python 3.10): venv exists but ensurepip fails — Yocto image lacks
+#                       plistlib.py and pyexpat.so in the stdlib
+# Pod 5+ (Python 3.10+): typically works out of the box
+#
+# Strategy: try normal venv first, fall back to --without-pip + get-pip.py.
+#
+# Usage: setup-python-venv <dest_dir>
+#   Creates <dest_dir>/venv with pip available.
+#   Exits 0 on success, 1 on failure.
+
+set -euo pipefail
+
+DEST="${1:?Usage: setup-python-venv <dest_dir>}"
+VENV_DIR="$DEST/venv"
+
+if [ -d "$VENV_DIR" ]; then
+  echo "  venv already exists at $VENV_DIR"
+  exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 not found" >&2
+  exit 1
+fi
+
+# Try 1: normal venv (works on Pod 5+ and Debian/Ubuntu)
+if python3 -m venv "$VENV_DIR" 2>/dev/null; then
+  exit 0
+fi
+# Clean up partial venv from failed attempt (ensurepip can fail after dir creation)
+rm -rf "$VENV_DIR"
+
+# Try 2: venv without pip + bootstrap (works on Pod 3/4 with broken ensurepip)
+if python3 -m venv --without-pip "$VENV_DIR" 2>/dev/null; then
+  echo "  ensurepip not available, bootstrapping pip via get-pip.py..."
+  if curl -fsSL https://bootstrap.pypa.io/get-pip.py | "$VENV_DIR/bin/python3"; then
+    exit 0
+  fi
+  # get-pip.py failed — clean up the broken venv
+  rm -rf "$VENV_DIR"
+fi
+
+echo "Error: could not create Python venv at $VENV_DIR" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Pod 4 (Python 3.10) and Pod 3 (Python 3.9) Yocto images lack `plistlib.py` and `pyexpat.so` in the stdlib, which breaks `ensurepip` and causes `python3 -m venv` to fail silently
- All 4 biometrics modules (piezo-processor, sleep-detector, environment-monitor, calibrator) are skipped with `Warning: python3-venv not available`
- Extracted venv setup into `scripts/setup-python-venv` so it's reusable and independently testable for future pod versions
- Falls back to `--without-pip` + `get-pip.py` bootstrap when `ensurepip` is unavailable

Reference: `throwaway31265/free-sleep` `install_python_packages.sh` for the root cause analysis (missing stdlib modules in Yocto builds).

## Test plan

- [ ] Verify on Pod 4: `scripts/setup-python-venv /tmp/test-venv` creates a working venv with pip
- [ ] Verify on Pod 5: normal `python3 -m venv` path still works (no regression)
- [ ] Full install on Pod 4: all 4 biometrics modules install and start
- [ ] `sp-update` on Pod 4: module venvs created correctly on update path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored Python virtual environment provisioning to use a dedicated setup script during initial installation and module updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->