### PR TITLE
fix(install): force /usr/local/bin to front of PATH to beat Volta shim

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Ensure /usr/local/bin is in PATH (Yocto's root SSH PATH is minimal)
-case ":$PATH:" in
-  *:/usr/local/bin:*) ;;
-  *) export PATH="/usr/local/bin:$PATH" ;;
-esac
+# Force /usr/local/bin to the front of PATH. Pod 3 ships Volta at
+# ~/.volta/bin ahead of /usr/local/bin; without this its node/npm/pnpm
+# shim shadows ours and fails with "Volta error: Node is not available".
+export PATH="/usr/local/bin:$PATH"
 
 # sp-update — self-update sleepypod-core from GitHub via curl+tarball
 #

--- a/scripts/install
+++ b/scripts/install
@@ -144,11 +144,11 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
-# Ensure /usr/local/bin is in PATH (Yocto's root PATH is minimal)
-case ":$PATH:" in
-  *:/usr/local/bin:*) ;;
-  *) export PATH="/usr/local/bin:$PATH" ;;
-esac
+# Force /usr/local/bin to the front of PATH. Pod 3 stock firmware ships
+# Volta at ~/.volta/bin ahead of /usr/local/bin; without this our freshly
+# installed node/npm/pnpm symlinks are shadowed by Volta's shim, which
+# fails with "Volta error: Node is not available".
+export PATH="/usr/local/bin:$PATH"
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"


### PR DESCRIPTION
## Summary

Fixes the Pod 3 install failure reported on Discord:

\`\`\`
Installing Node.js 22.17.0 (arm64)...
[curl downloads ok]
Volta error: Node is not available.
To run any Node command, first set a default version using \`volta install node\`
Node.js  installed.
Volta error: Node is not available.
Exit code: 126
\`\`\`

**Root cause:** Pod 3 stock firmware places Volta in `~/.volta/bin` ahead of `/usr/local/bin` in the root user's PATH. The script downloads Node and symlinks `node`/`npm`/`pnpm`/`npx` into `/usr/local/bin`, but the previous PATH guard only prepended `/usr/local/bin` when absent, so on Pod 3 every subsequent `node`/`npm`/`pnpm` call resolved through Volta's shim — which has no managed Node installed and exits with "Volta error: Node is not available".

Affected calls (post-symlink, all PATH-resolved): `node -v` at `scripts/install:277,279,283,285`, `npm install -g pnpm` (292), `npm config get prefix` (294), `pnpm install/build` (403, 428, 429), `npx prebuild-install` (410), `node scripts/generate-git-info.mjs` (424). Also affects `scripts/bin/sp-update` (193, 212, 213, 216) on OTA updates.

**Fix:** unconditionally prepend `/usr/local/bin` to PATH in both scripts. Safe on every Pod gen — a leading duplicate is harmless because shell PATH resolution is leftmost-wins. The systemd unit already uses absolute `/usr/local/bin/node` so the daemon was never affected.

Tracked as ygg `sleepypod-core-3`.

## Test plan

- [ ] Fresh install on a Pod 3 (Volta in PATH, no managed Node) — `node -v` after symlink install reports v22.17.0, no Volta errors, install completes.
- [ ] Fresh install on Pod 4 / Pod 5 — no regression, no duplicate-PATH warnings.
- [ ] `sp-update` on a Pod 3 succeeds.