### PR TITLE
feat: TypeScript Snoo client — pysnoo2 port (#406)

### DIFF
--- a/src/server/routers/mini.ts
+++ b/src/server/routers/mini.ts
@@ -5,8 +5,56 @@ export const miniRouter = router({
   status: publicProcedure
     .meta({ openapi: { method: 'GET', path: '/mini/status', protect: false, tags: ['Mini'] } })
     .input(z.object({}))
-    .output(z.object({
-      enabled: z.boolean(),
-    }))
+    .output(z.object({ enabled: z.boolean() }))
     .query(() => ({ enabled: true })),
+
+  devices: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/mini/devices', protect: false, tags: ['Mini'] } })
+    .input(z.object({}))
+    .output(z.object({
+      devices: z.array(z.object({
+        serialNumber: z.string(),
+        firmwareVersion: z.string(),
+        timezone: z.string(),
+      })),
+    }))
+    .query(async () => {
+      const { SnooClient } = await import('@/src/services/mini')
+      const client = new SnooClient()
+      const devices = await client.getDevices()
+      return {
+        devices: devices.map(d => ({
+          serialNumber: d.serialNumber,
+          firmwareVersion: d.firmwareVersion,
+          timezone: d.timezone,
+        })),
+      }
+    }),
+
+  baby: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/mini/baby', protect: false, tags: ['Mini'] } })
+    .input(z.object({}))
+    .output(z.object({
+      babyName: z.string(),
+      birthDate: z.string().nullable(),
+      settings: z.object({
+        responsivenessLevel: z.string(),
+        motionLimiter: z.boolean(),
+        weaning: z.boolean(),
+      }),
+    }))
+    .query(async () => {
+      const { SnooClient } = await import('@/src/services/mini')
+      const client = new SnooClient()
+      const baby = await client.getBaby()
+      return {
+        babyName: baby.babyName,
+        birthDate: baby.birthDate,
+        settings: {
+          responsivenessLevel: baby.settings.responsivenessLevel,
+          motionLimiter: baby.settings.motionLimiter,
+          weaning: baby.settings.weaning,
+        },
+      }
+    }),
 })

--- a/src/services/mini/client.ts
+++ b/src/services/mini/client.ts
@@ -1,11 +1,200 @@
 /**
- * Snoo client — Auth (OAuth PKCE) and data API.
- * Stub: implementation comes in the TS Snoo client step.
+ * Snoo API client — OAuth auth and data API.
+ * TypeScript port of pysnoo2's auth_session.py + snoo.py.
  */
 
+import type {
+  AggregatedSessionAvg,
+  AggregatedSessionInterval,
+  Baby,
+  BabyUpdate,
+  Device,
+  LastSession,
+  SnooToken,
+  User,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SNOO_API = 'https://api-us-east-1-prod.happiestbaby.com'
+
+const ENDPOINTS = {
+  login: `${SNOO_API}/us/v3/login`,
+  refresh: `${SNOO_API}/us/v2/refresh/`,
+  me: `${SNOO_API}/us/me/v10/me`,
+  devices: `${SNOO_API}/hds/me/v11/devices`,
+  baby: `${SNOO_API}/us/me/v10/baby`,
+  sessionsLast: (babyId: string) => `${SNOO_API}/ss/me/v10/babies/${babyId}/sessions/last`,
+  sessionsAvg: (babyId: string) => `${SNOO_API}/ss/v2/babies/${babyId}/sessions/aggregated/avg/`,
+  sessionsTotalTime: (babyId: string) => `${SNOO_API}/ss/v2/babies/${babyId}/sessions/total-time/`,
+  pubnubAuth: `${SNOO_API}/us/me/v10/pubnub/authorize`,
+} as const
+
+const BASE_HEADERS = {
+  'User-Agent': 'okhttp/4.7.2',
+  'Content-Type': 'application/json;charset=UTF-8',
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
 export class SnooClient {
-  // OAuth PKCE auth flow to Happiest Baby
-  async authenticate(): Promise<void> {
-    throw new Error('Not implemented — awaiting TS Snoo client step')
+  private token: SnooToken | null = null
+  private username: string | null = null
+  private password: string | null = null
+  private onTokenUpdate?: (token: SnooToken) => void
+
+  constructor(opts?: { onTokenUpdate?: (token: SnooToken) => void }) {
+    this.onTokenUpdate = opts?.onTokenUpdate
+  }
+
+  /** Restore a previously-persisted token (skips login). */
+  setToken(token: SnooToken): void {
+    this.token = token
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth
+  // -------------------------------------------------------------------------
+
+  async authenticate(username: string, password: string): Promise<SnooToken> {
+    this.username = username
+    this.password = password
+    return this.fetchToken()
+  }
+
+  private async fetchToken(): Promise<SnooToken> {
+    const res = await fetch(ENDPOINTS.login, {
+      method: 'POST',
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ username: this.username, password: this.password }),
+    })
+    if (!res.ok) {
+      throw new Error(`Snoo login failed: ${res.status} ${res.statusText}`)
+    }
+    const data = await res.json() as SnooToken
+    this.token = data
+    this.onTokenUpdate?.(data)
+    return data
+  }
+
+  private async refreshToken(): Promise<SnooToken> {
+    if (!this.token?.refreshToken) {
+      throw new Error('No refresh token available')
+    }
+    const res = await fetch(ENDPOINTS.refresh, {
+      method: 'POST',
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ refreshToken: this.token.refreshToken }),
+    })
+    if (!res.ok) {
+      // Refresh failed — try full re-auth if credentials are available
+      if (this.username && this.password) {
+        return this.fetchToken()
+      }
+      throw new Error(`Snoo token refresh failed: ${res.status} ${res.statusText}`)
+    }
+    const data = await res.json() as SnooToken
+    this.token = data
+    this.onTokenUpdate?.(data)
+    return data
+  }
+
+  // -------------------------------------------------------------------------
+  // Authenticated fetch with auto-refresh on 401/403
+  // -------------------------------------------------------------------------
+
+  private async authedFetch(url: string, init?: RequestInit): Promise<Response> {
+    if (!this.token) throw new Error('Not authenticated — call authenticate() first')
+
+    const doFetch = (accessToken: string) =>
+      fetch(url, {
+        ...init,
+        headers: {
+          ...BASE_HEADERS,
+          Authorization: `Bearer ${accessToken}`,
+          ...init?.headers,
+        },
+      })
+
+    let res = await doFetch(this.token.accessToken)
+
+    if (res.status === 401 || res.status === 403) {
+      const refreshed = await this.refreshToken()
+      res = await doFetch(refreshed.accessToken)
+    }
+
+    if (!res.ok) {
+      throw new Error(`Snoo API ${init?.method ?? 'GET'} ${url} failed: ${res.status} ${res.statusText}`)
+    }
+    return res
+  }
+
+  // -------------------------------------------------------------------------
+  // Data API
+  // -------------------------------------------------------------------------
+
+  async getMe(): Promise<User> {
+    const res = await this.authedFetch(ENDPOINTS.me)
+    return await res.json() as User
+  }
+
+  async getDevices(): Promise<Device[]> {
+    const res = await this.authedFetch(ENDPOINTS.devices)
+    const data = await res.json() as { snoo: Device[] }
+    return data.snoo
+  }
+
+  async getBaby(): Promise<Baby> {
+    const res = await this.authedFetch(ENDPOINTS.baby)
+    return await res.json() as Baby
+  }
+
+  async updateBaby(update: BabyUpdate): Promise<Baby> {
+    const res = await this.authedFetch(ENDPOINTS.baby, {
+      method: 'PATCH',
+      body: JSON.stringify(update),
+    })
+    return await res.json() as Baby
+  }
+
+  async getLastSession(babyId: string): Promise<LastSession> {
+    const res = await this.authedFetch(ENDPOINTS.sessionsLast(babyId))
+    return await res.json() as LastSession
+  }
+
+  async getSessionsAvg(
+    babyId: string,
+    startTime: Date,
+    interval: AggregatedSessionInterval,
+    includeDays: boolean = false,
+  ): Promise<AggregatedSessionAvg> {
+    const fmt = startTime.toISOString().replace('T', ' ').slice(0, 23)
+    const params = new URLSearchParams({
+      startTime: fmt,
+      interval,
+      days: String(includeDays),
+    })
+    const res = await this.authedFetch(`${ENDPOINTS.sessionsAvg(babyId)}?${params}`)
+    return await res.json() as AggregatedSessionAvg
+  }
+
+  async getTotalTime(babyId: string): Promise<number> {
+    const res = await this.authedFetch(ENDPOINTS.sessionsTotalTime(babyId))
+    const data = await res.json() as { totalTime: number }
+    return data.totalTime
+  }
+
+  // -------------------------------------------------------------------------
+  // PubNub token
+  // -------------------------------------------------------------------------
+
+  async getPubNubToken(): Promise<string> {
+    const res = await this.authedFetch(ENDPOINTS.pubnubAuth, { method: 'POST' })
+    const data = await res.json() as { snoo: { token: string } }
+    return data.snoo.token
   }
 }

--- a/src/services/mini/index.ts
+++ b/src/services/mini/index.ts
@@ -1,3 +1,4 @@
 export { SnooClient } from './client'
 export { MiniPubNubManager } from './pubnub'
-export type { MiniSession, MiniStatus, MiniSettings, MiniLevel, MiniCommand } from './types'
+export type { ActivityListener } from './pubnub'
+export * from './types'

--- a/src/services/mini/pubnub.ts
+++ b/src/services/mini/pubnub.ts
@@ -1,14 +1,158 @@
 /**
  * PubNub subscription manager for real-time Snoo state and commands.
- * Stub: implementation comes in the TS Snoo client step.
+ * TypeScript port of pysnoo2's pubnub.py.
  */
 
+import PubNub from 'pubnub'
+import type { SnooClient } from './client'
+import { EventType, type ActivityState, type SessionLevel, type SnooCommand } from './types'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SUBSCRIBE_KEY = 'sub-c-97bade2a-483d-11e6-8b3b-02ee2ddab7fe'
+const PUBLISH_KEY = 'pub-c-699074b0-7664-4be2-abf8-dcbb9b6cd2bf'
+const PUBNUB_ORIGIN = 'happiestbaby.pubnubapi.com'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseBoolStr(v: string): boolean {
+  return v === 'on' || v === 'true'
+}
+
+function parseEventType(raw: string): EventType {
+  const known = Object.values(EventType) as string[]
+  return known.includes(raw) ? (raw as EventType) : EventType.UNKNOWN
+}
+
+function parseActivityState(msg: Record<string, unknown>): ActivityState {
+  const sm = msg.state_machine as Record<string, unknown>
+  const sig = msg.rx_signal as Record<string, unknown>
+
+  const sinceMs = sm.since_session_start_ms as number
+  const timeLeft = sm.time_left as number
+
+  return {
+    leftSafetyClip: msg.left_safety_clip as boolean,
+    rightSafetyClip: msg.right_safety_clip as boolean,
+    swVersion: msg.sw_version as string,
+    eventTime: new Date(msg.event_time_ms as number),
+    systemState: msg.system_state as string,
+    event: parseEventType(msg.event as string),
+    rxSignal: {
+      rssi: sig.rssi as number,
+      strength: sig.strength as number,
+    },
+    stateMachine: {
+      state: sm.state as SessionLevel,
+      upTransition: sm.up_transition as SessionLevel,
+      downTransition: sm.down_transition as SessionLevel,
+      isActiveSession: parseBoolStr(sm.is_active_session as string),
+      sessionId: sm.session_id as string,
+      sinceSessionStartMs: sinceMs === -1 ? null : sinceMs,
+      timeLeftMs: timeLeft === -1 ? null : timeLeft,
+      stickyWhiteNoise: parseBoolStr(sm.sticky_white_noise as string),
+      weaning: parseBoolStr(sm.weaning as string),
+      hold: parseBoolStr(sm.hold as string),
+      audio: parseBoolStr(sm.audio as string),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+export type ActivityListener = (state: ActivityState) => void
+
 export class MiniPubNubManager {
+  private pubnub: PubNub | null = null
+  private serialNumber: string
+  private apiClient: SnooClient
+  private listeners: ActivityListener[] = []
+  private connected = false
+
+  constructor(serialNumber: string, apiClient: SnooClient) {
+    this.serialNumber = serialNumber
+    this.apiClient = apiClient
+  }
+
+  onActivity(listener: ActivityListener): () => void {
+    this.listeners.push(listener)
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener)
+    }
+  }
+
   async connect(): Promise<void> {
-    throw new Error('Not implemented — awaiting TS Snoo client step')
+    const token = await this.apiClient.getPubNubToken()
+    const uuid = `pn-sleepypod-${this.serialNumber}`
+
+    this.pubnub = new PubNub({
+      subscribeKey: SUBSCRIBE_KEY,
+      publishKey: PUBLISH_KEY,
+      authKey: token,
+      userId: uuid,
+      origin: PUBNUB_ORIGIN,
+      ssl: true,
+      restore: true,
+    })
+
+    this.pubnub.addListener({
+      status: (status) => {
+        if (status.category === 'PNConnectedCategory' || status.category === 'PNReconnectedCategory') {
+          this.connected = true
+        }
+        if (status.category === 'PNAccessDeniedCategory') {
+          this.refreshAuth()
+        }
+      },
+      message: (msg) => {
+        if (msg.channel === `ActivityState.${this.serialNumber}`) {
+          const state = parseActivityState(msg.message as Record<string, unknown>)
+          for (const listener of this.listeners) {
+            listener(state)
+          }
+        }
+      },
+    })
+
+    this.pubnub.subscribe({
+      channels: [`ActivityState.${this.serialNumber}`],
+    })
+  }
+
+  async sendCommand(command: SnooCommand): Promise<void> {
+    if (!this.pubnub) throw new Error('PubNub not connected')
+
+    await this.pubnub.publish({
+      channel: `ControlCommand.${this.serialNumber}`,
+      message: command as unknown as PubNub.Payload,
+    })
   }
 
   async disconnect(): Promise<void> {
-    // no-op until implemented
+    if (!this.pubnub) return
+    this.pubnub.unsubscribeAll()
+    this.pubnub.destroy()
+    this.pubnub = null
+    this.connected = false
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  private async refreshAuth(): Promise<void> {
+    try {
+      const token = await this.apiClient.getPubNubToken()
+      this.pubnub?.setToken(token)
+    }
+    catch (err) {
+      console.error('[Mini PubNub] Token refresh failed:', err instanceof Error ? err.message : err)
+    }
   }
 }

--- a/src/services/mini/types.ts
+++ b/src/services/mini/types.ts
@@ -1,29 +1,257 @@
-/**
- * TypeScript types matching the Snoo data model.
- * Populated in the TS Snoo client implementation step.
- */
+// Snoo data model — TypeScript port of pysnoo2
 
-export interface MiniSession {
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export enum ResponsivenessLevel {
+  VERY_LOW = 'lvl-2',
+  LOW = 'lvl-1',
+  NORMAL = 'lvl0',
+  HIGH = 'lvl+1',
+  VERY_HIGH = 'lvl+2',
+}
+
+export enum MinimalLevelVolume {
+  VERY_LOW = 'lvl-2',
+  LOW = 'lvl-1',
+  NORMAL = 'lvl0',
+  HIGH = 'lvl+1',
+  VERY_HIGH = 'lvl+2',
+}
+
+export enum SoothingLevelVolume {
+  NORMAL = 'lvl0',
+  HIGH = 'lvl+1',
+  VERY_HIGH = 'lvl+2',
+}
+
+export enum MinimalLevel {
+  BASELINE = 'baseline',
+  LEVEL1 = 'level1',
+  LEVEL2 = 'level2',
+}
+
+export enum Sex {
+  MALE = 'Male',
+  FEMALE = 'Female',
+}
+
+export enum SessionLevel {
+  ONLINE = 'ONLINE',
+  BASELINE = 'BASELINE',
+  WEANING_BASELINE = 'WEANING_BASELINE',
+  LEVEL1 = 'LEVEL1',
+  LEVEL2 = 'LEVEL2',
+  LEVEL3 = 'LEVEL3',
+  LEVEL4 = 'LEVEL4',
+  NONE = 'NONE',
+  PRETIMEOUT = 'PRETIMEOUT',
+  TIMEOUT = 'TIMEOUT',
+}
+
+export enum SessionItemType {
+  ASLEEP = 'asleep',
+  SOOTHING = 'soothing',
+  AWAKE = 'awake',
+}
+
+export enum EventType {
+  ACTIVITY = 'activity',
+  CRY = 'cry',
+  TIMER = 'timer',
+  COMMAND = 'command',
+  SAFETY_CLIP = 'safety_clip',
+  STATUS_REQUESTED = 'status_requested',
+  STICKY_WHITE_NOISE_UPDATED = 'sticky_white_noise_updated',
+  LONG_ACTIVITY_PRESS = 'long_activity_press',
+  UNKNOWN = 'unknown',
+}
+
+export enum AggregatedSessionInterval {
+  WEEK = 'week',
+  MONTH = 'month',
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+export interface SnooToken {
+  accessToken: string
+  tokenType: string
+  expiresIn: number
+  refreshToken: string
+}
+
+export interface User {
+  email: string
+  givenName: string
+  region: string
+  surname: string
+  userId: string
+  familyId: string
+}
+
+export interface SSID {
+  name: string
+  updatedAt: string
+}
+
+export interface Device {
+  babyIds: string[]
+  createdAt: string
+  firmwareUpdateDate: string
+  firmwareVersion: string
+  lastProvisionSuccess: string
+  lastSsid: SSID
+  serialNumber: string
+  timezone: string
+  updatedAt: string
+}
+
+export interface Picture {
+  id: string
+  mime: string
+  encoded: boolean
+  updatedAt: string
+}
+
+export interface Settings {
+  responsivenessLevel: ResponsivenessLevel
+  minimalLevelVolume: MinimalLevelVolume
+  soothingLevelVolume: SoothingLevelVolume
+  minimalLevel: MinimalLevel
+  motionLimiter: boolean
+  weaning: boolean
+  carRideMode: boolean
+  daytimeStart: number
+  stickyWhiteNoiseTimeout: number
+}
+
+export interface Baby {
+  babyId: string
+  babyName: string
+  birthDate: string | null
+  expectedBirthDate: string | null
+  createdAt: string
+  disabledLimiter: boolean
+  pictures: Picture[]
+  preemie: number | null
+  settings: Settings
+  sex: Sex | null
+  updatedAt: string
+  updatedByUserAt: string
+}
+
+export interface Signal {
+  rssi: number
+  strength: number
+}
+
+export interface StateMachine {
+  upTransition: SessionLevel
+  sinceSessionStartMs: number | null
+  stickyWhiteNoise: boolean
+  weaning: boolean
+  timeLeftMs: number | null
+  sessionId: string
+  state: SessionLevel
+  isActiveSession: boolean
+  downTransition: SessionLevel
+  hold: boolean
+  audio: boolean
+}
+
+export interface ActivityState {
+  leftSafetyClip: boolean
+  rxSignal: Signal
+  rightSafetyClip: boolean
+  swVersion: string
+  eventTime: Date
+  stateMachine: StateMachine
+  systemState: string
+  event: EventType
+}
+
+export interface LastSession {
+  endTime: string | null
+  levels: SessionLevel[]
+  startTime: string
+}
+
+export interface AggregatedSessionItem {
+  isActive: boolean
   sessionId: string
   startTime: string
-  endTime?: string
-  levels: string[]
+  stateDurationSec: number
+  type: SessionItemType
 }
 
-export interface MiniStatus {
-  isOnline: boolean
+export interface AggregatedSession {
+  daySleepSec: number
+  levels: AggregatedSessionItem[]
+  longestSleepSec: number
+  naps: number
+  nightSleepSec: number
+  nightWakings: number
+  timezone: string
+  totalSleepSec: number
+}
+
+export interface AggregatedDays {
+  totalSleepSec: number[]
+  daySleepSec: number[]
+  nightSleepSec: number[]
+  longestSleepSec: number[]
+  nightWakings: number[]
+}
+
+export interface AggregatedSessionAvg {
+  totalSleepAvgSec: number
+  daySleepAvgSec: number
+  nightSleepAvgSec: number
+  longestSleepAvgSec: number
+  nightWakingsAvg: number
+  days: AggregatedDays | null
+}
+
+// ---------------------------------------------------------------------------
+// Settings update (PATCH payload) — all fields optional
+// ---------------------------------------------------------------------------
+
+export interface SettingsUpdate {
+  minimalLevel?: MinimalLevel
+  minimalLevelVolume?: MinimalLevelVolume
+  soothingLevelVolume?: SoothingLevelVolume
+  responsivenessLevel?: ResponsivenessLevel
+  motionLimiter?: boolean
+  weaning?: boolean
+  carRideMode?: boolean
+  daytimeStart?: number
+  stickyWhiteNoiseTimeout?: number
+}
+
+export interface BabyUpdate {
   babyName?: string
-  firmwareVersion?: string
-  lastSSID?: string
+  birthDate?: string
+  preemie?: number | null
+  sex?: Sex | null
+  settings?: SettingsUpdate
 }
 
-export interface MiniSettings {
-  responsiveness: 'low' | 'normal' | 'high'
-  volume: number
-  weaning: boolean
-  motionLimiter: boolean
+// ---------------------------------------------------------------------------
+// PubNub command types
+// ---------------------------------------------------------------------------
+
+export interface StartSnooCommand {
+  command: 'start_snoo'
 }
 
-export type MiniLevel = 'baseline' | 'level1' | 'level2' | 'level3' | 'level4'
+export interface GoToStateCommand {
+  command: 'go_to_state'
+  state: SessionLevel
+  hold?: 'on' | 'off'
+}
 
-export type MiniCommand = 'start' | 'stop' | 'level_up' | 'level_down' | 'toggle'
+export type SnooCommand = StartSnooCommand | GoToStateCommand


### PR DESCRIPTION
## Summary
- Port pysnoo2 Python library to TypeScript in `src/services/mini/`
- `types.ts`: Full Snoo data model — enums (SessionLevel, EventType, etc.), interfaces (Device, Baby, ActivityState, StateMachine), command types
- `client.ts`: OAuth auth flow (login + auto-refresh on 401/403), all data API endpoints (me, devices, baby, sessions, PubNub token)
- `pubnub.ts`: PubNub subscription manager — real-time ActivityState parsing, command publishing to ControlCommand channel, token refresh on access denied
- Update Mini tRPC router with devices/baby/status endpoints (all behind feature flag)

Depends on #410

Closes #406

## Test plan
- [x] `pnpm tsc` passes
- [x] `pnpm build` with `ENABLE_MINI` unset — succeeds, identical routes, no Mini code bundled
- [x] `ENABLE_MINI=true pnpm build` — succeeds, Mini client available
- [x] `pnpm test -- --run` — all 620 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)