### PR TITLE
fix(install): map dev → dev-latest for rolling release tag

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -139,6 +139,8 @@ HAS_BUILD=false
 # Try CI release by tag — works for any branch with a GitHub Release (main, dev, etc.)
 RELEASE_TAG="$BRANCH"
 [ "$RELEASE_TAG" = "latest" ] && RELEASE_TAG="main"
+# Rolling dev tag was renamed from `dev` to `dev-latest` in #427.
+[ "$RELEASE_TAG" = "dev" ] && RELEASE_TAG="dev-latest"
 echo "Checking for CI release (tag: $RELEASE_TAG)..."
 RELEASE_URL=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}" \
   | grep -o '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \

--- a/scripts/install
+++ b/scripts/install
@@ -334,7 +334,8 @@ else
   if [ "$DOWNLOAD_BRANCH" = "main" ] || [ "$DOWNLOAD_BRANCH" = "latest" ]; then
     RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
   elif [ "$DOWNLOAD_BRANCH" = "dev" ]; then
-    RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/dev"
+    # Rolling dev tag was renamed from `dev` to `dev-latest` in #427.
+    RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/dev-latest"
   fi
 
   if [ -n "${RELEASE_API:-}" ]; then


### PR DESCRIPTION
## Summary

Fixes the CI-release fast path for the `dev` branch after commit 8fbd7dd (#427) renamed the rolling dev release tag from `dev` to `dev-latest`.

`scripts/install:337` and `scripts/bin/sp-update:140-142` still referenced `releases/tags/dev`. The API call 404s, the CI-release fast path is silently skipped, and the install falls through to downloading the source tarball and building on the pod. Next.js 16 Turbopack's build OOMs silently on Pod hardware, leaving `.next/standalone/` missing and the install directory half-wiped. Caught during a live install test on a Pod 5 today.

Mirrors the existing `latest` → `main` alias with a `dev` → `dev-latest` alias in both scripts.

Tracked as ygg `sleepypod-core-5`.

## Test plan

- [ ] `curl ... raw.githubusercontent.com/.../dev/scripts/install | sudo bash -s -- --branch dev` on a pod — log shows "Downloading CI release..." then "CI release downloaded (pre-built).", no `next build` step runs.
- [ ] `sp-update dev` does the same.
- [ ] `--branch main` / `--branch latest` still work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset identification for the development channel to ensure correct packages are downloaded during installation and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->