### PR TITLE
fix: Pod 4 install unblock (detect regex + sp-maintenance hardening)

### DIFF
--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -13,7 +13,15 @@ echo "=== SleepyPod Maintenance ==="
 
 # 1. Vacuum systemd journal (cap at 50MB)
 if command -v journalctl &>/dev/null; then
-  JOURNAL_SIZE=$(du -sm /persistent/journal 2>/dev/null | awk '{print $1}' || echo 0)
+  # Guard against two failure modes reported on a fresh Pod 4:
+  # (a) /persistent/journal missing → `du` fails, pipefail propagates, the
+  #     whole $(…) subshell errors under `set -e` unless we tolerate it.
+  # (b) directory exists but awk output is empty → `[ "" -gt 50 ]` errors
+  #     with "integer expression expected" under `set -e`.
+  # Belt-and-suspenders: tolerate pipeline failure with `|| true`, then
+  # default the variable to 0 if still unset/empty.
+  JOURNAL_SIZE=$(du -sm /persistent/journal 2>/dev/null | awk '{print $1}' || true)
+  JOURNAL_SIZE=${JOURNAL_SIZE:-0}
   if [ "$JOURNAL_SIZE" -gt 50 ]; then
     echo "Vacuuming journal (${JOURNAL_SIZE}MB → 50MB)..."
     journalctl --vacuum-size=50M 2>/dev/null || true
@@ -41,7 +49,8 @@ fi
 
 # 4. Prune pnpm content-addressable store
 if command -v pnpm &>/dev/null; then
-  STORE_SIZE=$(du -sm /home/root/.local/share/pnpm/store 2>/dev/null | awk '{print $1}' || echo 0)
+  STORE_SIZE=$(du -sm /home/root/.local/share/pnpm/store 2>/dev/null | awk '{print $1}' || true)
+  STORE_SIZE=${STORE_SIZE:-0}
   if [ "$STORE_SIZE" -gt 100 ]; then
     echo "Pruning pnpm store (${STORE_SIZE}MB)..."
     pnpm store prune 2>/dev/null || true

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -35,8 +35,12 @@ detect_dac_sock() {
 
   # Priority 2: Extract from frank.sh (what frankenfirmware actually uses)
   if [ -f /opt/eight/bin/frank.sh ]; then
-    path=$(grep 'DAC_SOCKET=' /opt/eight/bin/frank.sh 2>/dev/null \
-      | grep -o '[^ ]*dac\.sock' | head -1 || true)
+    # grep -o '[^ ]*dac\.sock' is greedy against the left; on a line like
+    # `DAC_SOCKET=/deviceinfo/dac.sock` (no spaces), it matches the whole
+    # string including `DAC_SOCKET=`. Anchor the capture to the prefix and
+    # strip it so we get just the path — on Pod 4 this is `/deviceinfo/dac.sock`.
+    path=$(grep -oE 'DAC_SOCKET=[^ ]*dac\.sock' /opt/eight/bin/frank.sh 2>/dev/null \
+      | head -1 | cut -d= -f2- || true)
     if [ -n "$path" ] && is_supported_dac_path "$path"; then
       echo "Detected dac.sock path from frank.sh: $path" >&2
       echo "$path"


### PR DESCRIPTION
## Summary

Reported by a user installing on a **Pod 4** via the canonical `curl … | sudo bash` path. Two bugs compounded on this firmware; the first caused the misdetection the second tripped on.

```
root@eight-pod:~# systemctl status sleepypod.service
Process: 1138 ExecStartPre=…ln -sf /persistent/deviceinfo/dac.sock /deviceinfo/dac.s…
Process: 1140 ExecStartPre=/home/dac/sleepypod-core/scripts/bin/sp-maintenance (code=exited, status=2)
```

### Bug 1 — `scripts/pod/detect` mis-extracts dac.sock path from frank.sh

`grep -o '[^ ]*dac\.sock'` is greedy against the left; on `DAC_SOCKET=/deviceinfo/dac.sock` (no spaces) it returns the whole string including `DAC_SOCKET=`. `is_supported_dac_path` rejects the malformed value (the "Ignoring unsupported" warning), detection falls through, Priority 4 defaults to the Pod 5 path, and POD_GEN gets stamped `"5"` on Pod 4 hardware.

Consequences on Pod 4: systemd unit written with `DAC_SOCK_PATH=/persistent/deviceinfo/dac.sock` → `ExecStartPre` runs `ln -sf /persistent/deviceinfo/dac.sock /deviceinfo/dac.sock` → the symlink overwrites Pod 4's **live socket owned by frankenfirmware**, breaking hardware connectivity.

**Fix:** anchor the grep with `-oE 'DAC_SOCKET=[^ ]*dac\.sock'` and strip the prefix with `cut -d= -f2-`. Verified on Pod 4, Pod 5, and lines with trailing flags.

### Bug 2 — `sp-maintenance` exits status 2 on empty / missing size targets

`sp-maintenance:16` and `sp-maintenance:44` compute `JOURNAL_SIZE` / `STORE_SIZE` from `du … | awk`. Under `set -euo pipefail`:

- **Missing dir** — `du` errors, stdout empty, awk exits 0 on empty input, the pre-existing `|| echo 0` doesn't always fire cleanly across shells when pipefail propagates.
- **Empty dir** — `du` succeeds with empty stdout (or 0), awk prints nothing or "0", the `|| echo 0` never fires because the pipeline exited 0, VAR ends up as the empty string. Then `[ "" -gt 50 ]` → "integer expression expected", exit status 2.

Systemd sees `sp-maintenance` exited 2 → the whole `sleepypod.service` ExecStartPre chain fails → unit "activating (auto-restart)" loop.

**Fix:** `|| true` inside the subshell catches any pipeline failure; `${VAR:-0}` defaults the variable if empty. Belt-and-suspenders across both modes.

### Why bundle

Both bugs compound on Pod 4 installs. Fixing either alone leaves the pod broken:

- Fix only Bug 1 → Pod 4 detects correctly but sp-maintenance still exits 2 on missing `/persistent/journal`.
- Fix only Bug 2 → sp-maintenance survives but the DAC socket is still mis-symlinked and the app can't reach hardware.

Shipping together under one `fix:` so the Pod 4 install path works end-to-end from one patch version bump.

## Test plan

- [ ] Fresh install on a Pod 4 (POD_GEN resolves to `3_4`, DAC_SOCK_PATH=`/deviceinfo/dac.sock`); `sleepypod.service` reaches `active (running)` without ExecStartPre failure.
- [ ] Fresh install on a Pod 5 (POD_GEN=5, DAC_SOCK_PATH=`/persistent/deviceinfo/dac.sock`) — no regression.
- [ ] `sp-maintenance` completes successfully on a pod where `/persistent/journal` doesn't exist (Pod 4 stock firmware).
- [ ] `sp-update` on any gen re-resolves correctly.

Tracks ygg `sleepypod-core-11`.
