### PR TITLE
fix: cut v1.7.1 — Pod 4 install unblock + react-compiler lint fixes

### DIFF
--- a/src/components/Schedule/SchedulePage.tsx
+++ b/src/components/Schedule/SchedulePage.tsx
@@ -45,16 +45,16 @@ export function SchedulePage() {
   const [creatingCurve, setCreatingCurve] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ days: DayOfWeek[], label: string } | null>(null)
 
-  const groups = useMemo<ScheduleGroup[]>(() => {
-    if (!data?.temperature) return []
-    return groupDaysBySharedCurve(data.temperature)
-  }, [data?.temperature])
+  // Recompute each render — React Compiler's lint (react-hooks/
+  // preserve-manual-memoization) objects to the previous useMemo here
+  // because it can't match the manual memo to its own plan. The
+  // computation is cheap relative to the tRPC fetch that precedes it.
+  const groups: ScheduleGroup[] = data?.temperature
+    ? groupDaysBySharedCurve(data.temperature)
+    : []
 
   // Curves to render: ones with set points OR explicitly paused
-  const visibleGroups = useMemo(
-    () => groups.filter(g => g.setPoints.length > 0 || g.allDisabled),
-    [groups],
-  )
+  const visibleGroups = groups.filter(g => g.setPoints.length > 0 || g.allDisabled)
 
   const hasAnyCurves = visibleGroups.length > 0
 

--- a/src/components/Sensors/RawFrameDrawer.tsx
+++ b/src/components/Sensors/RawFrameDrawer.tsx
@@ -25,12 +25,19 @@ export function RawFrameDrawer() {
   const [selectedFrame, setSelectedFrame] = useState<StoredFrame | null>(null)
   const framesRef = useRef<StoredFrame[]>([])
   const [frames, setFrames] = useState<StoredFrame[]>([])
+  // Track every frame type ever seen so the filter dropdown stays
+  // populated even while paused or when the displayed `frames` slice
+  // doesn't include a given type. Reading framesRef.current during
+  // render trips react-hooks/refs.
+  const [seenTypes, setSeenTypes] = useState<readonly string[]>([])
 
   useOnSensorFrame(useCallback((frame: SensorFrame) => {
     framesRef.current = [
       { ts: Date.now(), type: frame.type, data: JSON.stringify(frame, null, 2) },
       ...framesRef.current,
     ].slice(0, MAX_FRAMES * 5)
+
+    setSeenTypes(prev => prev.includes(frame.type) ? prev : [...prev, frame.type])
 
     if (open && !paused) {
       setFrames([...framesRef.current])
@@ -52,7 +59,7 @@ export function RawFrameDrawer() {
     ? frames.filter(f => f.type === filter).slice(0, MAX_FRAMES)
     : frames.slice(0, MAX_FRAMES)
 
-  const types = [...new Set(framesRef.current.map(f => f.type))]
+  const types = seenTypes
 
   return (
     <>

--- a/src/components/Sensors/TempTrendChart.tsx
+++ b/src/components/Sensors/TempTrendChart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useOnSensorFrame, type SensorFrame, type BedTempFrame, type BedTemp2Frame } from '@/src/hooks/useSensorStream'
 import { trpc } from '@/src/utils/trpc'
 import { useTemperatureUnit } from '@/src/hooks/useTemperatureUnit'
@@ -17,6 +17,13 @@ interface TempPoint {
   rightF: number | null
 }
 
+/** Raw Celsius point — what the WebSocket frames carry, converted at display time. */
+interface RawTempPoint {
+  time: number
+  leftC: number | null
+  rightC: number | null
+}
+
 /**
  * Temperature trend chart showing historical bed temperature readings.
  * Draws a simple SVG line chart of left vs right temps over time.
@@ -27,8 +34,11 @@ interface TempPoint {
  */
 export function TempTrendChart() {
   const { unit, convert } = useTemperatureUnit()
-  const [history, setHistory] = useState<TempPoint[]>([])
-  const seededRef = useRef(false)
+  // Live frames are stored in raw Celsius (what the WebSocket carries) and
+  // converted at display time via `history`. This keeps the buffer immune
+  // to mid-session unit changes — when `unit` flips F↔C, the seed re-fetches
+  // in the new unit and previously buffered live points re-convert from raw.
+  const [liveFrames, setLiveFrames] = useState<RawTempPoint[]>([])
 
   // tRPC: fetch last hour of bed temp history to pre-populate the chart
   // eslint-disable-next-line react-hooks/purity
@@ -52,52 +62,55 @@ export function TempTrendChart() {
     },
   )
 
-  // Seed the chart with historical data from tRPC (once)
-  useEffect(() => {
-    if (seededRef.current || !historicalBedTemp.data) return
+  // Derive the seed from tRPC data each render. Combining derived seed +
+  // live state in useMemo avoids the `set-state-in-effect` anti-pattern of
+  // copying async data into state via an effect.
+  const seed = useMemo<TempPoint[]>(() => {
     const data = historicalBedTemp.data as Array<{
       timestamp: Date | string
       leftCenterTemp: number | null
       leftInnerTemp: number | null
       rightCenterTemp: number | null
       rightInnerTemp: number | null
-    }>
-
-    if (data.length === 0) return
-
-    // Data comes in descending order from tRPC, reverse for chronological
-    const points: TempPoint[] = [...data].reverse().map(row => ({
-      time: new Date(row.timestamp).getTime(),
-      leftF: row.leftCenterTemp ?? row.leftInnerTemp ?? null,
-      rightF: row.rightCenterTemp ?? row.rightInnerTemp ?? null,
-    })).filter(p => p.leftF !== null || p.rightF !== null)
-
-    if (points.length > 0) {
-      setHistory(points.slice(-MAX_HISTORY))
-      seededRef.current = true
-    }
+    }> | undefined
+    if (!data || data.length === 0) return []
+    return [...data]
+      .reverse() // tRPC returns descending; chart wants chronological
+      .map(row => ({
+        time: new Date(row.timestamp).getTime(),
+        leftF: row.leftCenterTemp ?? row.leftInnerTemp ?? null,
+        rightF: row.rightCenterTemp ?? row.rightInnerTemp ?? null,
+      }))
+      .filter(p => p.leftF !== null || p.rightF !== null)
+      .slice(-MAX_HISTORY)
   }, [historicalBedTemp.data])
 
-  // Append live WebSocket frames
+  const history = useMemo<TempPoint[]>(() => {
+    const liveConverted: TempPoint[] = liveFrames
+      .map(p => ({
+        time: p.time,
+        leftF: convert(p.leftC),
+        rightF: convert(p.rightC),
+      }))
+      .filter(p => p.leftF !== null || p.rightF !== null)
+    const combined = seed.length === 0 ? liveConverted : [...seed, ...liveConverted]
+    return combined.length > MAX_HISTORY ? combined.slice(-MAX_HISTORY) : combined
+  }, [seed, liveFrames, convert])
+
+  // Append raw Celsius live frames; history derives + converts at display.
   useOnSensorFrame(useCallback((frame: SensorFrame) => {
     if (frame.type !== 'bedTemp' && frame.type !== 'bedTemp2') return
     const f = frame as BedTempFrame | BedTemp2Frame
 
-    // Average left and right center temps for trend
-    const leftC = f.leftCenterTemp ?? f.leftInnerTemp
-    const rightC = f.rightCenterTemp ?? f.rightInnerTemp
-    const leftF = convert(leftC)
-    const rightF = convert(rightC)
+    const leftC = f.leftCenterTemp ?? f.leftInnerTemp ?? null
+    const rightC = f.rightCenterTemp ?? f.rightInnerTemp ?? null
+    if (leftC === null && rightC === null) return
 
-    if (leftF === null && rightF === null) return
-
-    seededRef.current = true // Mark as seeded even from live data
-
-    setHistory((prev) => {
-      const next = [...prev, { time: Date.now(), leftF, rightF }]
+    setLiveFrames((prev) => {
+      const next = [...prev, { time: Date.now(), leftC, rightC }]
       return next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next
     })
-  }, [convert]))
+  }, []))
 
   if (history.length < 2) {
     return (

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useCallback, useSyncExternalStore } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, useSyncExternalStore } from 'react'
 import { normalizeFrame } from '@/src/streaming/normalizeFrame'
 
 // ---------------------------------------------------------------------------
@@ -222,10 +222,8 @@ interface SensorStreamSingleton {
   intentionalClose: boolean
   activeRefCount: number
   pendingSubscription: SensorType[] | null
-  /** Per-hook active sensor requests. Keyed by a unique hook ID. */
-  activeSubscriptions: Map<number, SensorType[] | null>
-  /** Counter for generating unique hook subscription IDs. */
-  nextSubscriptionId: number
+  /** Per-hook active sensor requests. Keyed by a unique per-instance Symbol. */
+  activeSubscriptions: Map<symbol, SensorType[] | null>
   /** Pending resolvers for getTimeRange() promises. */
   timeRangeResolvers: Array<(range: TimeRange | null) => void>
 }
@@ -257,8 +255,7 @@ if (!g[SINGLETON_KEY]) {
     intentionalClose: false,
     activeRefCount: 0,
     pendingSubscription: null,
-    activeSubscriptions: new Map<number, SensorType[] | null>(),
-    nextSubscriptionId: 0,
+    activeSubscriptions: new Map<symbol, SensorType[] | null>(),
     timeRangeResolvers: [],
   } satisfies SensorStreamSingleton
 }
@@ -589,11 +586,11 @@ export function useSensorStream(options: UseSensorStreamOptions = {}) {
   const { sensors = null, enabled = true } = options
   const sensorsKey = sensors ? sensors.slice().sort().join(',') : 'all'
 
-  // Stable subscription ID for this hook instance
-  const subIdRef = useRef<number | null>(null)
-  if (subIdRef.current === null) {
-    subIdRef.current = singleton.nextSubscriptionId++
-  }
+  // Stable subscription token for this hook instance. Symbol() is pure —
+  // unlike a counter increment it's safe to call twice (StrictMode dev
+  // double-render of useState lazy initializers) without burning IDs or
+  // mutating shared state.
+  const [subId] = useState(() => Symbol('sensor-stream-subscription'))
 
   // Ref-counted connection management
   useEffect(() => {
@@ -616,16 +613,15 @@ export function useSensorStream(options: UseSensorStreamOptions = {}) {
   // Subscription management — merge with other active hooks
   useEffect(() => {
     if (!enabled) return
-    const id = subIdRef.current ?? 0
-    singleton.activeSubscriptions.set(id, sensors ?? null)
+    singleton.activeSubscriptions.set(subId, sensors ?? null)
     recomputeAndSendSubscription()
 
     return () => {
-      singleton.activeSubscriptions.delete(id)
+      singleton.activeSubscriptions.delete(subId)
       recomputeAndSendSubscription()
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sensorsKey, enabled])
+  }, [sensorsKey, enabled, subId])
 
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 


### PR DESCRIPTION
## Summary

Retry of #458 (which merged but its release workflow couldn't push v1.7.1's tag because the pre-push lint hook errored on react-compiler rules from #456's eslint-config-next bump). #459 fixed those 5 lint errors by addressing the underlying patterns (no rule downgrades). dev now has 2 conventional `fix:` commits ready to release.

## Commits since v1.7.0

- `03eaf2a fix(react): resolve react-hooks compiler errors blocking v1.7.1 release (#459)`
- `538a9dd fix: Pod 4 install unblock round 2 (stale .env cache + sp-maintenance BAK_COUNT) (#457)`

## Merge instruction

**Use "Create a merge commit" or "Rebase and merge" — DO NOT SQUASH.** semantic-release needs the conventional `fix:` commits preserved on main's history.

## Test plan

- [ ] `Analyze & Release` workflow on main publishes **v1.7.1** (now that lint passes in pre-push hook).
- [ ] Pod 4 user re-runs canonical install; service reaches `active (running)`.
- [ ] No regression on Pod 5.
