### PR TITLE
Add boot-time maintenance script for disk housekeeping

### DIFF
--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# sp-maintenance — housekeeping tasks run on every boot
+#
+# Called by sleepypod.service ExecStartPre so it runs before the app starts.
+# Keeps disk usage in check on the pod's limited storage (~6GB).
+
+DATA_DIR="/persistent/sleepypod-data"
+INSTALL_DIR="/home/dac/sleepypod-core"
+
+echo "=== SleepyPod Maintenance ==="
+
+# 1. Vacuum systemd journal (cap at 50MB)
+if command -v journalctl &>/dev/null; then
+  JOURNAL_SIZE=$(du -sm /persistent/journal 2>/dev/null | awk '{print $1}' || echo 0)
+  if [ "$JOURNAL_SIZE" -gt 50 ]; then
+    echo "Vacuuming journal (${JOURNAL_SIZE}MB → 50MB)..."
+    journalctl --vacuum-size=50M 2>/dev/null || true
+  fi
+fi
+
+# 2. Clean stale temp files (leftover from failed updates, builds, etc.)
+TEMP_CLEANED=0
+for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*; do
+  if [ -e "$d" ]; then
+    rm -rf "$d" 2>/dev/null && TEMP_CLEANED=$((TEMP_CLEANED + 1))
+  fi
+done
+[ "$TEMP_CLEANED" -gt 0 ] && echo "Cleaned $TEMP_CLEANED stale temp entries."
+
+# 3. Prune old database backups (keep 3 most recent)
+if [ -d "$DATA_DIR" ]; then
+  BAK_COUNT=$(ls "$DATA_DIR"/sleepypod.db.bak.* 2>/dev/null | wc -l)
+  if [ "$BAK_COUNT" -gt 3 ]; then
+    PRUNE=$((BAK_COUNT - 3))
+    ls -t "$DATA_DIR"/sleepypod.db.bak.* | tail -n "$PRUNE" | xargs rm -f
+    echo "Pruned $PRUNE old DB backups (kept 3)."
+  fi
+fi
+
+# 4. Prune pnpm content-addressable store
+if command -v pnpm &>/dev/null; then
+  STORE_SIZE=$(du -sm /home/root/.local/share/pnpm/store 2>/dev/null | awk '{print $1}' || echo 0)
+  if [ "$STORE_SIZE" -gt 100 ]; then
+    echo "Pruning pnpm store (${STORE_SIZE}MB)..."
+    pnpm store prune 2>/dev/null || true
+  fi
+fi
+
+DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
+echo "Maintenance complete. ${DISK_AVAIL}MB free."

--- a/scripts/install
+++ b/scripts/install
@@ -491,6 +491,7 @@ Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
 ExecStartPre=/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
+ExecStartPre=$INSTALL_DIR/scripts/bin/sp-maintenance
 ExecStart=/usr/local/bin/pnpm start
 Restart=always
 RestartSec=10
@@ -506,6 +507,16 @@ ProtectKernelModules=true
 [Install]
 WantedBy=multi-user.target
 EOF
+
+# Cap journal size to prevent unbounded log growth on limited disk
+mkdir -p /etc/systemd/journald.conf.d
+cat > /etc/systemd/journald.conf.d/sleepypod.conf << 'JOURNALD'
+[Journal]
+SystemMaxUse=50M
+SystemKeepFree=200M
+MaxFileSec=1week
+JOURNALD
+systemctl restart systemd-journald 2>/dev/null || true
 
 # Reload systemd and enable service
 echo "Enabling service..."


### PR DESCRIPTION
## Summary

- New `sp-maintenance` script runs as `ExecStartPre` on every service boot
- Vacuums journal to 50MB, cleans stale /tmp, prunes DB backups to 3, prunes pnpm store
- Adds journald.conf.d drop-in capping journal at 50MB with 200MB keep-free
- Prevents the 1GB+ journal and 168 DB backups we found on the pod today

## Test plan

- [ ] `sp-update dev` on pod → maintenance runs before service starts
- [ ] Journal stays under 50MB across reboots
- [ ] DB backups pruned to 3 after multiple updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)