### PR TITLE
fix(install): default __BRANCH__ placeholder to main at runtime

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -153,6 +153,11 @@ esac
 INSTALL_DIR="/home/dac/sleepypod-core"
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
 SCRIPT_DEFAULT_BRANCH="__BRANCH__"  # substituted at release time by .github/workflows/{release,dev-release}.yml
+# Guard for users curling the raw source from main: the substitution only
+# happens inside the release tarball, so the file at raw.githubusercontent
+# still has the literal placeholder. Fall back to main so the install
+# doesn't try to download a branch literally named "__BRANCH__".
+[ "$SCRIPT_DEFAULT_BRANCH" = "__BRANCH__" ] && SCRIPT_DEFAULT_BRANCH="main"
 
 # Lock file to prevent concurrent installs
 LOCKFILE="/var/run/sleepypod-install.lock"


### PR DESCRIPTION
## Summary

Fixes the P0 install failure reported on Discord (punkmaniac, 4/14):

\`\`\`
Error: Failed to download branch '__BRANCH__'
\`\`\`

**Root cause:** Commit 384cd78 (#426) replaced the hardcoded `SCRIPT_DEFAULT_BRANCH="main"` with `SCRIPT_DEFAULT_BRANCH="__BRANCH__"` and added a `sed` step in both release workflows to substitute the placeholder **inside the release tarball**. The README's canonical install command, and what every user actually runs:

\`\`\`
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/main/scripts/install | sudo bash
\`\`\`

…fetches from `raw.githubusercontent`, which serves the source file with the placeholder unsubstituted. The script then tries to download `https://github.com/sleepypod/core/archive/refs/heads/__BRANCH__.tar.gz` and fails.

**Fix:** one-line runtime guard — if the placeholder is still literal, fall back to `main`. Released tarballs are templated by the workflow at build time so the guard is a no-op there; the previous behavior is preserved for in-tarball runs and the raw-curl path now works again.

Tracked as ygg `sleepypod-core-1`.

## Test plan

- [ ] `bash -c 'SCRIPT_DEFAULT_BRANCH="__BRANCH__"; [ "$SCRIPT_DEFAULT_BRANCH" = "__BRANCH__" ] && SCRIPT_DEFAULT_BRANCH=main; echo "$SCRIPT_DEFAULT_BRANCH"'` prints `main`.
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/sleepypod/core/<this-branch>/scripts/install | sudo bash` on a Pod and confirm it downloads `main` (no "Failed to download branch" error).
- [ ] After merge to `dev`, the dev release workflow's templated tarball still has `SCRIPT_DEFAULT_BRANCH="dev"` baked in — guard is a no-op.