### PR TITLE
Use webpack bundler to fix cross-platform better-sqlite3

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,9 @@
 const nextConfig = {
   // Source maps for debugging production crashes
   productionBrowserSourceMaps: true,
+  // Use webpack — Turbopack mangles native module requires with pnpm store
+  // hashes that differ between CI (x86_64) and pod (arm64)
+  bundler: 'webpack',
   // Keep native modules external — resolved from node_modules at runtime
   // so the correct platform binary (linux-arm64 on pod) is used
   serverExternalPackages: ['better-sqlite3'],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/generate-git-info.mjs && lingui compile",
-    "build": "next build --no-turbopack",
+    "build": "next build",
     "dev": "next dev",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
Turbopack mangles native module requires with pnpm store hashes that differ across platforms. Setting bundler: 'webpack' in next.config.mjs produces plain require('better-sqlite3').