### PR TITLE
Fix install script branch mismatch after #341 refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate install script branch default
+        if: github.event_name == 'pull_request'
+        run: |
+          expected="${{ github.base_ref }}"
+          actual=$(grep -oP 'SCRIPT_DEFAULT_BRANCH="\K[^"]+' scripts/install)
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::scripts/install has SCRIPT_DEFAULT_BRANCH=\"$actual\" but PR targets \"$expected\". Update it before merging."
+            exit 1
+          fi
+
       - name: Build
         run: pnpm build
 

--- a/scripts/install
+++ b/scripts/install
@@ -152,7 +152,7 @@ esac
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
-SCRIPT_DEFAULT_BRANCH="dev"  # must match the branch this script lives on
+SCRIPT_DEFAULT_BRANCH="dev"  # must match target branch (CI validates on PR)
 
 # Lock file to prevent concurrent installs
 LOCKFILE="/var/run/sleepypod-install.lock"

--- a/scripts/install
+++ b/scripts/install
@@ -152,6 +152,7 @@ esac
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
+SCRIPT_DEFAULT_BRANCH="dev"  # must match the branch this script lives on
 
 # Lock file to prevent concurrent installs
 LOCKFILE="/var/run/sleepypod-install.lock"
@@ -318,7 +319,7 @@ if [ "$INSTALL_LOCAL" = true ]; then
   fi
 else
   # Download code via tarball (no git required on device)
-  DOWNLOAD_BRANCH="${INSTALL_BRANCH:-main}"
+  DOWNLOAD_BRANCH="${INSTALL_BRANCH:-$SCRIPT_DEFAULT_BRANCH}"
   echo "Downloading $DOWNLOAD_BRANCH from GitHub..."
 
   DOWNLOAD_DIR=$(mktemp -d)
@@ -387,7 +388,14 @@ else
 fi
 
 # Detect pod generation and DAC socket path (code is now on disk)
-source "$INSTALL_DIR/scripts/pod/detect"
+if [ -f "$INSTALL_DIR/scripts/pod/detect" ]; then
+  source "$INSTALL_DIR/scripts/pod/detect"
+else
+  echo "Error: $INSTALL_DIR/scripts/pod/detect not found." >&2
+  echo "  The downloaded code does not match this install script." >&2
+  echo "  Try: curl -fsSL <url> | sudo bash -s -- --branch $SCRIPT_DEFAULT_BRANCH" >&2
+  exit 1
+fi
 echo "Pod generation: $POD_GEN (DAC: $DAC_SOCK_PATH)"
 
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
@@ -644,11 +652,14 @@ fi
 fix_db_permissions
 
 # Install CLI tools from scripts/bin/
-echo "Installing CLI tools..."
-for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-  cp "$tool" /usr/local/bin/
-  chmod +x "/usr/local/bin/$(basename "$tool")"
-done
+if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+  echo "Installing CLI tools..."
+  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+    [ -f "$tool" ] || continue
+    cp "$tool" /usr/local/bin/
+    chmod +x "/usr/local/bin/$(basename "$tool")"
+  done
+fi
 
 # Optional SSH configuration
 if [ "$SKIP_SSH" = true ]; then


### PR DESCRIPTION
## Summary

Fixes install failure on fresh firmware resets reported by a Pod 4 user. After #341 extracted pod detection into `scripts/pod/detect`, the install script broke when fetched from `dev` without `--branch dev`:

```
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/dev/scripts/install | sudo bash
```

**Root cause**: `DOWNLOAD_BRANCH` defaulted to `"main"` (line 321), so the script downloaded the `main` tarball — which doesn't have `scripts/pod/detect` yet. The dev-branch install script then failed at line 390:

```
bash: line 390: /home/dac/sleepypod-core/scripts/pod/detect: No such file or directory
```

**Device**: Pod 4 (Eight Pod), fresh firmware reset, confirmed `scripts/pod/` missing from extracted tarball contents on disk.

## Changes

- Add `SCRIPT_DEFAULT_BRANCH="dev"` constant — download branch now defaults to match the script's own branch instead of hardcoded `"main"`
- Guard `source scripts/pod/detect` — clear error message with recovery instructions if the file is missing (cross-version mismatch safety)
- Guard `scripts/bin/` CLI tools loop — skip gracefully if directory doesn't exist

> **Note**: When merging to `main`, update `SCRIPT_DEFAULT_BRANCH` to `"main"`.

## Test plan

- [ ] On a Pod 4 with reset firmware, run `curl -fsSL .../dev/scripts/install | sudo bash` — should download dev tarball and detect pod generation
- [ ] Verify `--branch main` override still works: `curl ... | sudo bash -s -- --branch main`
- [ ] Confirm existing `--branch dev` explicit usage still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation validation with clearer error messages when dependencies are missing
  * Installation process now gracefully handles missing components and provides informative feedback instead of cryptic failures
  * CLI tools installation only proceeds when prerequisites are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->