### PR TITLE
fix: persist free-sleep/sleepypod switch across reboots

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -939,6 +939,7 @@ echo "Switching to free-sleep..."
 systemctl stop sleepypod.service 2>/dev/null || true
 for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
   systemctl stop "$svc.service" 2>/dev/null || true
+  systemctl disable "$svc.service" 2>/dev/null || true
 done
 # Persist across reboots
 systemctl disable sleepypod.service 2>/dev/null || true
@@ -966,6 +967,7 @@ if command -v fuser &>/dev/null; then
 fi
 systemctl restart sleepypod.service
 for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
+  systemctl enable "$svc.service" 2>/dev/null || true
   systemctl restart "$svc.service" 2>/dev/null || true
 done
 sleep 3

--- a/scripts/install
+++ b/scripts/install
@@ -940,10 +940,13 @@ systemctl stop sleepypod.service 2>/dev/null || true
 for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
   systemctl stop "$svc.service" 2>/dev/null || true
 done
+# Persist across reboots
+systemctl disable sleepypod.service 2>/dev/null || true
+systemctl enable free-sleep.service free-sleep-stream.service 2>/dev/null || true
 systemctl start free-sleep.service free-sleep-stream.service 2>/dev/null || true
 sleep 2
 if systemctl is-active --quiet free-sleep.service; then
-  echo "✓ free-sleep is running on port 3000"
+  echo "✓ free-sleep is running on port 3000 (persists across reboots)"
 else
   echo "✗ free-sleep failed to start — check: journalctl -u free-sleep.service"
 fi
@@ -953,6 +956,9 @@ cat > /usr/local/bin/sp-sleepypod << 'EOF'
 #!/bin/bash
 echo "Switching to sleepypod..."
 systemctl stop free-sleep.service free-sleep-stream.service 2>/dev/null || true
+# Persist across reboots
+systemctl disable free-sleep.service free-sleep-stream.service 2>/dev/null || true
+systemctl enable sleepypod.service 2>/dev/null || true
 # Kill anything on port 3000
 if command -v fuser &>/dev/null; then
   fuser -k 3000/tcp 2>/dev/null || true
@@ -964,7 +970,7 @@ for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environm
 done
 sleep 3
 if systemctl is-active --quiet sleepypod.service; then
-  echo "✓ sleepypod is running on port 3000"
+  echo "✓ sleepypod is running on port 3000 (persists across reboots)"
 else
   echo "✗ sleepypod failed to start — check: sp-logs"
 fi


### PR DESCRIPTION
## Summary
- `sp-freesleep` now disables `sleepypod.service` and enables `free-sleep.service` / `free-sleep-stream.service` so the choice survives reboots
- `sp-sleepypod` does the reverse — disables free-sleep services and re-enables sleepypod

Previously both commands only stopped/started services at runtime without toggling `systemctl enable/disable`, so every reboot reverted to sleepypod regardless of which mode the user selected.

Fixes #334

## Test plan
- Run `sp-freesleep`, verify free-sleep is active
- Run `systemctl is-enabled sleepypod.service` → should be `disabled`
- Run `systemctl is-enabled free-sleep.service` → should be `enabled`
- Reboot pod → free-sleep should still be running
- Run `sp-sleepypod`, verify sleepypod is active and enabled states are reversed
- Reboot pod → sleepypod should still be running