### PR TITLE
perf: batch schedule mutations to eliminate N+1 API calls

### DIFF
--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -106,6 +106,10 @@ export function useSchedule() {
     onSuccess: () => invalidateAll(),
   })
 
+  const batchUpdate = trpc.schedules.batchUpdate.useMutation({
+    onSuccess: () => invalidateAll(),
+  })
+
   function invalidateAll() {
     void utils.schedules.getAll.invalidate()
     void utils.schedules.getByDay.invalidate()
@@ -145,24 +149,21 @@ export function useSchedule() {
 
     setConfirmMessage(null)
 
-    // Process each selected day
+    const powerUpdates: Array<{ id: number, enabled: boolean }> = []
+    const powerCreates: Array<{ side: Side, dayOfWeek: DayOfWeek, onTime: string, offTime: string, onTemperature: number, enabled: boolean }> = []
+
     for (const day of selectedDays) {
       const dayPowerSchedules = allData.power.filter(
         (p: PowerSchedule) => p.dayOfWeek === day
       )
 
       if (dayPowerSchedules.length > 0) {
-        // Update existing power schedules
         for (const ps of dayPowerSchedules) {
-          await updatePowerSchedule.mutateAsync({
-            id: ps.id,
-            enabled: newEnabled,
-          })
+          powerUpdates.push({ id: ps.id, enabled: newEnabled })
         }
       }
       else if (newEnabled) {
-        // Create a default power schedule when enabling a day that has none
-        await createPowerSchedule.mutateAsync({
+        powerCreates.push({
           side,
           dayOfWeek: day,
           onTime: '22:00',
@@ -173,11 +174,16 @@ export function useSchedule() {
       }
     }
 
+    await batchUpdate.mutateAsync({
+      updates: { power: powerUpdates },
+      creates: { power: powerCreates },
+    })
+
     setConfirmMessage(
       `Schedule ${newEnabled ? 'enabled' : 'disabled'} for ${selectedDays.size} day${selectedDays.size > 1 ? 's' : ''}`
     )
     confirmTimerRef.current = setTimeout(() => setConfirmMessage(null), 3000)
-  }, [allSchedulesQuery.data, isPowerEnabled, selectedDays, side, updatePowerSchedule, createPowerSchedule])
+  }, [allSchedulesQuery.data, isPowerEnabled, selectedDays, side, batchUpdate])
 
   /**
    * Toggle ALL schedule types (temperature + power + alarm) enable/disable
@@ -193,33 +199,26 @@ export function useSchedule() {
     }
     const newEnabled = !isPowerEnabled
 
-    // Process each selected day
+    const tempUpdates: Array<{ id: number, enabled: boolean }> = []
+    const powerUpdates: Array<{ id: number, enabled: boolean }> = []
+    const alarmUpdates: Array<{ id: number, enabled: boolean }> = []
+    const powerCreates: Array<{ side: Side, dayOfWeek: DayOfWeek, onTime: string, offTime: string, onTemperature: number, enabled: boolean }> = []
+
     for (const day of selectedDays) {
-      // Toggle temperature schedules
-      const dayTempSchedules = allData.temperature.filter(
-        (t: TemperatureSchedule) => t.dayOfWeek === day
-      )
-      for (const ts of dayTempSchedules) {
-        await updateTempSchedule.mutateAsync({
-          id: ts.id,
-          enabled: newEnabled,
-        })
+      // Temperature schedules
+      for (const ts of allData.temperature.filter((t: TemperatureSchedule) => t.dayOfWeek === day)) {
+        tempUpdates.push({ id: ts.id, enabled: newEnabled })
       }
 
-      // Toggle power schedules
-      const dayPowerSchedules = allData.power.filter(
-        (p: PowerSchedule) => p.dayOfWeek === day
-      )
+      // Power schedules
+      const dayPowerSchedules = allData.power.filter((p: PowerSchedule) => p.dayOfWeek === day)
       if (dayPowerSchedules.length > 0) {
         for (const ps of dayPowerSchedules) {
-          await updatePowerSchedule.mutateAsync({
-            id: ps.id,
-            enabled: newEnabled,
-          })
+          powerUpdates.push({ id: ps.id, enabled: newEnabled })
         }
       }
       else if (newEnabled) {
-        await createPowerSchedule.mutateAsync({
+        powerCreates.push({
           side,
           dayOfWeek: day,
           onTime: '22:00',
@@ -229,32 +228,22 @@ export function useSchedule() {
         })
       }
 
-      // Toggle alarm schedules
-      const dayAlarmSchedules = allData.alarm.filter(
-        (a: AlarmSchedule) => a.dayOfWeek === day
-      )
-      for (const as_ of dayAlarmSchedules) {
-        await updateAlarmSchedule.mutateAsync({
-          id: as_.id,
-          enabled: newEnabled,
-        })
+      // Alarm schedules
+      for (const as_ of allData.alarm.filter((a: AlarmSchedule) => a.dayOfWeek === day)) {
+        alarmUpdates.push({ id: as_.id, enabled: newEnabled })
       }
     }
+
+    await batchUpdate.mutateAsync({
+      updates: { temperature: tempUpdates, power: powerUpdates, alarm: alarmUpdates },
+      creates: { power: powerCreates },
+    })
 
     setConfirmMessage(
       `All schedules ${newEnabled ? 'enabled' : 'disabled'} for ${selectedDays.size} day${selectedDays.size > 1 ? 's' : ''}`
     )
     confirmTimerRef.current = setTimeout(() => setConfirmMessage(null), 3000)
-  }, [
-    allSchedulesQuery.data,
-    isPowerEnabled,
-    selectedDays,
-    side,
-    updateTempSchedule,
-    updatePowerSchedule,
-    updateAlarmSchedule,
-    createPowerSchedule,
-  ])
+  }, [allSchedulesQuery.data, isPowerEnabled, selectedDays, side, batchUpdate])
 
   /**
    * Apply the source day's schedule to target days.
@@ -272,7 +261,6 @@ export function useSchedule() {
       setConfirmMessage(null)
 
       try {
-        // Get the full schedule data for current side
         const allData = allSchedulesQuery.data as {
           temperature: TemperatureSchedule[]
           power: PowerSchedule[]
@@ -281,36 +269,32 @@ export function useSchedule() {
 
         if (!allData) return
 
+        const tempDeletes: number[] = []
+        const powerDeletes: number[] = []
+        const alarmDeletes: number[] = []
+        const tempCreates: Array<{ side: Side, dayOfWeek: DayOfWeek, time: string, temperature: number, enabled: boolean }> = []
+        const powerCreates: Array<{ side: Side, dayOfWeek: DayOfWeek, onTime: string, offTime: string, onTemperature: number, enabled: boolean }> = []
+        const alarmCreates: Array<{ side: Side, dayOfWeek: DayOfWeek, time: string, vibrationIntensity: number, vibrationPattern: 'double' | 'rise', duration: number, alarmTemperature: number, enabled: boolean }> = []
+
+        const sourceTemp = daySchedule.temperature || []
+        const sourcePower = daySchedule.power || []
+        const sourceAlarm = daySchedule.alarm || []
+
         for (const targetDay of targetDays) {
-          // 1. Delete all existing schedules for target day
-          const existingTemp = allData.temperature.filter(
-            (t: TemperatureSchedule) => t.dayOfWeek === targetDay
-          )
-          const existingPower = allData.power.filter(
-            (p: PowerSchedule) => p.dayOfWeek === targetDay
-          )
-          const existingAlarm = allData.alarm.filter(
-            (a: AlarmSchedule) => a.dayOfWeek === targetDay
-          )
-
-          // Delete existing
-          for (const t of existingTemp) {
-            await deleteTempSchedule.mutateAsync({ id: t.id })
+          // Collect IDs to delete
+          for (const t of allData.temperature.filter((t: TemperatureSchedule) => t.dayOfWeek === targetDay)) {
+            tempDeletes.push(t.id)
           }
-          for (const p of existingPower) {
-            await deletePowerSchedule.mutateAsync({ id: p.id })
+          for (const p of allData.power.filter((p: PowerSchedule) => p.dayOfWeek === targetDay)) {
+            powerDeletes.push(p.id)
           }
-          for (const a of existingAlarm) {
-            await deleteAlarmSchedule.mutateAsync({ id: a.id })
+          for (const a of allData.alarm.filter((a: AlarmSchedule) => a.dayOfWeek === targetDay)) {
+            alarmDeletes.push(a.id)
           }
 
-          // 2. Recreate from source day's schedule
-          const sourceTemp = daySchedule.temperature || []
-          const sourcePower = daySchedule.power || []
-          const sourceAlarm = daySchedule.alarm || []
-
+          // Collect creates from source day
           for (const t of sourceTemp) {
-            await createTempSchedule.mutateAsync({
+            tempCreates.push({
               side,
               dayOfWeek: targetDay,
               time: t.time,
@@ -318,9 +302,8 @@ export function useSchedule() {
               enabled: t.enabled,
             })
           }
-
           for (const p of sourcePower) {
-            await createPowerSchedule.mutateAsync({
+            powerCreates.push({
               side,
               dayOfWeek: targetDay,
               onTime: p.onTime,
@@ -329,9 +312,8 @@ export function useSchedule() {
               enabled: p.enabled,
             })
           }
-
           for (const a of sourceAlarm) {
-            await createAlarmSchedule.mutateAsync({
+            alarmCreates.push({
               side,
               dayOfWeek: targetDay,
               time: a.time,
@@ -343,6 +325,11 @@ export function useSchedule() {
             })
           }
         }
+
+        await batchUpdate.mutateAsync({
+          deletes: { temperature: tempDeletes, power: powerDeletes, alarm: alarmDeletes },
+          creates: { temperature: tempCreates, power: powerCreates, alarm: alarmCreates },
+        })
 
         setConfirmMessage(
           `Schedule applied to ${targetDays.length} day${targetDays.length > 1 ? 's' : ''}. Scheduler reloaded.`
@@ -358,17 +345,7 @@ export function useSchedule() {
         setIsApplying(false)
       }
     },
-    [
-      daySchedule,
-      allSchedulesQuery.data,
-      side,
-      createTempSchedule,
-      createPowerSchedule,
-      createAlarmSchedule,
-      deleteTempSchedule,
-      deletePowerSchedule,
-      deleteAlarmSchedule,
-    ]
+    [daySchedule, allSchedulesQuery.data, side, batchUpdate]
   )
 
   return {
@@ -392,7 +369,8 @@ export function useSchedule() {
     isLoading: allSchedulesQuery.isLoading || dayScheduleQuery.isLoading,
     isApplying,
     isMutating:
-      createTempSchedule.isPending
+      batchUpdate.isPending
+      || createTempSchedule.isPending
       || updateTempSchedule.isPending
       || deleteTempSchedule.isPending
       || createPowerSchedule.isPending

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -174,10 +174,12 @@ export function useSchedule() {
       }
     }
 
-    await batchUpdate.mutateAsync({
-      updates: { power: powerUpdates },
-      creates: { power: powerCreates },
-    })
+    if (powerUpdates.length > 0 || powerCreates.length > 0) {
+      await batchUpdate.mutateAsync({
+        updates: { power: powerUpdates },
+        creates: { power: powerCreates },
+      })
+    }
 
     setConfirmMessage(
       `Schedule ${newEnabled ? 'enabled' : 'disabled'} for ${selectedDays.size} day${selectedDays.size > 1 ? 's' : ''}`
@@ -234,10 +236,12 @@ export function useSchedule() {
       }
     }
 
-    await batchUpdate.mutateAsync({
-      updates: { temperature: tempUpdates, power: powerUpdates, alarm: alarmUpdates },
-      creates: { power: powerCreates },
-    })
+    if (tempUpdates.length > 0 || powerUpdates.length > 0 || alarmUpdates.length > 0 || powerCreates.length > 0) {
+      await batchUpdate.mutateAsync({
+        updates: { temperature: tempUpdates, power: powerUpdates, alarm: alarmUpdates },
+        creates: { power: powerCreates },
+      })
+    }
 
     setConfirmMessage(
       `All schedules ${newEnabled ? 'enabled' : 'disabled'} for ${selectedDays.size} day${selectedDays.size > 1 ? 's' : ''}`
@@ -326,10 +330,14 @@ export function useSchedule() {
           }
         }
 
-        await batchUpdate.mutateAsync({
-          deletes: { temperature: tempDeletes, power: powerDeletes, alarm: alarmDeletes },
-          creates: { temperature: tempCreates, power: powerCreates, alarm: alarmCreates },
-        })
+        const hasChanges = tempDeletes.length > 0 || powerDeletes.length > 0 || alarmDeletes.length > 0
+          || tempCreates.length > 0 || powerCreates.length > 0 || alarmCreates.length > 0
+        if (hasChanges) {
+          await batchUpdate.mutateAsync({
+            deletes: { temperature: tempDeletes, power: powerDeletes, alarm: alarmDeletes },
+            creates: { temperature: tempCreates, power: powerCreates, alarm: alarmCreates },
+          })
+        }
 
         setConfirmMessage(
           `Schedule applied to ${targetDays.length} day${targetDays.length > 1 ? 's' : ''}. Scheduler reloaded.`

--- a/src/server/routers/schedules.ts
+++ b/src/server/routers/schedules.ts
@@ -566,9 +566,9 @@ export const schedulesRouter = router({
     .input(
       z.object({
         deletes: z.object({
-          temperature: z.array(idSchema).default([]),
-          power: z.array(idSchema).default([]),
-          alarm: z.array(idSchema).default([]),
+          temperature: z.array(idSchema).max(100).default([]),
+          power: z.array(idSchema).max(100).default([]),
+          alarm: z.array(idSchema).max(100).default([]),
         }).default({ temperature: [], power: [], alarm: [] }),
         creates: z.object({
           temperature: z.array(z.object({
@@ -577,7 +577,7 @@ export const schedulesRouter = router({
             time: timeStringSchema,
             temperature: temperatureSchema,
             enabled: z.boolean().default(true),
-          })).default([]),
+          })).max(100).default([]),
           power: z.array(z.object({
             side: sideSchema,
             dayOfWeek: dayOfWeekSchema,
@@ -585,7 +585,7 @@ export const schedulesRouter = router({
             offTime: timeStringSchema,
             onTemperature: temperatureSchema,
             enabled: z.boolean().default(true),
-          })).default([]),
+          })).max(100).default([]),
           alarm: z.array(z.object({
             side: sideSchema,
             dayOfWeek: dayOfWeekSchema,
@@ -595,7 +595,7 @@ export const schedulesRouter = router({
             duration: alarmDurationSchema,
             alarmTemperature: temperatureSchema,
             enabled: z.boolean().default(true),
-          })).default([]),
+          })).max(100).default([]),
         }).default({ temperature: [], power: [], alarm: [] }),
         updates: z.object({
           temperature: z.array(z.object({
@@ -603,14 +603,14 @@ export const schedulesRouter = router({
             time: timeStringSchema.optional(),
             temperature: temperatureSchema.optional(),
             enabled: z.boolean().optional(),
-          })).default([]),
+          })).max(100).default([]),
           power: z.array(z.object({
             id: idSchema,
             onTime: timeStringSchema.optional(),
             offTime: timeStringSchema.optional(),
             onTemperature: temperatureSchema.optional(),
             enabled: z.boolean().optional(),
-          })).default([]),
+          })).max(100).default([]),
           alarm: z.array(z.object({
             id: idSchema,
             time: timeStringSchema.optional(),
@@ -619,7 +619,7 @@ export const schedulesRouter = router({
             duration: alarmDurationSchema.optional(),
             alarmTemperature: temperatureSchema.optional(),
             enabled: z.boolean().optional(),
-          })).default([]),
+          })).max(100).default([]),
         }).default({ temperature: [], power: [], alarm: [] }),
       })
     )
@@ -629,13 +629,16 @@ export const schedulesRouter = router({
         db.transaction((tx) => {
           // Deletes first
           for (const id of input.deletes.temperature) {
-            tx.delete(temperatureSchedules).where(eq(temperatureSchedules.id, id)).run()
+            const [deleted] = tx.delete(temperatureSchedules).where(eq(temperatureSchedules.id, id)).returning().all()
+            if (!deleted) throw new TRPCError({ code: 'NOT_FOUND', message: `Temperature schedule with ID ${id} not found` })
           }
           for (const id of input.deletes.power) {
-            tx.delete(powerSchedules).where(eq(powerSchedules.id, id)).run()
+            const [deleted] = tx.delete(powerSchedules).where(eq(powerSchedules.id, id)).returning().all()
+            if (!deleted) throw new TRPCError({ code: 'NOT_FOUND', message: `Power schedule with ID ${id} not found` })
           }
           for (const id of input.deletes.alarm) {
-            tx.delete(alarmSchedules).where(eq(alarmSchedules.id, id)).run()
+            const [deleted] = tx.delete(alarmSchedules).where(eq(alarmSchedules.id, id)).returning().all()
+            if (!deleted) throw new TRPCError({ code: 'NOT_FOUND', message: `Alarm schedule with ID ${id} not found` })
           }
 
           // Creates
@@ -651,22 +654,16 @@ export const schedulesRouter = router({
 
           // Updates
           for (const { id, ...updates } of input.updates.temperature) {
-            tx.update(temperatureSchedules)
-              .set({ ...updates, updatedAt: new Date() })
-              .where(eq(temperatureSchedules.id, id))
-              .run()
+            const [updated] = tx.update(temperatureSchedules).set({ ...updates, updatedAt: new Date() }).where(eq(temperatureSchedules.id, id)).returning().all()
+            if (!updated) throw new TRPCError({ code: 'NOT_FOUND', message: `Temperature schedule with ID ${id} not found` })
           }
           for (const { id, ...updates } of input.updates.power) {
-            tx.update(powerSchedules)
-              .set({ ...updates, updatedAt: new Date() })
-              .where(eq(powerSchedules.id, id))
-              .run()
+            const [updated] = tx.update(powerSchedules).set({ ...updates, updatedAt: new Date() }).where(eq(powerSchedules.id, id)).returning().all()
+            if (!updated) throw new TRPCError({ code: 'NOT_FOUND', message: `Power schedule with ID ${id} not found` })
           }
           for (const { id, ...updates } of input.updates.alarm) {
-            tx.update(alarmSchedules)
-              .set({ ...updates, updatedAt: new Date() })
-              .where(eq(alarmSchedules.id, id))
-              .run()
+            const [updated] = tx.update(alarmSchedules).set({ ...updates, updatedAt: new Date() }).where(eq(alarmSchedules.id, id)).returning().all()
+            if (!updated) throw new TRPCError({ code: 'NOT_FOUND', message: `Alarm schedule with ID ${id} not found` })
           }
         })
 

--- a/src/server/routers/schedules.ts
+++ b/src/server/routers/schedules.ts
@@ -558,6 +558,139 @@ export const schedulesRouter = router({
     }),
 
   /**
+   * Batch update schedules — deletes, creates, and updates in one transaction with one scheduler reload.
+   * Used by bulk operations (apply to other days, toggle all) to avoid N+1 API calls.
+   */
+  batchUpdate: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/schedules/batch', protect: false, tags: ['Schedules'] } })
+    .input(
+      z.object({
+        deletes: z.object({
+          temperature: z.array(idSchema).default([]),
+          power: z.array(idSchema).default([]),
+          alarm: z.array(idSchema).default([]),
+        }).default({ temperature: [], power: [], alarm: [] }),
+        creates: z.object({
+          temperature: z.array(z.object({
+            side: sideSchema,
+            dayOfWeek: dayOfWeekSchema,
+            time: timeStringSchema,
+            temperature: temperatureSchema,
+            enabled: z.boolean().default(true),
+          })).default([]),
+          power: z.array(z.object({
+            side: sideSchema,
+            dayOfWeek: dayOfWeekSchema,
+            onTime: timeStringSchema,
+            offTime: timeStringSchema,
+            onTemperature: temperatureSchema,
+            enabled: z.boolean().default(true),
+          })).default([]),
+          alarm: z.array(z.object({
+            side: sideSchema,
+            dayOfWeek: dayOfWeekSchema,
+            time: timeStringSchema,
+            vibrationIntensity: vibrationIntensitySchema,
+            vibrationPattern: vibrationPatternSchema.default('rise'),
+            duration: alarmDurationSchema,
+            alarmTemperature: temperatureSchema,
+            enabled: z.boolean().default(true),
+          })).default([]),
+        }).default({ temperature: [], power: [], alarm: [] }),
+        updates: z.object({
+          temperature: z.array(z.object({
+            id: idSchema,
+            time: timeStringSchema.optional(),
+            temperature: temperatureSchema.optional(),
+            enabled: z.boolean().optional(),
+          })).default([]),
+          power: z.array(z.object({
+            id: idSchema,
+            onTime: timeStringSchema.optional(),
+            offTime: timeStringSchema.optional(),
+            onTemperature: temperatureSchema.optional(),
+            enabled: z.boolean().optional(),
+          })).default([]),
+          alarm: z.array(z.object({
+            id: idSchema,
+            time: timeStringSchema.optional(),
+            vibrationIntensity: vibrationIntensitySchema.optional(),
+            vibrationPattern: vibrationPatternSchema.optional(),
+            duration: alarmDurationSchema.optional(),
+            alarmTemperature: temperatureSchema.optional(),
+            enabled: z.boolean().optional(),
+          })).default([]),
+        }).default({ temperature: [], power: [], alarm: [] }),
+      })
+    )
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ input }) => {
+      try {
+        db.transaction((tx) => {
+          // Deletes first
+          for (const id of input.deletes.temperature) {
+            tx.delete(temperatureSchedules).where(eq(temperatureSchedules.id, id)).run()
+          }
+          for (const id of input.deletes.power) {
+            tx.delete(powerSchedules).where(eq(powerSchedules.id, id)).run()
+          }
+          for (const id of input.deletes.alarm) {
+            tx.delete(alarmSchedules).where(eq(alarmSchedules.id, id)).run()
+          }
+
+          // Creates
+          for (const entry of input.creates.temperature) {
+            tx.insert(temperatureSchedules).values(entry).run()
+          }
+          for (const entry of input.creates.power) {
+            tx.insert(powerSchedules).values(entry).run()
+          }
+          for (const entry of input.creates.alarm) {
+            tx.insert(alarmSchedules).values(entry).run()
+          }
+
+          // Updates
+          for (const { id, ...updates } of input.updates.temperature) {
+            tx.update(temperatureSchedules)
+              .set({ ...updates, updatedAt: new Date() })
+              .where(eq(temperatureSchedules.id, id))
+              .run()
+          }
+          for (const { id, ...updates } of input.updates.power) {
+            tx.update(powerSchedules)
+              .set({ ...updates, updatedAt: new Date() })
+              .where(eq(powerSchedules.id, id))
+              .run()
+          }
+          for (const { id, ...updates } of input.updates.alarm) {
+            tx.update(alarmSchedules)
+              .set({ ...updates, updatedAt: new Date() })
+              .where(eq(alarmSchedules.id, id))
+              .run()
+          }
+        })
+
+        try {
+          await reloadScheduler()
+        }
+        catch (e) {
+          console.error('Scheduler reload failed:', e)
+        }
+
+        return { success: true }
+      }
+      catch (error) {
+        if (error instanceof TRPCError) throw error
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to batch update schedules: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          cause: error,
+        })
+      }
+    }),
+
+  /**
    * Get schedules for a specific day
    */
   getByDay: publicProcedure

--- a/src/server/routers/tests/schedules.test.ts
+++ b/src/server/routers/tests/schedules.test.ts
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+
+// Hoist mocks so they're available to vi.mock factories
+const mocks = vi.hoisted(() => ({
+  reloadSchedules: vi.fn(),
+}))
+
+vi.mock('@/src/scheduler', () => ({
+  getJobManager: vi.fn(async () => ({
+    reloadSchedules: mocks.reloadSchedules,
+  })),
+}))
+
+// Replace the real DB with an in-memory SQLite instance
+vi.mock('@/src/db', async () => {
+  const BetterSqlite3 = (await import('better-sqlite3')).default
+  const { drizzle } = await import('drizzle-orm/better-sqlite3')
+  const schema = await import('@/src/db/schema')
+  const sqlite = new BetterSqlite3(':memory:')
+  sqlite.pragma('foreign_keys = ON')
+  return { db: drizzle(sqlite, { schema }), sqlite }
+})
+
+import { schedulesRouter } from '@/src/server/routers/schedules'
+import { sqlite } from '@/src/db'
+
+const caller = schedulesRouter.createCaller({})
+
+function createTables() {
+  (sqlite as any).exec(`
+    CREATE TABLE IF NOT EXISTS temperature_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      time TEXT NOT NULL,
+      temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE IF NOT EXISTS power_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      on_time TEXT NOT NULL,
+      off_time TEXT NOT NULL,
+      on_temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE IF NOT EXISTS alarm_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      time TEXT NOT NULL,
+      vibration_intensity INTEGER NOT NULL,
+      vibration_pattern TEXT NOT NULL DEFAULT 'rise',
+      duration INTEGER NOT NULL,
+      alarm_temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+  `)
+}
+
+function clearTables() {
+  (sqlite as any).exec(`
+    DELETE FROM temperature_schedules;
+    DELETE FROM power_schedules;
+    DELETE FROM alarm_schedules;
+  `)
+}
+
+describe('schedules.batchUpdate', () => {
+  beforeAll(() => {
+    createTables()
+  })
+
+  beforeEach(() => {
+    clearTables()
+    mocks.reloadSchedules.mockClear()
+  })
+
+  afterAll(() => {
+    (sqlite as any).close()
+  })
+
+  it('creates schedules across all types in one call', async () => {
+    const result = await caller.batchUpdate({
+      creates: {
+        temperature: [
+          { side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68, enabled: true },
+          { side: 'left', dayOfWeek: 'tuesday', time: '22:00', temperature: 70, enabled: true },
+        ],
+        power: [
+          { side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 75, enabled: true },
+        ],
+        alarm: [
+          { side: 'left', dayOfWeek: 'monday', time: '07:00', vibrationIntensity: 50, vibrationPattern: 'rise', duration: 120, alarmTemperature: 80, enabled: true },
+        ],
+      },
+    })
+
+    expect(result).toEqual({ success: true })
+
+    const all = await caller.getAll({ side: 'left' })
+    expect(all.temperature).toHaveLength(2)
+    expect(all.power).toHaveLength(1)
+    expect(all.alarm).toHaveLength(1)
+  })
+
+  it('deletes schedules by ID', async () => {
+    // Seed
+    const t1 = await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 })
+    await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'tuesday', time: '22:00', temperature: 70 })
+
+    await caller.batchUpdate({
+      deletes: { temperature: [t1.id] },
+    })
+
+    const after = await caller.getAll({ side: 'left' })
+    expect(after.temperature).toHaveLength(1)
+    expect(after.temperature[0].id).not.toBe(t1.id)
+  })
+
+  it('updates schedules in batch', async () => {
+    const p1 = await caller.createPowerSchedule({ side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 75, enabled: true })
+    const p2 = await caller.createPowerSchedule({ side: 'left', dayOfWeek: 'tuesday', onTime: '22:00', offTime: '07:00', onTemperature: 75, enabled: true })
+
+    await caller.batchUpdate({
+      updates: {
+        power: [
+          { id: p1.id, enabled: false },
+          { id: p2.id, enabled: false },
+        ],
+      },
+    })
+
+    const after = await caller.getAll({ side: 'left' })
+    expect(after.power.every((p: any) => p.enabled === false)).toBe(true)
+  })
+
+  it('handles mixed deletes + creates atomically (apply-to-other-days pattern)', async () => {
+    // Monday has a schedule, Tuesday has a different one
+    await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 })
+    const tue = await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'tuesday', time: '23:00', temperature: 72 })
+
+    // "Apply Monday to Tuesday": delete Tuesday's, create copy of Monday's
+    await caller.batchUpdate({
+      deletes: { temperature: [tue.id] },
+      creates: {
+        temperature: [
+          { side: 'left', dayOfWeek: 'tuesday', time: '22:00', temperature: 68, enabled: true },
+        ],
+      },
+    })
+
+    const after = await caller.getAll({ side: 'left' })
+    expect(after.temperature).toHaveLength(2)
+
+    const tuesday = after.temperature.find((t: any) => t.dayOfWeek === 'tuesday')
+    expect(tuesday.time).toBe('22:00')
+    expect(tuesday.temperature).toBe(68)
+  })
+
+  it('calls reloadScheduler exactly once regardless of operation count', async () => {
+    await caller.batchUpdate({
+      creates: {
+        temperature: [
+          { side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 },
+          { side: 'left', dayOfWeek: 'tuesday', time: '22:00', temperature: 70 },
+          { side: 'left', dayOfWeek: 'wednesday', time: '22:00', temperature: 72 },
+        ],
+        power: [
+          { side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 75 },
+          { side: 'left', dayOfWeek: 'tuesday', onTime: '22:00', offTime: '07:00', onTemperature: 75 },
+        ],
+      },
+    })
+
+    expect(mocks.reloadSchedules).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts empty input without errors', async () => {
+    const result = await caller.batchUpdate({})
+    expect(result).toEqual({ success: true })
+  })
+
+  it('rolls back all changes on transaction failure', async () => {
+    // Seed a valid record
+    await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 })
+
+    const before = await caller.getAll({ side: 'left' })
+    expect(before.temperature).toHaveLength(1)
+
+    // Attempt a batch with an update referencing a non-existent table column
+    // won't work — drizzle builds SQL at call time. Instead, test that a valid
+    // batch with deletes + creates is atomic by verifying final state.
+    const id = before.temperature[0].id
+
+    await caller.batchUpdate({
+      deletes: { temperature: [id] },
+      creates: {
+        temperature: [
+          { side: 'left', dayOfWeek: 'tuesday', time: '22:00', temperature: 70 },
+          { side: 'left', dayOfWeek: 'wednesday', time: '22:00', temperature: 72 },
+        ],
+      },
+    })
+
+    const after = await caller.getAll({ side: 'left' })
+    // Old record gone, two new ones present
+    expect(after.temperature).toHaveLength(2)
+    expect(after.temperature.find((t: any) => t.id === id)).toBeUndefined()
+  })
+})

--- a/src/server/routers/tests/schedules.test.ts
+++ b/src/server/routers/tests/schedules.test.ts
@@ -189,16 +189,11 @@ describe('schedules.batchUpdate', () => {
     expect(result).toEqual({ success: true })
   })
 
-  it('rolls back all changes on transaction failure', async () => {
-    // Seed a valid record
+  it('applies deletes and creates atomically', async () => {
     await caller.createTemperatureSchedule({ side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 })
 
     const before = await caller.getAll({ side: 'left' })
     expect(before.temperature).toHaveLength(1)
-
-    // Attempt a batch with an update referencing a non-existent table column
-    // won't work — drizzle builds SQL at call time. Instead, test that a valid
-    // batch with deletes + creates is atomic by verifying final state.
     const id = before.temperature[0].id
 
     await caller.batchUpdate({
@@ -212,8 +207,19 @@ describe('schedules.batchUpdate', () => {
     })
 
     const after = await caller.getAll({ side: 'left' })
-    // Old record gone, two new ones present
     expect(after.temperature).toHaveLength(2)
     expect(after.temperature.find((t: any) => t.id === id)).toBeUndefined()
+  })
+
+  it('throws NOT_FOUND for missing delete IDs', async () => {
+    await expect(
+      caller.batchUpdate({ deletes: { temperature: [99999] } })
+    ).rejects.toThrow('not found')
+  })
+
+  it('throws NOT_FOUND for missing update IDs', async () => {
+    await expect(
+      caller.batchUpdate({ updates: { power: [{ id: 99999, enabled: false }] } })
+    ).rejects.toThrow('not found')
   })
 })


### PR DESCRIPTION
## Summary

- Added `batchUpdate` tRPC mutation that accepts arrays of deletes/creates/updates for all schedule types, runs them in one SQLite transaction, and calls `reloadScheduler()` once
- Rewired `togglePowerSchedule`, `toggleAllSchedules`, and `applyToOtherDays` in `useSchedule.ts` to build changesets in-memory then fire a single batch call
- Added 7 tests for the new endpoint (in-memory SQLite, mocked scheduler)

| Scenario | Before | After |
|---|---|---|
| Apply to 5 days (3 types each) | 30 API calls, 30 reloads | 1 call, 1 reload |
| Toggle all (5 days, 3 types) | 15 API calls, 15 reloads | 1 call, 1 reload |
| Toggle power (5 days) | 5 API calls, 5 reloads | 1 call, 1 reload |

Closes #342

## Test plan

- [x] `pnpm test` — 292 passed, 0 failures
- [x] 7 new tests cover: batch creates, deletes, updates, mixed ops (apply-to-other-days pattern), single reload assertion, empty input
- [ ] Manual: open schedule UI, apply a day's schedule to 5 other days — should complete in <1s vs 6-15s before

🤖 Generated with [Claude Code](https://claude.com/claude-code)