### PR TITLE
fix(internet-control): nuclear-flush unblock so WAN actually opens

### DIFF
--- a/scripts/internet-control
+++ b/scripts/internet-control
@@ -252,28 +252,38 @@ case "$COMMAND" in
     echo "========================================"
     echo ""
 
-    # Remove custom chains (IPv4)
-    if "$IPTABLES" -L SLEEPYPOD-BLOCK &>/dev/null; then
-      echo "Removing IPv4 firewall rules..."
-      "$IPTABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-      "$IPTABLES" -F SLEEPYPOD-BLOCK
-      "$IPTABLES" -X SLEEPYPOD-BLOCK
-    fi
-
+    # Nuclear flush: previous versions only tried to remove SLEEPYPOD-BLOCK
+    # and flip the default policy, but that's a no-op when the pod has
+    # pre-existing narrow-whitelist rules from stock firmware (e.g. cloud
+    # telemetry ACCEPTs + terminal INPUT DROP). We need to match the install
+    # script's unblock_wan() behavior so the unblock actually reaches GitHub.
+    echo "Flushing IPv4 rules and setting default policies to ACCEPT..."
+    "$IPTABLES" -P INPUT ACCEPT
     "$IPTABLES" -P OUTPUT ACCEPT
+    "$IPTABLES" -P FORWARD ACCEPT
+    "$IPTABLES" -F
+    "$IPTABLES" -X
+    "$IPTABLES" -t nat -F 2>/dev/null || true
+    "$IPTABLES" -t nat -X 2>/dev/null || true
+    "$IPTABLES" -t mangle -F 2>/dev/null || true
+    "$IPTABLES" -t mangle -X 2>/dev/null || true
 
     if command -v "${IPTABLES}-save" &>/dev/null; then
       mkdir -p /etc/iptables
       "${IPTABLES}-save" > /etc/iptables/rules.v4
     fi
 
-    # Remove IPv6 rules
-    if command -v "$IP6TABLES" &>/dev/null && "$IP6TABLES" -L SLEEPYPOD-BLOCK &>/dev/null; then
-      echo "Removing IPv6 firewall rules..."
-      "$IP6TABLES" -D OUTPUT -j SLEEPYPOD-BLOCK 2>/dev/null || true
-      "$IP6TABLES" -F SLEEPYPOD-BLOCK
-      "$IP6TABLES" -X SLEEPYPOD-BLOCK
+    if command -v "$IP6TABLES" &>/dev/null; then
+      echo "Flushing IPv6 rules and setting default policies to ACCEPT..."
+      "$IP6TABLES" -P INPUT ACCEPT
       "$IP6TABLES" -P OUTPUT ACCEPT
+      "$IP6TABLES" -P FORWARD ACCEPT
+      "$IP6TABLES" -F
+      "$IP6TABLES" -X
+      "$IP6TABLES" -t nat -F 2>/dev/null || true
+      "$IP6TABLES" -t nat -X 2>/dev/null || true
+      "$IP6TABLES" -t mangle -F 2>/dev/null || true
+      "$IP6TABLES" -t mangle -X 2>/dev/null || true
 
       if command -v "${IP6TABLES}-save" &>/dev/null; then
         "${IP6TABLES}-save" > /etc/iptables/rules.v6


### PR DESCRIPTION
## Summary

Found while running a live install test today: `sudo scripts/internet-control unblock` prints "✓ Internet access restored!" and exits 0, but `curl https://github.com` immediately afterwards still times out. The `curl ... | sudo bash` install command hit this exact failure mode — the user had to manually flush iptables to get past it.

## Root cause

The old unblock branch only removed a `SLEEPYPOD-BLOCK` custom chain and flipped default policies to `ACCEPT`. That works when the pod's iptables state was seeded by this same script's `block` action. It does **not** work when iptables was seeded by something else — in today's case, Eight Sleep stock firmware's narrow-whitelist ACCEPTs for cloud telemetry IPs (`35.186.*`, `34.120.*`) followed by a terminal `INPUT DROP all`. The `ACCEPT` policy is dominated by the explicit `DROP` rule in the chain.

Verified iptables state after the old unblock on a real pod:
```
Chain INPUT (policy ACCEPT)
...
ACCEPT     all  --  192.168.0.0/16       0.0.0.0/0
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0
DROP       all  --  0.0.0.0/0            0.0.0.0/0        ← still here
```

## Fix

Mirror the install script's `unblock_wan()` (`scripts/install:75-83`), which already works correctly: flush filter/nat/mangle tables, delete all custom chains, set every default policy to `ACCEPT`. Applied to both IPv4 and IPv6.

## Smoke test (live Pod 5, stock firmware WAN-block)

- [x] Before: `curl` to GitHub times out despite `unblock` reporting success, `INPUT DROP count = 1`.
- [x] After this fix: `unblock` completes → `curl https://github.com` and `curl https://raw.githubusercontent.com` both succeed, `iptables -L` reports 0 rules in every chain.
- [x] `iptables-restore` from the saved snapshot re-blocks WAN as before (regression guard).

Tracked as ygg `sleepypod-core-9`.

## Test plan (CI + manual)

- [ ] Lint / tsc pass (shell-only change, should be a no-op).
- [ ] On next pod deploy, `scripts/internet-control block && scripts/internet-control unblock && curl ... github.com` round-trips successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated firewall reset functionality to perform a comprehensive reset of all rules and policies for both IPv4 and IPv6 systems, replacing targeted removal with a complete firewall reset operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->