### PR TITLE
Disable Turbopack — use webpack for production builds

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,15 +5,6 @@ const nextConfig = {
   // Keep native modules external — resolved from node_modules at runtime
   // so the correct platform binary (linux-arm64 on pod) is used
   serverExternalPackages: ['better-sqlite3'],
-  // Keep Turbopack config for .po files (i18n)
-  turbopack: {
-    rules: {
-      '*.po': {
-        loaders: ['@lingui/loader'],
-        as: '*.js',
-      },
-    },
-  },
   reactCompiler: false,
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/generate-git-info.mjs && lingui compile",
-    "build": "next build",
+    "build": "next build --no-turbopack",
     "dev": "next dev",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
Turbopack mangles better-sqlite3 require() with content hashes from pnpm's virtual store, breaking cross-platform deploys (CI x86_64 → pod arm64). Webpack emits plain require('better-sqlite3') which resolves correctly on any platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to disable Turbopack during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->