### PR TITLE
Fix build: inline generateStaticParams for schedule day route

### DIFF
--- a/app/[lang]/schedule/[day]/page.tsx
+++ b/app/[lang]/schedule/[day]/page.tsx
@@ -1,8 +1,15 @@
 import { ScheduleDayDetail } from '@/src/components/Schedule/ScheduleDayDetail'
-import { DAYS } from '@/src/components/Schedule/DaySelector'
 
 export function generateStaticParams() {
-  return DAYS.map(d => ({ day: d.key }))
+  return [
+    { day: 'sunday' },
+    { day: 'monday' },
+    { day: 'tuesday' },
+    { day: 'wednesday' },
+    { day: 'thursday' },
+    { day: 'friday' },
+    { day: 'saturday' },
+  ]
 }
 
 export default async function ScheduleDayPage({


### PR DESCRIPTION
DAYS import from a 'use client' module isn't available in server context during Next.js static page collection. Inlines the 7 day keys directly.