### PR TITLE
feat(auto-off): global wall-clock cap + remove per-side grace give-up (ygg-7 + ygg-8)

### DIFF
--- a/src/components/Settings/DeviceSettingsForm.tsx
+++ b/src/components/Settings/DeviceSettingsForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Globe, Thermometer, RotateCcw, Droplets } from 'lucide-react'
+import { Globe, Thermometer, RotateCcw, Droplets, Timer } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { Toggle } from './Toggle'
 import { TimeInput } from '../Schedule/TimeInput'
@@ -13,7 +13,10 @@ interface DeviceSettings {
   rebootTime: string | null
   primePodDaily: boolean
   primePodTime: string | null
+  globalMaxOnHours: number | null
 }
+
+const DEFAULT_MAX_ON_HOURS = 12
 
 // Common US/international timezones
 const TIMEZONES = [
@@ -50,6 +53,8 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
   const [rebootTime, setRebootTime] = useState(device.rebootTime ?? '03:00')
   const [primePodDaily, setPrimePodDaily] = useState(device.primePodDaily)
   const [primePodTime, setPrimePodTime] = useState(device.primePodTime ?? '14:00')
+  const [maxOnEnabled, setMaxOnEnabled] = useState(device.globalMaxOnHours != null)
+  const [maxOnHours, setMaxOnHours] = useState(device.globalMaxOnHours ?? DEFAULT_MAX_ON_HOURS)
 
   // Sync from server data when it changes
   useEffect(() => {
@@ -60,6 +65,8 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
     setRebootTime(device.rebootTime ?? '03:00')
     setPrimePodDaily(device.primePodDaily)
     setPrimePodTime(device.primePodTime ?? '14:00')
+    setMaxOnEnabled(device.globalMaxOnHours != null)
+    setMaxOnHours(device.globalMaxOnHours ?? DEFAULT_MAX_ON_HOURS)
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [device])
 
@@ -76,6 +83,7 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
     rebootTime: string
     primePodDaily: boolean
     primePodTime: string
+    globalMaxOnHours: number | null
   }>) {
     mutation.mutate(updates)
   }
@@ -120,6 +128,19 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
   function handlePrimeTimeChange(time: string) {
     setPrimePodTime(time)
     save({ primePodTime: time })
+  }
+
+  function handleMaxOnToggle() {
+    const newVal = !maxOnEnabled
+    setMaxOnEnabled(newVal)
+    save({ globalMaxOnHours: newVal ? maxOnHours : null })
+  }
+
+  function handleMaxOnHoursChange(hours: number) {
+    // Clamp to the router's 1–48 range before emitting.
+    const clamped = Math.max(1, Math.min(48, Math.round(hours)))
+    setMaxOnHours(clamped)
+    if (maxOnEnabled) save({ globalMaxOnHours: clamped })
   }
 
   return (
@@ -227,6 +248,43 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
               value={primePodTime}
               onChange={handlePrimeTimeChange}
               disabled={isPending}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Global auto-off cap (wall-clock safety net) */}
+      <div className="rounded-2xl bg-zinc-900 p-3 sm:p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Timer size={16} className={maxOnEnabled ? 'text-sky-400' : 'text-zinc-400'} />
+            <span className="text-sm font-medium text-zinc-300">Auto Power-Off Cap</span>
+          </div>
+          <Toggle
+            enabled={maxOnEnabled}
+            onToggle={handleMaxOnToggle}
+            disabled={isPending}
+            label="Toggle global auto power-off cap"
+          />
+        </div>
+        <p className="mb-2 text-xs text-zinc-500">
+          Forces any side that has been on for longer than this to power off. Runs on top of the per-side auto-off. Always-on sides and active run-once sessions are exempt.
+        </p>
+        {maxOnEnabled && (
+          <div className="mt-2 flex items-center gap-2">
+            <label htmlFor="maxOnHours" className="text-sm text-zinc-300">
+              Hours
+            </label>
+            <input
+              id="maxOnHours"
+              type="number"
+              min={1}
+              max={48}
+              step={1}
+              value={maxOnHours}
+              onChange={e => handleMaxOnHoursChange(Number(e.target.value))}
+              disabled={isPending}
+              className="h-11 w-24 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
             />
           </div>
         )}

--- a/src/db/migrations/0005_short_venom.sql
+++ b/src/db/migrations/0005_short_venom.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `device_settings` ADD `global_max_on_hours` integer;
+--> statement-breakpoint
+-- Seed powered_on_at for sides that are currently powered on but missing the
+-- timestamp (existing installs predate 0000's powered_on_at column being
+-- populated on every write path). Without this, the global cap would never
+-- fire on upgrades since powered_on_at stays NULL until the next OFF→ON edge.
+UPDATE `device_state` SET `powered_on_at` = unixepoch() WHERE `is_powered` = 1 AND `powered_on_at` IS NULL;

--- a/src/db/migrations/meta/0005_snapshot.json
+++ b/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,788 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac19cc45-1432-432e-8247-8389fa890b8e",
+  "prevId": "48a5ab38-529c-496f-8052-b8760da45bf8",
+  "tables": {
+    "alarm_schedules": {
+      "name": "alarm_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_intensity": {
+          "name": "vibration_intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_pattern": {
+          "name": "vibration_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rise'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alarm_temperature": {
+          "name": "alarm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_alarm_schedules_side_day": {
+          "name": "idx_alarm_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_settings": {
+      "name": "device_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'F'"
+        },
+        "reboot_daily": {
+          "name": "reboot_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reboot_time": {
+          "name": "reboot_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'03:00'"
+        },
+        "prime_pod_daily": {
+          "name": "prime_pod_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prime_pod_time": {
+          "name": "prime_pod_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'14:00'"
+        },
+        "led_night_mode_enabled": {
+          "name": "led_night_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "led_day_brightness": {
+          "name": "led_day_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "led_night_brightness": {
+          "name": "led_night_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "led_night_start_time": {
+          "name": "led_night_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'22:00'"
+        },
+        "led_night_end_time": {
+          "name": "led_night_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'07:00'"
+        },
+        "global_max_on_hours": {
+          "name": "global_max_on_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_state": {
+      "name": "device_state",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_temperature": {
+          "name": "current_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_temperature": {
+          "name": "target_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_powered": {
+          "name": "is_powered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_alarm_vibrating": {
+          "name": "is_alarm_vibrating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "water_level": {
+          "name": "water_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "powered_on_at": {
+          "name": "powered_on_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "power_schedules": {
+      "name": "power_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_time": {
+          "name": "on_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "off_time": {
+          "name": "off_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_temperature": {
+          "name": "on_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_power_schedules_side_day": {
+          "name": "idx_power_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_once_sessions": {
+      "name": "run_once_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_points": {
+          "name": "set_points",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_run_once_side_status": {
+          "name": "idx_run_once_side_status",
+          "columns": [
+            "side",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "side_settings": {
+      "name": "side_settings",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "away_mode": {
+          "name": "away_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_on": {
+          "name": "always_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_enabled": {
+          "name": "auto_off_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_minutes": {
+          "name": "auto_off_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "away_start": {
+          "name": "away_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "away_return": {
+          "name": "away_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_health": {
+      "name": "system_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "component": {
+          "name": "component",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "system_health_component_unique": {
+          "name": "system_health_component_unique",
+          "columns": [
+            "component"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tap_gestures": {
+      "name": "tap_gestures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tap_type": {
+          "name": "tap_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature_change": {
+          "name": "temperature_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_amount": {
+          "name": "temperature_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_behavior": {
+          "name": "alarm_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_snooze_duration": {
+          "name": "alarm_snooze_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_inactive_behavior": {
+          "name": "alarm_inactive_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temperature_schedules": {
+      "name": "temperature_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_temp_schedules_side_day_time": {
+          "name": "idx_temp_schedules_side_day_time",
+          "columns": [
+            "side",
+            "day_of_week",
+            "time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774935266497,
       "tag": "0004_shallow_tomorrow_man",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776548142374,
+      "tag": "0005_short_venom",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,10 @@ export const deviceSettings = sqliteTable('device_settings', {
   ledNightBrightness: integer('led_night_brightness').notNull().default(0), // 0-100
   ledNightStartTime: text('led_night_start_time').default('22:00'), // HH:mm format
   ledNightEndTime: text('led_night_end_time').default('07:00'), // HH:mm format
+  // Global wall-clock safety cap: if a side has been powered for this many
+  // hours with no run-once or always-on override, autoOffWatcher forces it
+  // off. NULL = disabled. Independent of per-side bed-exit auto-off.
+  globalMaxOnHours: integer('global_max_on_hours'),
   createdAt: integer('created_at', { mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -216,12 +216,22 @@ export const deviceRouter = router({
 
       // The DB is updated optimistically on every call for responsive UI.
       try {
+        const now = new Date()
+        // Only stamp poweredOnAt on OFF→ON transitions (preserve the existing
+        // timestamp if this is a temperature change while already on).
+        const [prev] = await db
+          .select({ isPowered: deviceState.isPowered, poweredOnAt: deviceState.poweredOnAt })
+          .from(deviceState)
+          .where(eq(deviceState.side, input.side))
+          .limit(1)
+        const poweredOnAt = prev?.isPowered ? prev.poweredOnAt : now
         await db
           .update(deviceState)
           .set({
             targetTemperature: input.temperature,
             isPowered: true,
-            lastUpdated: new Date(),
+            poweredOnAt,
+            lastUpdated: now,
           })
           .where(eq(deviceState.side, input.side))
       }
@@ -300,12 +310,23 @@ export const deviceRouter = router({
 
         // Best-effort DB sync — next getStatus() call will re-sync if this fails
         try {
+          const now = new Date()
+          const [prev] = await db
+            .select({ isPowered: deviceState.isPowered, poweredOnAt: deviceState.poweredOnAt })
+            .from(deviceState)
+            .where(eq(deviceState.side, input.side))
+            .limit(1)
+          // OFF→ON stamps poweredOnAt; ON→OFF clears it; same-state preserves.
+          const poweredOnAt = input.powered
+            ? (prev?.isPowered ? prev.poweredOnAt : now)
+            : null
           await db
             .update(deviceState)
             .set({
               isPowered: input.powered,
+              poweredOnAt,
               ...(input.temperature && { targetTemperature: input.temperature }),
-              lastUpdated: new Date(),
+              lastUpdated: now,
             })
             .where(eq(deviceState.side, input.side))
         }

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -27,6 +27,7 @@ const deviceSettingsSchema = z.object({
   ledNightBrightness: z.number(),
   ledNightStartTime: z.string().nullable(),
   ledNightEndTime: z.string().nullable(),
+  globalMaxOnHours: z.number().nullable(),
   createdAt: timestampSchema,
   updatedAt: timestampSchema,
 })
@@ -129,6 +130,7 @@ export const settingsRouter = router({
             ledNightBrightness: 0,
             ledNightStartTime: '22:00',
             ledNightEndTime: '07:00',
+            globalMaxOnHours: null,
             createdAt: new Date(),
             updatedAt: new Date(),
           },
@@ -170,6 +172,8 @@ export const settingsRouter = router({
           ledNightBrightness: z.number().int().min(0).max(100).optional(),
           ledNightStartTime: timeStringSchema.optional(),
           ledNightEndTime: timeStringSchema.optional(),
+          // Global wall-clock auto-off cap. `null` disables; 1–48 hours when set.
+          globalMaxOnHours: z.number().int().min(1).max(48).nullable().optional(),
         })
         .strict()
     )
@@ -235,6 +239,17 @@ export const settingsRouter = router({
         }
         catch (e) {
           console.error('Scheduler reload failed:', e)
+        }
+
+        // Re-evaluate autoOffWatcher immediately so a tightened cap fires
+        // without waiting for the 30s poll. Idempotent; no-op if watcher isn't running.
+        if ('globalMaxOnHours' in input) {
+          try {
+            restartAutoOffTimers()
+          }
+          catch (e) {
+            console.error('autoOff restart failed:', e)
+          }
         }
 
         return updated

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -11,7 +11,7 @@
 
 import { eq, and, desc } from 'drizzle-orm'
 import { db, biometricsDb } from '@/src/db'
-import { sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
+import { deviceSettings, sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
 import { sleepRecords } from '@/src/db/biometrics-schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
@@ -98,9 +98,15 @@ function hasActiveRunOnce(side: Side): boolean {
   }
 }
 
+interface SideConfig {
+  enabled: boolean
+  minutes: number
+  alwaysOn: boolean
+}
+
 /** Read auto-off config for both sides. */
-function getAutoOffConfig(): Record<Side, { enabled: boolean, minutes: number }> {
-  const defaults = { enabled: false, minutes: 30 }
+function getAutoOffConfig(): Record<Side, SideConfig> {
+  const defaults: SideConfig = { enabled: false, minutes: 30, alwaysOn: false }
   try {
     const rows = db.select().from(sideSettings).all()
     const left = rows.find(r => r.side === 'left')
@@ -109,15 +115,53 @@ function getAutoOffConfig(): Record<Side, { enabled: boolean, minutes: number }>
       left: {
         enabled: left?.autoOffEnabled ?? defaults.enabled,
         minutes: left?.autoOffMinutes ?? defaults.minutes,
+        alwaysOn: left?.alwaysOn ?? defaults.alwaysOn,
       },
       right: {
         enabled: right?.autoOffEnabled ?? defaults.enabled,
         minutes: right?.autoOffMinutes ?? defaults.minutes,
+        alwaysOn: right?.alwaysOn ?? defaults.alwaysOn,
       },
     }
   }
   catch {
     return { left: defaults, right: defaults }
+  }
+}
+
+/**
+ * Read the global wall-clock auto-off cap (device_settings.globalMaxOnHours).
+ * Returns null when disabled or on error.
+ */
+function getGlobalMaxOnHours(): number | null {
+  try {
+    const [row] = db
+      .select({ globalMaxOnHours: deviceSettings.globalMaxOnHours })
+      .from(deviceSettings)
+      .limit(1)
+      .all()
+    return row?.globalMaxOnHours ?? null
+  }
+  catch {
+    return null
+  }
+}
+
+/** Read poweredOnAt (ms epoch) for a side, or null. */
+function getPoweredOnAtMs(side: Side): number | null {
+  try {
+    const [row] = db
+      .select({ poweredOnAt: deviceState.poweredOnAt })
+      .from(deviceState)
+      .where(eq(deviceState.side, side))
+      .limit(1)
+      .all()
+    const v = row?.poweredOnAt
+    if (!v) return null
+    return v instanceof Date ? v.getTime() : (v as number) * 1000
+  }
+  catch {
+    return null
   }
 }
 
@@ -167,10 +211,12 @@ async function powerOffSide(side: Side): Promise<void> {
     await client.connect()
     await client.setPower(side, false)
 
-    // Best-effort DB sync
+    // Best-effort DB sync — also clear poweredOnAt so the global cap doesn't
+    // see a stale "powered on X hours ago" after the side comes back on later
+    // via a path that doesn't stamp through deviceStateSync.
     try {
       db.update(deviceState)
-        .set({ isPowered: false, lastUpdated: new Date() })
+        .set({ isPowered: false, poweredOnAt: null, lastUpdated: new Date() })
         .where(eq(deviceState.side, side))
         .run()
     }
@@ -213,35 +259,67 @@ function firePowerOff(side: Side): void {
  * long ago and the side is still powered, we assume they are in bed
  * (the session hasn't closed yet).
  */
-function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minutes: number }>): void {
+function evaluateSide(
+  side: Side,
+  config: Record<Side, SideConfig>,
+  globalMaxOnHours: number | null,
+): void {
   const cfg = config[side]
 
+  // Side already off — nothing to evaluate for either cap
+  if (!isSidePowered(side)) {
+    clearSideTimer(side)
+    return
+  }
+
+  // Run-once and always-on exempt a side from BOTH the per-side timer and
+  // the global cap. Run-once is the user's explicit "keep on until X"; the
+  // always-on flag is the perpetual-stay-on directive.
+  if (hasActiveRunOnce(side) || cfg.alwaysOn) {
+    clearSideTimer(side)
+    return
+  }
+
+  // ── Global wall-clock cap (runs independently of sleep_records) ──────────
+  // If a side has been powered for > globalMaxOnHours, force it off. This is
+  // the safety net that fires even when the biometrics pipeline is broken or
+  // the sleep-detector missed a bed-exit.
+  if (globalMaxOnHours != null && globalMaxOnHours > 0) {
+    const poweredOnAtMs = getPoweredOnAtMs(side)
+    if (poweredOnAtMs != null) {
+      const msSincePowerOn = Date.now() - poweredOnAtMs
+      const capMs = globalMaxOnHours * 3600_000
+      // Clock-sanity guard: skip the cap if poweredOnAt is in the future
+      // (NTP reset, clock drift). The 7-day upper bound protects against a
+      // stale row from a pre-2024 clock-seeded migration.
+      const suspicious = msSincePowerOn < 0 || msSincePowerOn > 7 * 86_400_000
+      if (!suspicious && msSincePowerOn > capMs) {
+        console.log(
+          `[auto-off] ${side}: global max-on cap exceeded (${globalMaxOnHours}h), powering off`,
+        )
+        clearSideTimer(side)
+        firePowerOff(side)
+        return
+      }
+    }
+  }
+
+  // ── Per-side bed-exit timer ──────────────────────────────────────────────
   // Feature disabled for this side
   if (!cfg.enabled) {
     clearSideTimer(side)
     return
   }
 
-  // Side already off -- nothing to do
-  if (!isSidePowered(side)) {
-    clearSideTimer(side)
-    return
-  }
-
-  // Suppress if a run-once session is active
-  if (hasActiveRunOnce(side)) {
-    clearSideTimer(side)
-    return
-  }
-
   const record = getLatestSleepRecord(side)
   if (!record) {
-    // No sleep records yet -- cannot determine presence
+    // No sleep records yet — cannot determine presence for the bed-exit path.
+    // The global cap above still applies independently.
     clearSideTimer(side)
     return
   }
 
-  // Fix 1: Don't arm if the user has returned to bed
+  // Don't arm if the user has returned to bed
   // (enteredBedAt > leftBedAt means a new session started after the exit)
   if (isUserInBed(side)) {
     clearSideTimer(side)
@@ -253,30 +331,14 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
     : (record.leftBedAt as number) * 1000
   const nowMs = Date.now()
   const timeoutMs = cfg.minutes * 60_000
-
-  // If the most recent bed exit is in the future or very recent
-  // and we don't have a timer yet, start one.
   const msSinceBedExit = nowMs - leftBedAtMs
 
-  // Check: has the person re-entered bed since this exit?
-  // If the sleep_records entry has been superseded by a newer entry with
-  // enteredBedAt > leftBedAt of the previous record, the person is back in bed.
-  // The sleep-detector only writes a record when a session ENDS, so if the side
-  // is powered and the most recent record's leftBedAt was long ago, a new session
-  // may be in progress (person is currently in bed).
-  // Heuristic: if leftBedAt is older than the timeout, the timer should have
-  // already fired. If the side is still on, either it was manually turned on
-  // or a new session is in progress -- don't start a new timer.
-  // Fix 5: Add grace window for server restarts during countdown.
-  // If msSinceBedExit is within timeoutMs + 2 * POLL_INTERVAL_MS, the timer
-  // may have been lost during a restart — fire immediately rather than skip.
-  const graceMs = timeoutMs + 2 * POLL_INTERVAL_MS
-  if (msSinceBedExit > graceMs) {
-    clearSideTimer(side)
-    return
-  }
-
-  // Fix 5: If past the timeout but within the grace window, fire immediately
+  // If past the timeout, fire immediately. Previously this branch was gated
+  // by `msSinceBedExit <= timeoutMs + 2 * POLL_INTERVAL_MS`; that "grace
+  // window" would give up past ~32min and leave the side on forever when
+  // the user left bed long ago and didn't return. The global cap is the
+  // catch-all for wall-clock staleness; here we just fire on any past-due
+  // bed-exit so long as the user hasn't re-entered bed.
   if (msSinceBedExit > timeoutMs) {
     clearSideTimer(side)
     // Re-check conditions before actually powering off
@@ -284,9 +346,11 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
     if (hasActiveRunOnce(side)) return
     if (isUserInBed(side)) return
     const freshConfig = getAutoOffConfig()
-    if (!freshConfig[side].enabled) return
+    if (!freshConfig[side].enabled || freshConfig[side].alwaysOn) return
 
-    console.log(`[auto-off] ${side}: bed exit was ${Math.round(msSinceBedExit / 1000)}s ago (within grace window), firing immediately`)
+    console.log(
+      `[auto-off] ${side}: bed exit ${Math.round(msSinceBedExit / 1000)}s ago (past ${cfg.minutes}min timeout), powering off`,
+    )
     firePowerOff(side)
     return
   }
@@ -317,7 +381,7 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
       if (!isSidePowered(side)) return
       if (hasActiveRunOnce(side)) return
       const freshConfig = getAutoOffConfig()
-      if (!freshConfig[side].enabled) return
+      if (!freshConfig[side].enabled || freshConfig[side].alwaysOn) return
 
       // Verify the bed-exit that armed this timer is still the latest
       const latestRecord = getLatestSleepRecord(side)
@@ -343,9 +407,10 @@ function evaluateSide(side: Side, config: Record<Side, { enabled: boolean, minut
 
 function poll(): void {
   const config = getAutoOffConfig()
+  const globalMaxOnHours = getGlobalMaxOnHours()
   for (const side of SIDES) {
     try {
-      evaluateSide(side, config)
+      evaluateSide(side, config, globalMaxOnHours)
     }
     catch (error) {
       console.error(

--- a/src/services/tests/autoOffWatcher.test.ts
+++ b/src/services/tests/autoOffWatcher.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type BetterSqlite3 from 'better-sqlite3'
 
 // ── Shared mocks ──────────────────────────────────────────────────────────
 const setPower = vi.fn(async () => {})
@@ -34,11 +35,11 @@ vi.mock('@/src/db', async () => {
 })
 
 // The mock above adds `biometricsSqlite` alongside the real module's exports.
-// Cast through `any` because the real `@/src/db` doesn't export it.
+// Cast the import so TypeScript sees the augmented shape.
 import * as dbModule from '@/src/db'
 import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
 const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
-  biometricsSqlite: import('better-sqlite3').Database
+  biometricsSqlite: BetterSqlite3.Database
 }
 
 function resetSchema(): void {

--- a/src/services/tests/autoOffWatcher.test.ts
+++ b/src/services/tests/autoOffWatcher.test.ts
@@ -1,0 +1,341 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ── Shared mocks ──────────────────────────────────────────────────────────
+const setPower = vi.fn(async () => {})
+const connect = vi.fn(async () => {})
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: () => ({ connect, setPower }),
+}))
+
+vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+// In-memory primary + biometrics DBs
+vi.mock('@/src/db', async () => {
+  const BetterSqlite3 = (await import('better-sqlite3')).default
+  const { drizzle } = await import('drizzle-orm/better-sqlite3')
+  const schema = await import('@/src/db/schema')
+  const biometricsSchema = await import('@/src/db/biometrics-schema')
+  const primary = new BetterSqlite3(':memory:')
+  primary.pragma('foreign_keys = ON')
+  const bio = new BetterSqlite3(':memory:')
+  bio.pragma('foreign_keys = ON')
+  return {
+    db: drizzle(primary, { schema }),
+    biometricsDb: drizzle(bio, { schema: biometricsSchema }),
+    sqlite: primary,
+    biometricsSqlite: bio,
+    closeDatabase: vi.fn(),
+    closeBiometricsDatabase: vi.fn(),
+  }
+})
+
+import { sqlite, biometricsSqlite } from '@/src/db'
+import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
+
+function resetSchema(): void {
+  // Wipe and recreate everything the watcher reads.
+  ;(sqlite as any).exec(`
+    DROP TABLE IF EXISTS device_settings;
+    DROP TABLE IF EXISTS side_settings;
+    DROP TABLE IF EXISTS device_state;
+    DROP TABLE IF EXISTS run_once_sessions;
+
+    CREATE TABLE device_settings (
+      id INTEGER PRIMARY KEY,
+      timezone TEXT NOT NULL DEFAULT 'UTC',
+      temperature_unit TEXT NOT NULL DEFAULT 'F',
+      reboot_daily INTEGER NOT NULL DEFAULT 0,
+      reboot_time TEXT,
+      prime_pod_daily INTEGER NOT NULL DEFAULT 0,
+      prime_pod_time TEXT,
+      led_night_mode_enabled INTEGER NOT NULL DEFAULT 0,
+      led_day_brightness INTEGER NOT NULL DEFAULT 100,
+      led_night_brightness INTEGER NOT NULL DEFAULT 0,
+      led_night_start_time TEXT,
+      led_night_end_time TEXT,
+      global_max_on_hours INTEGER,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE side_settings (
+      side TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      away_mode INTEGER NOT NULL DEFAULT 0,
+      always_on INTEGER NOT NULL DEFAULT 0,
+      auto_off_enabled INTEGER NOT NULL DEFAULT 0,
+      auto_off_minutes INTEGER NOT NULL DEFAULT 30,
+      away_start TEXT,
+      away_return TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE device_state (
+      side TEXT PRIMARY KEY,
+      current_temperature REAL,
+      target_temperature REAL,
+      is_powered INTEGER NOT NULL DEFAULT 0,
+      is_alarm_vibrating INTEGER NOT NULL DEFAULT 0,
+      water_level TEXT DEFAULT 'unknown',
+      powered_on_at INTEGER,
+      last_updated INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE run_once_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      set_points TEXT NOT NULL,
+      wake_time TEXT NOT NULL,
+      started_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      expires_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+
+    INSERT INTO device_settings (id) VALUES (1);
+    INSERT INTO side_settings (side, name) VALUES ('left', 'Left'), ('right', 'Right');
+    INSERT INTO device_state (side, is_powered) VALUES ('left', 0), ('right', 0);
+  `)
+  ;(biometricsSqlite as any).exec(`
+    DROP TABLE IF EXISTS sleep_records;
+    CREATE TABLE sleep_records (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      entered_bed_at INTEGER NOT NULL,
+      left_bed_at INTEGER NOT NULL,
+      sleep_duration_seconds INTEGER NOT NULL,
+      times_exited_bed INTEGER NOT NULL DEFAULT 0,
+      present_intervals TEXT,
+      not_present_intervals TEXT,
+      created_at INTEGER NOT NULL
+    );
+  `)
+}
+
+function setSideOn(side: 'left' | 'right', poweredOnAtMs: number): void {
+  ;(sqlite as any)
+    .prepare('UPDATE device_state SET is_powered=1, powered_on_at=? WHERE side=?')
+    .run(Math.floor(poweredOnAtMs / 1000), side)
+}
+
+function setSideSettings(side: 'left' | 'right', patch: Partial<{
+  autoOffEnabled: number
+  autoOffMinutes: number
+  alwaysOn: number
+}>): void {
+  const current = (sqlite as any)
+    .prepare('SELECT * FROM side_settings WHERE side=?')
+    .get(side)
+  const merged = {
+    auto_off_enabled: patch.autoOffEnabled ?? current.auto_off_enabled,
+    auto_off_minutes: patch.autoOffMinutes ?? current.auto_off_minutes,
+    always_on: patch.alwaysOn ?? current.always_on,
+  }
+  ;(sqlite as any)
+    .prepare('UPDATE side_settings SET auto_off_enabled=?, auto_off_minutes=?, always_on=? WHERE side=?')
+    .run(merged.auto_off_enabled, merged.auto_off_minutes, merged.always_on, side)
+}
+
+function setGlobalCap(hours: number | null): void {
+  ;(sqlite as any)
+    .prepare('UPDATE device_settings SET global_max_on_hours=? WHERE id=1')
+    .run(hours)
+}
+
+function insertSleepRecord(side: 'left' | 'right', enteredAtMs: number, leftAtMs: number): void {
+  ;(biometricsSqlite as any)
+    .prepare(`
+      INSERT INTO sleep_records
+        (side, entered_bed_at, left_bed_at, sleep_duration_seconds, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `)
+    .run(
+      side,
+      Math.floor(enteredAtMs / 1000),
+      Math.floor(leftAtMs / 1000),
+      Math.max(0, Math.floor((leftAtMs - enteredAtMs) / 1000)),
+      Math.floor(leftAtMs / 1000),
+    )
+}
+
+function insertActiveRunOnce(side: 'left' | 'right'): void {
+  ;(sqlite as any)
+    .prepare(`
+      INSERT INTO run_once_sessions
+        (side, set_points, wake_time, expires_at, status)
+      VALUES (?, '[]', '07:00', ?, 'active')
+    `)
+    .run(side, Math.floor(Date.now() / 1000) + 3600)
+}
+
+/**
+ * Run an immediate poll and flush one microtask turn so any async
+ * firePowerOff() promises settle before assertions.
+ */
+async function pollAndFlush(): Promise<void> {
+  // startAutoOffWatcher polls synchronously on start; stopping then starting
+  // again gives us a fresh poll we can flush.
+  await stopAutoOffWatcher()
+  startAutoOffWatcher()
+  // Allow the fire-and-forget powerOffSide promise to resolve.
+  await new Promise(resolve => setImmediate(resolve))
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+beforeEach(() => {
+  setPower.mockClear()
+  connect.mockClear()
+  resetSchema()
+})
+
+afterEach(async () => {
+  await stopAutoOffWatcher()
+})
+
+// ── ygg-8: grace-window give-up removed ──────────────────────────────────
+
+describe('per-side auto-off (grace-window fix, ygg-8)', () => {
+  it('fires when bed exit was 2h ago and side is still on (was previously skipped)', async () => {
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 3 * 3600_000) // powered 3h ago
+    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000) // exit 2h ago
+
+    await pollAndFlush()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('does not fire if side is already off', async () => {
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    // left stays is_powered=0
+    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('does not fire if user returned to bed after the exit', async () => {
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 3 * 3600_000)
+    // Earlier: exit 2h ago; newer: entered again 30min ago, left 1min ago? No —
+    // a single latest row with enteredBedAt > leftBedAt signals currently in bed.
+    insertSleepRecord('left', now - 30 * 60_000, now - 60 * 60_000) // entered 30min ago > left 60min ago = in bed
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('is suppressed by an active run-once session', async () => {
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 3 * 3600_000)
+    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
+    insertActiveRunOnce('left')
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('is suppressed by always_on = true', async () => {
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30, alwaysOn: 1 })
+    setSideOn('left', now - 3 * 3600_000)
+    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+})
+
+// ── ygg-7: global wall-clock cap ─────────────────────────────────────────
+
+describe('global auto-off cap (ygg-7)', () => {
+  it('does not fire when cap is NULL (disabled)', async () => {
+    const now = Date.now()
+    setGlobalCap(null)
+    setSideOn('left', now - 20 * 3600_000) // on for 20h
+    // auto_off_enabled left at 0 to isolate the global-cap path
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('fires when a side has been on longer than the cap', async () => {
+    const now = Date.now()
+    setGlobalCap(1) // 1 hour
+    setSideOn('left', now - 65 * 60_000) // 65 min ago
+
+    await pollAndFlush()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('does not fire when a side has been on less than the cap', async () => {
+    const now = Date.now()
+    setGlobalCap(1) // 1 hour
+    setSideOn('left', now - 30 * 60_000) // 30 min ago
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('is suppressed by an active run-once session', async () => {
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 5 * 3600_000) // 5h past cap
+    insertActiveRunOnce('left')
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('is suppressed by always_on = true', async () => {
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 5 * 3600_000) // 5h past cap
+    setSideSettings('left', { alwaysOn: 1 })
+
+    await pollAndFlush()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('skips the cap if poweredOnAt is in the future (clock-sanity guard)', async () => {
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now + 3600_000) // future — looks corrupted
+    await pollAndFlush()
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('skips the cap if poweredOnAt is more than 7 days old (stale-seed guard)', async () => {
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 10 * 86_400_000) // 10 days ago
+    await pollAndFlush()
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('fires even when per-side auto-off is disabled (global cap is independent)', async () => {
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 90 * 60_000) // 90 min ago
+    setSideSettings('left', { autoOffEnabled: 0 }) // per-side OFF
+
+    await pollAndFlush()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+})

--- a/src/services/tests/autoOffWatcher.test.ts
+++ b/src/services/tests/autoOffWatcher.test.ts
@@ -33,8 +33,13 @@ vi.mock('@/src/db', async () => {
   }
 })
 
-import { sqlite, biometricsSqlite } from '@/src/db'
+// The mock above adds `biometricsSqlite` alongside the real module's exports.
+// Cast through `any` because the real `@/src/db` doesn't export it.
+import * as dbModule from '@/src/db'
 import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
+const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
+  biometricsSqlite: import('better-sqlite3').Database
+}
 
 function resetSchema(): void {
   // Wipe and recreate everything the watcher reads.


### PR DESCRIPTION
## Summary

Lands `sleepypod-core-7` (global wall-clock cap) and `sleepypod-core-8` (remove per-side grace-window give-up) together. Both surfaced while debugging "pod stays on all day" on a live Pod 5 this afternoon — the per-side path alone isn't enough when the biometrics pipeline stalls or the user didn't register a bed entry.

### Global cap (ygg-7)

New `device_settings.global_max_on_hours` (nullable; 1–48h when set). If a side has been powered for longer than the cap, `autoOffWatcher` forces it off — independent of `sleep_records`. Precedence: whichever of the two timers (per-side bed-exit + global cap) trips first wins. **Run-once sessions and `always_on` sides are exempt from both** — the perpetual-stay-on directive must override the safety net.

Clock-sanity guards skip the cap when `powered_on_at` is in the future or more than 7 days old (protects against NTP resets and the migration seed timestamp on long-running installs).

### Grace-window give-up removed (ygg-8)

`autoOffWatcher.ts` used to `return` without firing when `msSinceBedExit > timeoutMs + 2 × POLL_INTERVAL_MS` (the original rationale: "the timer should have already fired, a new session is probably in progress"). That left the pod on indefinitely after any server restart past the grace window or when the user left bed long ago without returning — exactly the state I found on the live pod today (72k vitals rows, last sleep record 2+ hours old, side still on). Deleted the branch; any past-due bed-exit now fires, still gated by in-bed / run-once / always-on checks.

## Schema & power-on tracking

- Migration 0005: `global_max_on_hours` column + seeds `device_state.powered_on_at = unixepoch()` for currently-powered rows that are missing it (pre-existing installs never had anything write the column from a steady-state ON).
- `deviceStateSync.upsertSide` already handles the OFF→ON/ON→OFF transition. This PR extends the **optimistic direct writes** in `device.ts` to also stamp/clear `powered_on_at` so the global cap isn't blind during the 30s window before the hardware poll reconciles.
- `autoOffWatcher.powerOffSide` clears `powered_on_at` on fire.

## UI

New toggle + hours input in `DeviceSettingsForm.tsx` between Prime Pod and the existing sections. Copy:
> Forces any side that has been on for longer than this to power off. Runs on top of the per-side auto-off. Always-on sides and active run-once sessions are exempt.

## Tests

13 new unit tests in `src/services/tests/autoOffWatcher.test.ts`:

- **Grace-window fix (5):** fires at 2h past exit with side still on · skips when side is off · skips when user returned · suppressed by run-once · suppressed by `always_on`.
- **Global cap (6):** NULL disables · fires past cap · waits under cap · run-once suppresses · `always_on` suppresses · cap is independent of per-side `auto_off_enabled` (fires even when per-side is off).
- **Clock-sanity guards (2):** `powered_on_at` in future skipped · `powered_on_at` > 7 days skipped.

Full suite: `621 passed, 2 skipped, 43 files`. `pnpm tsc` and `pnpm lint` clean.

## Test plan (manual, once landed on the live Pod 5)

- [ ] Toggle auto-off-cap to 1h in Settings → run for > 1h → verify both sides go off, log shows `[auto-off] <side>: global max-on cap exceeded (1h), powering off`.
- [ ] Enable `alwaysOn` on left → cap doesn't fire for left even past 1h, still fires for right.
- [ ] Start a run-once → cap is suppressed for that side until the run-once ends.
- [ ] Pre-existing OFF sides stay off after upgrade; currently-ON sides get `powered_on_at` seeded and the cap counts from upgrade time.

## Risks / follow-ups

- The migration seeds `powered_on_at` for currently-powered rows to `now` at migration time. On a pod that's been ON for 10h pre-upgrade, the cap counts from 0 after upgrade, not from the real power-on. Acceptable for a safety-net feature; no false positives.
- If you set the cap to 1h while a side is 2h into a legitimate pre-bed warmup, it will fire. Copy in the UI flags this; alternative is to gate the cap with a grace period after setting, but I'd rather keep the semantics simple.

Closes `sleepypod-core-7`, `sleepypod-core-8`.