### PR TITLE
chore: template install script branch at release time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Validate install script branch default
-        if: github.event_name == 'pull_request'
-        run: |
-          expected="${{ github.base_ref }}"
-          actual=$(grep -oP 'SCRIPT_DEFAULT_BRANCH="\K[^"]+' scripts/install)
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::scripts/install has SCRIPT_DEFAULT_BRANCH=\"$actual\" but PR targets \"$expected\". Update it before merging."
-            exit 1
-          fi
-
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Set install script default branch
+        run: sed -i 's/__BRANCH__/${{ github.ref_name }}/' scripts/install
+
       - name: Create deploy tarball
         run: |
           tar czf /tmp/sleepypod-core.tar.gz \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Set install script default branch
+        run: sed -i 's/__BRANCH__/${{ github.ref_name }}/' scripts/install
+
       - name: Create deploy tarball
         run: |
           tar czf /tmp/sleepypod-core.tar.gz \

--- a/scripts/install
+++ b/scripts/install
@@ -152,7 +152,7 @@ esac
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
-SCRIPT_DEFAULT_BRANCH="main"  # must match target branch (CI validates on PR)
+SCRIPT_DEFAULT_BRANCH="__BRANCH__"  # substituted at release time by .github/workflows/{release,dev-release}.yml
 
 # Lock file to prevent concurrent installs
 LOCKFILE="/var/run/sleepypod-install.lock"


### PR DESCRIPTION
## Summary

- Replace the hardcoded `SCRIPT_DEFAULT_BRANCH="main"` / `"dev"` in `scripts/install` with a `__BRANCH__` placeholder.
- Both release workflows (`release.yml` on `main`, `dev-release.yml` on `dev`) now run a `sed` step before tarballing to substitute `__BRANCH__` with `github.ref_name`.
- Remove the now-unnecessary "Validate install script branch default" gate from `build.yml` — the source file no longer holds a real branch name, so there's nothing for CI to validate.

This supersedes the manual dev→main flip of `SCRIPT_DEFAULT_BRANCH` that was required before every release merge. The shipped tarball still contains the correct branch; it's just stamped in at build time now instead of being tracked in git.

## Test plan

- [ ] Merge to dev → `dev-release.yml` runs, extract the tarball's `scripts/install`, confirm `SCRIPT_DEFAULT_BRANCH="dev"`.
- [ ] Merge dev → main → `release.yml` runs, confirm tarball's `scripts/install` has `SCRIPT_DEFAULT_BRANCH="main"`.
- [ ] Confirm `build.yml` no longer has the validate step and PR checks still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed branch consistency validation check from the CI build workflow
  * Modified release workflows to dynamically set the default branch reference in the installation script during the release process, replacing a static placeholder with the actual branch name at release time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->