### PR TITLE
Wire ScheduleWeekOverview into schedule page and fix water level spacing

### DIFF
--- a/src/components/Schedule/SchedulePage.tsx
+++ b/src/components/Schedule/SchedulePage.tsx
@@ -11,6 +11,7 @@ import { TimePicker } from './TimePicker'
 import { ScheduleToggle } from './ScheduleToggle'
 import { SchedulerConfirmation } from './SchedulerConfirmation'
 import { ManualControlsSheet } from './ManualControlsSheet'
+import { ScheduleWeekOverview } from './ScheduleWeekOverview'
 import { trpc } from '@/src/utils/trpc'
 import {
   generateSleepCurve,
@@ -240,6 +241,12 @@ export function SchedulePage() {
         hasScheduleData={hasScheduleData}
         isApplying={isApplying}
         onApplyToOtherDays={targetDays => void applyToOtherDays(targetDays)}
+      />
+
+      {/* 6. Week Overview */}
+      <ScheduleWeekOverview
+        selectedDay={selectedDay}
+        onDayChange={setSelectedDay}
       />
 
     </div>

--- a/src/components/status/HealthCircle.tsx
+++ b/src/components/status/HealthCircle.tsx
@@ -171,6 +171,7 @@ export function HealthCircle({
                     <Droplet size={10} />
                     {' '}
                     Water
+                    {' '}
                     {waterLevel === 'ok' ? 'OK' : 'Low'}
                   </button>
                 )


### PR DESCRIPTION
## Summary

- Rendered the orphaned `ScheduleWeekOverview` component in `SchedulePage.tsx` — shows a week-at-a-glance summary of which days have schedules configured (returns null on clean installs with no schedules)
- Fixed "WaterOK" → "Water OK" spacing in `HealthCircle.tsx` status display

## Test plan

- [ ] Manual: create a schedule, verify Week Overview appears below manual controls
- [ ] Manual: with no schedules, verify Week Overview is hidden (clean install)
- [ ] Manual: check Status page shows "Water OK" with space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a week overview panel to the schedule page, enabling users to select and navigate between different days more efficiently. This new feature provides an intuitive interface for updating the active day in the schedule.

* **Style**
  * Improved spacing in the water status button text for better visual presentation and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->