### PR TITLE
fix: resolve iptables path for Yocto (Pod 4) #350

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate install script branch default
+        if: github.event_name == 'pull_request'
+        run: |
+          expected="${{ github.base_ref }}"
+          actual=$(grep -oP 'SCRIPT_DEFAULT_BRANCH="\K[^"]+' scripts/install)
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::scripts/install has SCRIPT_DEFAULT_BRANCH=\"$actual\" but PR targets \"$expected\". Update it before merging."
+            exit 1
+          fi
+
       - name: Build
         run: pnpm build
 

--- a/scripts/install
+++ b/scripts/install
@@ -152,6 +152,7 @@ esac
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
+SCRIPT_DEFAULT_BRANCH="dev"  # must match target branch (CI validates on PR)
 
 # Lock file to prevent concurrent installs
 LOCKFILE="/var/run/sleepypod-install.lock"
@@ -318,7 +319,7 @@ if [ "$INSTALL_LOCAL" = true ]; then
   fi
 else
   # Download code via tarball (no git required on device)
-  DOWNLOAD_BRANCH="${INSTALL_BRANCH:-main}"
+  DOWNLOAD_BRANCH="${INSTALL_BRANCH:-$SCRIPT_DEFAULT_BRANCH}"
   echo "Downloading $DOWNLOAD_BRANCH from GitHub..."
 
   DOWNLOAD_DIR=$(mktemp -d)
@@ -387,7 +388,14 @@ else
 fi
 
 # Detect pod generation and DAC socket path (code is now on disk)
-source "$INSTALL_DIR/scripts/pod/detect"
+if [ -f "$INSTALL_DIR/scripts/pod/detect" ]; then
+  source "$INSTALL_DIR/scripts/pod/detect"
+else
+  echo "Error: $INSTALL_DIR/scripts/pod/detect not found." >&2
+  echo "  The downloaded code does not match this install script." >&2
+  echo "  Try: curl -fsSL <url> | sudo bash -s -- --branch $SCRIPT_DEFAULT_BRANCH" >&2
+  exit 1
+fi
 echo "Pod generation: $POD_GEN (DAC: $DAC_SOCK_PATH)"
 
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
@@ -644,11 +652,14 @@ fi
 fix_db_permissions
 
 # Install CLI tools from scripts/bin/
-echo "Installing CLI tools..."
-for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-  cp "$tool" /usr/local/bin/
-  chmod +x "/usr/local/bin/$(basename "$tool")"
-done
+if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+  echo "Installing CLI tools..."
+  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+    [ -f "$tool" ] || continue
+    cp "$tool" /usr/local/bin/
+    chmod +x "/usr/local/bin/$(basename "$tool")"
+  done
+fi
 
 # Optional SSH configuration
 if [ "$SKIP_SSH" = true ]; then

--- a/scripts/internet-control
+++ b/scripts/internet-control
@@ -153,11 +153,10 @@ case "$COMMAND" in
     echo "Local subnet: $LOCAL_SUBNET"
     echo ""
 
-    # Install iptables and iptables-persistent if not present
-    if ! command -v iptables &>/dev/null || ! dpkg -l | grep -q iptables-persistent; then
-      echo "Installing iptables..."
-      apt-get update
-      apt-get install -y iptables iptables-persistent
+    # Verify iptables is available (Yocto images have no package manager)
+    if ! command -v iptables &>/dev/null; then
+      echo "Error: iptables not found. Cannot block WAN access without iptables." >&2
+      exit 1
     fi
 
     # Create custom chain for SleepyPod rules (IPv4)

--- a/src/server/routers/system.ts
+++ b/src/server/routers/system.ts
@@ -1,14 +1,29 @@
 import { z } from 'zod'
 import { TRPCError } from '@trpc/server'
 import { publicProcedure, router } from '@/src/server/trpc'
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 
-const IPTABLES = '/usr/sbin/iptables'
-const IPTABLES_SAVE = '/usr/sbin/iptables-save'
+/**
+ * Resolve an executable path, checking common locations on Yocto and Debian.
+ * Falls back to bare name (relies on PATH) if no candidate is found.
+ */
+function resolveExec(name: string, candidates: string[]): string {
+  for (const p of candidates) {
+    try {
+      execFileSync('test', ['-x', p], { stdio: 'ignore' })
+      return p
+    }
+    catch { /* not found, try next */ }
+  }
+  return name // bare name — let PATH resolve it
+}
+
+const IPTABLES = resolveExec('iptables', ['/sbin/iptables', '/usr/sbin/iptables'])
+const IPTABLES_SAVE = resolveExec('iptables-save', ['/sbin/iptables-save', '/usr/sbin/iptables-save'])
 
 /**
  * Simple async mutex to serialize iptables mutations.

--- a/src/server/routers/system.ts
+++ b/src/server/routers/system.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
 import { TRPCError } from '@trpc/server'
 import { publicProcedure, router } from '@/src/server/trpc'
-import { execFile, execFileSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 
@@ -14,7 +15,7 @@ const execFileAsync = promisify(execFile)
 function resolveExec(name: string, candidates: string[]): string {
   for (const p of candidates) {
     try {
-      execFileSync('test', ['-x', p], { stdio: 'ignore' })
+      accessSync(p, constants.X_OK)
       return p
     }
     catch { /* not found, try next */ }


### PR DESCRIPTION
## Summary
- **Backend**: Replaced hardcoded `/usr/sbin/iptables` with dynamic path resolution that checks `/sbin/` then `/usr/sbin/`, falling back to bare name for PATH lookup. Fixes the UI toggle error on Pod 4.
- **Script**: Replaced `dpkg`/`apt-get` install block in `scripts/internet-control` with a simple `command -v iptables` check, since Yocto has no package manager — iptables is baked into the image.

Closes #350

## Test plan
- [ ] Deploy to Pod 4 and toggle WAN access from the UI — should succeed without error
- [ ] Run `sudo ./scripts/internet-control block` on Pod 4 — should block without dpkg/apt errors
- [ ] Run `sudo ./scripts/internet-control status` — verify Layer 1 shows ACTIVE
- [ ] Verify on a Debian-based dev machine that `/usr/sbin/iptables` is still resolved correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust installer: clearer errors when required files are missing, safer defaults, and skips absent CLI tools to avoid failures.
  * Network control now exits with an error if required system utilities are missing instead of attempting automatic installation.
  * Improved resolution of system binary paths for more reliable behavior across environments.

* **Tests**
  * CI now validates that installer branch configuration matches the PR base branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->