### PR TITLE
feat: back up biometrics.db and add --restore flag #347

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -16,17 +16,81 @@ echo ""
 #   --local    Skip download (code already on disk, e.g. via scp/deploy)
 #   --no-ssh   Skip interactive SSH setup prompt
 #   --branch X Install a specific branch (default: main)
+#   --restore  List available DB backups and restore a selected one
 INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
+RESTORE_MODE=false
 while [ $# -gt 0 ]; do
   case "$1" in
-    --local)  INSTALL_LOCAL=true ;;
-    --no-ssh) SKIP_SSH=true ;;
-    --branch) shift; INSTALL_BRANCH="${1:-}" ;;
+    --local)   INSTALL_LOCAL=true ;;
+    --no-ssh)  SKIP_SSH=true ;;
+    --branch)  shift; INSTALL_BRANCH="${1:-}" ;;
+    --restore) RESTORE_MODE=true ;;
   esac
   shift
 done
+
+# --------------------------------------------------------------------------------
+# Restore mode — list and restore a DB backup, then exit
+if [ "$RESTORE_MODE" = true ]; then
+  DATA_DIR="/persistent/sleepypod-data"
+
+  # Collect all backup files for both databases
+  mapfile -t BACKUPS < <(ls -1t "$DATA_DIR"/*.db.bak.* 2>/dev/null)
+
+  if [ ${#BACKUPS[@]} -eq 0 ]; then
+    echo "No backups found in $DATA_DIR"
+    exit 0
+  fi
+
+  echo ""
+  echo "Available backups:"
+  echo ""
+  for i in "${!BACKUPS[@]}"; do
+    bak="${BACKUPS[$i]}"
+    fname="$(basename "$bak")"
+    # Extract epoch from filename (last dot-separated field)
+    epoch="${fname##*.bak.}"
+    ts="$(date -d "@$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -r "$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$epoch")"
+    size="$(du -h "$bak" | cut -f1)"
+    printf "  [%d] %s  (%s, %s)\n" "$((i + 1))" "$fname" "$ts" "$size"
+  done
+
+  echo ""
+  read -rp "Enter number to restore (or q to quit): " choice
+
+  if [ "$choice" = "q" ] || [ -z "$choice" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  idx=$((choice - 1))
+  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#BACKUPS[@]} ]; then
+    echo "Invalid selection." >&2
+    exit 1
+  fi
+
+  selected="${BACKUPS[$idx]}"
+  fname="$(basename "$selected")"
+
+  # Determine which database this backup belongs to
+  if [[ "$fname" == sleepypod.db.bak.* ]]; then
+    target="$DATA_DIR/sleepypod.db"
+  elif [[ "$fname" == biometrics.db.bak.* ]]; then
+    target="$DATA_DIR/biometrics.db"
+  else
+    echo "Unrecognized backup format: $fname" >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "Restoring $fname -> $(basename "$target")"
+  cp "$selected" "$target"
+  echo "Done. Restart the service to pick up the restored database:"
+  echo "  systemctl restart sleepypod"
+  exit 0
+fi
 
 # Cleanup handler — re-blocks WAN if we unblocked it
 WAN_WAS_BLOCKED=false
@@ -454,11 +518,24 @@ NODE_ENV=production
 EOF
 fi
 
-# Initialize database with migrations (not destructive push)
+# Back up existing databases before migrations
+BACKUP_TS="$(date +%s)"
 if [ -f "$DATA_DIR/sleepypod.db" ]; then
-  echo "Existing database found, backing up..."
-  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak.$(date +%s)"
+  echo "Existing config database found, backing up..."
+  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak.$BACKUP_TS"
 fi
+if [ -f "$DATA_DIR/biometrics.db" ]; then
+  echo "Existing biometrics database found, backing up..."
+  cp "$DATA_DIR/biometrics.db" "$DATA_DIR/biometrics.db.bak.$BACKUP_TS"
+fi
+
+# Prune old backups (keep last 5 per database)
+for db in sleepypod.db biometrics.db; do
+  mapfile -t old < <(ls -1t "$DATA_DIR/$db.bak."* 2>/dev/null | tail -n +6)
+  for f in "${old[@]}"; do
+    rm -f "$f"
+  done
+done
 
 # Database migrations run automatically on app startup (instrumentation.ts)
 echo "Database migrations will run on first startup."

--- a/scripts/install
+++ b/scripts/install
@@ -30,11 +30,13 @@ echo ""
 #   --artifact-url URL Pin to an exact CI build artifact (zip from GH Actions).
 #                      Posted on every PR comment so reviewers can install the
 #                      exact SHA the run built, not whatever's latest.
+#   --restore          List available DB backups and restore a selected one
 INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
+RESTORE_MODE=false
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;
@@ -42,9 +44,71 @@ while [ $# -gt 0 ]; do
     --branch)             shift; INSTALL_BRANCH="${1:-}" ;;
     --artifact-url)       shift; ARTIFACT_URL_OVERRIDE="${1:-}" ;;
     --purge-free-sleep)   PURGE_FREE_SLEEP=true ;;
+    --restore)            RESTORE_MODE=true ;;
   esac
   shift
 done
+
+# --------------------------------------------------------------------------------
+# Restore mode — list and restore a DB backup, then exit
+if [ "$RESTORE_MODE" = true ]; then
+  DATA_DIR="/persistent/sleepypod-data"
+
+  # Collect all backup files for both databases
+  mapfile -t BACKUPS < <(ls -1t "$DATA_DIR"/*.db.bak.* 2>/dev/null)
+
+  if [ ${#BACKUPS[@]} -eq 0 ]; then
+    echo "No backups found in $DATA_DIR"
+    exit 0
+  fi
+
+  echo ""
+  echo "Available backups:"
+  echo ""
+  for i in "${!BACKUPS[@]}"; do
+    bak="${BACKUPS[$i]}"
+    fname="$(basename "$bak")"
+    # Extract epoch from filename (last dot-separated field)
+    epoch="${fname##*.bak.}"
+    ts="$(date -d "@$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -r "$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$epoch")"
+    size="$(du -h "$bak" | cut -f1)"
+    printf "  [%d] %s  (%s, %s)\n" "$((i + 1))" "$fname" "$ts" "$size"
+  done
+
+  echo ""
+  read -rp "Enter number to restore (or q to quit): " choice
+
+  if [ "$choice" = "q" ] || [ -z "$choice" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  idx=$((choice - 1))
+  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#BACKUPS[@]} ]; then
+    echo "Invalid selection." >&2
+    exit 1
+  fi
+
+  selected="${BACKUPS[$idx]}"
+  fname="$(basename "$selected")"
+
+  # Determine which database this backup belongs to
+  if [[ "$fname" == sleepypod.db.bak.* ]]; then
+    target="$DATA_DIR/sleepypod.db"
+  elif [[ "$fname" == biometrics.db.bak.* ]]; then
+    target="$DATA_DIR/biometrics.db"
+  else
+    echo "Unrecognized backup format: $fname" >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "Restoring $fname -> $(basename "$target")"
+  cp "$selected" "$target"
+  echo "Done. Restart the service to pick up the restored database:"
+  echo "  systemctl restart sleepypod"
+  exit 0
+fi
 
 # Cleanup handler — re-blocks WAN if we unblocked it
 WAN_WAS_BLOCKED=false
@@ -1027,11 +1091,24 @@ if [ -f "$INSTALL_DIR/.env" ] && id sleepypod &>/dev/null; then
   chmod 640 "$INSTALL_DIR/.env"
 fi
 
-# Initialize database with migrations (not destructive push)
+# Back up existing databases before migrations
+BACKUP_TS="$(date +%s)"
 if [ -f "$DATA_DIR/sleepypod.db" ]; then
-  echo "Existing database found, backing up..."
-  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak.$(date +%s)"
+  echo "Existing config database found, backing up..."
+  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak.$BACKUP_TS"
 fi
+if [ -f "$DATA_DIR/biometrics.db" ]; then
+  echo "Existing biometrics database found, backing up..."
+  cp "$DATA_DIR/biometrics.db" "$DATA_DIR/biometrics.db.bak.$BACKUP_TS"
+fi
+
+# Prune old backups (keep last 5 per database)
+for db in sleepypod.db biometrics.db; do
+  mapfile -t old < <(ls -1t "$DATA_DIR/$db.bak."* 2>/dev/null | tail -n +6)
+  for f in "${old[@]}"; do
+    rm -f "$f"
+  done
+done
 
 # Database migrations run automatically on app startup (instrumentation.ts)
 echo "Database migrations will run on first startup."


### PR DESCRIPTION
## Summary
- Back up `biometrics.db` alongside `sleepypod.db` before migrations, using a shared timestamp so paired backups match
- Add `--restore` flag that lists available `.db.bak.*` files sorted newest-first with human-readable timestamps and sizes, lets the user pick one to restore
- Prune backups to keep only the 5 most recent per database

Closes #347

## Test plan
- [ ] Run `scripts/install --restore` with no backups present — should print "No backups found"
- [ ] Run a normal install with both DBs present — verify both get `.bak.<timestamp>` copies
- [ ] Create >5 backups for one DB — verify oldest are pruned
- [ ] Run `--restore`, pick a backup — verify the DB file is replaced
- [ ] Verify `bash -n scripts/install` passes (syntax check)

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/347-db-backup
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/347-db-backup/scripts/install \
  | sudo bash -s -- --branch fix/347-db-backup
```

🎯 **Pin to this exact build** ([run 26428008135](https://github.com/sleepypod/core/actions/runs/26428008135) · `b6dc0aa`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/b6dc0aabe87c94807d760d7bef910cda360183cf/scripts/install \
  | sudo bash -s -- \
      --branch fix/347-db-backup \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26428008135/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26428008135/artifacts/7207531557) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

