### PR TITLE
fix: resolve Pod 3 install failures (#380)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -400,7 +400,7 @@ echo "Pod generation: $POD_GEN (DAC: $DAC_SOCK_PATH)"
 
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
 echo "Installing dependencies..."
-pnpm install --frozen-lockfile --prod
+CI=true pnpm install --frozen-lockfile --prod
 
 # Verify better-sqlite3 native module is ready
 if [ ! -f "$INSTALL_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ] && \
@@ -425,7 +425,7 @@ if [ -d "$INSTALL_DIR/.next" ]; then
 else
   echo "No pre-built .next found, building from source..."
   echo "Installing all dependencies (including devDependencies for build)..."
-  pnpm install --frozen-lockfile
+  CI=true pnpm install --frozen-lockfile
   SP_BRANCH="$EFFECTIVE_BRANCH" pnpm build
 fi
 

--- a/scripts/patch-python-stdlib
+++ b/scripts/patch-python-stdlib
@@ -160,7 +160,7 @@ log "Stdlib patching complete: $COPIED copied, $SKIPPED already present, $FAILED
 # Verify critical modules now import
 # --------------------------------------------------------------------------
 VERIFY_OK=true
-for mod in plistlib ensurepip; do
+for mod in ensurepip; do
   if python3 -c "import $mod" 2>/dev/null; then
     log "  ✓ $mod"
   else
@@ -168,6 +168,13 @@ for mod in plistlib ensurepip; do
     VERIFY_OK=false
   fi
 done
+
+# plistlib depends on pyexpat (C extension) — can't be fixed via .py patching
+if python3 -c "import plistlib" 2>/dev/null; then
+  log "  ✓ plistlib"
+else
+  warn "  ✗ plistlib — depends on pyexpat C extension, not needed for biometrics"
+fi
 
 # pyexpat is a C extension — .py patching won't fix it, but log the status
 if python3 -c "import pyexpat" 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Set `CI=true` on `pnpm install` calls so the interactive modules-purge prompt is skipped when running via `curl | bash` (no TTY)
- Downgrade `plistlib` from a fatal verification check to a warning in `patch-python-stdlib` — it depends on the `pyexpat` C extension which can't be .py-patched on Yocto, and isn't needed for biometrics modules

Closes #380

## Test plan

On a Pod 3, run the install script pointing at this branch:

```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/380-pod3-install-fails/scripts/install | sudo bash -s -- --branch fix/380-pod3-install-fails
```

Verify:
- [ ] No `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` error
- [ ] `patch-python-stdlib` completes with warnings (not errors) for `plistlib`/`pyexpat`
- [ ] Biometrics modules install and start (`sp-status`)
- [ ] Web UI accessible at `http://<pod-ip>:3000/`