### PR TITLE
Release: rolling-tag rename for semantic-release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -55,12 +55,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # --cleanup-tag removed: it can delete a branch named 'dev' on older gh versions
-          gh release delete dev --yes 2>/dev/null || true
-          git push -d --no-verify origin refs/tags/dev 2>/dev/null || true
-          git tag -f dev
-          git push -f --no-verify origin refs/tags/dev
-          gh release create dev sleepypod-core.tar.gz \
+          gh release delete dev-latest --yes 2>/dev/null || true
+          git push -d --no-verify origin refs/tags/dev-latest 2>/dev/null || true
+          git tag -f dev-latest
+          git push -f --no-verify origin refs/tags/dev-latest
+          gh release create dev-latest sleepypod-core.tar.gz \
             --target "${{ github.sha }}" \
             --title "Dev (latest)" \
             --notes "Rolling pre-built release from the \`dev\` branch.


### PR DESCRIPTION
Forward-merges #427 (rename rolling tag to \`dev-latest\`) into main so semantic-release can run cleanly. The old conflicting \`dev\` tag has already been deleted from origin.

After merge:
- \`Analyze & Release\` on main should succeed and cut the next \`vX.Y.Z\`
- Future dev pushes will publish under \`dev-latest\`, no more tag/branch collision