### PR TITLE
Fix status page showing wrong pod model name

### DIFF
--- a/src/components/status/HealthCircle.tsx
+++ b/src/components/status/HealthCircle.tsx
@@ -22,10 +22,9 @@ interface HealthCircleProps {
 
 function podModelName(version: string): string {
   switch (version.toUpperCase()) {
-    case 'H00': return 'Pod 5'
-    case 'H01': return 'Pod 4'
-    case 'H02': return 'Pod 3'
-    case 'H03': return 'Pod 2'
+    case 'H00': return 'Pod 3'
+    case 'I00': return 'Pod 4'
+    case 'J00': return 'Pod 5'
     default: return version
   }
 }


### PR DESCRIPTION
## Summary
- Fix `podModelName()` in `HealthCircle.tsx` using wrong hardware revision codes (sequential H00–H03) instead of actual `PodVersion` enum values (H00, I00, J00)
- Pod 4 (I00) was falling through to default and showing raw code; Pod 3 (H00) was labeled "Pod 5"

Closes #349

## Test plan
- [ ] Verify on Pod 3 (H00) → displays "Pod 3"
- [ ] Verify on Pod 4 (I00) → displays "Pod 4"
- [ ] Verify on Pod 5 (J00) → displays "Pod 5"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected pod model name mappings to ensure users see accurate product identification information. Updates provide improved consistency in how device models are labeled throughout the application's status monitoring features. This helps users quickly identify their device models and understand model-specific capabilities when reviewing device health indicators and operational status information within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->