### PR TITLE
chore: rename dev rolling tag to dev-latest

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -55,12 +55,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --cleanup-tag removed: it can delete a branch named 'dev' on older gh versions
-          gh release delete dev --yes 2>/dev/null || true
-          git push -d --no-verify origin refs/tags/dev 2>/dev/null || true
-          git tag -f dev
-          git push -f --no-verify origin refs/tags/dev
-          gh release create dev sleepypod-core.tar.gz \
+          gh release delete dev-latest --yes 2>/dev/null || true
+          git push -d --no-verify origin refs/tags/dev-latest 2>/dev/null || true
+          git tag -f dev-latest
+          git push -f --no-verify origin refs/tags/dev-latest
+          gh release create dev-latest sleepypod-core.tar.gz \
             --target "${{ github.sha }}" \
             --title "Dev (latest)" \
             --notes "Rolling pre-built release from the \`dev\` branch.


### PR DESCRIPTION
## Summary

Unblocks semantic-release on `main`. The Dev Release workflow currently publishes a rolling pre-release under a git **tag** named `dev`, which collides with the `dev` **branch**. When semantic-release runs on `main` and does `git fetch --tags`, git rejects the fetch with `would clobber existing tag` and the versioned release never publishes — the latest stable is stuck at v1.5.0 despite dev → main merges landing.

This PR renames the rolling tag (and its GitHub Release) from `dev` to `dev-latest` in `.github/workflows/dev-release.yml`. The tag name is the only thing that changes — release title, notes, branch trigger, build steps, and tarball handling are all untouched. The ``\`dev\`` reference inside the release notes body refers to the branch and is intentionally left as-is.

## Test plan

- [ ] Merge this PR to `dev`; confirm the Dev Release workflow runs green and publishes a release under the `dev-latest` tag
- [ ] Confirm no new release is created under the bare `dev` tag
- [ ] After merge, manually delete the stale `dev` tag from origin (separate cleanup — not part of this PR)
- [ ] On the next `dev` → `main` merge, confirm semantic-release on `main` completes `git fetch --tags` without the "would clobber existing tag" error and cuts a versioned release past v1.5.0