### PR TITLE
fix(install): drop --python python3 so uv respects requires-python

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -233,7 +233,8 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
       rm -rf "$MODULES_DEST/$mod/venv"
       if command -v uv &>/dev/null; then
-        (cd "$MODULES_DEST/$mod" && uv sync --frozen) || true
+        (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
+          || echo "Warning: uv sync failed for module $mod"
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -233,7 +233,7 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
       rm -rf "$MODULES_DEST/$mod/venv"
       if command -v uv &>/dev/null; then
-        (cd "$MODULES_DEST/$mod" && uv sync --frozen --python python3) || true
+        (cd "$MODULES_DEST/$mod" && uv sync --frozen) || true
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then

--- a/scripts/install
+++ b/scripts/install
@@ -637,8 +637,11 @@ else
     # Remove orphaned venv/ from pre-uv installs
     rm -rf "$dest/venv"
 
-    # Create Python environment with uv (no ensurepip/pyexpat needed)
-    (cd "$dest" && uv sync --frozen --python python3) || {
+    # Create Python environment with uv (no ensurepip/pyexpat needed).
+    # No --python flag: let uv pick from requires-python in pyproject.toml.
+    # If system python3 is in range it's used; otherwise uv downloads a
+    # compatible managed interpreter.
+    (cd "$dest" && uv sync --frozen) || {
       echo "Warning: uv sync failed for module $name"
       return
     }


### PR DESCRIPTION
## Summary

Fixes biometrics-module install failures on Pods with a system Python outside `>=3.9,<3.11`. Reported on Discord (Xcessive Overlord, Pod 4 with python 3.14.4):

\`\`\`
Using CPython 3.14.4
error: The requested interpreter resolved to Python 3.14.4, which is incompatible with the project's Python requirement: \`>=3.9, <3.11\`
\`\`\`

`scripts/install:641` and `scripts/bin/sp-update:236` passed `--python python3`, which forces uv to use the system interpreter even when it doesn't satisfy `requires-python`. With the flag dropped, uv consults `requires-python` (already pinned in every module's `pyproject.toml` and `uv.lock`):

- Pod 3 (system 3.9), Pod 4 (3.10), Pod 5 (3.10.4) — system python3 is in range, used as-is. No regression, no download.
- Pods with newer/drifted firmware (e.g. 3.14.4) — uv downloads a compatible managed interpreter (~30MB, ~2 min first install) instead of bailing.

Tracked as ygg `sleepypod-core-2`.

## Test plan

- [ ] Fresh install on a Pod with system python3 in `>=3.9,<3.11` — no `uv python install` prompt; modules install in the same time as before.
- [ ] Fresh install on a Pod with system python3 outside the range — uv downloads managed Python and modules install successfully.
- [ ] `sp-update` on each scenario above mirrors the install behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python environment configuration for biometrics modules to dynamically select the appropriate interpreter based on module specifications instead of explicitly specifying a fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->