### PR TITLE
feat: add per-pod capabilities manifest

### DIFF
--- a/scripts/internet-control
+++ b/scripts/internet-control
@@ -44,6 +44,21 @@ fi
 COMMAND="$1"
 
 # ---------------------------------------------------------------------------
+# Pod OS / iptables detection
+# ---------------------------------------------------------------------------
+# Pod 3/4 run Yocto (no apt, iptables at /sbin/iptables)
+# Pod 5 runs Debian (has apt, iptables at /usr/sbin/iptables)
+if [ -x /usr/bin/apt-get ]; then
+  POD_OS="debian"
+  IPTABLES="/usr/sbin/iptables"
+  IP6TABLES="/usr/sbin/ip6tables"
+else
+  POD_OS="yocto"
+  IPTABLES="/sbin/iptables"
+  IP6TABLES="/sbin/ip6tables"
+fi
+
+# ---------------------------------------------------------------------------
 # /etc/hosts management for Eight Sleep telemetry blocking
 # ---------------------------------------------------------------------------
 
@@ -153,51 +168,59 @@ case "$COMMAND" in
     echo "Local subnet: $LOCAL_SUBNET"
     echo ""
 
-    # Verify iptables is available (Yocto images have no package manager)
-    if ! command -v iptables &>/dev/null; then
-      echo "Error: iptables not found. Cannot block WAN access without iptables." >&2
-      exit 1
+    # Install iptables + persistence on Debian; on Yocto it must be pre-installed
+    if [ "$POD_OS" = "debian" ]; then
+      if ! command -v "$IPTABLES" &>/dev/null || ! dpkg -l | grep -q iptables-persistent; then
+        echo "Installing iptables..."
+        apt-get update
+        apt-get install -y iptables iptables-persistent
+      fi
+    else
+      if ! command -v "$IPTABLES" &>/dev/null; then
+        echo "Error: iptables not found at $IPTABLES. Cannot block WAN access." >&2
+        exit 1
+      fi
     fi
 
     # Create custom chain for SleepyPod rules (IPv4)
-    iptables -N SLEEPYPOD-BLOCK 2>/dev/null || iptables -F SLEEPYPOD-BLOCK
-    iptables -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-    iptables -I OUTPUT -j SLEEPYPOD-BLOCK
+    "$IPTABLES" -N SLEEPYPOD-BLOCK 2>/dev/null || "$IPTABLES" -F SLEEPYPOD-BLOCK
+    "$IPTABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
+    "$IPTABLES" -I OUTPUT -j SLEEPYPOD-BLOCK
 
     # Allow loopback
-    iptables -A SLEEPYPOD-BLOCK -o lo -j ACCEPT
+    "$IPTABLES" -A SLEEPYPOD-BLOCK -o lo -j ACCEPT
 
     # Allow established/related connections
-    iptables -A SLEEPYPOD-BLOCK -m state --state ESTABLISHED,RELATED -j ACCEPT
+    "$IPTABLES" -A SLEEPYPOD-BLOCK -m state --state ESTABLISHED,RELATED -j ACCEPT
 
     # Allow local network
-    iptables -A SLEEPYPOD-BLOCK -d "$LOCAL_SUBNET" -j ACCEPT
+    "$IPTABLES" -A SLEEPYPOD-BLOCK -d "$LOCAL_SUBNET" -j ACCEPT
 
     # Allow mDNS for local discovery
-    iptables -A SLEEPYPOD-BLOCK -d 224.0.0.251/32 -p udp --dport 5353 -j ACCEPT
+    "$IPTABLES" -A SLEEPYPOD-BLOCK -d 224.0.0.251/32 -p udp --dport 5353 -j ACCEPT
 
     # Block all other outbound traffic
-    iptables -A SLEEPYPOD-BLOCK -j DROP
+    "$IPTABLES" -A SLEEPYPOD-BLOCK -j DROP
 
     # Save IPv4 rules
     mkdir -p /etc/iptables
-    iptables-save > /etc/iptables/rules.v4
+    "${IPTABLES}-save" > /etc/iptables/rules.v4
 
     # Block IPv6 as well (prevents bypass)
-    if command -v ip6tables &>/dev/null; then
+    if command -v "$IP6TABLES" &>/dev/null; then
       echo "Configuring IPv6 rules..."
 
-      ip6tables -N SLEEPYPOD-BLOCK 2>/dev/null || ip6tables -F SLEEPYPOD-BLOCK
-      ip6tables -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-      ip6tables -I OUTPUT -j SLEEPYPOD-BLOCK
+      "$IP6TABLES" -N SLEEPYPOD-BLOCK 2>/dev/null || "$IP6TABLES" -F SLEEPYPOD-BLOCK
+      "$IP6TABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
+      "$IP6TABLES" -I OUTPUT -j SLEEPYPOD-BLOCK
 
-      ip6tables -A SLEEPYPOD-BLOCK -o lo -j ACCEPT
-      ip6tables -A SLEEPYPOD-BLOCK -m state --state ESTABLISHED,RELATED -j ACCEPT
-      ip6tables -A SLEEPYPOD-BLOCK -d fe80::/10 -j ACCEPT
-      ip6tables -A SLEEPYPOD-BLOCK -j DROP
+      "$IP6TABLES" -A SLEEPYPOD-BLOCK -o lo -j ACCEPT
+      "$IP6TABLES" -A SLEEPYPOD-BLOCK -m state --state ESTABLISHED,RELATED -j ACCEPT
+      "$IP6TABLES" -A SLEEPYPOD-BLOCK -d fe80::/10 -j ACCEPT
+      "$IP6TABLES" -A SLEEPYPOD-BLOCK -j DROP
 
-      if command -v ip6tables-save &>/dev/null; then
-        ip6tables-save > /etc/iptables/rules.v6
+      if command -v "${IP6TABLES}-save" &>/dev/null; then
+        "${IP6TABLES}-save" > /etc/iptables/rules.v6
       fi
     fi
 
@@ -210,7 +233,7 @@ case "$COMMAND" in
     echo "  Layer 1: iptables DROP on all non-LAN outbound"
     echo "  Layer 2: /etc/hosts null routes for *.8slp.net"
     echo "  Local network ($LOCAL_SUBNET) is still accessible"
-    if command -v ip6tables &>/dev/null; then
+    if command -v "$IP6TABLES" &>/dev/null; then
       echo "  IPv6 is also blocked"
     fi
     echo ""
@@ -225,30 +248,30 @@ case "$COMMAND" in
     echo ""
 
     # Remove custom chains (IPv4)
-    if iptables -L SLEEPYPOD-BLOCK &>/dev/null; then
+    if "$IPTABLES" -L SLEEPYPOD-BLOCK &>/dev/null; then
       echo "Removing IPv4 firewall rules..."
-      iptables -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-      iptables -F SLEEPYPOD-BLOCK
-      iptables -X SLEEPYPOD-BLOCK
+      "$IPTABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
+      "$IPTABLES" -F SLEEPYPOD-BLOCK
+      "$IPTABLES" -X SLEEPYPOD-BLOCK
     fi
 
-    iptables -P OUTPUT ACCEPT
+    "$IPTABLES" -P OUTPUT ACCEPT
 
-    if command -v iptables-save &>/dev/null; then
+    if command -v "${IPTABLES}-save" &>/dev/null; then
       mkdir -p /etc/iptables
-      iptables-save > /etc/iptables/rules.v4
+      "${IPTABLES}-save" > /etc/iptables/rules.v4
     fi
 
     # Remove IPv6 rules
-    if command -v ip6tables &>/dev/null && ip6tables -L SLEEPYPOD-BLOCK &>/dev/null; then
+    if command -v "$IP6TABLES" &>/dev/null && "$IP6TABLES" -L SLEEPYPOD-BLOCK &>/dev/null; then
       echo "Removing IPv6 firewall rules..."
-      ip6tables -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-      ip6tables -F SLEEPYPOD-BLOCK
-      ip6tables -X SLEEPYPOD-BLOCK
-      ip6tables -P OUTPUT ACCEPT
+      "$IP6TABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
+      "$IP6TABLES" -F SLEEPYPOD-BLOCK
+      "$IP6TABLES" -X SLEEPYPOD-BLOCK
+      "$IP6TABLES" -P OUTPUT ACCEPT
 
-      if command -v ip6tables-save &>/dev/null; then
-        ip6tables-save > /etc/iptables/rules.v6
+      if command -v "${IP6TABLES}-save" &>/dev/null; then
+        "${IP6TABLES}-save" > /etc/iptables/rules.v6
       fi
     fi
 
@@ -292,11 +315,11 @@ case "$COMMAND" in
     echo ""
 
     # Layer 1: iptables — check both OUTPUT and SLEEPYPOD-BLOCK chains
-    if iptables -L SLEEPYPOD-BLOCK -n 2>/dev/null | grep -q "DROP"; then
-      DROP_STATS=$(iptables -L SLEEPYPOD-BLOCK -n -v 2>/dev/null | grep "DROP" | awk '{print $1 " packets, " $2}')
+    if "$IPTABLES" -L SLEEPYPOD-BLOCK -n 2>/dev/null | grep -q "DROP"; then
+      DROP_STATS=$("$IPTABLES" -L SLEEPYPOD-BLOCK -n -v 2>/dev/null | grep "DROP" | awk '{print $1 " packets, " $2}')
       echo "  Layer 1 (iptables):  ACTIVE — SLEEPYPOD-BLOCK chain ($DROP_STATS blocked)"
-    elif iptables -L OUTPUT -n 2>/dev/null | grep -q "DROP"; then
-      DROP_STATS=$(iptables -L OUTPUT -n -v 2>/dev/null | grep "DROP" | awk '{print $1 " packets, " $2}')
+    elif "$IPTABLES" -L OUTPUT -n 2>/dev/null | grep -q "DROP"; then
+      DROP_STATS=$("$IPTABLES" -L OUTPUT -n -v 2>/dev/null | grep "DROP" | awk '{print $1 " packets, " $2}')
       echo "  Layer 1 (iptables):  ACTIVE — DROP rule in OUTPUT ($DROP_STATS blocked)"
     else
       echo "  Layer 1 (iptables):  INACTIVE — no DROP rule found"

--- a/scripts/setup-python-venv
+++ b/scripts/setup-python-venv
@@ -5,6 +5,11 @@
 # Keeps a --without-pip fallback for safety, but the normal path should work
 # on all pod generations after patching.
 #
+# Per-pod behavior (see src/hardware/pods.ts for full capabilities manifest):
+#   Pod 3 (H00, Yocto, Python 3.9):  hasEnsurepip=false — uses Try 2 fallback
+#   Pod 4 (I00, Yocto, Python 3.10): hasEnsurepip=false — uses Try 2 fallback
+#   Pod 5 (J00, Debian, Python 3.10): hasEnsurepip=true  — uses Try 1 (normal)
+#
 # Usage: setup-python-venv <dest_dir>
 #   Creates <dest_dir>/venv with pip available.
 #   Exits 0 on success, 1 on failure.

--- a/src/hardware/iptablesCheck.ts
+++ b/src/hardware/iptablesCheck.ts
@@ -11,6 +11,8 @@
 
 import { execSync } from 'node:child_process'
 
+import { POD_CAPS } from './pods'
+
 export interface IptablesStatus {
   ok: boolean
   rules: IptablesRule[]
@@ -24,62 +26,91 @@ interface IptablesRule {
   critical: boolean
 }
 
-const REQUIRED_RULES: Array<{
-  name: string
-  chain: 'INPUT' | 'OUTPUT'
-  check: string // grep pattern to verify rule exists
-  repair: string // iptables command to add the rule
-  critical: boolean
-}> = [
-  {
-    name: 'mDNS outbound (UDP 5353)',
-    chain: 'OUTPUT',
-    check: 'udp dpt:5353',
-    repair: 'iptables -I OUTPUT 2 -p udp --dport 5353 -j ACCEPT',
-    critical: true,
-  },
-  {
-    name: 'mDNS inbound (UDP 5353)',
-    chain: 'INPUT',
-    check: 'udp dpt:5353',
-    repair: 'iptables -I INPUT 2 -p udp --dport 5353 -j ACCEPT',
-    critical: true,
-  },
-  {
-    name: 'mDNS outbound source (UDP 5353)',
-    chain: 'OUTPUT',
-    check: 'udp spt:5353',
-    repair: 'iptables -I OUTPUT 2 -p udp --sport 5353 -j ACCEPT',
-    critical: true,
-  },
-  {
-    name: 'LAN access (192.168.0.0/16)',
-    chain: 'INPUT',
-    check: '192.168.0.0/16',
-    repair: 'iptables -A INPUT -s 192.168.0.0/16 -j ACCEPT',
-    critical: true,
-  },
-  {
-    name: 'NTP outbound (UDP 123)',
-    chain: 'OUTPUT',
-    check: 'udp dpt:123',
-    repair: 'iptables -I OUTPUT 2 -p udp --dport 123 -j ACCEPT',
-    critical: true,
-  },
-]
+/** Known iptables paths from the pod capabilities manifest, used as fallbacks */
+const KNOWN_IPTABLES_PATHS = [...new Set(Object.values(POD_CAPS).map(c => c.iptablesPath))]
+
+/**
+ * Resolve the absolute path to the iptables binary.
+ * Tries `which iptables` first, then falls back to known paths from the manifest.
+ */
+function resolveIptablesPath(override?: string): string {
+  if (override) return override
+
+  try {
+    return execSync('which iptables 2>/dev/null', { encoding: 'utf-8', timeout: 3000 }).trim()
+  }
+  catch {
+    // `which` failed — try known paths
+  }
+
+  for (const candidate of KNOWN_IPTABLES_PATHS) {
+    try {
+      execSync(`test -x ${candidate}`, { timeout: 2000 })
+      return candidate
+    }
+    catch {
+      // not found at this path
+    }
+  }
+
+  // Fall back to bare name and let execSync resolve via PATH
+  return 'iptables'
+}
+
+function buildRequiredRules(iptables: string) {
+  return [
+    {
+      name: 'mDNS outbound (UDP 5353)',
+      chain: 'OUTPUT' as const,
+      check: 'udp dpt:5353',
+      repair: `${iptables} -I OUTPUT 2 -p udp --dport 5353 -j ACCEPT`,
+      critical: true,
+    },
+    {
+      name: 'mDNS inbound (UDP 5353)',
+      chain: 'INPUT' as const,
+      check: 'udp dpt:5353',
+      repair: `${iptables} -I INPUT 2 -p udp --dport 5353 -j ACCEPT`,
+      critical: true,
+    },
+    {
+      name: 'mDNS outbound source (UDP 5353)',
+      chain: 'OUTPUT' as const,
+      check: 'udp spt:5353',
+      repair: `${iptables} -I OUTPUT 2 -p udp --sport 5353 -j ACCEPT`,
+      critical: true,
+    },
+    {
+      name: 'LAN access (192.168.0.0/16)',
+      chain: 'INPUT' as const,
+      check: '192.168.0.0/16',
+      repair: `${iptables} -A INPUT -s 192.168.0.0/16 -j ACCEPT`,
+      critical: true,
+    },
+    {
+      name: 'NTP outbound (UDP 123)',
+      chain: 'OUTPUT' as const,
+      check: 'udp dpt:123',
+      repair: `${iptables} -I OUTPUT 2 -p udp --dport 123 -j ACCEPT`,
+      critical: true,
+    },
+  ]
+}
 
 /**
  * Check if all required iptables rules are present.
  * Returns status without modifying anything.
  */
-export function checkIptables(): IptablesStatus {
+export function checkIptables(iptablesPath?: string): IptablesStatus {
+  const iptables = resolveIptablesPath(iptablesPath)
+  const requiredRules = buildRequiredRules(iptables)
   const rules: IptablesRule[] = []
   let allOk = true
 
-  for (const rule of REQUIRED_RULES) {
+  for (const rule of requiredRules) {
     let present = false
     try {
-      const output = execSync(`iptables -L ${rule.chain} -n 2>/dev/null`, {
+      const output = execSync(`${iptables} -L ${rule.chain} -n 2>/dev/null`, {
         encoding: 'utf-8',
         timeout: 5000,
       })
@@ -121,13 +152,15 @@ export function checkIptables(): IptablesStatus {
  * Check and auto-repair missing iptables rules.
  * Returns list of rules that were repaired.
  */
-export function checkAndRepairIptables(): IptablesStatus {
-  const status = checkIptables()
+export function checkAndRepairIptables(iptablesPath?: string): IptablesStatus {
+  const iptables = resolveIptablesPath(iptablesPath)
+  const requiredRules = buildRequiredRules(iptables)
+  const status = checkIptables(iptables)
   const repaired: string[] = []
 
   for (const rule of status.rules) {
     if (!rule.present) {
-      const def = REQUIRED_RULES.find(r => r.name === rule.name)
+      const def = requiredRules.find(r => r.name === rule.name)
       if (!def) continue
 
       try {
@@ -142,9 +175,10 @@ export function checkAndRepairIptables(): IptablesStatus {
   }
 
   if (repaired.length > 0) {
-    // Persist the repaired rules
+    // Persist the repaired rules — derive iptables-save path from iptables path
+    const iptablesSave = iptables.replace(/iptables$/, 'iptables-save')
     try {
-      execSync('iptables-save > /etc/iptables/rules.v4', { encoding: 'utf-8', timeout: 5000 })
+      execSync(`${iptablesSave} > /etc/iptables/rules.v4`, { encoding: 'utf-8', timeout: 5000 })
       console.log(`[iptables] Saved ${repaired.length} repaired rules to rules.v4`)
     }
     catch {

--- a/src/hardware/pods.ts
+++ b/src/hardware/pods.ts
@@ -1,0 +1,66 @@
+import type { PodVersion } from './types'
+
+export interface PodCapabilities {
+  /** Human-readable model name */
+  modelName: string
+  /** Base OS type */
+  os: 'yocto' | 'debian'
+  /** Absolute path to iptables binary */
+  iptablesPath: string
+  /** Whether a system package manager is available */
+  hasPackageManager: boolean
+  /** Which package manager, if any */
+  packageManager?: 'apt'
+  /** Default Python version shipped with the image */
+  pythonVersion: string
+  /** Whether python3 -m ensurepip works reliably */
+  hasEnsurepip: boolean
+  /** Whether nftables is available (Debian pods) */
+  hasNftables: boolean
+  /** Path to DAC hardware socket */
+  dacSocketPath: string
+  /** Whether iptables-persistent is available for rule persistence */
+  hasIptablesPersistent: boolean
+}
+
+export const POD_CAPS: Record<PodVersion, PodCapabilities> = {
+  H00: {
+    modelName: 'Pod 3',
+    os: 'yocto',
+    iptablesPath: '/sbin/iptables',
+    hasPackageManager: false,
+    pythonVersion: '3.9',
+    hasEnsurepip: false,
+    hasNftables: false,
+    dacSocketPath: '/deviceinfo/dac.sock',
+    hasIptablesPersistent: false,
+  },
+  I00: {
+    modelName: 'Pod 4',
+    os: 'yocto',
+    iptablesPath: '/sbin/iptables',
+    hasPackageManager: false,
+    pythonVersion: '3.10',
+    hasEnsurepip: false,
+    hasNftables: false,
+    dacSocketPath: '/deviceinfo/dac.sock',
+    hasIptablesPersistent: false,
+  },
+  J00: {
+    modelName: 'Pod 5',
+    os: 'debian',
+    iptablesPath: '/usr/sbin/iptables',
+    hasPackageManager: true,
+    packageManager: 'apt',
+    pythonVersion: '3.10',
+    hasEnsurepip: true,
+    hasNftables: true,
+    dacSocketPath: '/persistent/deviceinfo/dac.sock',
+    hasIptablesPersistent: true,
+  },
+}
+
+/** Get capabilities for a specific pod version */
+export function getPodCapabilities(version: PodVersion): PodCapabilities {
+  return POD_CAPS[version]
+}

--- a/src/hardware/tests/pods.test.ts
+++ b/src/hardware/tests/pods.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { type PodCapabilities, POD_CAPS, getPodCapabilities } from '../pods'
+import { PodVersion } from '../types'
+
+describe('POD_CAPS manifest', () => {
+  const allVersions = Object.values(PodVersion)
+
+  it('has an entry for every PodVersion enum value', () => {
+    for (const version of allVersions) {
+      expect(POD_CAPS).toHaveProperty(version)
+    }
+  })
+
+  it('has no extra entries beyond PodVersion enum values', () => {
+    const manifestKeys = Object.keys(POD_CAPS)
+    expect(manifestKeys.sort()).toEqual([...allVersions].sort())
+  })
+
+  it('sets packageManager only when hasPackageManager is true', () => {
+    for (const [version, caps] of Object.entries(POD_CAPS) as Array<[PodVersion, PodCapabilities]>) {
+      if (caps.hasPackageManager) {
+        expect(caps.packageManager, `${version} has package manager but no packageManager field`).toBeDefined()
+      }
+      else {
+        expect(caps.packageManager, `${version} has no package manager but packageManager is set`).toBeUndefined()
+      }
+    }
+  })
+
+  it('Yocto pods lack ensurepip and package manager', () => {
+    for (const [, caps] of Object.entries(POD_CAPS) as Array<[PodVersion, PodCapabilities]>) {
+      if (caps.os === 'yocto') {
+        expect(caps.hasEnsurepip).toBe(false)
+        expect(caps.hasPackageManager).toBe(false)
+        expect(caps.hasIptablesPersistent).toBe(false)
+      }
+    }
+  })
+
+  it('Debian pods have ensurepip and package manager', () => {
+    for (const [, caps] of Object.entries(POD_CAPS) as Array<[PodVersion, PodCapabilities]>) {
+      if (caps.os === 'debian') {
+        expect(caps.hasEnsurepip).toBe(true)
+        expect(caps.hasPackageManager).toBe(true)
+      }
+    }
+  })
+})
+
+describe('getPodCapabilities', () => {
+  it('returns correct data for Pod 3', () => {
+    const caps = getPodCapabilities(PodVersion.POD_3)
+    expect(caps.modelName).toBe('Pod 3')
+    expect(caps.os).toBe('yocto')
+    expect(caps.iptablesPath).toBe('/sbin/iptables')
+  })
+
+  it('returns correct data for Pod 4', () => {
+    const caps = getPodCapabilities(PodVersion.POD_4)
+    expect(caps.modelName).toBe('Pod 4')
+    expect(caps.os).toBe('yocto')
+    expect(caps.pythonVersion).toBe('3.10')
+  })
+
+  it('returns correct data for Pod 5', () => {
+    const caps = getPodCapabilities(PodVersion.POD_5)
+    expect(caps.modelName).toBe('Pod 5')
+    expect(caps.os).toBe('debian')
+    expect(caps.iptablesPath).toBe('/usr/sbin/iptables')
+    expect(caps.hasNftables).toBe(true)
+    expect(caps.dacSocketPath).toBe('/persistent/deviceinfo/dac.sock')
+  })
+
+  it('returns the same object as POD_CAPS lookup', () => {
+    for (const version of Object.values(PodVersion)) {
+      expect(getPodCapabilities(version)).toBe(POD_CAPS[version])
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Added `src/hardware/pods.ts` with typed `PodCapabilities` interface and `POD_CAPS` map covering Pod 3/4/5 differences (OS type, iptables path, package manager, Python/ensurepip, DAC socket, nftables)
- Refactored `src/hardware/iptablesCheck.ts` to resolve iptables path from the manifest via `resolveIptablesPath()` — tries `which`, then falls back to known paths from `POD_CAPS`
- Refactored `scripts/internet-control` to detect Yocto vs Debian at runtime and use correct `$IPTABLES`/`$IP6TABLES` paths; skips apt on Yocto
- Updated `scripts/setup-python-venv` with per-pod documentation referencing the manifest as source of truth
- 9 new tests covering manifest completeness, type constraints, and `getPodCapabilities()`

Closes #353

## Test plan

- [x] `pnpm test run` — 294 passed, 0 failures
- [x] 9 new tests in `src/hardware/tests/pods.test.ts`
- [x] 5 existing iptablesCheck tests still pass with refactored path resolution
- [ ] Manual: verify `scripts/internet-control block` on Pod 4 (Yocto) uses `/sbin/iptables`
- [ ] Manual: verify `scripts/internet-control block` on Pod 5 (Debian) uses `/usr/sbin/iptables`

🤖 Generated with [Claude Code](https://claude.com/claude-code)