### PR TITLE
fix(react): resolve react-hooks compiler errors blocking v1.7.1 release

### DIFF
--- a/src/components/Schedule/SchedulePage.tsx
+++ b/src/components/Schedule/SchedulePage.tsx
@@ -45,16 +45,16 @@ export function SchedulePage() {
   const [creatingCurve, setCreatingCurve] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ days: DayOfWeek[], label: string } | null>(null)
 
-  const groups = useMemo<ScheduleGroup[]>(() => {
-    if (!data?.temperature) return []
-    return groupDaysBySharedCurve(data.temperature)
-  }, [data?.temperature])
+  // Recompute each render — React Compiler's lint (react-hooks/
+  // preserve-manual-memoization) objects to the previous useMemo here
+  // because it can't match the manual memo to its own plan. The
+  // computation is cheap relative to the tRPC fetch that precedes it.
+  const groups: ScheduleGroup[] = data?.temperature
+    ? groupDaysBySharedCurve(data.temperature)
+    : []
 
   // Curves to render: ones with set points OR explicitly paused
-  const visibleGroups = useMemo(
-    () => groups.filter(g => g.setPoints.length > 0 || g.allDisabled),
-    [groups],
-  )
+  const visibleGroups = groups.filter(g => g.setPoints.length > 0 || g.allDisabled)
 
   const hasAnyCurves = visibleGroups.length > 0
 

--- a/src/components/Sensors/RawFrameDrawer.tsx
+++ b/src/components/Sensors/RawFrameDrawer.tsx
@@ -25,12 +25,19 @@ export function RawFrameDrawer() {
   const [selectedFrame, setSelectedFrame] = useState<StoredFrame | null>(null)
   const framesRef = useRef<StoredFrame[]>([])
   const [frames, setFrames] = useState<StoredFrame[]>([])
+  // Track every frame type ever seen so the filter dropdown stays
+  // populated even while paused or when the displayed `frames` slice
+  // doesn't include a given type. Reading framesRef.current during
+  // render trips react-hooks/refs.
+  const [seenTypes, setSeenTypes] = useState<readonly string[]>([])
 
   useOnSensorFrame(useCallback((frame: SensorFrame) => {
     framesRef.current = [
       { ts: Date.now(), type: frame.type, data: JSON.stringify(frame, null, 2) },
       ...framesRef.current,
     ].slice(0, MAX_FRAMES * 5)
+
+    setSeenTypes(prev => prev.includes(frame.type) ? prev : [...prev, frame.type])
 
     if (open && !paused) {
       setFrames([...framesRef.current])
@@ -52,7 +59,7 @@ export function RawFrameDrawer() {
     ? frames.filter(f => f.type === filter).slice(0, MAX_FRAMES)
     : frames.slice(0, MAX_FRAMES)
 
-  const types = [...new Set(framesRef.current.map(f => f.type))]
+  const types = seenTypes
 
   return (
     <>

--- a/src/components/Sensors/TempTrendChart.tsx
+++ b/src/components/Sensors/TempTrendChart.tsx
@@ -17,6 +17,13 @@ interface TempPoint {
   rightF: number | null
 }
 
+/** Raw Celsius point — what the WebSocket frames carry, converted at display time. */
+interface RawTempPoint {
+  time: number
+  leftC: number | null
+  rightC: number | null
+}
+
 /**
  * Temperature trend chart showing historical bed temperature readings.
  * Draws a simple SVG line chart of left vs right temps over time.
@@ -27,7 +34,11 @@ interface TempPoint {
  */
 export function TempTrendChart() {
   const { unit, convert } = useTemperatureUnit()
-  const [liveFrames, setLiveFrames] = useState<TempPoint[]>([])
+  // Live frames are stored in raw Celsius (what the WebSocket carries) and
+  // converted at display time via `history`. This keeps the buffer immune
+  // to mid-session unit changes — when `unit` flips F↔C, the seed re-fetches
+  // in the new unit and previously buffered live points re-convert from raw.
+  const [liveFrames, setLiveFrames] = useState<RawTempPoint[]>([])
 
   // tRPC: fetch last hour of bed temp history to pre-populate the chart
   // eslint-disable-next-line react-hooks/purity
@@ -75,28 +86,31 @@ export function TempTrendChart() {
   }, [historicalBedTemp.data])
 
   const history = useMemo<TempPoint[]>(() => {
-    const combined = seed.length === 0 ? liveFrames : [...seed, ...liveFrames]
+    const liveConverted: TempPoint[] = liveFrames
+      .map(p => ({
+        time: p.time,
+        leftF: convert(p.leftC),
+        rightF: convert(p.rightC),
+      }))
+      .filter(p => p.leftF !== null || p.rightF !== null)
+    const combined = seed.length === 0 ? liveConverted : [...seed, ...liveConverted]
     return combined.length > MAX_HISTORY ? combined.slice(-MAX_HISTORY) : combined
-  }, [seed, liveFrames])
+  }, [seed, liveFrames, convert])
 
-  // Append live WebSocket frames to a dedicated buffer; history derives.
+  // Append raw Celsius live frames; history derives + converts at display.
   useOnSensorFrame(useCallback((frame: SensorFrame) => {
     if (frame.type !== 'bedTemp' && frame.type !== 'bedTemp2') return
     const f = frame as BedTempFrame | BedTemp2Frame
 
-    // Average left and right center temps for trend
-    const leftC = f.leftCenterTemp ?? f.leftInnerTemp
-    const rightC = f.rightCenterTemp ?? f.rightInnerTemp
-    const leftF = convert(leftC)
-    const rightF = convert(rightC)
-
-    if (leftF === null && rightF === null) return
+    const leftC = f.leftCenterTemp ?? f.leftInnerTemp ?? null
+    const rightC = f.rightCenterTemp ?? f.rightInnerTemp ?? null
+    if (leftC === null && rightC === null) return
 
     setLiveFrames((prev) => {
-      const next = [...prev, { time: Date.now(), leftF, rightF }]
+      const next = [...prev, { time: Date.now(), leftC, rightC }]
       return next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next
     })
-  }, [convert]))
+  }, []))
 
   if (history.length < 2) {
     return (

--- a/src/components/Sensors/TempTrendChart.tsx
+++ b/src/components/Sensors/TempTrendChart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useOnSensorFrame, type SensorFrame, type BedTempFrame, type BedTemp2Frame } from '@/src/hooks/useSensorStream'
 import { trpc } from '@/src/utils/trpc'
 import { useTemperatureUnit } from '@/src/hooks/useTemperatureUnit'
@@ -27,8 +27,7 @@ interface TempPoint {
  */
 export function TempTrendChart() {
   const { unit, convert } = useTemperatureUnit()
-  const [history, setHistory] = useState<TempPoint[]>([])
-  const seededRef = useRef(false)
+  const [liveFrames, setLiveFrames] = useState<TempPoint[]>([])
 
   // tRPC: fetch last hour of bed temp history to pre-populate the chart
   // eslint-disable-next-line react-hooks/purity
@@ -52,33 +51,35 @@ export function TempTrendChart() {
     },
   )
 
-  // Seed the chart with historical data from tRPC (once)
-  useEffect(() => {
-    if (seededRef.current || !historicalBedTemp.data) return
+  // Derive the seed from tRPC data each render. Combining derived seed +
+  // live state in useMemo avoids the `set-state-in-effect` anti-pattern of
+  // copying async data into state via an effect.
+  const seed = useMemo<TempPoint[]>(() => {
     const data = historicalBedTemp.data as Array<{
       timestamp: Date | string
       leftCenterTemp: number | null
       leftInnerTemp: number | null
       rightCenterTemp: number | null
       rightInnerTemp: number | null
-    }>
-
-    if (data.length === 0) return
-
-    // Data comes in descending order from tRPC, reverse for chronological
-    const points: TempPoint[] = [...data].reverse().map(row => ({
-      time: new Date(row.timestamp).getTime(),
-      leftF: row.leftCenterTemp ?? row.leftInnerTemp ?? null,
-      rightF: row.rightCenterTemp ?? row.rightInnerTemp ?? null,
-    })).filter(p => p.leftF !== null || p.rightF !== null)
-
-    if (points.length > 0) {
-      setHistory(points.slice(-MAX_HISTORY))
-      seededRef.current = true
-    }
+    }> | undefined
+    if (!data || data.length === 0) return []
+    return [...data]
+      .reverse() // tRPC returns descending; chart wants chronological
+      .map(row => ({
+        time: new Date(row.timestamp).getTime(),
+        leftF: row.leftCenterTemp ?? row.leftInnerTemp ?? null,
+        rightF: row.rightCenterTemp ?? row.rightInnerTemp ?? null,
+      }))
+      .filter(p => p.leftF !== null || p.rightF !== null)
+      .slice(-MAX_HISTORY)
   }, [historicalBedTemp.data])
 
-  // Append live WebSocket frames
+  const history = useMemo<TempPoint[]>(() => {
+    const combined = seed.length === 0 ? liveFrames : [...seed, ...liveFrames]
+    return combined.length > MAX_HISTORY ? combined.slice(-MAX_HISTORY) : combined
+  }, [seed, liveFrames])
+
+  // Append live WebSocket frames to a dedicated buffer; history derives.
   useOnSensorFrame(useCallback((frame: SensorFrame) => {
     if (frame.type !== 'bedTemp' && frame.type !== 'bedTemp2') return
     const f = frame as BedTempFrame | BedTemp2Frame
@@ -91,9 +92,7 @@ export function TempTrendChart() {
 
     if (leftF === null && rightF === null) return
 
-    seededRef.current = true // Mark as seeded even from live data
-
-    setHistory((prev) => {
+    setLiveFrames((prev) => {
       const next = [...prev, { time: Date.now(), leftF, rightF }]
       return next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next
     })

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -222,10 +222,8 @@ interface SensorStreamSingleton {
   intentionalClose: boolean
   activeRefCount: number
   pendingSubscription: SensorType[] | null
-  /** Per-hook active sensor requests. Keyed by a unique hook ID. */
-  activeSubscriptions: Map<number, SensorType[] | null>
-  /** Counter for generating unique hook subscription IDs. */
-  nextSubscriptionId: number
+  /** Per-hook active sensor requests. Keyed by a unique per-instance Symbol. */
+  activeSubscriptions: Map<symbol, SensorType[] | null>
   /** Pending resolvers for getTimeRange() promises. */
   timeRangeResolvers: Array<(range: TimeRange | null) => void>
 }
@@ -257,8 +255,7 @@ if (!g[SINGLETON_KEY]) {
     intentionalClose: false,
     activeRefCount: 0,
     pendingSubscription: null,
-    activeSubscriptions: new Map<number, SensorType[] | null>(),
-    nextSubscriptionId: 0,
+    activeSubscriptions: new Map<symbol, SensorType[] | null>(),
     timeRangeResolvers: [],
   } satisfies SensorStreamSingleton
 }
@@ -589,12 +586,11 @@ export function useSensorStream(options: UseSensorStreamOptions = {}) {
   const { sensors = null, enabled = true } = options
   const sensorsKey = sensors ? sensors.slice().sort().join(',') : 'all'
 
-  // Stable subscription ID for this hook instance. Allocating during
-  // render (ref.current === null branch) trips react-hooks/immutability
-  // and would burn IDs on StrictMode double-renders. useState's lazy
-  // initializer runs exactly once per instance and is the idiomatic way
-  // to bind a shared-store identity to a component.
-  const [subId] = useState(() => singleton.nextSubscriptionId++)
+  // Stable subscription token for this hook instance. Symbol() is pure —
+  // unlike a counter increment it's safe to call twice (StrictMode dev
+  // double-render of useState lazy initializers) without burning IDs or
+  // mutating shared state.
+  const [subId] = useState(() => Symbol('sensor-stream-subscription'))
 
   // Ref-counted connection management
   useEffect(() => {

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useCallback, useSyncExternalStore } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useSyncExternalStore } from 'react'
 import { normalizeFrame } from '@/src/streaming/normalizeFrame'
 
 // ---------------------------------------------------------------------------
@@ -589,11 +589,12 @@ export function useSensorStream(options: UseSensorStreamOptions = {}) {
   const { sensors = null, enabled = true } = options
   const sensorsKey = sensors ? sensors.slice().sort().join(',') : 'all'
 
-  // Stable subscription ID for this hook instance
-  const subIdRef = useRef<number | null>(null)
-  if (subIdRef.current === null) {
-    subIdRef.current = singleton.nextSubscriptionId++
-  }
+  // Stable subscription ID for this hook instance. Allocating during
+  // render (ref.current === null branch) trips react-hooks/immutability
+  // and would burn IDs on StrictMode double-renders. useState's lazy
+  // initializer runs exactly once per instance and is the idiomatic way
+  // to bind a shared-store identity to a component.
+  const [subId] = useState(() => singleton.nextSubscriptionId++)
 
   // Ref-counted connection management
   useEffect(() => {
@@ -616,16 +617,15 @@ export function useSensorStream(options: UseSensorStreamOptions = {}) {
   // Subscription management — merge with other active hooks
   useEffect(() => {
     if (!enabled) return
-    const id = subIdRef.current ?? 0
-    singleton.activeSubscriptions.set(id, sensors ?? null)
+    singleton.activeSubscriptions.set(subId, sensors ?? null)
     recomputeAndSendSubscription()
 
     return () => {
-      singleton.activeSubscriptions.delete(id)
+      singleton.activeSubscriptions.delete(subId)
       recomputeAndSendSubscription()
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sensorsKey, enabled])
+  }, [sensorsKey, enabled, subId])
 
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 


### PR DESCRIPTION
## Why

#458 merged dev→main to cut v1.7.1 (Pod 4 install fixes). The release workflow's `git push --tags` invocation hit the project's `pre-push` git hook, which runs `pnpm lint` — and lint failed with **5 errors** raised to error level by Renovate's eslint-config-next 16.2.4 bump (#456). Release computed v1.7.1 but couldn't publish.

Locally these errors weren't visible because my `node_modules` had cached eslint-config-next 16.2.2; once I ran `pnpm install --frozen-lockfile` the same 5 errors reproduced.

## Fixes (each at the pattern level, no rule downgrades)

| File | Rule | Pattern → Fix |
|---|---|---|
| `src/components/Sensors/TempTrendChart.tsx` | `react-hooks/set-state-in-effect` | Effect that copied tRPC data → state. Replaced with `useMemo` deriving `seed` + a `liveFrames` state buffer; history is `[...seed, ...liveFrames]` in a useMemo. Removes the seededRef guard. |
| `src/hooks/useSensorStream.ts` | `react-hooks/immutability` | `useRef(null) + assign-during-render` for the subscription ID. Replaced with `useState(() => singleton.nextSubscriptionId++)` so the ID allocation is a one-shot lazy initializer (also safer under StrictMode double-renders). |
| `src/components/Schedule/SchedulePage.tsx` | `react-hooks/preserve-manual-memoization` | Manual `useMemo(() => groupDaysBySharedCurve(...))` the compiler couldn't preserve. Dropped the wrapper — recompute is cheap relative to the tRPC fetch that gates it. |
| `src/components/Sensors/RawFrameDrawer.tsx` | `react-hooks/refs` | Reading `framesRef.current.map(...)` during render to populate a filter dropdown. Replaced with a dedicated `seenTypes` state slice updated from the WS handler — dropdown stays populated even while paused. |

## Validation

- `pnpm lint` — clean
- `pnpm tsc` — clean
- `pnpm vitest run` — 636 passed, 2 skipped, 44 files

## Impact

Once this lands on dev and gets promoted to main, semantic-release should successfully publish **v1.7.1** with the Pod 4 install fixes from #457 / #458.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensor type filter dropdown now preserves all observed types even when frames are paused or limited, preventing the filter list from shrinking unexpectedly.

* **Refactor**
  * Optimized schedule computation and sensor stream subscription management for improved stability.
  * Enhanced temperature trend chart data handling to better integrate historical and live sensor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->