### PR TITLE
fix(install): set BIOMETRICS_DATABASE_URL in systemd unit

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -489,6 +489,7 @@ UMask=0002
 WorkingDirectory=$INSTALL_DIR
 Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
+Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
 ExecStartPre=/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
 ExecStartPre=$INSTALL_DIR/scripts/bin/sp-maintenance


### PR DESCRIPTION
## Summary

Fixes the silent biometrics-DB path divergence that surfaces as `vitals table not found` from `piezo-processor` after a fresh install (reported on Discord, all Pod gens affected).

**Root cause:** `scripts/install` writes `BIOMETRICS_DATABASE_URL` into `$INSTALL_DIR/.env`, but the standalone Next.js server does `process.chdir(__dirname)` to `.next/standalone/` on startup, so the install-root `.env` is never loaded. With the env var missing, `src/db/biometrics.ts:6-7` falls back to `./biometrics.dev.db` — under the standalone dir, not `/persistent/sleepypod-data/`. Drizzle migrations then create the `vitals` table inside the wrong file. Python modules (which set the env var in their own systemd units) keep reading the correct, unmigrated DB.

This PR adds `Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"` to the `sleepypod.service` unit template alongside the other `Environment=` lines, so the Node app, the Python modules, and the install `.env` all point at the same file.

Tracked as ygg `sleepypod-core-4`.

## Test plan

- [ ] On a fresh Pod install, confirm `sqlite3 /persistent/sleepypod-data/biometrics.db .tables` includes `vitals`.
- [ ] No `biometrics.dev.db` file exists under `/home/dac/sleepypod-core/.next/standalone/`.
- [ ] `journalctl -u sleepypod-piezo-processor.service` no longer logs "vitals table not found".
- [ ] Calibration completes from the iOS app without manual DB intervention.