### PR TITLE
fix: convert temperatures to user's preferred unit (#333)

### DIFF
--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -17,6 +17,7 @@ import {
   vibrationPatternSchema,
   alarmDurationSchema,
 } from '@/src/server/validation-schemas'
+import { toC } from '@/src/lib/tempUtils'
 
 // ---------------------------------------------------------------------------
 // Command name → HardwareCommand mapping for the raw execute endpoint
@@ -85,9 +86,9 @@ export const deviceRouter = router({
    */
   getStatus: publicProcedure
     .meta({ openapi: { method: 'GET', path: '/device/status', protect: false, tags: ['Device'] } })
-    .input(z.object({}))
+    .input(z.object({ unit: z.enum(['F', 'C']).default('F') }).strict())
     .output(z.any())
-    .query(async () => {
+    .query(async ({ input }) => {
       return withHardwareClient(async (client) => {
         const status = await client.getDeviceStatus()
 
@@ -138,8 +139,21 @@ export const deviceRouter = router({
         const primeCompletedAt = getPrimeCompletedAt()
         const leftSnooze = getSnoozeStatus('left')
         const rightSnooze = getSnoozeStatus('right')
+
+        const convertTemp = (f: number) => input.unit === 'C' ? Math.round(toC(f) * 10) / 10 : f
+
         return {
           ...status,
+          leftSide: {
+            ...status.leftSide,
+            currentTemperature: convertTemp(status.leftSide.currentTemperature),
+            targetTemperature: convertTemp(status.leftSide.targetTemperature),
+          },
+          rightSide: {
+            ...status.rightSide,
+            currentTemperature: convertTemp(status.rightSide.currentTemperature),
+            targetTemperature: convertTemp(status.rightSide.targetTemperature),
+          },
           ...(primeCompletedAt && { primeCompletedNotification: { timestamp: primeCompletedAt } }),
           snooze: { left: leftSnooze, right: rightSnooze },
         }

--- a/src/server/routers/schedules.ts
+++ b/src/server/routers/schedules.ts
@@ -19,6 +19,7 @@ import {
   alarmDurationSchema,
 } from '@/src/server/validation-schemas'
 import { getJobManager } from '@/src/scheduler'
+import { toC } from '@/src/lib/tempUtils'
 
 /**
  * Reload schedules in the job manager after database changes
@@ -26,6 +27,21 @@ import { getJobManager } from '@/src/scheduler'
 async function reloadScheduler(): Promise<void> {
   const jobManager = await getJobManager()
   await jobManager.reloadSchedules()
+}
+
+const unitSchema = z.enum(['F', 'C']).default('F')
+
+function convertScheduleTemps(
+  data: { temperature: (typeof temperatureSchedules.$inferSelect)[], power: (typeof powerSchedules.$inferSelect)[], alarm: (typeof alarmSchedules.$inferSelect)[] },
+  unit: 'F' | 'C',
+) {
+  if (unit === 'F') return data
+  const c = (f: number) => Math.round(toC(f) * 10) / 10
+  return {
+    temperature: data.temperature.map(s => ({ ...s, temperature: c(s.temperature) })),
+    power: data.power.map(s => ({ ...s, onTemperature: c(s.onTemperature) })),
+    alarm: data.alarm.map(s => ({ ...s, alarmTemperature: c(s.alarmTemperature) })),
+  }
 }
 
 /**
@@ -41,6 +57,7 @@ export const schedulesRouter = router({
       z
         .object({
           side: sideSchema,
+          unit: unitSchema,
         })
         .strict()
     )
@@ -63,11 +80,11 @@ export const schedulesRouter = router({
               .where(eq(alarmSchedules.side, input.side)),
           ])
 
-        return {
+        return convertScheduleTemps({
           temperature: temperatureSchedulesList,
           power: powerSchedulesList,
           alarm: alarmSchedulesList,
-        }
+        }, input.unit)
       }
       catch (error) {
         throw new TRPCError({
@@ -697,6 +714,7 @@ export const schedulesRouter = router({
         .object({
           side: sideSchema,
           dayOfWeek: dayOfWeekSchema,
+          unit: unitSchema,
         })
         .strict()
     )
@@ -734,11 +752,11 @@ export const schedulesRouter = router({
               ),
           ])
 
-        return {
+        return convertScheduleTemps({
           temperature: temperatureSchedulesList,
           power: powerSchedulesList,
           alarm: alarmSchedulesList,
-        }
+        }, input.unit)
       }
       catch (error) {
         throw new TRPCError({

--- a/src/server/routers/tests/schedules.test.ts
+++ b/src/server/routers/tests/schedules.test.ts
@@ -222,4 +222,44 @@ describe('schedules.batchUpdate', () => {
       caller.batchUpdate({ updates: { power: [{ id: 99999, enabled: false }] } })
     ).rejects.toThrow('not found')
   })
+
+  it('getAll converts temperatures to Celsius when unit=C', async () => {
+    await caller.batchUpdate({
+      creates: {
+        temperature: [
+          { side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 },
+        ],
+        power: [
+          { side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 77 },
+        ],
+        alarm: [
+          { side: 'left', dayOfWeek: 'monday', time: '07:00', vibrationIntensity: 50, vibrationPattern: 'rise', duration: 120, alarmTemperature: 95 },
+        ],
+      },
+    })
+
+    const celsius = await caller.getAll({ side: 'left', unit: 'C' })
+    expect(celsius.temperature[0].temperature).toBe(20) // 68°F = 20°C
+    expect(celsius.power[0].onTemperature).toBe(25) // 77°F = 25°C
+    expect(celsius.alarm[0].alarmTemperature).toBe(35) // 95°F = 35°C
+
+    // Fahrenheit (default) returns raw values
+    const fahrenheit = await caller.getAll({ side: 'left' })
+    expect(fahrenheit.temperature[0].temperature).toBe(68)
+    expect(fahrenheit.power[0].onTemperature).toBe(77)
+    expect(fahrenheit.alarm[0].alarmTemperature).toBe(95)
+  })
+
+  it('getByDay converts temperatures to Celsius when unit=C', async () => {
+    await caller.createTemperatureSchedule({
+      side: 'left', dayOfWeek: 'wednesday', time: '23:00', temperature: 86,
+    })
+
+    const celsius = await caller.getByDay({ side: 'left', dayOfWeek: 'wednesday', unit: 'C' })
+    expect(celsius.temperature[0].temperature).toBe(30) // 86°F = 30°C
+
+    const fahrenheit = await caller.getByDay({ side: 'left', dayOfWeek: 'wednesday', unit: 'F' })
+    expect(fahrenheit.temperature[0].temperature).toBe(86)
+  })
 })
+


### PR DESCRIPTION
## Summary
- Add optional `unit` param (F/C, default F) to `device.getStatus`, `schedules.getAll`, and `schedules.getByDay`
- When `unit=C`, temperatures are converted from Fahrenheit (native storage) to Celsius using `toC` from tempUtils
- Follows the pattern established by the environment router

## Test plan
- [x] Added Celsius conversion tests for getAll and getByDay covering all 3 schedule types (temperature, power, alarm)
- [x] Typecheck passes
- [x] 20/20 schedule tests pass
- [ ] Manual: call `GET /schedules?side=left&unit=C` and verify temperatures are in Celsius

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Temperature unit selection now available for device status queries (Fahrenheit or Celsius; defaults to Fahrenheit)
  * Temperature unit selection now available for schedule queries (Fahrenheit or Celsius; defaults to Fahrenheit)
  * Temperatures are automatically converted to the requested unit with single decimal precision

* **Tests**
  * Added test coverage for temperature unit conversion across device and schedule endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->