### PR TITLE
Replace misleading Promise.all with sequential sync calls

### DIFF
--- a/src/server/routers/schedules.ts
+++ b/src/server/routers/schedules.ts
@@ -47,21 +47,21 @@ export const schedulesRouter = router({
     .output(z.any())
     .query(async ({ input }) => {
       try {
-        const [temperatureSchedulesList, powerSchedulesList, alarmSchedulesList]
-          = await Promise.all([
-            db
-              .select()
-              .from(temperatureSchedules)
-              .where(eq(temperatureSchedules.side, input.side)),
-            db
-              .select()
-              .from(powerSchedules)
-              .where(eq(powerSchedules.side, input.side)),
-            db
-              .select()
-              .from(alarmSchedules)
-              .where(eq(alarmSchedules.side, input.side)),
-          ])
+        const temperatureSchedulesList = db
+          .select()
+          .from(temperatureSchedules)
+          .where(eq(temperatureSchedules.side, input.side))
+          .all()
+        const powerSchedulesList = db
+          .select()
+          .from(powerSchedules)
+          .where(eq(powerSchedules.side, input.side))
+          .all()
+        const alarmSchedulesList = db
+          .select()
+          .from(alarmSchedules)
+          .where(eq(alarmSchedules.side, input.side))
+          .all()
 
         return {
           temperature: temperatureSchedulesList,
@@ -703,36 +703,36 @@ export const schedulesRouter = router({
     .output(z.any())
     .query(async ({ input }) => {
       try {
-        const [temperatureSchedulesList, powerSchedulesList, alarmSchedulesList]
-          = await Promise.all([
-            db
-              .select()
-              .from(temperatureSchedules)
-              .where(
-                and(
-                  eq(temperatureSchedules.side, input.side),
-                  eq(temperatureSchedules.dayOfWeek, input.dayOfWeek)
-                )
-              ),
-            db
-              .select()
-              .from(powerSchedules)
-              .where(
-                and(
-                  eq(powerSchedules.side, input.side),
-                  eq(powerSchedules.dayOfWeek, input.dayOfWeek)
-                )
-              ),
-            db
-              .select()
-              .from(alarmSchedules)
-              .where(
-                and(
-                  eq(alarmSchedules.side, input.side),
-                  eq(alarmSchedules.dayOfWeek, input.dayOfWeek)
-                )
-              ),
-          ])
+        const temperatureSchedulesList = db
+          .select()
+          .from(temperatureSchedules)
+          .where(
+            and(
+              eq(temperatureSchedules.side, input.side),
+              eq(temperatureSchedules.dayOfWeek, input.dayOfWeek)
+            )
+          )
+          .all()
+        const powerSchedulesList = db
+          .select()
+          .from(powerSchedules)
+          .where(
+            and(
+              eq(powerSchedules.side, input.side),
+              eq(powerSchedules.dayOfWeek, input.dayOfWeek)
+            )
+          )
+          .all()
+        const alarmSchedulesList = db
+          .select()
+          .from(alarmSchedules)
+          .where(
+            and(
+              eq(alarmSchedules.side, input.side),
+              eq(alarmSchedules.dayOfWeek, input.dayOfWeek)
+            )
+          )
+          .all()
 
         return {
           temperature: temperatureSchedulesList,


### PR DESCRIPTION
## Summary
- Replaced `Promise.all` wrapping synchronous better-sqlite3/drizzle queries with sequential `.all()` calls in `getAll` and `getByDay` handlers
- better-sqlite3 is synchronous and single-connection — `Promise.all` provided no parallelism, only a false suggestion of concurrency

Closes #201

## Test plan
- [x] TypeScript type check passes
- [x] All 9 schedules tests pass
- [ ] Manual: verify `getAll` and `getByDay` endpoints return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal query execution for schedule data retrieval to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->