### PR TITLE
Address CodeRabbit feedback from #400 and #401

### DIFF
--- a/src/server/routers/health.ts
+++ b/src/server/routers/health.ts
@@ -149,17 +149,18 @@ export const healthRouter = router({
       // Scheduler drift detection: compare DB enabled schedule count vs scheduler job count
       let drift: { dbScheduleCount: number, schedulerJobCount: number, drifted: boolean } | undefined
       try {
-        const [tempSchedules, powSchedules, almSchedules] = await Promise.all([
-          db.select({ id: temperatureSchedules.id })
-            .from(temperatureSchedules)
-            .where(eq(temperatureSchedules.enabled, true)),
-          db.select({ id: powerSchedules.id })
-            .from(powerSchedules)
-            .where(eq(powerSchedules.enabled, true)),
-          db.select({ id: alarmSchedules.id })
-            .from(alarmSchedules)
-            .where(eq(alarmSchedules.enabled, true)),
-        ])
+        const tempSchedules = db.select({ id: temperatureSchedules.id })
+          .from(temperatureSchedules)
+          .where(eq(temperatureSchedules.enabled, true))
+          .all()
+        const powSchedules = db.select({ id: powerSchedules.id })
+          .from(powerSchedules)
+          .where(eq(powerSchedules.enabled, true))
+          .all()
+        const almSchedules = db.select({ id: alarmSchedules.id })
+          .from(alarmSchedules)
+          .where(eq(alarmSchedules.enabled, true))
+          .all()
 
         // Each power schedule creates 2 jobs (on + off), others create 1 each
         const expectedJobCount = tempSchedules.length + (powSchedules.length * 2) + almSchedules.length

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -11,6 +11,64 @@ import {
   temperatureUnitSchema,
   timeStringSchema,
 } from '@/src/server/validation-schemas'
+
+const timestampSchema = z.coerce.date()
+
+const deviceSettingsSchema = z.object({
+  id: z.number(),
+  timezone: z.string(),
+  temperatureUnit: temperatureUnitSchema,
+  rebootDaily: z.boolean(),
+  rebootTime: z.string().nullable(),
+  primePodDaily: z.boolean(),
+  primePodTime: z.string().nullable(),
+  ledNightModeEnabled: z.boolean(),
+  ledDayBrightness: z.number(),
+  ledNightBrightness: z.number(),
+  ledNightStartTime: z.string().nullable(),
+  ledNightEndTime: z.string().nullable(),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+})
+
+const sideSettingsSchema = z.object({
+  side: sideSchema,
+  name: z.string(),
+  awayMode: z.boolean(),
+  alwaysOn: z.boolean(),
+  autoOffEnabled: z.boolean(),
+  autoOffMinutes: z.number(),
+  awayStart: z.string().nullable().optional(),
+  awayReturn: z.string().nullable().optional(),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+})
+
+const tapGestureSchema = z.object({
+  id: z.number(),
+  side: sideSchema,
+  tapType: tapTypeSchema,
+  actionType: z.enum(['temperature', 'alarm']),
+  temperatureChange: z.enum(['increment', 'decrement']).nullable().optional(),
+  temperatureAmount: z.number().nullable().optional(),
+  alarmBehavior: z.enum(['snooze', 'dismiss']).nullable().optional(),
+  alarmSnoozeDuration: z.number().nullable().optional(),
+  alarmInactiveBehavior: z.enum(['power', 'none']).nullable().optional(),
+  createdAt: timestampSchema,
+  updatedAt: timestampSchema,
+})
+
+const getAllSettingsResponse = z.object({
+  device: deviceSettingsSchema,
+  sides: z.object({
+    left: sideSettingsSchema,
+    right: sideSettingsSchema,
+  }),
+  gestures: z.object({
+    left: z.array(tapGestureSchema),
+    right: z.array(tapGestureSchema),
+  }),
+})
 import { getJobManager } from '@/src/scheduler'
 import { startKeepalive, stopKeepalive } from '@/src/services/temperatureKeepalive'
 import { restartAutoOffTimers } from '@/src/services/autoOffWatcher'
@@ -50,7 +108,7 @@ export const settingsRouter = router({
   getAll: publicProcedure
     .meta({ openapi: { method: 'GET', path: '/settings', protect: false, tags: ['Settings'] } })
     .input(z.object({}))
-    .output(z.any())
+    .output(getAllSettingsResponse)
     .query(async () => {
       try {
         const [device] = await db.select().from(deviceSettings).limit(1)


### PR DESCRIPTION
## Summary
- Replace misleading `Promise.all` with sequential `.all()` calls in health router drift detection — mirrors the fix applied to schedules.ts in #400
- Replace `z.any()` with concrete Zod output schema for settings `getAll` endpoint — prevents missing-field regressions like the one fixed in #401

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Lint passes (pre-commit hook)
- [ ] Verify `/health/system` endpoint returns drift detection data correctly
- [ ] Verify `/settings` endpoint returns full settings payload without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized health monitoring detection to execute database queries sequentially, improving monitoring consistency.

* **Chores**
  * Added stricter validation schemas for settings API responses to ensure type safety and consistency across device settings, gesture controls, and side-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->