### PR TITLE
Hoist better-sqlite3 to fix cross-platform deploy

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,14 +34,10 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Prune to production dependencies
-        run: |
-          pnpm install --frozen-lockfile --prod
-          pnpm store prune
-
       - name: Create deploy tarball
         run: |
           tar czf /tmp/sleepypod-core.tar.gz \
+            --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.env*' \
             --exclude='*.db' \

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=better-sqlite3

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -189,14 +189,10 @@ echo "Source updated."
 
 cd "$INSTALL_DIR"
 
-# Install prod deps only if node_modules wasn't included in the tarball
-# CI tarballs ship node_modules to avoid native module hash mismatches on arm64
-if [ -d "$INSTALL_DIR/node_modules/next" ]; then
-  echo "node_modules included in tarball, skipping install."
-else
-  echo "Installing production dependencies..."
-  pnpm install --frozen-lockfile --prod
-fi
+# Install production dependencies
+# better-sqlite3 is hoisted via .npmrc so the resolution path is stable
+# across CI (x86_64) and pod (arm64) — pnpm rebuilds the native addon
+pnpm install --frozen-lockfile --prod
 
 # Build only if no pre-built .next exists
 if [ ! -d "$INSTALL_DIR/.next" ]; then


### PR DESCRIPTION
## Problem

CI builds .next on x86_64 and tarballs it. Pod (arm64) runs `pnpm install --prod` which creates different pnpm virtual store hashes. The .next build references `better-sqlite3-{ci_hash}` but the pod has `better-sqlite3-{pod_hash}` → module-not-found at runtime.

Shipping all of node_modules in the tarball (213MB) filled the pod's disk.

## Fix

- Add `.npmrc` with `public-hoist-pattern[]=better-sqlite3` so it resolves at `node_modules/better-sqlite3/` (stable path, no hash)
- Revert tarball to exclude node_modules (back to ~15MB)
- `sp-update` always runs `pnpm install --prod` on pod

## Test plan

- [ ] CI dev-release succeeds
- [ ] `sp-update dev` on pod → service starts, /en/status returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)