### PR TITLE
feat(install): probe and expose Pod capabilities at install time

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -398,6 +398,14 @@ else
 fi
 echo "Pod generation: $POD_GEN (DAC: $DAC_SOCK_PATH)"
 
+# Probe environment capabilities (Volta, system Python, ensurepip, ...).
+# Future Pod-specific install paths should branch on these vars rather
+# than re-probing inline. See scripts/pod/capabilities.
+if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
+  source "$INSTALL_DIR/scripts/pod/capabilities"
+  print_pod_capabilities
+fi
+
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
 echo "Installing dependencies..."
 CI=true pnpm install --frozen-lockfile --prod

--- a/scripts/pod/capabilities
+++ b/scripts/pod/capabilities
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Pod capabilities — install-time mirror of src/hardware/pods.ts POD_CAPS.
+#
+# Sourced by scripts/install (after scripts/pod/detect runs) and by
+# scripts/bin/sp-update. Provides bash variables that install paths can
+# branch on, so we can keep a single install script that adapts to each
+# Pod gen instead of duplicating logic per gen.
+#
+# Detection strategy: prefer environment probes (command -v, version
+# checks) over POD_GEN lookups. Probes survive firmware drift; lookups
+# don't. POD_GEN is only the fallback when probing isn't possible.
+#
+# Sets in caller's scope (all are exported):
+#
+#   MODEL_NAME                      "Pod 3", "Pod 4", "Pod 5", or "Pod (unknown)"
+#   POD_OS                          "yocto" or "debian"
+#   IPTABLES_PATH                   absolute path to iptables binary, "" if missing
+#   HAS_PACKAGE_MANAGER             "true" / "false"
+#   PACKAGE_MANAGER                 "apt" or "" (none)
+#   SYSTEM_PYTHON_VERSION           e.g. "3.10.4", "" if python3 missing
+#   SYSTEM_PYTHON_IN_BIOMETRICS_RANGE  "true" if in [3.9, 3.11), else "false"
+#   HAS_ENSUREPIP                   "true" / "false"
+#   HAS_NFTABLES                    "true" / "false"
+#   HAS_VOLTA                       "true" if Volta is present in PATH or ~/.volta
+#   HAS_IPTABLES_PERSISTENT         "true" / "false"
+#
+# Requires POD_GEN ("3_4" or "5") to be set by scripts/pod/detect first.
+
+# --- Probes ---------------------------------------------------------------
+
+_probe_iptables_path() {
+  local p
+  p="$(command -v iptables 2>/dev/null || true)"
+  if [ -n "$p" ]; then echo "$p"; return; fi
+  # Fallback to known canonical paths if the PATH lookup missed it
+  for p in /usr/sbin/iptables /sbin/iptables; do
+    [ -x "$p" ] && { echo "$p"; return; }
+  done
+  echo ""
+}
+
+_probe_python_version() {
+  command -v python3 >/dev/null 2>&1 || { echo ""; return; }
+  python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])' 2>/dev/null \
+    || echo ""
+}
+
+_python_in_biometrics_range() {
+  # Modules pin requires-python = ">=3.9,<3.11"
+  command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
+  if python3 -c 'import sys; sys.exit(0 if (3,9) <= sys.version_info[:2] < (3,11) else 1)' 2>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+_probe_has_ensurepip() {
+  command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
+  if python3 -c 'import ensurepip' 2>/dev/null; then echo "true"; else echo "false"; fi
+}
+
+_probe_has_volta() {
+  if command -v volta >/dev/null 2>&1; then echo "true"; return; fi
+  for d in "$HOME/.volta" /home/root/.volta /root/.volta; do
+    [ -d "$d" ] && { echo "true"; return; }
+  done
+  echo "false"
+}
+
+_probe_has_iptables_persistent() {
+  if command -v iptables-save >/dev/null 2>&1; then echo "true"; return; fi
+  [ -d /etc/iptables ] && { echo "true"; return; }
+  echo "false"
+}
+
+# --- Defaults from POD_GEN (fallback when probes can't tell us) -----------
+
+case "${POD_GEN:-}" in
+  3_4)
+    MODEL_NAME="Pod 3 / Pod 4"
+    POD_OS="yocto"
+    HAS_PACKAGE_MANAGER="false"
+    PACKAGE_MANAGER=""
+    HAS_NFTABLES="false"
+    ;;
+  5)
+    MODEL_NAME="Pod 5"
+    POD_OS="debian"
+    HAS_PACKAGE_MANAGER="true"
+    PACKAGE_MANAGER="apt"
+    HAS_NFTABLES="$(command -v nft >/dev/null 2>&1 && echo true || echo false)"
+    ;;
+  *)
+    MODEL_NAME="Pod (unknown)"
+    POD_OS="unknown"
+    HAS_PACKAGE_MANAGER="$(command -v apt >/dev/null 2>&1 && echo true || echo false)"
+    PACKAGE_MANAGER="$(command -v apt >/dev/null 2>&1 && echo apt || echo '')"
+    HAS_NFTABLES="$(command -v nft >/dev/null 2>&1 && echo true || echo false)"
+    ;;
+esac
+
+IPTABLES_PATH="$(_probe_iptables_path)"
+SYSTEM_PYTHON_VERSION="$(_probe_python_version)"
+SYSTEM_PYTHON_IN_BIOMETRICS_RANGE="$(_python_in_biometrics_range)"
+HAS_ENSUREPIP="$(_probe_has_ensurepip)"
+HAS_VOLTA="$(_probe_has_volta)"
+HAS_IPTABLES_PERSISTENT="$(_probe_has_iptables_persistent)"
+
+export MODEL_NAME POD_OS IPTABLES_PATH HAS_PACKAGE_MANAGER PACKAGE_MANAGER
+export SYSTEM_PYTHON_VERSION SYSTEM_PYTHON_IN_BIOMETRICS_RANGE HAS_ENSUREPIP
+export HAS_NFTABLES HAS_VOLTA HAS_IPTABLES_PERSISTENT
+
+print_pod_capabilities() {
+  echo "Pod capabilities:"
+  echo "  Model:                $MODEL_NAME (POD_GEN=${POD_GEN:-?})"
+  echo "  OS:                   $POD_OS"
+  echo "  iptables:             ${IPTABLES_PATH:-<missing>}"
+  echo "  Package manager:      ${PACKAGE_MANAGER:-none}"
+  echo "  System python3:       ${SYSTEM_PYTHON_VERSION:-<missing>} (in biometrics range: $SYSTEM_PYTHON_IN_BIOMETRICS_RANGE)"
+  echo "  ensurepip:            $HAS_ENSUREPIP"
+  echo "  nftables:             $HAS_NFTABLES"
+  echo "  Volta:                $HAS_VOLTA"
+  echo "  iptables-persistent:  $HAS_IPTABLES_PERSISTENT"
+}


### PR DESCRIPTION
## Summary

Adopt the Pod-style install pattern requested in the install-bug discussion: mirror the Node-side `POD_CAPS` table from `src/hardware/pods.ts` in bash, so install paths can branch on detected capabilities rather than re-probing inline.

`scripts/pod/capabilities` (sourced after `scripts/pod/detect` in `scripts/install`) probes the environment directly and exports:

- `MODEL_NAME`, `POD_OS`, `IPTABLES_PATH`, `HAS_PACKAGE_MANAGER`, `PACKAGE_MANAGER`
- `SYSTEM_PYTHON_VERSION`, `SYSTEM_PYTHON_IN_BIOMETRICS_RANGE`, `HAS_ENSUREPIP`
- `HAS_NFTABLES`, `HAS_VOLTA`, `HAS_IPTABLES_PERSISTENT`

Probes are preferred over `POD_GEN` lookups because they survive firmware drift (e.g., Pod 4 with python 3.14.4, Pod 3 with Volta pre-installed) — both real cases reported on Discord.

The install script prints the detected capabilities so users sharing logs include the relevant environment up front.

**No behavior change today.** The three install fixes already on this branch's parent (`fix/biometrics-database-url-systemd`, `fix/uv-respect-requires-python`, `fix/path-prepend-usr-local-bin`) are universally correct without branching. This PR is the foundation for future Pod-specific paths — e.g., skipping the `uv` install when `HAS_ENSUREPIP=true`, using `$IPTABLES_PATH` for the absolute binary, choosing the right package manager.

## Test plan

- [ ] Run install on Pod 3 → output includes `Volta: true`, `System python3: 3.9.x (in biometrics range: true)`.
- [ ] Run install on Pod 4 → `Volta: false`, `System python3: 3.10.x (in biometrics range: true)`.
- [ ] Run install on Pod 5 → `OS: debian`, `Package manager: apt`, `nftables: true`.
- [ ] On a dev machine, `POD_GEN=3_4 source scripts/pod/capabilities && print_pod_capabilities` runs without error and reports something sensible.

## Follow-ups (not in this PR)

- Use `IPTABLES_PATH` in `block_wan` / `unblock_wan` instead of bare `iptables`.
- Skip the `uv` install entirely when `HAS_ENSUREPIP=true` (Pod 5).
- Mirror to `scripts/bin/sp-update` once we add a path that branches on capabilities.