### PR TITLE
fix: use absolute node path in systemd service unit

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -492,7 +492,8 @@ Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
 ExecStartPre=/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
 ExecStartPre=$INSTALL_DIR/scripts/bin/sp-maintenance
-ExecStart=/bin/sh -c 'if [ -f .next/standalone/server.js ]; then exec node .next/standalone/server.js; else exec /usr/local/bin/pnpm start; fi'
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+ExecStart=/bin/sh -c 'if [ -f .next/standalone/server.js ]; then exec /usr/local/bin/node .next/standalone/server.js; else exec /usr/local/bin/pnpm start; fi'
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
## Summary
- ExecStart used bare `node` which resolves to `/usr/bin/node` (Yocto's v16) instead of `/usr/local/bin/node` (v22 installed by the script)
- Causes 500 errors on startup — Next.js 16 uses syntax unsupported by Node 16
- Also sets `PATH` in the unit so any child processes resolve correctly

## Test plan
- [x] Verified on Pod: bare `node` → v16 → 500; `/usr/local/bin/node` → v22 → working
- [ ] Fresh install on Pod confirms service starts with correct Node version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability by ensuring proper resolution of system dependencies required for the application to run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->