### PR TITLE
refactor: extract pod modules and CLI tools from install script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,25 +21,28 @@ curl -fsSL https://raw.githubusercontent.com/sleepypod/core/main/scripts/install
 
 This will:
 1. **Pre-flight checks** - Verify disk space, network, dependencies
-2. **Detect dac.sock** - Auto-detect hardware socket location
-3. **Install Node.js 20** - Via nodesource repository
-4. **Clone repository** - From GitHub main branch
-5. **Install dependencies** - With `--frozen-lockfile` and `--ignore-scripts` for security
-6. **Build application** - Next.js production build
-7. **Database migrations** - Safe schema updates (not destructive push)
+2. **Download code** - From GitHub tarball (or use `--local`)
+3. **Detect pod generation** - Auto-detect dac.sock path and pod hardware (`scripts/pod/detect`)
+4. **Install Node.js 22** - Binary download (no apt required)
+5. **Install dependencies** - With `--frozen-lockfile`
+6. **Build application** - Next.js production build (skipped if pre-built)
+7. **Database migrations** - Run automatically on startup
 8. **Create systemd service** - With auto-restart and hardening
-9. **CLI shortcuts** - sp-status, sp-restart, sp-logs, sp-update
-10. **Start scheduler** - Automated temperature/power/alarm jobs
+9. **Install CLI tools** - From `scripts/bin/` to `/usr/local/bin/`
+10. **Install biometrics modules** - Python venvs + systemd services
 11. **Optional SSH setup** - Interactive prompt for SSH on port 8822 (keys only)
 
 ## CLI Commands
 
-After installation:
+After installation (installed from `scripts/bin/`):
 
 - `sp-status` - View service status
-- `sp-restart` - Restart sleepypod service
+- `sp-restart` - Restart sleepypod + reconnect frankenfirmware
 - `sp-logs` - View live logs
-- `sp-update` - Update to latest version
+- `sp-update` - Update to latest version from GitHub
+- `sp-freesleep` - Switch to free-sleep (persists across reboots)
+- `sp-sleepypod` - Switch to sleepypod (persists across reboots)
+- `sp-uninstall` - Remove sleepypod and all related services
 
 ## Internet Control
 
@@ -105,6 +108,28 @@ After installation, sleepypod provides:
 - **Hardware Control** - Direct DAC socket communication
 - **Health Monitoring** - Scheduler status and hardware connectivity checks
 - **Timezone Support** - Full timezone awareness for all schedules
+
+## Script Structure
+
+```
+scripts/
+├── install                # Core orchestrator
+├── lib/
+│   └── iptables-helpers   # Shared WAN/iptables functions (sourced by sp-update)
+├── pod/
+│   └── detect             # Pod detection: DAC_SOCK_PATH, POD_GEN
+├── bin/                   # CLI tools — copied to /usr/local/bin/ during install
+│   ├── sp-status
+│   ├── sp-restart
+│   ├── sp-logs
+│   ├── sp-update
+│   ├── sp-freesleep
+│   ├── sp-sleepypod
+│   └── sp-uninstall
+├── deploy                 # Dev deploy (build local, push to pod)
+├── push                   # Fast push (pre-built .next only)
+└── internet-control       # WAN block/unblock utility
+```
 
 ## File Locations
 

--- a/scripts/bin/sp-freesleep
+++ b/scripts/bin/sp-freesleep
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+echo "Switching to free-sleep..."
+systemctl stop sleepypod.service 2>/dev/null || true
+for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
+  systemctl stop "$svc.service" 2>/dev/null || true
+  systemctl disable "$svc.service" 2>/dev/null || true
+done
+# Persist across reboots
+systemctl disable sleepypod.service 2>/dev/null || true
+systemctl enable free-sleep.service free-sleep-stream.service 2>/dev/null || true
+systemctl start free-sleep.service free-sleep-stream.service 2>/dev/null || true
+sleep 2
+if systemctl is-active --quiet free-sleep.service; then
+  echo "✓ free-sleep is running on port 3000 (persists across reboots)"
+else
+  echo "✗ free-sleep failed to start — check: journalctl -u free-sleep.service"
+fi

--- a/scripts/bin/sp-logs
+++ b/scripts/bin/sp-logs
@@ -1,0 +1,2 @@
+#!/bin/bash
+journalctl -u sleepypod.service -f

--- a/scripts/bin/sp-restart
+++ b/scripts/bin/sp-restart
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="/home/dac/sleepypod-core"
+
+systemctl restart sleepypod.service
+
+# Wait for sleepypod to create dac.sock before killing frankenfirmware
+DAC_SOCK=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2- || true)
+if [ -z "$DAC_SOCK" ]; then
+  # Fall back to pod detection if .env doesn't have it
+  source "$INSTALL_DIR/scripts/pod/detect" 2>/dev/null || true
+  DAC_SOCK="${DAC_SOCK_PATH:-/persistent/deviceinfo/dac.sock}"
+fi
+
+for i in $(seq 1 10); do
+  [ -S "$DAC_SOCK" ] && break
+  sleep 1
+done
+
+if [ -S "$DAC_SOCK" ]; then
+  # Kill frankenfirmware so its supervisor restarts it against the new dac.sock
+  pkill frankenfirmware 2>/dev/null || true
+else
+  echo "Warning: dac.sock not found after 10s — skipping frankenfirmware restart" >&2
+fi

--- a/scripts/bin/sp-sleepypod
+++ b/scripts/bin/sp-sleepypod
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+echo "Switching to sleepypod..."
+systemctl stop free-sleep.service free-sleep-stream.service 2>/dev/null || true
+# Persist across reboots
+systemctl disable free-sleep.service free-sleep-stream.service 2>/dev/null || true
+systemctl enable sleepypod.service 2>/dev/null || true
+# Kill anything on port 3000
+if command -v fuser &>/dev/null; then
+  fuser -k 3000/tcp 2>/dev/null || true
+  sleep 1
+fi
+systemctl restart sleepypod.service
+for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
+  systemctl enable "$svc.service" 2>/dev/null || true
+  systemctl restart "$svc.service" 2>/dev/null || true
+done
+sleep 3
+if systemctl is-active --quiet sleepypod.service; then
+  echo "✓ sleepypod is running on port 3000 (persists across reboots)"
+else
+  echo "✗ sleepypod failed to start — check: sp-logs"
+fi

--- a/scripts/bin/sp-status
+++ b/scripts/bin/sp-status
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl status sleepypod.service

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -98,7 +98,7 @@ if grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
   sed -i '/# BEGIN sleepypod-telemetry-block/,/# END sleepypod-telemetry-block/d' /etc/hosts
 fi
 
-# Restore iptables to allow all traffic
+# Restore iptables to allow all traffic (IPv4 and IPv6)
 echo "Restoring iptables (allowing all traffic)..."
 iptables -F 2>/dev/null || true
 iptables -X 2>/dev/null || true
@@ -107,11 +107,18 @@ iptables -t nat -X 2>/dev/null || true
 iptables -P INPUT ACCEPT 2>/dev/null || true
 iptables -P OUTPUT ACCEPT 2>/dev/null || true
 iptables -P FORWARD ACCEPT 2>/dev/null || true
-rm -f /etc/iptables/iptables.rules
+ip6tables -F 2>/dev/null || true
+ip6tables -X 2>/dev/null || true
+ip6tables -t nat -F 2>/dev/null || true
+ip6tables -t nat -X 2>/dev/null || true
+ip6tables -P INPUT ACCEPT 2>/dev/null || true
+ip6tables -P OUTPUT ACCEPT 2>/dev/null || true
+ip6tables -P FORWARD ACCEPT 2>/dev/null || true
+rm -f /etc/iptables/iptables.rules /etc/iptables/rules.v4 /etc/iptables/rules.v6
 
 # Re-enable free-sleep if available
 for fs_svc in free-sleep.service free-sleep-stream.service; do
-  if systemctl list-unit-files "$fs_svc" &>/dev/null; then
+  if systemctl list-unit-files "$fs_svc" 2>/dev/null | grep -q "$fs_svc"; then
     echo "Re-enabling $fs_svc..."
     systemctl enable "$fs_svc" 2>/dev/null || true
     systemctl start "$fs_svc" 2>/dev/null || true

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -93,9 +93,12 @@ else
 fi
 
 # Remove /etc/hosts telemetry block
-if grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
+if grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null && \
+   grep -q "# END sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
   echo "Removing /etc/hosts telemetry block..."
   sed -i '/# BEGIN sleepypod-telemetry-block/,/# END sleepypod-telemetry-block/d' /etc/hosts
+elif grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
+  echo "Warning: Incomplete telemetry block in /etc/hosts (missing END marker), skipping removal"
 fi
 
 # Restore iptables to allow all traffic (IPv4 and IPv6)

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -euo pipefail
+
+# sp-uninstall — remove sleepypod-core and all installed artifacts
+#
+# Usage:
+#   sp-uninstall              # interactive (prompts for confirmation)
+#   sp-uninstall --force      # skip confirmation
+#   sp-uninstall --keep-data  # remove everything except databases
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Error: Must run as root (use sudo)" >&2
+  exit 1
+fi
+
+KEEP_DATA=false
+FORCE=false
+for arg in "$@"; do
+  case "$arg" in
+    --keep-data) KEEP_DATA=true ;;
+    --force)     FORCE=true ;;
+  esac
+done
+
+INSTALL_DIR="/home/dac/sleepypod-core"
+DATA_DIR="/persistent/sleepypod-data"
+MODULES_DIR="/opt/sleepypod/modules"
+
+if [ "$FORCE" != true ]; then
+  echo "This will remove sleepypod-core and all related services."
+  if [ "$KEEP_DATA" = true ]; then
+    echo "Databases at $DATA_DIR will be preserved."
+  else
+    echo "WARNING: Databases at $DATA_DIR will be DELETED."
+  fi
+  echo ""
+  read -rp "Continue? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+echo "=== Uninstalling SleepyPod ==="
+
+# Stop and disable services
+echo "Stopping services..."
+SERVICES=(
+  sleepypod.service
+  sleepypod-piezo-processor.service
+  sleepypod-sleep-detector.service
+  sleepypod-environment-monitor.service
+  sleepypod-calibrator.service
+)
+for svc in "${SERVICES[@]}"; do
+  systemctl stop "$svc" 2>/dev/null || true
+  systemctl disable "$svc" 2>/dev/null || true
+  rm -f "/etc/systemd/system/$svc"
+done
+systemctl daemon-reload
+
+# Remove CLI tools
+echo "Removing CLI tools..."
+rm -f /usr/local/bin/sp-status
+rm -f /usr/local/bin/sp-restart
+rm -f /usr/local/bin/sp-logs
+rm -f /usr/local/bin/sp-update
+rm -f /usr/local/bin/sp-freesleep
+rm -f /usr/local/bin/sp-sleepypod
+rm -f /usr/local/bin/sp-uninstall
+
+# Remove Python modules
+if [ -d "$MODULES_DIR" ]; then
+  echo "Removing Python modules..."
+  rm -rf "$MODULES_DIR"
+fi
+rm -rf /etc/sleepypod
+
+# Remove application code
+if [ -d "$INSTALL_DIR" ]; then
+  echo "Removing application code..."
+  rm -rf "$INSTALL_DIR"
+fi
+
+# Remove data (unless --keep-data)
+if [ "$KEEP_DATA" = true ]; then
+  echo "Keeping databases at $DATA_DIR"
+else
+  if [ -d "$DATA_DIR" ]; then
+    echo "Removing databases..."
+    rm -rf "$DATA_DIR"
+  fi
+fi
+
+# Remove /etc/hosts telemetry block
+if grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
+  echo "Removing /etc/hosts telemetry block..."
+  sed -i '/# BEGIN sleepypod-telemetry-block/,/# END sleepypod-telemetry-block/d' /etc/hosts
+fi
+
+# Restore iptables to allow all traffic
+echo "Restoring iptables (allowing all traffic)..."
+iptables -F 2>/dev/null || true
+iptables -X 2>/dev/null || true
+iptables -t nat -F 2>/dev/null || true
+iptables -t nat -X 2>/dev/null || true
+iptables -P INPUT ACCEPT 2>/dev/null || true
+iptables -P OUTPUT ACCEPT 2>/dev/null || true
+iptables -P FORWARD ACCEPT 2>/dev/null || true
+rm -f /etc/iptables/iptables.rules
+
+# Re-enable free-sleep if available
+for fs_svc in free-sleep.service free-sleep-stream.service; do
+  if systemctl list-unit-files "$fs_svc" &>/dev/null; then
+    echo "Re-enabling $fs_svc..."
+    systemctl enable "$fs_svc" 2>/dev/null || true
+    systemctl start "$fs_svc" 2>/dev/null || true
+  fi
+done
+
+echo ""
+echo "=== SleepyPod uninstalled ==="
+if [ "$KEEP_DATA" = true ]; then
+  echo "Databases preserved at: $DATA_DIR"
+fi
+echo "Note: Node.js and pnpm were left in place (/usr/local/lib/nodejs)"
+echo "Note: SSH config changes (if any) were not reverted — edit /etc/ssh/sshd_config manually"

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -1,0 +1,246 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure /usr/local/bin is in PATH (Yocto's root SSH PATH is minimal)
+case ":$PATH:" in
+  *:/usr/local/bin:*) ;;
+  *) export PATH="/usr/local/bin:$PATH" ;;
+esac
+
+# sp-update — self-update sleepypod-core from GitHub via curl+tarball
+#
+# Usage:
+#   sp-update              # update to latest main
+#   sp-update feat/alarms  # update to a specific branch
+#
+# Handles iptables toggle automatically (opens WAN, downloads, closes WAN).
+# No git required — uses GitHub's tarball API.
+
+INSTALL_DIR="/home/dac/sleepypod-core"
+DATA_DIR="/persistent/sleepypod-data"
+GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
+BRANCH="${1:-main}"
+
+echo "=== SleepyPod Update ==="
+echo "Branch: $BRANCH"
+echo "Repo:   $GITHUB_REPO"
+echo ""
+
+# Source shared iptables helpers (with inline fallback for transitional installs)
+if [ -f "$INSTALL_DIR/scripts/lib/iptables-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/iptables-helpers"
+else
+  # Inline fallback — remove once all pods have scripts/lib/
+  SAVED_IPTABLES=""
+  WAN_WAS_BLOCKED=false
+  wan_is_blocked() {
+    iptables -L OUTPUT -n 2>/dev/null | grep -q "DROP" 2>/dev/null
+  }
+  unblock_wan() {
+    echo "Opening WAN access..."
+    SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
+    iptables -F && iptables -X && iptables -t nat -F && iptables -t nat -X
+    echo "WAN open."
+  }
+  restore_wan() {
+    if [ -n "$SAVED_IPTABLES" ]; then
+      echo "Restoring iptables rules..."
+      echo "$SAVED_IPTABLES" | iptables-restore 2>/dev/null || iptables -P OUTPUT DROP
+    else
+      iptables -P OUTPUT DROP
+    fi
+    echo "WAN blocked."
+  }
+fi
+
+# Cleanup — always re-block WAN and restart service on failure
+cleanup() {
+  local exit_code=$?
+  if [ "$WAN_WAS_BLOCKED" = true ]; then
+    restore_wan
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    echo "Update failed, starting service with existing code..." >&2
+    systemctl start sleepypod.service 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Pre-flight: disk space
+DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
+if [ "$DISK_AVAIL" -lt 300 ]; then
+  echo "Error: Need 300MB free, only ${DISK_AVAIL}MB available" >&2
+  exit 1
+fi
+
+# Open WAN if blocked
+if wan_is_blocked; then
+  # Ensure /etc/hosts telemetry block is in place before opening WAN
+  if ! grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
+    echo "Installing /etc/hosts telemetry block before opening WAN..."
+    "$INSTALL_DIR/scripts/internet-control" hosts-block 2>/dev/null || true
+  fi
+  WAN_WAS_BLOCKED=true
+  unblock_wan
+fi
+
+# Check connectivity
+if ! curl -sf --max-time 10 https://github.com > /dev/null 2>&1; then
+  echo "Error: Cannot reach GitHub. Check network." >&2
+  exit 1
+fi
+
+# Backup database
+if [ -f "$DATA_DIR/sleepypod.db" ]; then
+  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak"
+  echo "Database backed up."
+fi
+
+# Backup current code for rollback (everything except node_modules)
+BACKUP_DIR="/tmp/sleepypod-rollback"
+rm -rf "$BACKUP_DIR"
+mkdir -p "$BACKUP_DIR"
+tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . 2>/dev/null | tar xf - -C "$BACKUP_DIR" || true
+
+# Stop service
+systemctl stop sleepypod.service
+
+# Download code — try CI release first (includes pre-built .next), fall back to source tarball
+WORK_DIR=$(mktemp -d)
+HAS_BUILD=false
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "latest" ]; then
+  # Try latest GitHub Release (CI-built, includes .next)
+  echo "Checking for CI release..."
+  RELEASE_URL=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
+    | grep -o '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \
+    | grep -o 'https://[^"]*' || true)
+
+  if [ -n "$RELEASE_URL" ]; then
+    echo "Downloading CI release..."
+    if curl -fSL "$RELEASE_URL" | tar xz -C "$WORK_DIR"; then
+      HAS_BUILD=true
+      echo "CI release downloaded (pre-built)."
+    fi
+  fi
+fi
+
+if [ "$HAS_BUILD" = false ]; then
+  # Fall back to source tarball (no .next — would need build on pod)
+  echo "Downloading $BRANCH from GitHub..."
+  TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${BRANCH}.tar.gz"
+  if ! curl -fSL "$TARBALL_URL" | tar xz -C "$WORK_DIR"; then
+    echo "Error: Failed to download branch '$BRANCH'" >&2
+    exit 1
+  fi
+  # Source tarball extracts to a subdirectory (e.g., core-main/)
+  SUBDIR=$(ls "$WORK_DIR" | head -1)
+  if [ -z "$SUBDIR" ] || [ ! -d "$WORK_DIR/$SUBDIR" ]; then
+    echo "Error: Unexpected tarball structure in $WORK_DIR" >&2
+    exit 1
+  fi
+  # Move contents up so WORK_DIR is the root
+  mv "$WORK_DIR/$SUBDIR"/* "$WORK_DIR/$SUBDIR"/.[!.]* "$WORK_DIR/" 2>/dev/null || true
+  rmdir "$WORK_DIR/$SUBDIR" 2>/dev/null || true
+fi
+
+# Clean old files (preserve node_modules, .env)
+find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
+  ! -name 'node_modules' \
+  ! -name '.env' \
+  -exec rm -rf {} +
+
+# Move new code into place
+cp -r "$WORK_DIR/." "$INSTALL_DIR/"
+rm -rf "$WORK_DIR"
+echo "Source updated."
+
+cd "$INSTALL_DIR"
+
+# Install prod deps (migrations run automatically on app startup via instrumentation.ts)
+if pnpm install --frozen-lockfile --prod; then
+
+  # Build only if no pre-built .next exists
+  if [ ! -d "$INSTALL_DIR/.next" ]; then
+    echo "No pre-built .next found, building..."
+    pnpm install --frozen-lockfile
+    pnpm build
+  fi
+
+  # Sync biometrics modules
+  if [ -d "$INSTALL_DIR/modules" ]; then
+    MODULES_DEST="/opt/sleepypod/modules"
+    mkdir -p "$MODULES_DEST"
+    if [ -d "$INSTALL_DIR/modules/common" ]; then
+      mkdir -p "$MODULES_DEST/common"
+      cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
+    fi
+    for mod in piezo-processor sleep-detector environment-monitor calibrator; do
+      if [ -d "$INSTALL_DIR/modules/$mod" ]; then
+        mkdir -p "$MODULES_DEST/$mod"
+        cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
+        if [ ! -d "$MODULES_DEST/$mod/venv" ] && command -v python3 &>/dev/null; then
+          python3 -m venv "$MODULES_DEST/$mod/venv" 2>/dev/null || true
+        fi
+        if [ -d "$MODULES_DEST/$mod/venv" ] && [ -f "$MODULES_DEST/$mod/requirements.txt" ]; then
+          "$MODULES_DEST/$mod/venv/bin/pip" install --quiet -r "$MODULES_DEST/$mod/requirements.txt" || true
+        fi
+        svc="sleepypod-$mod.service"
+        if [ -f "$MODULES_DEST/$mod/$svc" ]; then
+          cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
+          systemctl daemon-reload
+          systemctl enable "$svc" 2>/dev/null || true
+          systemctl restart "$svc" 2>/dev/null || true
+        fi
+      fi
+    done
+  fi
+
+  # Install CLI tools from new source
+  if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+    for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+      cp "$tool" /usr/local/bin/
+      chmod +x "/usr/local/bin/$(basename "$tool")"
+    done
+  fi
+
+  # Re-block WAN before starting service
+  if [ "$WAN_WAS_BLOCKED" = true ]; then
+    restore_wan
+    WAN_WAS_BLOCKED=false
+  fi
+
+  echo "Starting service..."
+  systemctl start sleepypod.service
+
+  sleep 5
+  if systemctl is-active --quiet sleepypod.service; then
+    echo "Update complete! Service is running."
+    exit 0
+  fi
+fi
+
+# Rollback on failure — restore full previous code and database
+echo "Update failed, restoring previous code..." >&2
+if [ -d "$BACKUP_DIR" ]; then
+  find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
+    ! -name 'node_modules' \
+    ! -name '.env' \
+    -exec rm -rf {} +
+  cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
+  # Restore CLI tools from rolled-back code
+  if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+    for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+      cp "$tool" /usr/local/bin/
+      chmod +x "/usr/local/bin/$(basename "$tool")"
+    done
+  fi
+  echo "Previous code restored."
+fi
+if [ -f "$DATA_DIR/sleepypod.db.bak" ]; then
+  cp "$DATA_DIR/sleepypod.db.bak" "$DATA_DIR/sleepypod.db"
+  echo "Database restored."
+fi
+systemctl start sleepypod.service 2>/dev/null || true
+
+exit 1

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -53,14 +53,40 @@ else
   }
 fi
 
-# Cleanup — always re-block WAN and restart service on failure
+# Cleanup — re-block WAN, rollback code, and restart service on failure
+ROLLBACK_READY=false
 cleanup() {
   local exit_code=$?
   if [ "$WAN_WAS_BLOCKED" = true ]; then
     restore_wan
+    WAN_WAS_BLOCKED=false
   fi
-  if [ "$exit_code" -ne 0 ]; then
-    echo "Update failed, starting service with existing code..." >&2
+  if [ "$exit_code" -ne 0 ] && [ "$ROLLBACK_READY" = true ]; then
+    echo "Update failed, rolling back..." >&2
+    if [ -d "$BACKUP_DIR" ]; then
+      find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
+        ! -name 'node_modules' \
+        ! -name '.env' \
+        -exec rm -rf {} +
+      cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
+      # Restore CLI tools from rolled-back code
+      if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+        for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+          cp "$tool" /usr/local/bin/
+          chmod +x "/usr/local/bin/$(basename "$tool")"
+        done
+      fi
+      echo "Previous code restored."
+    fi
+    if [ -f "$DATA_DIR/sleepypod.db.bak" ]; then
+      cp "$DATA_DIR/sleepypod.db.bak" "$DATA_DIR/sleepypod.db"
+      [ -f "$DATA_DIR/sleepypod.db-wal.bak" ] && cp "$DATA_DIR/sleepypod.db-wal.bak" "$DATA_DIR/sleepypod.db-wal"
+      [ -f "$DATA_DIR/sleepypod.db-shm.bak" ] && cp "$DATA_DIR/sleepypod.db-shm.bak" "$DATA_DIR/sleepypod.db-shm"
+      echo "Database restored."
+    fi
+    systemctl start sleepypod.service 2>/dev/null || true
+  elif [ "$exit_code" -ne 0 ]; then
+    echo "Update failed before rollback point, starting service with existing code..." >&2
     systemctl start sleepypod.service 2>/dev/null || true
   fi
 }
@@ -90,20 +116,22 @@ if ! curl -sf --max-time 10 https://github.com > /dev/null 2>&1; then
   exit 1
 fi
 
-# Backup database
-if [ -f "$DATA_DIR/sleepypod.db" ]; then
-  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak"
-  echo "Database backed up."
-fi
-
 # Backup current code for rollback (everything except node_modules)
 BACKUP_DIR="/tmp/sleepypod-rollback"
 rm -rf "$BACKUP_DIR"
 mkdir -p "$BACKUP_DIR"
 tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . 2>/dev/null | tar xf - -C "$BACKUP_DIR" || true
 
-# Stop service
+# Stop service before DB backup (ensures WAL is flushed)
 systemctl stop sleepypod.service
+
+# Backup database (after stop so WAL/SHM are consistent)
+if [ -f "$DATA_DIR/sleepypod.db" ]; then
+  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak"
+  [ -f "$DATA_DIR/sleepypod.db-wal" ] && cp "$DATA_DIR/sleepypod.db-wal" "$DATA_DIR/sleepypod.db-wal.bak"
+  [ -f "$DATA_DIR/sleepypod.db-shm" ] && cp "$DATA_DIR/sleepypod.db-shm" "$DATA_DIR/sleepypod.db-shm.bak"
+  echo "Database backed up."
+fi
 
 # Download code — try CI release first (includes pre-built .next), fall back to source tarball
 WORK_DIR=$(mktemp -d)
@@ -127,8 +155,11 @@ fi
 
 if [ "$HAS_BUILD" = false ]; then
   # Fall back to source tarball (no .next — would need build on pod)
-  echo "Downloading $BRANCH from GitHub..."
-  TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${BRANCH}.tar.gz"
+  # "latest" is not a real branch — use main for the source tarball
+  SOURCE_BRANCH="$BRANCH"
+  [ "$SOURCE_BRANCH" = "latest" ] && SOURCE_BRANCH="main"
+  echo "Downloading $SOURCE_BRANCH from GitHub..."
+  TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${SOURCE_BRANCH}.tar.gz"
   if ! curl -fSL "$TARBALL_URL" | tar xz -C "$WORK_DIR"; then
     echo "Error: Failed to download branch '$BRANCH'" >&2
     exit 1
@@ -149,6 +180,7 @@ find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
   ! -name 'node_modules' \
   ! -name '.env' \
   -exec rm -rf {} +
+ROLLBACK_READY=true
 
 # Move new code into place
 cp -r "$WORK_DIR/." "$INSTALL_DIR/"
@@ -220,27 +252,6 @@ if pnpm install --frozen-lockfile --prod; then
   fi
 fi
 
-# Rollback on failure — restore full previous code and database
-echo "Update failed, restoring previous code..." >&2
-if [ -d "$BACKUP_DIR" ]; then
-  find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
-    ! -name 'node_modules' \
-    ! -name '.env' \
-    -exec rm -rf {} +
-  cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
-  # Restore CLI tools from rolled-back code
-  if [ -d "$INSTALL_DIR/scripts/bin" ]; then
-    for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-      cp "$tool" /usr/local/bin/
-      chmod +x "/usr/local/bin/$(basename "$tool")"
-    done
-  fi
-  echo "Previous code restored."
-fi
-if [ -f "$DATA_DIR/sleepypod.db.bak" ]; then
-  cp "$DATA_DIR/sleepypod.db.bak" "$DATA_DIR/sleepypod.db"
-  echo "Database restored."
-fi
-systemctl start sleepypod.service 2>/dev/null || true
-
+# If we get here, update failed (pnpm install returned non-zero or service didn't start).
+# Cleanup trap handles rollback — just exit with failure.
 exit 1

--- a/scripts/install
+++ b/scripts/install
@@ -62,6 +62,8 @@ trap 'cleanup $LINENO' EXIT
 
 # --------------------------------------------------------------------------------
 # iptables helpers
+# Canonical copy: scripts/lib/iptables-helpers (sourced by sp-update at runtime).
+# Kept inline here because install needs them before the source tree is on disk.
 
 wan_is_blocked() {
   # Check if the OUTPUT chain has a DROP rule (WAN is blocked)
@@ -203,62 +205,8 @@ if [ "$DISK_AVAIL" -lt 500 ]; then
   exit 1
 fi
 
-# Detect dac.sock path — read from frank.sh (the firmware launcher) to match
-# whatever path frankenfirmware actually connects to. Different pod hardware
-# versions use different paths:
-#   Pod 3/4: /deviceinfo/dac.sock (tmpfs)
-#   Pod 5:   /persistent/deviceinfo/dac.sock (ext4)
-DAC_SOCK_PATH=""
-
-# Only accept known firmware-supported socket locations
-is_supported_dac_path() {
-  case "$1" in
-    /deviceinfo/dac.sock|/persistent/deviceinfo/dac.sock) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-# Priority 1: Read from existing .env (validate against known paths)
-if [ -f "$INSTALL_DIR/.env" ]; then
-  EXISTING_PATH=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
-  if [ -n "$EXISTING_PATH" ] && is_supported_dac_path "$EXISTING_PATH"; then
-    DAC_SOCK_PATH="$EXISTING_PATH"
-  elif [ -n "$EXISTING_PATH" ]; then
-    echo "Warning: Ignoring unsupported DAC_SOCK_PATH from .env: $EXISTING_PATH"
-  fi
-fi
-
-# Priority 2: Extract from frank.sh (what frankenfirmware actually uses)
-if [ -z "$DAC_SOCK_PATH" ] && [ -f /opt/eight/bin/frank.sh ]; then
-  FRANK_PATH=$(grep 'DAC_SOCKET=' /opt/eight/bin/frank.sh 2>/dev/null \
-    | sed -n 's/.*DAC_SOCKET=\([^ ]*dac\.sock\).*/\1/p' | head -1 || true)
-  if [ -n "$FRANK_PATH" ] && is_supported_dac_path "$FRANK_PATH"; then
-    DAC_SOCK_PATH="$FRANK_PATH"
-    echo "Detected dac.sock path from frank.sh: $DAC_SOCK_PATH"
-  elif [ -n "$FRANK_PATH" ]; then
-    echo "Warning: Ignoring unsupported DAC_SOCK_PATH from frank.sh: $FRANK_PATH"
-  fi
-fi
-
-# Priority 3: Check known socket locations
-if [ -z "$DAC_SOCK_PATH" ]; then
-  for sock_path in \
-    /persistent/deviceinfo/dac.sock \
-    /deviceinfo/dac.sock \
-  ; do
-    if [ -S "$sock_path" ]; then
-      DAC_SOCK_PATH="$sock_path"
-      echo "Found active dac.sock at: $DAC_SOCK_PATH"
-      break
-    fi
-  done
-fi
-
-# Priority 4: Default to /persistent/deviceinfo/dac.sock
-if [ -z "$DAC_SOCK_PATH" ]; then
-  DAC_SOCK_PATH="/persistent/deviceinfo/dac.sock"
-  echo "Warning: dac.sock not found, using default: $DAC_SOCK_PATH"
-fi
+# DAC_SOCK_PATH detection is in scripts/pod/detect — sourced after code is on disk.
+# Pre-create both possible parent directories so mkdir works before detection runs.
 
 # Create data directory with shared group for multi-user SQLite access.
 # The Node.js app (root) creates biometrics.db, but calibrator and
@@ -272,7 +220,6 @@ echo "Creating data directory at $DATA_DIR..."
 # /run/dac is handled by RuntimeDirectory=dac in the service unit.
 mkdir -p /persistent/deviceinfo
 mkdir -p /deviceinfo
-mkdir -p "$(dirname "$DAC_SOCK_PATH")"
 groupadd --force sleepypod
 if id dac &>/dev/null; then
   usermod -aG sleepypod dac
@@ -438,6 +385,10 @@ else
   cd "$INSTALL_DIR"
   echo "Source downloaded."
 fi
+
+# Detect pod generation and DAC socket path (code is now on disk)
+source "$INSTALL_DIR/scripts/pod/detect"
+echo "Pod generation: $POD_GEN (DAC: $DAC_SOCK_PATH)"
 
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
 echo "Installing dependencies..."
@@ -692,319 +643,12 @@ fi
 # files with 0644 between the initial fixup and the service restarts above.
 fix_db_permissions
 
-# Create CLI shortcuts
-echo "Creating CLI shortcuts..."
-cat > /usr/local/bin/sp-status << 'EOF'
-#!/bin/bash
-systemctl status sleepypod.service
-EOF
-
-cat > /usr/local/bin/sp-restart << RESTARTEOF
-#!/bin/bash
-set -euo pipefail
-systemctl restart sleepypod.service
-# Wait for sleepypod to create dac.sock before killing frankenfirmware
-DAC_SOCK=\$(grep '^DAC_SOCK_PATH=' $INSTALL_DIR/.env 2>/dev/null | cut -d= -f2- || echo "")
-[ -z "\$DAC_SOCK" ] && DAC_SOCK="$DAC_SOCK_PATH"
-for i in \$(seq 1 10); do
-  [ -S "\$DAC_SOCK" ] && break
-  sleep 1
+# Install CLI tools from scripts/bin/
+echo "Installing CLI tools..."
+for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+  cp "$tool" /usr/local/bin/
+  chmod +x "/usr/local/bin/$(basename "$tool")"
 done
-if [ -S "\$DAC_SOCK" ]; then
-  # Kill frankenfirmware so its supervisor restarts it against the new dac.sock
-  pkill frankenfirmware 2>/dev/null || true
-else
-  echo "Warning: dac.sock not found after 10s — skipping frankenfirmware restart" >&2
-fi
-RESTARTEOF
-
-cat > /usr/local/bin/sp-logs << 'EOF'
-#!/bin/bash
-journalctl -u sleepypod.service -f
-EOF
-
-cat > /usr/local/bin/sp-update << 'UPDATEEOF'
-#!/bin/bash
-set -euo pipefail
-
-# Ensure /usr/local/bin is in PATH (Yocto's root SSH PATH is minimal)
-case ":$PATH:" in
-  *:/usr/local/bin:*) ;;
-  *) export PATH="/usr/local/bin:$PATH" ;;
-esac
-
-# sp-update — self-update sleepypod-core from GitHub via curl+tarball
-#
-# Usage:
-#   sp-update              # update to latest main
-#   sp-update feat/alarms  # update to a specific branch
-#
-# Handles iptables toggle automatically (opens WAN, downloads, closes WAN).
-# No git required — uses GitHub's tarball API.
-
-INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
-GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
-BRANCH="${1:-main}"
-IPTABLES="/usr/sbin/iptables"
-
-echo "=== SleepyPod Update ==="
-echo "Branch: $BRANCH"
-echo "Repo:   $GITHUB_REPO"
-echo ""
-
-# iptables helpers
-wan_is_blocked() {
-  $IPTABLES -L OUTPUT -n 2>/dev/null | grep -q "DROP" 2>/dev/null
-}
-
-SAVED_IPTABLES=""
-WAN_WAS_BLOCKED=false
-
-unblock_wan() {
-  echo "Opening WAN access..."
-  SAVED_IPTABLES="$(/usr/sbin/iptables-save 2>/dev/null || true)"
-  $IPTABLES -F && $IPTABLES -X && $IPTABLES -t nat -F && $IPTABLES -t nat -X
-  echo "WAN open."
-}
-
-restore_wan() {
-  if [ -n "$SAVED_IPTABLES" ]; then
-    echo "Restoring iptables rules..."
-    echo "$SAVED_IPTABLES" | /usr/sbin/iptables-restore 2>/dev/null || true
-  fi
-  echo "WAN blocked."
-}
-
-# Cleanup — always re-block WAN and restart service on failure
-cleanup() {
-  local exit_code=$?
-  if [ "$WAN_WAS_BLOCKED" = true ]; then
-    restore_wan
-  fi
-  if [ $exit_code -ne 0 ]; then
-    echo "Update failed, starting service with existing code..." >&2
-    systemctl start sleepypod.service 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT
-
-# Pre-flight: disk space
-DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
-if [ "$DISK_AVAIL" -lt 300 ]; then
-  echo "Error: Need 300MB free, only ${DISK_AVAIL}MB available" >&2
-  exit 1
-fi
-
-# Open WAN if blocked
-if wan_is_blocked; then
-  # Ensure /etc/hosts telemetry block is in place before opening WAN
-  if ! grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
-    echo "Installing /etc/hosts telemetry block before opening WAN..."
-    "$INSTALL_DIR/scripts/internet-control" hosts-block 2>/dev/null || true
-  fi
-  WAN_WAS_BLOCKED=true
-  unblock_wan
-fi
-
-# Check connectivity
-if ! curl -sf --max-time 10 https://github.com > /dev/null 2>&1; then
-  echo "Error: Cannot reach GitHub. Check network." >&2
-  exit 1
-fi
-
-# Backup database
-if [ -f "$DATA_DIR/sleepypod.db" ]; then
-  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak"
-  echo "Database backed up."
-fi
-
-# Backup current code for rollback (everything except node_modules)
-BACKUP_DIR="/tmp/sleepypod-rollback"
-rm -rf "$BACKUP_DIR"
-mkdir -p "$BACKUP_DIR"
-tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . 2>/dev/null | tar xf - -C "$BACKUP_DIR" || true
-
-# Stop service
-systemctl stop sleepypod.service
-
-# Download code — try CI release first (includes pre-built .next), fall back to source tarball
-TMPDIR=$(mktemp -d)
-HAS_BUILD=false
-
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "latest" ]; then
-  # Try latest GitHub Release (CI-built, includes .next)
-  echo "Checking for CI release..."
-  RELEASE_URL=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
-    | grep -o '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \
-    | grep -o 'https://[^"]*' || true)
-
-  if [ -n "$RELEASE_URL" ]; then
-    echo "Downloading CI release..."
-    if curl -fSL "$RELEASE_URL" | tar xz -C "$TMPDIR"; then
-      HAS_BUILD=true
-      echo "CI release downloaded (pre-built)."
-    fi
-  fi
-fi
-
-if [ "$HAS_BUILD" = false ]; then
-  # Fall back to source tarball (no .next — would need build on pod)
-  echo "Downloading $BRANCH from GitHub..."
-  TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${BRANCH}.tar.gz"
-  if ! curl -fSL "$TARBALL_URL" | tar xz -C "$TMPDIR"; then
-    echo "Error: Failed to download branch '$BRANCH'" >&2
-    exit 1
-  fi
-  # Source tarball extracts to a subdirectory (e.g., core-main/)
-  SUBDIR=$(ls "$TMPDIR" | head -1)
-  if [ -z "$SUBDIR" ] || [ ! -d "$TMPDIR/$SUBDIR" ]; then
-    echo "Error: Unexpected tarball structure in $TMPDIR" >&2
-    exit 1
-  fi
-  # Move contents up so TMPDIR is the root
-  mv "$TMPDIR/$SUBDIR"/* "$TMPDIR/$SUBDIR"/.[!.]* "$TMPDIR/" 2>/dev/null || true
-  rmdir "$TMPDIR/$SUBDIR" 2>/dev/null || true
-fi
-
-# Clean old files (preserve node_modules, .env)
-find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
-  ! -name 'node_modules' \
-  ! -name '.env' \
-  -exec rm -rf {} +
-
-# Move new code into place
-cp -r "$TMPDIR/." "$INSTALL_DIR/"
-rm -rf "$TMPDIR"
-echo "Source updated."
-
-cd "$INSTALL_DIR"
-
-# Install prod deps (migrations run automatically on app startup via instrumentation.ts)
-if pnpm install --frozen-lockfile --prod; then
-
-  # Build only if no pre-built .next exists
-  if [ ! -d "$INSTALL_DIR/.next" ]; then
-    echo "No pre-built .next found, building..."
-    pnpm install --frozen-lockfile
-    pnpm build
-  fi
-
-  # Sync biometrics modules
-  if [ -d "$INSTALL_DIR/modules" ]; then
-    MODULES_DEST="/opt/sleepypod/modules"
-    mkdir -p "$MODULES_DEST"
-    if [ -d "$INSTALL_DIR/modules/common" ]; then
-      mkdir -p "$MODULES_DEST/common"
-      cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
-    fi
-    for mod in piezo-processor sleep-detector environment-monitor calibrator; do
-      if [ -d "$INSTALL_DIR/modules/$mod" ]; then
-        mkdir -p "$MODULES_DEST/$mod"
-        cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
-        if [ ! -d "$MODULES_DEST/$mod/venv" ] && command -v python3 &>/dev/null; then
-          "$INSTALL_DIR/scripts/setup-python-venv" "$MODULES_DEST/$mod" 2>/dev/null || true
-        fi
-        if [ -d "$MODULES_DEST/$mod/venv" ] && [ -f "$MODULES_DEST/$mod/requirements.txt" ]; then
-          "$MODULES_DEST/$mod/venv/bin/pip" install --quiet -r "$MODULES_DEST/$mod/requirements.txt" 2>/dev/null || true
-        fi
-        svc="sleepypod-$mod.service"
-        if [ -f "$MODULES_DEST/$mod/$svc" ]; then
-          cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
-          systemctl daemon-reload
-          systemctl enable "$svc" 2>/dev/null || true
-          systemctl restart "$svc" 2>/dev/null || true
-        fi
-      fi
-    done
-  fi
-
-  # Re-block WAN before starting service
-  if [ "$WAN_WAS_BLOCKED" = true ]; then
-    restore_wan
-    WAN_WAS_BLOCKED=false
-  fi
-
-  echo "Starting service..."
-  systemctl start sleepypod.service
-
-  sleep 5
-  if systemctl is-active --quiet sleepypod.service; then
-    echo "Update complete! Service is running."
-    exit 0
-  fi
-fi
-
-# Rollback on failure — restore full previous code and database
-echo "Update failed, restoring previous code..." >&2
-if [ -d "$BACKUP_DIR" ]; then
-  find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
-    ! -name 'node_modules' \
-    ! -name '.env' \
-    -exec rm -rf {} +
-  cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
-  echo "Previous code restored."
-fi
-if [ -f "$DATA_DIR/sleepypod.db.bak" ]; then
-  cp "$DATA_DIR/sleepypod.db.bak" "$DATA_DIR/sleepypod.db"
-  echo "Database restored."
-fi
-systemctl start sleepypod.service 2>/dev/null || true
-
-exit 1
-UPDATEEOF
-
-cat > /usr/local/bin/sp-freesleep << 'EOF'
-#!/bin/bash
-echo "Switching to free-sleep..."
-systemctl stop sleepypod.service 2>/dev/null || true
-for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
-  systemctl stop "$svc.service" 2>/dev/null || true
-  systemctl disable "$svc.service" 2>/dev/null || true
-done
-# Persist across reboots
-systemctl disable sleepypod.service 2>/dev/null || true
-systemctl enable free-sleep.service free-sleep-stream.service 2>/dev/null || true
-systemctl start free-sleep.service free-sleep-stream.service 2>/dev/null || true
-sleep 2
-if systemctl is-active --quiet free-sleep.service; then
-  echo "✓ free-sleep is running on port 3000 (persists across reboots)"
-else
-  echo "✗ free-sleep failed to start — check: journalctl -u free-sleep.service"
-fi
-EOF
-
-cat > /usr/local/bin/sp-sleepypod << 'EOF'
-#!/bin/bash
-echo "Switching to sleepypod..."
-systemctl stop free-sleep.service free-sleep-stream.service 2>/dev/null || true
-# Persist across reboots
-systemctl disable free-sleep.service free-sleep-stream.service 2>/dev/null || true
-systemctl enable sleepypod.service 2>/dev/null || true
-# Kill anything on port 3000
-if command -v fuser &>/dev/null; then
-  fuser -k 3000/tcp 2>/dev/null || true
-  sleep 1
-fi
-systemctl restart sleepypod.service
-for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
-  systemctl enable "$svc.service" 2>/dev/null || true
-  systemctl restart "$svc.service" 2>/dev/null || true
-done
-sleep 3
-if systemctl is-active --quiet sleepypod.service; then
-  echo "✓ sleepypod is running on port 3000 (persists across reboots)"
-else
-  echo "✗ sleepypod failed to start — check: sp-logs"
-fi
-EOF
-
-chmod +x /usr/local/bin/sp-status
-chmod +x /usr/local/bin/sp-restart
-chmod +x /usr/local/bin/sp-logs
-chmod +x /usr/local/bin/sp-update
-chmod +x /usr/local/bin/sp-freesleep
-chmod +x /usr/local/bin/sp-sleepypod
 
 # Optional SSH configuration
 if [ "$SKIP_SSH" = true ]; then
@@ -1106,10 +750,13 @@ echo "  - Sleep session detection and movement tracking (sleep-detector)"
 echo "  - Ambient, bed zone, and freezer temperature monitoring (environment-monitor)"
 echo ""
 echo "CLI Commands:"
-echo "  sp-status   - View service status"
-echo "  sp-restart  - Restart service"
-echo "  sp-logs     - View live logs"
-echo "  sp-update   - Update to latest version"
+echo "  sp-status      - View service status"
+echo "  sp-restart     - Restart service"
+echo "  sp-logs        - View live logs"
+echo "  sp-update      - Update to latest version"
+echo "  sp-freesleep   - Switch to free-sleep"
+echo "  sp-sleepypod   - Switch to sleepypod"
+echo "  sp-uninstall   - Remove sleepypod"
 echo ""
 echo "Files:"
 echo "  Config DB:      $DATA_DIR/sleepypod.db"

--- a/scripts/lib/iptables-helpers
+++ b/scripts/lib/iptables-helpers
@@ -15,10 +15,10 @@ wan_is_blocked() {
 unblock_wan() {
   echo "Temporarily unblocking WAN access..."
   SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
-  iptables -F
-  iptables -X
-  iptables -t nat -F
-  iptables -t nat -X
+  iptables -F 2>/dev/null || true
+  iptables -X 2>/dev/null || true
+  iptables -t nat -F 2>/dev/null || true
+  iptables -t nat -X 2>/dev/null || true
   echo "WAN unblocked."
 }
 

--- a/scripts/lib/iptables-helpers
+++ b/scripts/lib/iptables-helpers
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Shared iptables helpers for WAN access control.
+# Sourced by scripts/bin/sp-update at runtime.
+# NOTE: scripts/install has an inline copy of these functions because it needs
+# them before the source tree exists on disk (curl-pipe install case).
+
+SAVED_IPTABLES=""
+WAN_WAS_BLOCKED=false
+
+wan_is_blocked() {
+  # Check if the OUTPUT chain has a DROP rule (WAN is blocked)
+  iptables -L OUTPUT -n 2>/dev/null | grep -q "DROP" 2>/dev/null
+}
+
+unblock_wan() {
+  echo "Temporarily unblocking WAN access..."
+  SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
+  iptables -F
+  iptables -X
+  iptables -t nat -F
+  iptables -t nat -X
+  echo "WAN unblocked."
+}
+
+restore_wan() {
+  if [ -n "$SAVED_IPTABLES" ]; then
+    echo "Restoring saved iptables rules..."
+    echo "$SAVED_IPTABLES" | iptables-restore 2>/dev/null || block_wan
+  else
+    block_wan
+  fi
+}
+
+block_wan() {
+  echo "Re-blocking WAN access..."
+
+  # Flush first to avoid duplicate rules
+  iptables -F 2>/dev/null || true
+  iptables -X 2>/dev/null || true
+  iptables -t nat -F 2>/dev/null || true
+  iptables -t nat -X 2>/dev/null || true
+
+  # Allow established connections
+  iptables -I INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  iptables -I OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+  # Allow LAN traffic (RFC 1918)
+  for cidr in 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16; do
+    iptables -A INPUT  -s "$cidr" -j ACCEPT
+    iptables -A OUTPUT -d "$cidr" -j ACCEPT
+  done
+
+  # Allow NTP
+  iptables -I OUTPUT -p udp --dport 123 -j ACCEPT
+  iptables -I INPUT  -p udp --sport 123 -j ACCEPT
+
+  # Allow mDNS (Bonjour — iOS discovers pod via _sleepypod._tcp)
+  iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
+  iptables -I OUTPUT -p udp --sport 5353 -j ACCEPT
+  iptables -I INPUT  -p udp --dport 5353 -j ACCEPT
+  iptables -I INPUT  -p udp --sport 5353 -j ACCEPT
+
+  # Allow loopback
+  iptables -A INPUT  -i lo -j ACCEPT
+  iptables -A OUTPUT -o lo -j ACCEPT
+
+  # Block everything else
+  iptables -A INPUT  -j DROP
+  iptables -A OUTPUT -j DROP
+
+  # Persist
+  if command -v iptables-save &>/dev/null; then
+    mkdir -p /etc/iptables
+    iptables-save > /etc/iptables/iptables.rules
+  fi
+
+  echo "WAN blocked."
+}

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Pod detection — determines DAC socket path and pod generation.
+# Sourced by scripts/install (after code is on disk) and usable by CLI tools.
+#
+# Sets in caller's scope: INSTALL_DIR, DATA_DIR, DAC_SOCK_PATH, POD_GEN
+#
+# POD_GEN is "3_4" or "5" — enough for install-time branching.
+# Precise pod version (H00/I00/J00) is only available at runtime
+# via the hardware sensor label (see src/hardware/responseParser.ts).
+
+INSTALL_DIR="${INSTALL_DIR:-/home/dac/sleepypod-core}"
+DATA_DIR="${DATA_DIR:-/persistent/sleepypod-data}"
+
+# Only accept known firmware-supported socket locations
+is_supported_dac_path() {
+  case "$1" in
+    /deviceinfo/dac.sock|/persistent/deviceinfo/dac.sock) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_dac_sock() {
+  local path=""
+
+  # Priority 1: Read from existing .env (validate against known paths)
+  if [ -f "$INSTALL_DIR/.env" ]; then
+    path=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
+    if [ -n "$path" ] && is_supported_dac_path "$path"; then
+      echo "$path"
+      return
+    elif [ -n "$path" ]; then
+      echo "Warning: Ignoring unsupported DAC_SOCK_PATH from .env: $path" >&2
+    fi
+  fi
+
+  # Priority 2: Extract from frank.sh (what frankenfirmware actually uses)
+  if [ -f /opt/eight/bin/frank.sh ]; then
+    path=$(grep 'DAC_SOCKET=' /opt/eight/bin/frank.sh 2>/dev/null \
+      | grep -o '[^ ]*dac\.sock' | head -1 || true)
+    if [ -n "$path" ] && is_supported_dac_path "$path"; then
+      echo "Detected dac.sock path from frank.sh: $path" >&2
+      echo "$path"
+      return
+    elif [ -n "$path" ]; then
+      echo "Warning: Ignoring unsupported DAC_SOCK_PATH from frank.sh: $path" >&2
+    fi
+  fi
+
+  # Priority 3: Check known socket locations
+  for sock in /persistent/deviceinfo/dac.sock /deviceinfo/dac.sock; do
+    if [ -S "$sock" ]; then
+      echo "Found active dac.sock at: $sock" >&2
+      echo "$sock"
+      return
+    fi
+  done
+
+  # Priority 4: Default to Pod 5 path
+  echo "Warning: dac.sock not found, using default: /persistent/deviceinfo/dac.sock" >&2
+  echo "/persistent/deviceinfo/dac.sock"
+}
+
+DAC_SOCK_PATH="$(detect_dac_sock)"
+
+# Derive pod generation from socket path
+case "$DAC_SOCK_PATH" in
+  /persistent/deviceinfo/dac.sock) POD_GEN="5" ;;
+  /deviceinfo/dac.sock)            POD_GEN="3_4" ;;
+  *)                               POD_GEN="5" ;;
+esac


### PR DESCRIPTION
## Summary

- Extract DAC socket detection into `scripts/pod/detect`
- Extract iptables helpers into `scripts/lib/iptables-helpers`
- Move all CLI tools from inline heredocs into `scripts/bin/sp-*`
- Add `sp-uninstall` for clean removal
- CLI tools read `DAC_SOCK_PATH` from `.env` at runtime

Closes #338
Supersedes #339

## Test plan

- [x] `bash -n` and `shellcheck` pass on all scripts
- [x] Deployed to Pod 5 — all commands verified working
- [x] `sp-restart` reads DAC_SOCK_PATH from `.env`
- [x] `sp-freesleep` / `sp-sleepypod` switch and persist correctly