### PR TITLE
fix: Pod 4 install unblock round 2 (stale .env cache + sp-maintenance BAK_COUNT)

### DIFF
--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -39,10 +39,16 @@ done
 
 # 3. Prune old database backups (keep 3 most recent)
 if [ -d "$DATA_DIR" ]; then
-  BAK_COUNT=$(ls "$DATA_DIR"/sleepypod.db.bak.* 2>/dev/null | wc -l)
+  # `ls $DIR/glob | wc -l` dies under set -euo pipefail when the glob
+  # doesn't match (ls exits 1 on "no such file", pipefail propagates,
+  # set -e kills the command substitution). Use `find` instead: clean
+  # exit 0 whether or not matches exist.
+  BAK_COUNT=$(find "$DATA_DIR" -maxdepth 1 -name 'sleepypod.db.bak.*' -type f 2>/dev/null | wc -l)
+  BAK_COUNT=${BAK_COUNT:-0}
   if [ "$BAK_COUNT" -gt 3 ]; then
     PRUNE=$((BAK_COUNT - 3))
-    ls -t "$DATA_DIR"/sleepypod.db.bak.* | tail -n "$PRUNE" | xargs rm -f
+    find "$DATA_DIR" -maxdepth 1 -name 'sleepypod.db.bak.*' -type f -printf '%T@ %p\n' 2>/dev/null \
+      | sort -rn | tail -n "$PRUNE" | awk '{print $2}' | xargs -r rm -f
     echo "Pruned $PRUNE old DB backups (kept 3)."
   fi
 fi

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -22,12 +22,29 @@ is_supported_dac_path() {
 detect_dac_sock() {
   local path=""
 
-  # Priority 1: Read from existing .env (validate against known paths)
+  # Priority 1: Read from existing .env, but cross-check the value against
+  # hardware. A previous mis-detected install can cache a path that's on the
+  # allowlist but wrong for the current pod (e.g. Pod 5 path on Pod 4), and
+  # the cache stays sticky until .env is deleted. Only honor the cache if
+  # the socket is live OR frank.sh confirms it.
   if [ -f "$INSTALL_DIR/.env" ]; then
     path=$(grep '^DAC_SOCK_PATH=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2-)
     if [ -n "$path" ] && is_supported_dac_path "$path"; then
-      echo "$path"
-      return
+      local verified=false
+      # (a) Socket is a live socket → authoritative
+      [ -S "$path" ] && verified=true
+      # (b) frank.sh agrees with .env → authoritative
+      if [ "$verified" = false ] && [ -f /opt/eight/bin/frank.sh ]; then
+        local frank_path
+        frank_path=$(grep -oE 'DAC_SOCKET=[^ ]*dac\.sock' /opt/eight/bin/frank.sh 2>/dev/null \
+          | head -1 | cut -d= -f2- || true)
+        [ -n "$frank_path" ] && [ "$frank_path" = "$path" ] && verified=true
+      fi
+      if [ "$verified" = true ]; then
+        echo "$path"
+        return
+      fi
+      echo "Warning: Ignoring stale DAC_SOCK_PATH from .env ($path); re-detecting from hardware" >&2
     elif [ -n "$path" ]; then
       echo "Warning: Ignoring unsupported DAC_SOCK_PATH from .env: $path" >&2
     fi


### PR DESCRIPTION
## Summary

Two follow-up bugs surfaced from a Pod 4 user's install log after v1.7.0 landed.

### Bug 1 — sticky `.env` DAC_SOCK_PATH cache

Pre-v1.7.0 installs on Pod 4 wrote `DAC_SOCK_PATH=/persistent/deviceinfo/dac.sock` (wrong Pod 5 path from the broken regex) into `/home/dac/sleepypod-core/.env`. v1.7.0 fixed the regex but `scripts/pod/detect` Priority 1 still returns the cached value because `is_supported_dac_path` only checks the allowlist — doesn't verify against hardware. Three sequential attempts on a real Pod 4 all resolved to `Pod generation: 5`.

**Fix:** Priority 1 now requires either the path is a live socket (`[ -S ]`) or frank.sh agrees. Otherwise emit a "stale" warning and fall through to frank.sh (authoritative).

### Bug 2 — `sp-maintenance` dies on fresh install, status 2

User's journalctl confirms `sp-maintenance` ExecStartPre printed its banner then exited 2 even on v1.7.0. The earlier `JOURNAL_SIZE`/`STORE_SIZE` hardening missed line 34:

```bash
BAK_COUNT=$(ls "$DATA_DIR"/sleepypod.db.bak.* 2>/dev/null | wc -l)
```

On a fresh install, `/persistent/sleepypod-data/` exists but has no `.db.bak.*` files. `ls` exits 1 on the unmatched glob, pipefail propagates, `set -e` kills the command substitution — right after the "=== SleepyPod Maintenance ===" banner.

Reproduced locally with a verbatim simulation.

**Fix:** switch to `find`, which exits 0 with or without matches. Also replaces the prune sort step to use `find -printf '%T@ %p'` + `sort -rn` + `xargs -r` for matching robustness.

## Why bundle

Both bugs bite every fresh Pod 4 install that ran before these fixes. Shipping one PR → one v1.7.1 patch release → one user action ("re-run the canonical install").

## Immediate unblock for the affected Pod 4 user (until v1.7.1 publishes)

```bash
rm -f /home/dac/sleepypod-core/.env
# then re-run install
```

With the stale `.env` removed, detect falls through to v1.7.0's fixed frank.sh parser and sets the right DAC path. But the `sp-maintenance` failure will still hit on the fresh install — this PR is needed to fully unblock.

## Test plan

- [ ] Fresh install on a Pod 4 with no prior `.env`: detect resolves `POD_GEN=3_4`, `sp-maintenance` completes, service active.
- [ ] Re-install on a Pod 4 with stale `.env` from a pre-v1.7.0 install: detect warns "Ignoring stale", falls through to frank.sh, resolves correctly.
- [ ] Fresh install on a Pod 5: no regression (live socket verifies, or frank.sh agrees).
- [ ] `sp-maintenance` runs to completion on a fresh install (no `.db.bak.*` files yet).

Tracks ygg `sleepypod-core-12`.
