### PR TITLE
fix(capabilities): probe package manager + iptables, don't trust POD_GEN

### DIFF
--- a/scripts/internet-control
+++ b/scripts/internet-control
@@ -46,16 +46,21 @@ COMMAND="$1"
 # ---------------------------------------------------------------------------
 # Pod OS / iptables detection
 # ---------------------------------------------------------------------------
-# Pod 3/4 run Yocto (no apt, iptables at /sbin/iptables)
-# Pod 5 runs Debian (has apt, iptables at /usr/sbin/iptables)
-if [ -x /usr/bin/apt-get ]; then
-  POD_OS="debian"
-  IPTABLES="/usr/sbin/iptables"
-  IP6TABLES="/usr/sbin/ip6tables"
-else
-  POD_OS="yocto"
-  IPTABLES="/sbin/iptables"
-  IP6TABLES="/sbin/ip6tables"
+# Probe for iptables directly — firmware variants exist where the
+# apt-get-presence assumption breaks (e.g. Pod 5 with iptables at
+# /usr/sbin but no apt-get). Fall back to the canonical paths by OS class.
+POD_OS="$(command -v apt-get >/dev/null 2>&1 && echo debian || echo yocto)"
+IPTABLES="$(command -v iptables 2>/dev/null || true)"
+IP6TABLES="$(command -v ip6tables 2>/dev/null || true)"
+if [ -z "$IPTABLES" ]; then
+  for p in /usr/sbin/iptables /sbin/iptables; do
+    [ -x "$p" ] && { IPTABLES="$p"; break; }
+  done
+fi
+if [ -z "$IP6TABLES" ]; then
+  for p in /usr/sbin/ip6tables /sbin/ip6tables; do
+    [ -x "$p" ] && { IP6TABLES="$p"; break; }
+  done
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/pod/capabilities
+++ b/scripts/pod/capabilities
@@ -74,31 +74,31 @@ _probe_has_iptables_persistent() {
   echo "false"
 }
 
-# --- Defaults from POD_GEN (fallback when probes can't tell us) -----------
+# --- Defaults ---------------------------------------------------------------
+# Model name + OS class come from POD_GEN since they can't be probed cheaply.
+# Everything else is probed below — firmware variants (seen in the wild:
+# Pod 5 with no apt-get, mediatek kirkstone with python 3.14) break any
+# hardcoded-by-gen assumption.
 
 case "${POD_GEN:-}" in
-  3_4)
-    MODEL_NAME="Pod 3 / Pod 4"
-    POD_OS="yocto"
-    HAS_PACKAGE_MANAGER="false"
-    PACKAGE_MANAGER=""
-    HAS_NFTABLES="false"
-    ;;
-  5)
-    MODEL_NAME="Pod 5"
-    POD_OS="debian"
-    HAS_PACKAGE_MANAGER="true"
-    PACKAGE_MANAGER="apt"
-    HAS_NFTABLES="$(command -v nft >/dev/null 2>&1 && echo true || echo false)"
-    ;;
-  *)
-    MODEL_NAME="Pod (unknown)"
-    POD_OS="unknown"
-    HAS_PACKAGE_MANAGER="$(command -v apt >/dev/null 2>&1 && echo true || echo false)"
-    PACKAGE_MANAGER="$(command -v apt >/dev/null 2>&1 && echo apt || echo '')"
-    HAS_NFTABLES="$(command -v nft >/dev/null 2>&1 && echo true || echo false)"
-    ;;
+  3_4) MODEL_NAME="Pod 3 / Pod 4"; POD_OS="yocto" ;;
+  5)   MODEL_NAME="Pod 5";         POD_OS="debian" ;;
+  *)   MODEL_NAME="Pod (unknown)"; POD_OS="unknown" ;;
 esac
+
+if command -v apt-get >/dev/null 2>&1; then
+  HAS_PACKAGE_MANAGER="true"
+  PACKAGE_MANAGER="apt"
+else
+  HAS_PACKAGE_MANAGER="false"
+  PACKAGE_MANAGER=""
+fi
+
+if command -v nft >/dev/null 2>&1; then
+  HAS_NFTABLES="true"
+else
+  HAS_NFTABLES="false"
+fi
 
 IPTABLES_PATH="$(_probe_iptables_path)"
 SYSTEM_PYTHON_VERSION="$(_probe_python_version)"


### PR DESCRIPTION
## Summary

Two firmware variants seen in the wild break the hardcoded-by-`POD_GEN` assumptions:

- **Pod 5** with DAC socket at `/persistent/deviceinfo/dac.sock` but **no** `apt-get` and iptables at `/usr/sbin/iptables` (caught during today's live install test). `scripts/internet-control unblock` died with `/sbin/iptables: No such file or directory` because its "no apt-get → Yocto → /sbin/iptables" heuristic pointed at a non-existent path.
- **Pod 3** on Eight Layer 4.0.2 kirkstone shipping Python 3.14, not the 3.9 that `src/hardware/pods.ts` POD_CAPS claims Pod 3 ships with.

Both confirm the pattern: probe the environment, don't trust the gen table.

### Changes

`scripts/pod/capabilities`:
- Keep POD_GEN-derived `MODEL_NAME` and `POD_OS` (those still reflect platform class).
- Probe `HAS_PACKAGE_MANAGER` / `PACKAGE_MANAGER` with `command -v apt-get` unconditionally, not from POD_GEN=5.
- Probe `HAS_NFTABLES` with `command -v nft` unconditionally.

`scripts/internet-control`:
- Probe `iptables` / `ip6tables` paths with `command -v`, fall back to `/usr/sbin` then `/sbin` canonical locations.
- `POD_OS` keeps the apt-get-based label purely for log output — no behavior branching on it.

Tracked as ygg `sleepypod-core-6`.

## Test plan

- [ ] On the user's Pod 5 with no apt-get: `sudo scripts/internet-control status` succeeds; `unblock` / `block` work using `/usr/sbin/iptables`.
- [ ] On a stock Debian Pod 5 with apt-get: `PACKAGE_MANAGER=apt`, behavior unchanged.
- [ ] On a Pod 3/4 Yocto install: `PACKAGE_MANAGER=""`, iptables resolves via `/sbin/iptables`.
- [ ] `bash -c 'POD_GEN=5 source scripts/pod/capabilities && print_pod_capabilities'` on a dev machine prints sensible values.