### PR TITLE
Redesign schedule page: read-only dashboard + per-day detail route

### DIFF
--- a/app/[lang]/schedule/[day]/page.tsx
+++ b/app/[lang]/schedule/[day]/page.tsx
@@ -1,0 +1,15 @@
+import { ScheduleDayDetail } from '@/src/components/Schedule/ScheduleDayDetail'
+import { DAYS } from '@/src/components/Schedule/DaySelector'
+
+export function generateStaticParams() {
+  return DAYS.map(d => ({ day: d.key }))
+}
+
+export default async function ScheduleDayPage({
+  params,
+}: {
+  params: Promise<{ day: string }>
+}) {
+  const { day } = await params
+  return <ScheduleDayDetail day={day} />
+}

--- a/src/components/Schedule/DaySummaryCard.tsx
+++ b/src/components/Schedule/DaySummaryCard.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { trpc } from '@/src/utils/trpc'
+import { useSide } from '@/src/hooks/useSide'
+import type { DayScheduleData } from '@/src/hooks/useSchedule'
+import { formatTime12h } from './TimeInput'
+import type { DayOfWeek } from './DaySelector'
+import { DAYS } from './DaySelector'
+import { Moon, Sun, Bell, Thermometer, ChevronRight } from 'lucide-react'
+
+interface DaySummaryCardProps {
+  day: DayOfWeek
+  onTap: () => void
+}
+
+export function DaySummaryCard({ day, onTap }: DaySummaryCardProps) {
+  const { side } = useSide()
+  const { data: rawData, isLoading } = trpc.schedules.getByDay.useQuery({ side, dayOfWeek: day })
+  const data = rawData as DayScheduleData | undefined
+
+  const dayLabel = DAYS.find(d => d.key === day)?.label ?? day
+
+  if (isLoading) {
+    return (
+      <div className="h-24 animate-pulse rounded-xl bg-zinc-900" />
+    )
+  }
+
+  const power = data?.power?.[0]
+  const temps = data?.temperature ?? []
+  const alarm = data?.alarm?.[0]
+
+  const hasAnySchedule = !!power || temps.length > 0 || !!alarm
+
+  if (!hasAnySchedule) {
+    return (
+      <button
+        type="button"
+        onClick={onTap}
+        className="flex w-full items-center justify-between rounded-xl bg-zinc-900 p-4 text-left transition-colors active:bg-zinc-800"
+      >
+        <div>
+          <div className="text-sm font-medium text-white">{dayLabel}</div>
+          <div className="mt-1 text-xs text-zinc-500">No schedule — tap to create</div>
+        </div>
+        <ChevronRight size={16} className="text-zinc-600" />
+      </button>
+    )
+  }
+
+  const tempValues = temps.map(t => t.temperature)
+  const minTemp = tempValues.length > 0 ? Math.min(...tempValues) : null
+  const maxTemp = tempValues.length > 0 ? Math.max(...tempValues) : null
+
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      className="flex w-full items-center justify-between rounded-xl bg-zinc-900 p-4 text-left transition-colors active:bg-zinc-800"
+    >
+      <div className="flex-1 space-y-2">
+        <div className="text-sm font-medium text-white">{dayLabel}</div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          {power && (
+            <>
+              <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+                <Moon size={12} className="text-purple-400" />
+                {formatTime12h(power.onTime)}
+              </div>
+              <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+                <Sun size={12} className="text-amber-400" />
+                {formatTime12h(power.offTime)}
+              </div>
+            </>
+          )}
+          {minTemp !== null && maxTemp !== null && (
+            <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+              <Thermometer size={12} className="text-sky-400" />
+              {minTemp}
+              –
+              {maxTemp}
+              °F
+            </div>
+          )}
+          {alarm && (
+            <div className="flex items-center gap-1.5 text-xs text-zinc-400">
+              <Bell size={12} className="text-emerald-400" />
+              {formatTime12h(alarm.time)}
+            </div>
+          )}
+        </div>
+      </div>
+      <ChevronRight size={16} className="text-zinc-600" />
+    </button>
+  )
+}

--- a/src/components/Schedule/ManualControlsSheet.tsx
+++ b/src/components/Schedule/ManualControlsSheet.tsx
@@ -1,3 +1,8 @@
+/**
+ * @deprecated Replaced by ScheduleDayDetail route (/schedule/[day]).
+ * Kept for reference — will be removed in a future cleanup.
+ */
+
 'use client'
 
 import { useEffect, useRef, useState } from 'react'

--- a/src/components/Schedule/ScheduleDayDetail.tsx
+++ b/src/components/Schedule/ScheduleDayDetail.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useMemo } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { trpc } from '@/src/utils/trpc'
+import { useSide } from '@/src/hooks/useSide'
+import { useSchedule } from '@/src/hooks/useSchedule'
+import { timeStringToMinutes } from '@/src/lib/sleepCurve/generate'
+import type { CurvePoint, Phase } from '@/src/lib/sleepCurve/types'
+import { DAYS, type DayOfWeek } from './DaySelector'
+import { CurvePresets } from './CurvePresets'
+import { CurveChart } from './CurveChart'
+import { PhaseLegend } from './PhaseLegend'
+import { TemperatureSetPoints } from './TemperatureSetPoints'
+import { PowerScheduleSection } from './PowerScheduleSection'
+import { AlarmScheduleSection } from './AlarmScheduleSection'
+import { ApplyToOtherDays } from './ApplyToOtherDays'
+import { SchedulerConfirmation } from './SchedulerConfirmation'
+
+interface ScheduleDayDetailProps {
+  day: string
+}
+
+export function ScheduleDayDetail({ day }: ScheduleDayDetailProps) {
+  const router = useRouter()
+  const { side } = useSide()
+
+  const validDay = DAYS.find(d => d.key === day)
+  const dayOfWeek = validDay?.key as DayOfWeek
+
+  const { data, isLoading } = trpc.schedules.getByDay.useQuery(
+    { side, dayOfWeek },
+    { enabled: !!validDay },
+  )
+
+  const utils = trpc.useUtils()
+
+  const {
+    selectedDays,
+    applyToOtherDays,
+    hasScheduleData,
+    isApplying,
+    confirmMessage,
+  } = useSchedule()
+
+  // Derive CurvePoint[] from temperature schedule data
+  const { curvePoints, bedtimeMinutes, minTempF, maxTempF } = useMemo(() => {
+    const temps = data?.temperature ?? []
+    const power = data?.power?.[0]
+    const bedtime = power?.onTime ?? '22:00'
+    const btMin = timeStringToMinutes(bedtime)
+
+    if (temps.length === 0) {
+      return { curvePoints: [] as CurvePoint[], bedtimeMinutes: btMin, minTempF: 68, maxTempF: 86 }
+    }
+
+    const sorted = [...temps]
+      .map((t) => {
+        let mfb = timeStringToMinutes(t.time) - btMin
+        if (mfb < -120) mfb += 24 * 60
+        return { ...t, minutesFromBedtime: mfb }
+      })
+      .sort((a, b) => a.minutesFromBedtime - b.minutesFromBedtime)
+
+    const tempValues = sorted.map(t => t.temperature)
+    const min = Math.min(...tempValues)
+    const max = Math.max(...tempValues)
+    const total = sorted.length
+
+    const points: CurvePoint[] = sorted.map((t, i) => {
+      const frac = total > 1 ? i / (total - 1) : 0
+      const phase: Phase = frac < 0.1
+        ? 'warmUp'
+        : frac < 0.25
+          ? 'coolDown'
+          : frac < 0.55
+            ? 'deepSleep'
+            : frac < 0.75
+              ? 'maintain'
+              : frac < 0.9
+                ? 'preWake'
+                : 'wake'
+
+      return {
+        minutesFromBedtime: t.minutesFromBedtime,
+        tempOffset: t.temperature - 80,
+        phase,
+      }
+    })
+
+    return { curvePoints: points, bedtimeMinutes: btMin, minTempF: min, maxTempF: max }
+  }, [data])
+
+  if (!validDay) {
+    return (
+      <div className="py-12 text-center text-sm text-zinc-500">
+        Invalid day.
+        {' '}
+        <button onClick={() => router.back()} className="text-sky-400 underline">Go back</button>
+      </div>
+    )
+  }
+
+  const dayLabel = DAYS.find(d => d.key === day)?.label ?? day
+
+  return (
+    <div className="space-y-3 sm:space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="flex items-center gap-1.5 text-sm text-sky-400 transition-colors active:text-sky-300"
+        >
+          <ArrowLeft size={16} />
+          Schedule
+        </button>
+      </div>
+
+      <h1 className="text-lg font-semibold text-white">{dayLabel}</h1>
+
+      {/* Curve Presets */}
+      <CurvePresets
+        side={side}
+        selectedDay={dayOfWeek}
+        selectedDays={new Set([dayOfWeek])}
+        onApplied={() => void utils.schedules.invalidate()}
+        onAICurveApplied={() => void utils.schedules.invalidate()}
+      />
+
+      {/* Curve Chart */}
+      {curvePoints.length > 0 && (
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-3">
+          <CurveChart
+            points={curvePoints}
+            bedtimeMinutes={bedtimeMinutes}
+            minTempF={minTempF}
+            maxTempF={maxTempF}
+          />
+          <div className="mt-2">
+            <PhaseLegend />
+          </div>
+        </div>
+      )}
+
+      {/* Temperature Set Points */}
+      <TemperatureSetPoints selectedDay={dayOfWeek} />
+
+      {/* Power Schedule */}
+      <PowerScheduleSection
+        schedules={data?.power ?? []}
+        selectedDay={dayOfWeek}
+        isLoading={isLoading}
+      />
+
+      {/* Alarm Schedule */}
+      <AlarmScheduleSection
+        schedules={data?.alarm ?? []}
+        selectedDay={dayOfWeek}
+        isLoading={isLoading}
+      />
+
+      {/* Apply to Other Days */}
+      <ApplyToOtherDays
+        sourceDay={dayOfWeek}
+        selectedDays={selectedDays}
+        onApply={targetDays => void applyToOtherDays(targetDays)}
+        isLoading={isApplying}
+        hasSchedule={hasScheduleData}
+      />
+
+      {/* Confirmation */}
+      <SchedulerConfirmation
+        message={confirmMessage}
+        isLoading={isApplying}
+        variant={confirmMessage?.includes('Failed') ? 'error' : 'success'}
+      />
+    </div>
+  )
+}

--- a/src/components/Schedule/SchedulePage.tsx
+++ b/src/components/Schedule/SchedulePage.tsx
@@ -1,247 +1,58 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
-import { Moon, Sun } from 'lucide-react'
 import { useSchedule } from '@/src/hooks/useSchedule'
 import { DaySelector } from './DaySelector'
-import { CurvePresets } from './CurvePresets'
-import { CurveChart } from './CurveChart'
-import { PhaseLegend } from './PhaseLegend'
-import { TimePicker } from './TimePicker'
+import { ScheduleWeekOverview } from './ScheduleWeekOverview'
+import { DaySummaryCard } from './DaySummaryCard'
 import { ScheduleToggle } from './ScheduleToggle'
 import { SchedulerConfirmation } from './SchedulerConfirmation'
-import { ManualControlsSheet } from './ManualControlsSheet'
-import { trpc } from '@/src/utils/trpc'
-import {
-  generateSleepCurve,
-  timeStringToMinutes,
-} from '@/src/lib/sleepCurve/generate'
-import type { CoolingIntensity, CurvePoint } from '@/src/lib/sleepCurve/types'
+import { useRouter, usePathname } from 'next/navigation'
 
-/**
- * Redesigned Schedule page layout:
- * 1. Day selector (multi-select for bulk ops)
- * 2. Curve presets (horizontal scroll: Hot Sleeper, Balanced, Cold Sleeper)
- * 3. Bedtime/wake time pickers + visual temperature curve chart
- * 4. Schedule enable/disable toggle
- * 5. Manual Controls button → opens bottom sheet
- * 6. Week overview summary
- */
 export function SchedulePage() {
+  const router = useRouter()
+  const pathname = usePathname()
   const {
-    side,
     selectedDay,
-    selectedDays,
     setSelectedDay,
-    setSelectedDays,
     confirmMessage,
-    isPowerEnabled,
-    hasScheduleData,
+    isGlobalEnabled,
     isApplying,
     isMutating,
-    toggleAllSchedules,
-    applyToOtherDays,
+    toggleGlobalSchedules,
     isLoading: hookLoading,
   } = useSchedule()
 
-  const { data, isLoading, error } = trpc.schedules.getAll.useQuery({ side })
-
-  // Curve state — updated when presets are applied or times change
-  const [bedtime, setBedtime] = useState('22:00')
-  const [wakeTime, setWakeTime] = useState('07:00')
-  const [intensity, setIntensity] = useState<CoolingIntensity>('balanced')
-  const [minTempF, setMinTempF] = useState(68)
-  const [maxTempF, setMaxTempF] = useState(86)
-
-  // Custom AI curve points override the generated curve
-  const [customPoints, setCustomPoints] = useState<CurvePoint[] | null>(null)
-
-  const bedtimeMinutes = useMemo(() => timeStringToMinutes(bedtime), [bedtime])
-  const wakeMinutes = useMemo(() => timeStringToMinutes(wakeTime), [wakeTime])
-
-  const generatedPoints: CurvePoint[] = useMemo(
-    () =>
-      generateSleepCurve({
-        bedtimeMinutes,
-        wakeMinutes,
-        intensity,
-        minTempF,
-        maxTempF,
-      }),
-    [bedtimeMinutes, wakeMinutes, intensity, minTempF, maxTempF],
-  )
-
-  // Use custom AI points if set, otherwise generated
-  const curvePoints = customPoints ?? generatedPoints
-
-  // When a preset is applied, sync curve display state
-  const handlePresetApplied = useCallback(
-    (config: {
-      points: CurvePoint[]
-      bedtimeMinutes: number
-      minTempF: number
-      maxTempF: number
-      intensity: CoolingIntensity
-      bedtime: string
-      wakeTime: string
-    }) => {
-      setBedtime(config.bedtime)
-      setWakeTime(config.wakeTime)
-      setMinTempF(config.minTempF)
-      setMaxTempF(config.maxTempF)
-      setIntensity(config.intensity)
-      setCustomPoints(null) // Clear AI curve, back to generated
-    },
-    [],
-  )
-
-  // When AI curve is applied, convert set points to CurvePoints for chart
-  const handleAICurveApplied = useCallback(
-    (config: {
-      setPoints: Array<{ time: string, tempF: number }>
-      bedtime: string
-      wakeTime: string
-    }) => {
-      const btMin = timeStringToMinutes(config.bedtime)
-      const temps = config.setPoints.map(p => p.tempF)
-      const min = Math.min(...temps)
-      const max = Math.max(...temps)
-
-      setBedtime(config.bedtime)
-      setWakeTime(config.wakeTime)
-      setMinTempF(min)
-      setMaxTempF(max)
-
-      // Compute minutesFromBedtime, then sort by that (not by time string — overnight wraps)
-      const withRelative = config.setPoints.map((p) => {
-        let tMin = timeStringToMinutes(p.time) - btMin
-        if (tMin < -120) tMin += 24 * 60
-        return { ...p, minutesFromBedtime: tMin }
-      }).sort((a, b) => a.minutesFromBedtime - b.minutesFromBedtime)
-
-      const totalMin = withRelative.length
-      const points: CurvePoint[] = withRelative.map((p, i) => {
-        const frac = i / (totalMin - 1)
-        const phase = frac < 0.1
-          ? 'warmUp' as const
-          : frac < 0.25
-            ? 'coolDown' as const
-            : frac < 0.55
-              ? 'deepSleep' as const
-              : frac < 0.75
-                ? 'maintain' as const
-                : frac < 0.9
-                  ? 'preWake' as const
-                  : 'wake' as const
-
-        return {
-          minutesFromBedtime: p.minutesFromBedtime,
-          tempOffset: p.tempF - 80,
-          phase,
-        }
-      })
-
-      setCustomPoints(points)
-    },
-    [],
-  )
+  // Extract lang from pathname for navigation
+  const lang = pathname.split('/')[1] || 'en'
 
   return (
     <div className="space-y-3 sm:space-y-4">
-      {/* 1. Day Selector */}
       <DaySelector
         activeDay={selectedDay}
         onActiveDayChange={setSelectedDay}
-        selectedDays={selectedDays}
-        onSelectedDaysChange={setSelectedDays}
       />
 
-      {/* Multi-day info banner */}
-      {selectedDays.size > 1 && (
-        <div className="rounded-lg bg-sky-500/10 px-3 py-2 text-xs text-sky-400">
-          {selectedDays.size}
-          {' '}
-          days selected — changes affect all selected days
-        </div>
-      )}
-
-      {/* 2. Curve Presets */}
-      <CurvePresets
-        side={side}
+      <ScheduleWeekOverview
         selectedDay={selectedDay}
-        selectedDays={selectedDays}
-        onApplied={handlePresetApplied}
-        onAICurveApplied={handleAICurveApplied}
+        onDayChange={setSelectedDay}
       />
 
-      {/* 3. Time Pickers + Curve Chart */}
-      <div className="space-y-3">
-        <div className="flex gap-4">
-          <TimePicker
-            label="Bedtime"
-            icon={<Moon size={14} />}
-            accentClass="text-purple-400"
-            value={bedtime}
-            onChange={setBedtime}
-          />
-          <TimePicker
-            label="Wake Up"
-            icon={<Sun size={14} />}
-            accentClass="text-amber-400"
-            value={wakeTime}
-            onChange={setWakeTime}
-          />
-        </div>
+      <DaySummaryCard
+        day={selectedDay}
+        onTap={() => router.push(`/${lang}/schedule/${selectedDay}`)}
+      />
 
-        <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-3">
-          <CurveChart
-            points={curvePoints}
-            bedtimeMinutes={bedtimeMinutes}
-            minTempF={minTempF}
-            maxTempF={maxTempF}
-          />
-          <div className="mt-2">
-            <PhaseLegend />
-          </div>
-        </div>
-      </div>
-
-      {/* 4. Schedule Toggle */}
       <ScheduleToggle
-        enabled={isPowerEnabled}
-        onToggle={() => void toggleAllSchedules()}
-        affectedDayCount={selectedDays.size}
+        enabled={isGlobalEnabled}
+        onToggle={() => void toggleGlobalSchedules()}
         isLoading={isMutating || hookLoading}
       />
 
-      {/* Confirmation banner */}
       <SchedulerConfirmation
         message={confirmMessage}
         isLoading={isApplying}
         variant={confirmMessage?.includes('Failed') ? 'error' : 'success'}
       />
-
-      {/* Error state */}
-      {error && (
-        <div className="rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-400">
-          Failed to load schedules:
-          {' '}
-          {error.message}
-        </div>
-      )}
-
-      {/* 5. Manual Controls → Bottom Sheet */}
-      <ManualControlsSheet
-        selectedDay={selectedDay}
-        selectedDays={selectedDays}
-        powerSchedules={data?.power ?? []}
-        alarmSchedules={data?.alarm ?? []}
-        isLoading={isLoading}
-        hasScheduleData={hasScheduleData}
-        isApplying={isApplying}
-        onApplyToOtherDays={targetDays => void applyToOtherDays(targetDays)}
-      />
-
     </div>
   )
 }

--- a/src/components/Schedule/ScheduleToggle.tsx
+++ b/src/components/Schedule/ScheduleToggle.tsx
@@ -7,21 +7,17 @@ interface ScheduleToggleProps {
   enabled: boolean
   /** Called when user toggles the switch */
   onToggle: () => void
-  /** Number of days affected by this toggle */
-  affectedDayCount: number
   /** Whether a mutation is in-flight */
   isLoading?: boolean
 }
 
 /**
  * Schedule enable/disable toggle card.
- * Shows "Schedule Active" with a toggle switch.
- * When multiple days are selected, shows how many days will be affected.
+ * Shows "Schedule Active" with a toggle switch for all days.
  */
 export function ScheduleToggle({
   enabled,
   onToggle,
-  affectedDayCount,
   isLoading = false,
 }: ScheduleToggleProps) {
   return (
@@ -32,9 +28,7 @@ export function ScheduleToggle({
             Schedule Active
           </span>
           <span className="text-xs text-zinc-400">
-            {affectedDayCount > 1
-              ? `Applies to ${affectedDayCount} selected days`
-              : 'Automatically adjust temperature'}
+            All days
           </span>
         </div>
 

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -124,6 +124,21 @@ export function useSchedule() {
     return daySchedule.power.some((p: PowerSchedule) => p.enabled)
   }, [daySchedule])
 
+  // Check if ANY day has enabled schedules (global view)
+  const isGlobalEnabled = useMemo(() => {
+    const allData = allSchedulesQuery.data as {
+      temperature: TemperatureSchedule[]
+      power: PowerSchedule[]
+      alarm: AlarmSchedule[]
+    } | undefined
+    if (!allData) return false
+    return (
+      allData.power.some(p => p.enabled)
+      || allData.temperature.some(t => t.enabled)
+      || allData.alarm.some(a => a.enabled)
+    )
+  }, [allSchedulesQuery.data])
+
   // Check if this day has any schedule data
   const hasScheduleData = useMemo(() => {
     if (!daySchedule) return false
@@ -250,6 +265,46 @@ export function useSchedule() {
   }, [allSchedulesQuery.data, isPowerEnabled, selectedDays, side, batchUpdate])
 
   /**
+   * Toggle ALL schedule types across ALL 7 days globally.
+   * Uses isGlobalEnabled to determine new state.
+   */
+  const toggleGlobalSchedules = useCallback(async () => {
+    if (!allSchedulesQuery.data) return
+
+    const allData = allSchedulesQuery.data as {
+      temperature: TemperatureSchedule[]
+      power: PowerSchedule[]
+      alarm: AlarmSchedule[]
+    }
+    const newEnabled = !isGlobalEnabled
+
+    const tempUpdates: Array<{ id: number, enabled: boolean }> = []
+    const powerUpdates: Array<{ id: number, enabled: boolean }> = []
+    const alarmUpdates: Array<{ id: number, enabled: boolean }> = []
+
+    for (const ts of allData.temperature) {
+      tempUpdates.push({ id: ts.id, enabled: newEnabled })
+    }
+    for (const ps of allData.power) {
+      powerUpdates.push({ id: ps.id, enabled: newEnabled })
+    }
+    for (const as_ of allData.alarm) {
+      alarmUpdates.push({ id: as_.id, enabled: newEnabled })
+    }
+
+    if (tempUpdates.length > 0 || powerUpdates.length > 0 || alarmUpdates.length > 0) {
+      await batchUpdate.mutateAsync({
+        updates: { temperature: tempUpdates, power: powerUpdates, alarm: alarmUpdates },
+      })
+    }
+
+    setConfirmMessage(
+      `All schedules ${newEnabled ? 'enabled' : 'disabled'}`
+    )
+    confirmTimerRef.current = setTimeout(() => setConfirmMessage(null), 3000)
+  }, [allSchedulesQuery.data, isGlobalEnabled, batchUpdate])
+
+  /**
    * Apply the source day's schedule to target days.
    * Uses the iOS pattern: delete all existing schedules for target days,
    * then recreate from source day's data.
@@ -371,6 +426,7 @@ export function useSchedule() {
     | { temperature: TemperatureSchedule[], power: PowerSchedule[], alarm: AlarmSchedule[] }
     | undefined,
     isPowerEnabled,
+    isGlobalEnabled,
     hasScheduleData,
 
     // Loading states
@@ -391,6 +447,7 @@ export function useSchedule() {
     // Actions
     togglePowerSchedule,
     toggleAllSchedules,
+    toggleGlobalSchedules,
     applyToOtherDays,
 
     // Refetch


### PR DESCRIPTION
## Summary

- Split schedule page into two views: read-only dashboard (`/schedule`) and per-day editor (`/schedule/[day]`)
- Main page shows: DaySelector (single-select), ScheduleWeekOverview, DaySummaryCard (read-only summary with bedtime/wake/temps/alarm), global ScheduleToggle
- Detail route shows: CurvePresets, CurveChart (derived from actual data), TemperatureSetPoints, PowerScheduleSection, AlarmScheduleSection, ApplyToOtherDays
- Global toggle now operates on all 7 days via `batchUpdate` instead of only selected days
- Added `isGlobalEnabled` and `toggleGlobalSchedules` to `useSchedule` hook
- Deprecated ManualControlsSheet (replaced by ScheduleDayDetail route)

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `pnpm test run` — 303 passed, 0 failures
- [ ] Manual: `/schedule` shows read-only dashboard, tapping summary card navigates to `/schedule/monday` etc.
- [ ] Manual: Detail view shows all editing controls, curve chart reflects actual set point data
- [ ] Manual: Global toggle enables/disables all days in one call
- [ ] Manual: Back navigation from detail view returns to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added day-by-day schedule pages with detailed editing interface
  * Added week overview with daily schedule summary cards
  * Introduced global schedule toggle control

* **Changes**
  * Reorganized schedule management interface with improved navigation
  * Deprecated manual controls component in favor of day detail pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->