### PR TITLE
Silence TS baseUrl deprecation for TS 5.9+

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://www.schemastore.org/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@/*": [
         "./*"


### PR DESCRIPTION
baseUrl is deprecated in TS 7.0 but can't be removed yet (bare imports like lingui.config depend on it). Add ignoreDeprecations to unblock CI pre-push hook.