### PR TITLE
ci: harden releases against branch/tag name collisions

### DIFF
--- a/.github/workflows/ref-collision-check.yml
+++ b/.github/workflows/ref-collision-check.yml
@@ -1,0 +1,37 @@
+name: Ref Collision Check
+
+# Fails if any branch and tag share a name. A collision (e.g. branch `dev` +
+# tag `dev`) breaks `git fetch --tags`, which is what semantic-release runs
+# before every release. We hit this when the dev rolling release used a tag
+# literally named `dev`; PR #427 renamed it to `dev-latest`. This guard makes
+# sure the same shape of bug can't silently come back.
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect branch/tag name collisions
+        run: |
+          set -euo pipefail
+          branches=$(git for-each-ref --format='%(refname:lstrip=3)' refs/remotes/origin \
+            | grep -vx HEAD | sort -u)
+          tags=$(git for-each-ref --format='%(refname:lstrip=2)' refs/tags | sort -u)
+          collisions=$(comm -12 <(echo "$branches") <(echo "$tags") || true)
+          if [ -n "$collisions" ]; then
+            echo "::error::Branch/tag name collision detected — semantic-release will fail on next release. Offending names:"
+            echo "$collisions" | sed 's/^/  - /'
+            exit 1
+          fi
+          echo "No branch/tag name collisions."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
             .
           mv /tmp/sleepypod-core.tar.gz .
 
+      - name: Refresh tags (force, prune)
+        # semantic-release runs `git fetch --tags` unconditionally and aborts
+        # on any "would clobber existing tag" conflict. Force-prune up front so
+        # a stale or colliding tag can't block the release.
+        run: git fetch --tags --force --prune --prune-tags origin
+
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #427 (rolling dev tag rename). Two additions so the same shape of bug — a tag name colliding with a branch name, which made `git fetch --tags` fail and silently blocked every versioned release on `main` — can't silently recur.

- **`release.yml`**: run `git fetch --tags --force --prune --prune-tags origin` before `semantic-release`. semantic-release itself runs `git fetch --tags` unconditionally and aborts on any "would clobber existing tag" conflict, so force-pruning up front means a stray colliding tag recovers instead of blocking the release.
- **`ref-collision-check.yml`** (new): runs on push to `main` / `dev`, fails CI if any branch and tag share a name. Loud early signal instead of a silently-missing GitHub Release.

Neither change touches `dev-release.yml` — #427 already fixed the original collision by renaming the rolling tag to `dev-latest`, and `v1.6.0` cut cleanly on 2026-04-13 with the tarball attached.

## Test plan

- [ ] Merge; confirm the new `Ref Collision Check` job runs green on `dev` and `main`
- [ ] On the next `dev` → `main` merge, confirm `Analyze & Release` completes `git fetch --tags --force` and cuts a new versioned release
- [ ] (Optional manual test) push a tag named `dev` to a scratch branch; confirm `Ref Collision Check` fails with the offending name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic validation to detect branch and tag name collisions in the CI/CD pipeline.
  * Enhanced release workflow with improved tag synchronization to ensure clean release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->