### PR TITLE
fix: update channel picker and stale git-info on OTA #362

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -196,7 +196,10 @@ if pnpm install --frozen-lockfile --prod; then
   if [ ! -d "$INSTALL_DIR/.next" ]; then
     echo "No pre-built .next found, building..."
     pnpm install --frozen-lockfile
-    pnpm build
+    SP_BRANCH="$BRANCH" pnpm build
+  else
+    # Regenerate .git-info with the correct branch for pre-built releases
+    SP_BRANCH="$BRANCH" node scripts/generate-git-info.mjs 2>/dev/null || true
   fi
 
   # Sync biometrics modules

--- a/scripts/generate-git-info.mjs
+++ b/scripts/generate-git-info.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process'
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 
 const run = (cmd) => {
   try {
@@ -14,12 +14,25 @@ const run = (cmd) => {
 const branch = process.env.SP_BRANCH || run('git rev-parse --abbrev-ref HEAD')
 
 try {
-  writeFileSync('.git-info', JSON.stringify({
-    branch,
-    commitHash: run('git rev-parse --short HEAD'),
-    commitTitle: run('git log -1 --format=%s'),
-    buildDate: new Date().toISOString(),
-  }))
+  // If SP_BRANCH is set and a .git-info already exists (e.g. from CI build),
+  // patch the branch in-place to preserve the correct commitHash/commitTitle.
+  if (process.env.SP_BRANCH) {
+    let existing = {}
+    try { existing = JSON.parse(readFileSync('.git-info', 'utf-8')) } catch {}
+    writeFileSync('.git-info', JSON.stringify({
+      ...existing,
+      branch,
+      buildDate: new Date().toISOString(),
+    }))
+  }
+  else {
+    writeFileSync('.git-info', JSON.stringify({
+      branch,
+      commitHash: run('git rev-parse --short HEAD'),
+      commitTitle: run('git log -1 --format=%s'),
+      buildDate: new Date().toISOString(),
+    }))
+  }
   console.log('Generated .git-info')
 }
 catch (err) {

--- a/scripts/generate-git-info.mjs
+++ b/scripts/generate-git-info.mjs
@@ -11,9 +11,11 @@ const run = (cmd) => {
   }
 }
 
+const branch = process.env.SP_BRANCH || run('git rev-parse --abbrev-ref HEAD')
+
 try {
   writeFileSync('.git-info', JSON.stringify({
-    branch: run('git rev-parse --abbrev-ref HEAD'),
+    branch,
     commitHash: run('git rev-parse --short HEAD'),
     commitTitle: run('git log -1 --format=%s'),
     buildDate: new Date().toISOString(),

--- a/scripts/generate-git-info.mjs
+++ b/scripts/generate-git-info.mjs
@@ -20,8 +20,9 @@ try {
     let existing = {}
     try { existing = JSON.parse(readFileSync('.git-info', 'utf-8')) } catch {}
     writeFileSync('.git-info', JSON.stringify({
-      ...existing,
       branch,
+      commitHash: existing.commitHash || run('git rev-parse --short HEAD'),
+      commitTitle: existing.commitTitle || run('git log -1 --format=%s'),
       buildDate: new Date().toISOString(),
     }))
   }

--- a/scripts/install
+++ b/scripts/install
@@ -416,13 +416,17 @@ if [ ! -f "$INSTALL_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3
 fi
 
 # Build application (skip if .next already exists — pre-built by deploy script or CI)
+# Effective branch: --branch flag, download branch, or script default
+EFFECTIVE_BRANCH="${INSTALL_BRANCH:-${DOWNLOAD_BRANCH:-$SCRIPT_DEFAULT_BRANCH}}"
 if [ -d "$INSTALL_DIR/.next" ]; then
   echo "Pre-built .next found, skipping build."
+  # Regenerate .git-info with the correct branch (CI builds may have a different branch baked in)
+  SP_BRANCH="$EFFECTIVE_BRANCH" node scripts/generate-git-info.mjs 2>/dev/null || true
 else
   echo "No pre-built .next found, building from source..."
   echo "Installing all dependencies (including devDependencies for build)..."
   pnpm install --frozen-lockfile
-  pnpm build
+  SP_BRANCH="$EFFECTIVE_BRANCH" pnpm build
 fi
 
 # Turbopack hashes the better-sqlite3 module name — create a symlink so the

--- a/src/components/status/UpdateCard.tsx
+++ b/src/components/status/UpdateCard.tsx
@@ -71,6 +71,8 @@ export function UpdateCard() {
 
   const handleUpdate = async () => {
     if (updateState === 'idle') {
+      // No version data yet — do nothing
+      if (!versionData) return
       // Non-standard branch → let user pick main or dev first
       if (!isStandardBranch) {
         setUpdateState('branch-picker')
@@ -239,7 +241,7 @@ export function UpdateCard() {
       {updateState === 'branch-picker' && (
         <div className="mb-3">
           <p className="mb-2 text-xs text-amber-400">
-            Current branch ({versionData?.branch}) is not a release channel. Pick a channel to update to:
+            {`Current branch (${versionData?.branch}) is not a release channel. Pick a channel to update to:`}
           </p>
           <div className="flex gap-2">
             <button

--- a/src/components/status/UpdateCard.tsx
+++ b/src/components/status/UpdateCard.tsx
@@ -27,8 +27,9 @@ export function UpdateCard() {
   const setInternetAccess = trpc.system.setInternetAccess.useMutation()
 
   const [updateState, setUpdateState] = useState<
-    'idle' | 'confirming' | 'internet-prompt' | 'unblocking' | 'updating' | 'reconnecting' | 'error'
+    'idle' | 'confirming' | 'branch-picker' | 'internet-prompt' | 'unblocking' | 'updating' | 'reconnecting' | 'error'
   >('idle')
+  const [selectedBranch, setSelectedBranch] = useState<string | undefined>(undefined)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   /** Tracks whether we temporarily unblocked internet and need to re-block */
   const didUnblockRef = useRef(false)
@@ -50,6 +51,7 @@ export function UpdateCard() {
   }, [])
 
   const versionData = version.data
+  const isStandardBranch = versionData?.branch === 'main' || versionData?.branch === 'dev'
 
   /**
    * Re-block internet if we temporarily unblocked it.
@@ -69,6 +71,11 @@ export function UpdateCard() {
 
   const handleUpdate = async () => {
     if (updateState === 'idle') {
+      // Non-standard branch → let user pick main or dev first
+      if (!isStandardBranch) {
+        setUpdateState('branch-picker')
+        return
+      }
       setUpdateState('confirming')
       return
     }
@@ -92,6 +99,11 @@ export function UpdateCard() {
     }
   }
 
+  const handleBranchSelected = (branch: string) => {
+    setSelectedBranch(branch)
+    setUpdateState('confirming')
+  }
+
   /** Unblock internet then proceed with the update */
   const handleAllowInternet = async () => {
     setUpdateState('unblocking')
@@ -113,10 +125,11 @@ export function UpdateCard() {
   const startUpdate = async () => {
     setUpdateState('updating')
 
+    const branch = selectedBranch
+      ?? (versionData?.branch !== 'unknown' ? versionData?.branch : undefined)
+
     try {
-      await triggerUpdate.mutateAsync({
-        branch: versionData?.branch !== 'unknown' ? versionData?.branch : undefined,
-      })
+      await triggerUpdate.mutateAsync({ branch })
       setUpdateState('reconnecting')
       pollForReconnection()
     }
@@ -159,6 +172,7 @@ export function UpdateCard() {
 
   const handleCancel = () => {
     setUpdateState('idle')
+    setSelectedBranch(undefined)
     setErrorMessage(null)
   }
 
@@ -166,7 +180,7 @@ export function UpdateCard() {
     <div className="rounded-2xl bg-zinc-900/80 p-3 sm:p-4">
       {/* Header */}
       <div className="mb-2 flex items-center gap-2 sm:mb-3">
-        {updateState === 'idle' || updateState === 'confirming' || updateState === 'internet-prompt'
+        {updateState === 'idle' || updateState === 'confirming' || updateState === 'branch-picker' || updateState === 'internet-prompt'
           ? (
               <>
                 <CheckCircle size={16} className="text-emerald-400" />
@@ -221,10 +235,41 @@ export function UpdateCard() {
         <p className="mb-3 text-xs text-red-400">{errorMessage}</p>
       )}
 
+      {/* Branch picker for non-standard branches */}
+      {updateState === 'branch-picker' && (
+        <div className="mb-3">
+          <p className="mb-2 text-xs text-amber-400">
+            Current branch ({versionData?.branch}) is not a release channel. Pick a channel to update to:
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => handleBranchSelected('main')}
+              className="flex-1 rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-emerald-400 transition-colors active:bg-zinc-700"
+            >
+              main
+            </button>
+            <button
+              onClick={() => handleBranchSelected('dev')}
+              className="flex-1 rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-sky-400 transition-colors active:bg-zinc-700"
+            >
+              dev
+            </button>
+            <button
+              onClick={handleCancel}
+              className="rounded-lg border border-zinc-800 px-4 py-2.5 text-xs font-medium text-zinc-400 transition-colors active:bg-zinc-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Confirmation prompt */}
       {updateState === 'confirming' && (
         <p className="mb-3 text-xs text-amber-400">
-          This will download the latest code, rebuild, and restart the service. The pod will be briefly unavailable.
+          {selectedBranch
+            ? `This will switch to ${selectedBranch}, rebuild, and restart the service. The pod will be briefly unavailable.`
+            : 'This will download the latest code, rebuild, and restart the service. The pod will be briefly unavailable.'}
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- **Branch picker UI**: When the pod is on a non-standard branch (not `main`/`dev`), the "Check for Updates" button shows a channel picker instead of immediately triggering. On `main`/`dev` the existing flow is unchanged.
- **Stale `.git-info` fix**: `generate-git-info.mjs` now accepts `SP_BRANCH` env var. Both `sp-update` and `scripts/install` pass the target branch through so OTA updates report the correct branch. When `SP_BRANCH` is set, the script patches `.git-info` in-place to preserve CI-baked `commitHash`/`commitTitle`.
- **Edge case guard**: Branch picker is guarded against missing version data (query failure no longer shows "Current branch (undefined)").

Closes #362

## Test plan
- [ ] Deploy a feature branch via `scripts/deploy`, verify status page shows branch picker with `main`/`dev` options
- [ ] On `main` or `dev`, verify update button goes directly to confirmation (no picker)
- [ ] Trigger OTA update to `dev` via UI — verify `.git-info` shows correct branch after restart
- [ ] Kill the backend while on status page — verify "Check for Updates" doesn't crash into branch picker with undefined branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added branch selection interface when updating from non-standard branches.

* **Bug Fixes**
  * Ensured correct branch metadata is preserved during builds and installations.
  * Fixed branch information handling for pre-built releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->