### PR TITLE
Fix Python venv creation: patch Yocto stdlib on Pod 3/4

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,8 +29,59 @@ This will:
 7. **Database migrations** - Run automatically on startup
 8. **Create systemd service** - With auto-restart and hardening
 9. **Install CLI tools** - From `scripts/bin/` to `/usr/local/bin/`
-10. **Install biometrics modules** - Python venvs + systemd services
-11. **Optional SSH setup** - Interactive prompt for SSH on port 8822 (keys only)
+10. **Patch Python stdlib** - Download matching CPython source, fill missing modules (Pod 3/4 only)
+11. **Install biometrics modules** - Python venvs + systemd services
+12. **Optional SSH setup** - Interactive prompt for SSH on port 8822 (keys only)
+
+### Install Flow
+
+```mermaid
+flowchart TD
+    Start([curl install | bash]) --> Preflight[Pre-flight checks\ndisk, network, deps]
+    Preflight --> Download{Code source?}
+
+    Download -->|--local| Local[Use code on disk]
+    Download -->|default| Release{CI release\navailable?}
+    Release -->|yes| Tarball[Download pre-built tarball]
+    Release -->|no| Source[Download source tarball\nfallback build on pod]
+
+    Local --> Detect
+    Tarball --> Detect
+    Source --> Detect
+
+    Detect[Detect pod generation\nscripts/pod/detect] --> Node[Install Node.js 22 + pnpm]
+    Node --> Deps[pnpm install --frozen-lockfile --prod]
+    Deps --> Build{.next exists?}
+    Build -->|yes| Skip[Skip build]
+    Build -->|no| BuildApp[pnpm build\n⚠️ needs ~1GB RAM]
+    Skip --> Env
+    BuildApp --> Env
+
+    Env[Write .env\nDAC_SOCK_PATH, DATABASE_URL] --> DB[Backup existing DB\nMigrations run on startup]
+    DB --> Service[Create systemd service\nstart sleepypod]
+    Service --> CLI[Install CLI tools\nscripts/bin/ → /usr/local/bin/]
+
+    CLI --> Python{python3\navailable?}
+    Python -->|no| SkipBio[Skip biometrics]
+    Python -->|yes| Patch[Patch Python stdlib\nscripts/patch-python-stdlib]
+
+    Patch --> PatchCheck{stdlib\ncomplete?}
+    PatchCheck -->|yes| Noop[No-op Pod 5+]
+    PatchCheck -->|no| CPython[Download CPython source\ncopy missing .py files]
+
+    Noop --> Modules
+    CPython --> Modules
+
+    Modules[Install biometrics modules] --> Venv[Create venv per module\nscripts/setup-python-venv]
+    Venv --> Pip[pip install -r requirements.txt]
+    Pip --> ModService[Create module systemd services]
+
+    ModService --> SSH{Interactive\nterminal?}
+    SkipBio --> SSH
+    SSH -->|yes| SSHSetup[Optional SSH setup\nport 8822, keys only]
+    SSH -->|no| Done
+    SSHSetup --> Done([Installation complete])
+```
 
 ## CLI Commands
 
@@ -113,12 +164,14 @@ After installation, sleepypod provides:
 
 ```
 scripts/
-├── install                # Core orchestrator
+├── install                  # Core orchestrator
+├── patch-python-stdlib      # Fix incomplete Yocto Python (Pod 3/4)
+├── setup-python-venv        # Create venv per biometrics module
 ├── lib/
-│   └── iptables-helpers   # Shared WAN/iptables functions (sourced by sp-update)
+│   └── iptables-helpers     # Shared WAN/iptables functions (sourced by sp-update)
 ├── pod/
-│   └── detect             # Pod detection: DAC_SOCK_PATH, POD_GEN
-├── bin/                   # CLI tools — copied to /usr/local/bin/ during install
+│   └── detect               # Pod detection: DAC_SOCK_PATH, POD_GEN
+├── bin/                     # CLI tools — copied to /usr/local/bin/ during install
 │   ├── sp-status
 │   ├── sp-restart
 │   ├── sp-logs
@@ -126,9 +179,35 @@ scripts/
 │   ├── sp-freesleep
 │   ├── sp-sleepypod
 │   └── sp-uninstall
-├── deploy                 # Dev deploy (build local, push to pod)
-├── push                   # Fast push (pre-built .next only)
-└── internet-control       # WAN block/unblock utility
+├── deploy                   # Dev deploy (build local, push to pod)
+├── push                     # Fast push (pre-built .next only)
+└── internet-control         # WAN block/unblock utility
+```
+
+## Python Stdlib Patching (Pod 3/4)
+
+Pod 3 and Pod 4 Yocto images ship with an incomplete Python stdlib — missing modules like `plistlib`, `pyexpat`, and `ensurepip` internals. This breaks `python3 -m venv`.
+
+`scripts/patch-python-stdlib` runs once before biometrics module installation and:
+
+1. Detects the exact Python version (e.g. `3.10.4`)
+2. Checks if critical modules (`plistlib`, `ensurepip`, `pyexpat`) are importable
+3. If any are missing, downloads the matching CPython source tarball
+4. Copies missing `.py` files into the system lib dir (non-destructive — skips existing)
+5. Verifies critical modules now import
+
+Pod 5+ has a complete stdlib and the script no-ops.
+
+All output is prefixed with `[patch-python-stdlib]` for easy grep in install logs:
+
+```
+[patch-python-stdlib] Detected Python 3.10.4
+[patch-python-stdlib] Module 'plistlib' is missing — patching needed
+[patch-python-stdlib] Downloading CPython 3.10.4 source...
+[patch-python-stdlib] Stdlib patching complete: 147 copied, 312 already present, 0 failed
+[patch-python-stdlib]   ✓ plistlib
+[patch-python-stdlib]   ✓ ensurepip
+[patch-python-stdlib] Python stdlib is ready for venv creation
 ```
 
 ## File Locations

--- a/scripts/install
+++ b/scripts/install
@@ -589,6 +589,9 @@ if ! command -v python3 &>/dev/null; then
   echo "Warning: python3 not found — skipping biometrics module installation"
   echo "Install Python 3 and re-run the installer to enable health monitoring"
 else
+  # Patch incomplete Python stdlib on Yocto images (Pod 3/4) so venv/ensurepip work
+  "$INSTALL_DIR/scripts/patch-python-stdlib"
+
   install_module() {
     local name="$1"
     local src="$MODULES_SRC/$name"

--- a/scripts/patch-python-stdlib
+++ b/scripts/patch-python-stdlib
@@ -39,7 +39,6 @@ PY_LIB_DIR=""
 for candidate in \
   "/usr/lib64/python${PY_MAJOR_MINOR}" \
   "/usr/lib/python${PY_MAJOR_MINOR}" \
-  "/usr/lib/python3/dist-packages/../" \
 ; do
   if [ -d "$candidate" ]; then
     PY_LIB_DIR="$candidate"
@@ -74,13 +73,12 @@ for mod in plistlib ensurepip; do
 done
 
 if [ "$NEEDS_PATCH" = false ]; then
-  # Also check pyexpat (C extension) — if present, stdlib is likely complete
   if python3 -c "import pyexpat" 2>/dev/null; then
     log "Python stdlib appears complete, no patching needed"
-    exit 0
   else
-    log "Module 'pyexpat' is missing — patching needed"
+    warn "pyexpat C extension missing — cannot fix via .py patching, pip/venv still work"
   fi
+  exit 0
 fi
 
 # --------------------------------------------------------------------------
@@ -97,7 +95,7 @@ trap cleanup EXIT
 log "Downloading CPython $PY_VERSION source..."
 log "  URL: $CPYTHON_URL"
 
-if ! curl -fSL --max-time 120 "$CPYTHON_URL" -o "$WORK_DIR/cpython.tar.gz" 2>&1; then
+if ! curl -fsSL --max-time 120 "$CPYTHON_URL" -o "$WORK_DIR/cpython.tar.gz"; then
   err "Failed to download CPython source"
   err "  URL: $CPYTHON_URL"
   err "  This may mean Python $PY_VERSION is not a tagged CPython release"
@@ -105,9 +103,9 @@ if ! curl -fSL --max-time 120 "$CPYTHON_URL" -o "$WORK_DIR/cpython.tar.gz" 2>&1;
 fi
 
 log "Extracting Lib/ directory..."
-if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-${PY_VERSION}/Lib/" 2>&1; then
+if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-${PY_VERSION}/Lib/"; then
   # Try alternate archive directory name format
-  if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-v${PY_VERSION}/Lib/" 2>&1; then
+  if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-v${PY_VERSION}/Lib/"; then
     err "Failed to extract Lib/ from CPython source tarball"
     err "  Listing top-level contents for debugging:"
     tar tzf "$WORK_DIR/cpython.tar.gz" | head -5 >&2 || true

--- a/scripts/patch-python-stdlib
+++ b/scripts/patch-python-stdlib
@@ -1,0 +1,190 @@
+#!/bin/bash
+# Patch the system Python stdlib on Yocto images that ship incomplete installs.
+#
+# Pod 3 (Python 3.9) and Pod 4 (Python 3.10) Yocto images are missing stdlib
+# modules (plistlib, pyexpat, ensurepip internals, etc.) which breaks venv
+# creation. This script downloads the matching CPython source and copies any
+# missing .py files into the system lib directory.
+#
+# Idempotent: skips files that already exist. Safe to re-run.
+#
+# Usage: patch-python-stdlib
+#   Exits 0 on success or if no patching needed.
+#   Exits 1 on failure.
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Logging helpers
+# --------------------------------------------------------------------------
+log()  { echo "[patch-python-stdlib] $*"; }
+warn() { echo "[patch-python-stdlib] WARNING: $*" >&2; }
+err()  { echo "[patch-python-stdlib] ERROR: $*" >&2; }
+
+# --------------------------------------------------------------------------
+# Detect Python version and lib directory
+# --------------------------------------------------------------------------
+if ! command -v python3 &>/dev/null; then
+  err "python3 not found in PATH"
+  exit 1
+fi
+
+PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
+PY_MAJOR_MINOR=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+
+log "Detected Python $PY_VERSION"
+
+# Find the system lib directory (varies by distro/arch)
+PY_LIB_DIR=""
+for candidate in \
+  "/usr/lib64/python${PY_MAJOR_MINOR}" \
+  "/usr/lib/python${PY_MAJOR_MINOR}" \
+  "/usr/lib/python3/dist-packages/../" \
+; do
+  if [ -d "$candidate" ]; then
+    PY_LIB_DIR="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PY_LIB_DIR" ]; then
+  # Ask Python itself
+  PY_LIB_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_path('stdlib'))")
+  if [ ! -d "$PY_LIB_DIR" ]; then
+    err "Could not locate Python stdlib directory"
+    err "  Tried: /usr/lib64/python${PY_MAJOR_MINOR}, /usr/lib/python${PY_MAJOR_MINOR}"
+    err "  sysconfig reported: $PY_LIB_DIR"
+    exit 1
+  fi
+fi
+
+log "System lib directory: $PY_LIB_DIR"
+
+# --------------------------------------------------------------------------
+# Quick check: is patching needed?
+# --------------------------------------------------------------------------
+# Test the modules that are known to break venv/ensurepip on Yocto
+NEEDS_PATCH=false
+for mod in plistlib ensurepip; do
+  if ! python3 -c "import $mod" 2>/dev/null; then
+    log "Module '$mod' is missing — patching needed"
+    NEEDS_PATCH=true
+    break
+  fi
+done
+
+if [ "$NEEDS_PATCH" = false ]; then
+  # Also check pyexpat (C extension) — if present, stdlib is likely complete
+  if python3 -c "import pyexpat" 2>/dev/null; then
+    log "Python stdlib appears complete, no patching needed"
+    exit 0
+  else
+    log "Module 'pyexpat' is missing — patching needed"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# Download matching CPython source
+# --------------------------------------------------------------------------
+CPYTHON_URL="https://github.com/python/cpython/archive/refs/tags/v${PY_VERSION}.tar.gz"
+WORK_DIR=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+log "Downloading CPython $PY_VERSION source..."
+log "  URL: $CPYTHON_URL"
+
+if ! curl -fSL --max-time 120 "$CPYTHON_URL" -o "$WORK_DIR/cpython.tar.gz" 2>&1; then
+  err "Failed to download CPython source"
+  err "  URL: $CPYTHON_URL"
+  err "  This may mean Python $PY_VERSION is not a tagged CPython release"
+  exit 1
+fi
+
+log "Extracting Lib/ directory..."
+if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-${PY_VERSION}/Lib/" 2>&1; then
+  # Try alternate archive directory name format
+  if ! tar xzf "$WORK_DIR/cpython.tar.gz" -C "$WORK_DIR" --strip-components=1 "cpython-v${PY_VERSION}/Lib/" 2>&1; then
+    err "Failed to extract Lib/ from CPython source tarball"
+    err "  Listing top-level contents for debugging:"
+    tar tzf "$WORK_DIR/cpython.tar.gz" | head -5 >&2 || true
+    exit 1
+  fi
+fi
+
+SRC_LIB="$WORK_DIR/Lib"
+if [ ! -d "$SRC_LIB" ]; then
+  err "Expected $SRC_LIB after extraction but directory not found"
+  ls -la "$WORK_DIR" >&2
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# Copy missing .py files (non-destructive)
+# --------------------------------------------------------------------------
+COPIED=0
+SKIPPED=0
+FAILED=0
+
+log "Copying missing stdlib .py files to $PY_LIB_DIR..."
+
+# Use find to get all .py files, preserving directory structure
+while IFS= read -r src_file; do
+  # Get the relative path from the Lib/ directory
+  rel_path="${src_file#$SRC_LIB/}"
+  dest_file="$PY_LIB_DIR/$rel_path"
+
+  if [ -f "$dest_file" ]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Create parent directory if needed
+  dest_dir=$(dirname "$dest_file")
+  if [ ! -d "$dest_dir" ]; then
+    mkdir -p "$dest_dir"
+  fi
+
+  if cp "$src_file" "$dest_file" 2>/dev/null; then
+    COPIED=$((COPIED + 1))
+  else
+    warn "Failed to copy: $rel_path"
+    FAILED=$((FAILED + 1))
+  fi
+done < <(find "$SRC_LIB" -name '*.py' -type f)
+
+log "Stdlib patching complete: $COPIED copied, $SKIPPED already present, $FAILED failed"
+
+# --------------------------------------------------------------------------
+# Verify critical modules now import
+# --------------------------------------------------------------------------
+VERIFY_OK=true
+for mod in plistlib ensurepip; do
+  if python3 -c "import $mod" 2>/dev/null; then
+    log "  ✓ $mod"
+  else
+    err "  ✗ $mod — still not importable after patching"
+    VERIFY_OK=false
+  fi
+done
+
+# pyexpat is a C extension — .py patching won't fix it, but log the status
+if python3 -c "import pyexpat" 2>/dev/null; then
+  log "  ✓ pyexpat"
+else
+  warn "  ✗ pyexpat — C extension, not fixable via .py patching"
+  warn "    pip/venv should still work without pyexpat"
+fi
+
+if [ "$VERIFY_OK" = false ]; then
+  err "Some critical modules still missing after patching"
+  err "  Python: $PY_VERSION"
+  err "  Lib dir: $PY_LIB_DIR"
+  err "  Source: $CPYTHON_URL"
+  exit 1
+fi
+
+log "Python stdlib is ready for venv creation"

--- a/scripts/setup-python-venv
+++ b/scripts/setup-python-venv
@@ -1,12 +1,9 @@
 #!/bin/bash
-# Create a Python virtual environment with pip, handling Yocto image quirks.
+# Create a Python virtual environment with pip.
 #
-# Pod 3 (Python 3.9): venv module may be entirely missing
-# Pod 4 (Python 3.10): venv exists but ensurepip fails — Yocto image lacks
-#                       plistlib.py and pyexpat.so in the stdlib
-# Pod 5+ (Python 3.10+): typically works out of the box
-#
-# Strategy: try normal venv first, fall back to --without-pip + get-pip.py.
+# Expects patch-python-stdlib to have run first (fixes Yocto stdlib gaps).
+# Keeps a --without-pip fallback for safety, but the normal path should work
+# on all pod generations after patching.
 #
 # Usage: setup-python-venv <dest_dir>
 #   Creates <dest_dir>/venv with pip available.
@@ -17,32 +14,51 @@ set -euo pipefail
 DEST="${1:?Usage: setup-python-venv <dest_dir>}"
 VENV_DIR="$DEST/venv"
 
+log()  { echo "  [setup-python-venv] $*"; }
+warn() { echo "  [setup-python-venv] WARNING: $*" >&2; }
+err()  { echo "  [setup-python-venv] ERROR: $*" >&2; }
+
 if [ -d "$VENV_DIR" ]; then
-  echo "  venv already exists at $VENV_DIR"
+  log "venv already exists at $VENV_DIR, skipping"
   exit 0
 fi
 
 if ! command -v python3 &>/dev/null; then
-  echo "Error: python3 not found" >&2
+  err "python3 not found"
   exit 1
 fi
 
-# Try 1: normal venv (works on Pod 5+ and Debian/Ubuntu)
-if python3 -m venv "$VENV_DIR" 2>/dev/null; then
+PY_VERSION=$(python3 --version 2>&1)
+log "Creating venv at $VENV_DIR ($PY_VERSION)"
+
+# Try 1: normal venv (should work after patch-python-stdlib)
+if python3 -m venv "$VENV_DIR" 2>&1; then
+  log "venv created successfully"
   exit 0
 fi
-# Clean up partial venv from failed attempt (ensurepip can fail after dir creation)
+
+# Clean up partial venv from failed attempt
+warn "Normal venv creation failed, cleaning up partial directory"
 rm -rf "$VENV_DIR"
 
-# Try 2: venv without pip + bootstrap (works on Pod 3/4 with broken ensurepip)
-if python3 -m venv --without-pip "$VENV_DIR" 2>/dev/null; then
-  echo "  ensurepip not available, bootstrapping pip via get-pip.py..."
-  if curl -fsSL https://bootstrap.pypa.io/get-pip.py | "$VENV_DIR/bin/python3"; then
-    exit 0
-  fi
-  # get-pip.py failed — clean up the broken venv
+# Try 2: venv without pip + bootstrap via get-pip.py
+log "Falling back to --without-pip + get-pip.py"
+if ! python3 -m venv --without-pip "$VENV_DIR" 2>&1; then
+  err "python3 -m venv --without-pip also failed"
+  err "  This usually means the venv module itself is missing"
+  err "  Check: python3 -c 'import venv'"
   rm -rf "$VENV_DIR"
+  exit 1
 fi
 
-echo "Error: could not create Python venv at $VENV_DIR" >&2
+log "venv created without pip, bootstrapping via get-pip.py..."
+if curl -fsSL https://bootstrap.pypa.io/get-pip.py | "$VENV_DIR/bin/python3" 2>&1; then
+  log "pip bootstrapped successfully"
+  exit 0
+fi
+
+err "get-pip.py bootstrap failed"
+err "  venv exists at $VENV_DIR but has no pip"
+err "  Check network connectivity and Python stdlib completeness"
+rm -rf "$VENV_DIR"
 exit 1

--- a/scripts/setup-python-venv
+++ b/scripts/setup-python-venv
@@ -32,7 +32,7 @@ PY_VERSION=$(python3 --version 2>&1)
 log "Creating venv at $VENV_DIR ($PY_VERSION)"
 
 # Try 1: normal venv (should work after patch-python-stdlib)
-if python3 -m venv "$VENV_DIR" 2>&1; then
+if python3 -m venv "$VENV_DIR"; then
   log "venv created successfully"
   exit 0
 fi


### PR DESCRIPTION
## Summary

Biometrics module installation fails on Pod 3/4 because Python venv creation fails — even with the `--without-pip` + `get-pip.py` fallback from #336. The Yocto image is missing too many stdlib modules for any pip bootstrapping to work.

**New approach**: patch the system Python stdlib *before* creating venvs. Downloads the matching CPython source and copies any missing `.py` files into the system lib directory (non-destructive, skips existing files). After patching, `ensurepip` works natively and normal `python3 -m venv` succeeds.

## Changes

- **`scripts/patch-python-stdlib`** (new) — detects Python version, downloads matching CPython source tarball, fills in missing stdlib `.py` files. Idempotent, verbose logging with `[patch-python-stdlib]` prefix for easy debugging. No-ops on Pod 5+ where stdlib is already complete.
- **`scripts/install`** — calls `patch-python-stdlib` once before the biometrics module loop
- **`scripts/setup-python-venv`** — simplified with proper logging. Normal venv path should now always work after stdlib patching. `--without-pip` fallback kept as safety net.

## Logging

All scripts use tagged prefixes (`[patch-python-stdlib]`, `[setup-python-venv]`) so users can share install logs and we can pinpoint failures:

```
[patch-python-stdlib] Detected Python 3.10.4
[patch-python-stdlib] System lib directory: /usr/lib64/python3.10
[patch-python-stdlib] Module 'plistlib' is missing — patching needed
[patch-python-stdlib] Downloading CPython 3.10.4 source...
[patch-python-stdlib] Stdlib patching complete: 147 copied, 312 already present, 0 failed
[patch-python-stdlib]   ✓ plistlib
[patch-python-stdlib]   ✓ ensurepip
[patch-python-stdlib] Python stdlib is ready for venv creation
```

## Test plan

- [ ] On Pod 4 (fresh firmware reset): run install, confirm `patch-python-stdlib` downloads CPython source and copies missing files
- [ ] Confirm all 4 biometrics modules install successfully after patching
- [ ] On Pod 5: confirm `patch-python-stdlib` no-ops ("no patching needed")
- [ ] Re-run install on already-patched Pod 4: confirm idempotent (skips, no re-download... actually it will re-download since it checks imports not file presence — acceptable for now)
- [ ] Have user share install log if issues persist