### PR TITLE
Hoist better-sqlite3 + dynamic schedule routes to fix deploy

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,14 +34,10 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Prune to production dependencies
-        run: |
-          pnpm install --frozen-lockfile --prod
-          pnpm store prune
-
       - name: Create deploy tarball
         run: |
           tar czf /tmp/sleepypod-core.tar.gz \
+            --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.env*' \
             --exclude='*.db' \

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=better-sqlite3

--- a/app/[lang]/schedule/[day]/page.tsx
+++ b/app/[lang]/schedule/[day]/page.tsx
@@ -1,16 +1,7 @@
 import { ScheduleDayDetail } from '@/src/components/Schedule/ScheduleDayDetail'
 
-export function generateStaticParams() {
-  return [
-    { day: 'sunday' },
-    { day: 'monday' },
-    { day: 'tuesday' },
-    { day: 'wednesday' },
-    { day: 'thursday' },
-    { day: 'friday' },
-    { day: 'saturday' },
-  ]
-}
+export const dynamic = 'force-dynamic'
+export const dynamicParams = true
 
 export default async function ScheduleDayPage({
   params,

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -189,14 +189,10 @@ echo "Source updated."
 
 cd "$INSTALL_DIR"
 
-# Install prod deps only if node_modules wasn't included in the tarball
-# CI tarballs ship node_modules to avoid native module hash mismatches on arm64
-if [ -d "$INSTALL_DIR/node_modules/next" ]; then
-  echo "node_modules included in tarball, skipping install."
-else
-  echo "Installing production dependencies..."
-  pnpm install --frozen-lockfile --prod
-fi
+# Install production dependencies
+# better-sqlite3 is hoisted via .npmrc so the resolution path is stable
+# across CI (x86_64) and pod (arm64) — pnpm rebuilds the native addon
+pnpm install --frozen-lockfile --prod
 
 # Build only if no pre-built .next exists
 if [ ! -d "$INSTALL_DIR/.next" ]; then


### PR DESCRIPTION
Hoists better-sqlite3 via .npmrc for stable cross-platform resolution. Makes schedule/[day] route dynamic (no generateStaticParams) to eliminate 7×2 pre-rendered pages that bloated .next and filled pod disk.