### PR TITLE
Fix Turbopack native module resolution with resolveAlias

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,12 +2,23 @@
 const nextConfig = {
   // Source maps for debugging production crashes
   productionBrowserSourceMaps: true,
-  // Use webpack — Turbopack mangles native module requires with pnpm store
-  // hashes that differ between CI (x86_64) and pod (arm64)
-  bundler: 'webpack',
   // Keep native modules external — resolved from node_modules at runtime
   // so the correct platform binary (linux-arm64 on pod) is used
   serverExternalPackages: ['better-sqlite3'],
+  turbopack: {
+    // Lingui .po file loader
+    rules: {
+      '*.po': {
+        loaders: ['@lingui/loader'],
+        as: '*.js',
+      },
+    },
+    // Force plain require() for native modules — prevents Turbopack from
+    // mangling the module name with pnpm virtual store hashes
+    resolveAlias: {
+      'better-sqlite3': 'better-sqlite3',
+    },
+  },
   reactCompiler: false,
 }
 


### PR DESCRIPTION
Restore .po loader config and add resolveAlias to force plain require('better-sqlite3') instead of pnpm virtual store hash.