### PR TITLE
fix(install): put uv-managed Python in /opt/sleepypod/python so User=dac modules can exec it

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -221,6 +221,13 @@ fi
 if [ -d "$INSTALL_DIR/modules" ]; then
   MODULES_DEST="/opt/sleepypod/modules"
   mkdir -p "$MODULES_DEST"
+  # Match the install script's shared uv cache + Python install dir so
+  # User=dac modules can execute the managed Python (otherwise it lives
+  # under root's home at 0700 and the .venv symlink fails with 203/EXEC).
+  export UV_PYTHON_INSTALL_DIR="/opt/sleepypod/python"
+  export UV_CACHE_DIR="/opt/sleepypod/uv-cache"
+  mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+  chmod 0755 /opt/sleepypod "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" 2>/dev/null || true
   if [ -d "$INSTALL_DIR/modules/common" ]; then
     mkdir -p "$MODULES_DEST/common"
     cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
@@ -236,6 +243,7 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       if command -v uv &>/dev/null; then
         (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
           || echo "Warning: uv sync failed for module $mod"
+        chmod -R o+rX "$MODULES_DEST/$mod/.venv" 2>/dev/null || true
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then

--- a/scripts/install
+++ b/scripts/install
@@ -643,6 +643,18 @@ MODULES_DEST="/opt/sleepypod/modules"
 mkdir -p "$MODULES_DEST"
 mkdir -p /etc/sleepypod/modules
 
+# Shared world-readable cache for uv-managed Python interpreters. Without
+# this, uv defaults to ~/.local/share/uv which (running as root via sudo)
+# is /root/.local/share/uv — mode 0700, unreadable by `dac` user. Modules
+# whose unit has User=dac (calibrator, environment-monitor) then fail to
+# even execve the .venv/bin/python symlink → systemd status 203/EXEC.
+# Reported on a Pod 4 install where uv downloaded cpython-3.10.20.
+UV_PYTHON_INSTALL_DIR="/opt/sleepypod/python"
+UV_CACHE_DIR="/opt/sleepypod/uv-cache"
+mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+chmod 0755 /opt/sleepypod "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+export UV_PYTHON_INSTALL_DIR UV_CACHE_DIR
+
 # Install uv (Rust-based Python package manager — bypasses broken ensurepip/pyexpat on Yocto)
 if ! command -v uv &>/dev/null; then
   echo "Installing uv..."
@@ -675,11 +687,16 @@ else
     # Create Python environment with uv (no ensurepip/pyexpat needed).
     # No --python flag: let uv pick from requires-python in pyproject.toml.
     # If system python3 is in range it's used; otherwise uv downloads a
-    # compatible managed interpreter.
+    # compatible managed interpreter into UV_PYTHON_INSTALL_DIR (set above
+    # to /opt/sleepypod/python so User=dac modules can execute it).
     (cd "$dest" && uv sync --frozen) || {
       echo "Warning: uv sync failed for module $name"
       return
     }
+
+    # Ensure non-root service users (User=dac on calibrator + env-monitor)
+    # can read the venv dir + traverse the managed-Python symlink target.
+    chmod -R o+rX "$dest/.venv" 2>/dev/null || true
 
     # Install systemd service
     if [ -f "$dest/$service" ]; then


### PR DESCRIPTION
## Why

Pod 4 user on v1.7.2: install completes cleanly, but `sleepypod-environment-monitor` and `sleepypod-calibrator` (both `User=dac`) crash-loop with systemd status **203/EXEC**:

\`\`\`
Failed to execute /opt/sleepypod/modules/environment-monitor/.venv/bin/python: Permission denied
\`\`\`

systemd can't even \`execve\` the interpreter as the \`dac\` user.

## Root cause

Install runs as root via sudo. uv's default Python install dir is \`$HOME/.local/share/uv/python/\` — on this Pod 4 (Yocto, \`HOME=/home/root\`) that's \`/home/root/.local/share/uv/python/cpython-3.10.20-…\`, mode 0700. The .venv/bin/python symlink resolves through that root-only path; \`User=dac\` services can't traverse → 203/EXEC, crash-loop, never starts.

Confirmed end-to-end with the affected user:
- \`readlink -f /opt/sleepypod/modules/environment-monitor/.venv/bin/python\` → \`/home/root/.local/share/uv/python/cpython-3.10.20-linux-aarch64-gnu/bin/python3.10\`
- After \`sudo chmod o+x /home/root && sudo chmod -R o+rX /home/root/.local\` + restart → both services reach \`active\` and start ingesting RAW frames

My own Pod 5 didn't hit this because uv used the in-range system \`python3\` directly without downloading a managed interpreter. Neither install path exercised the \`User=dac\` + managed-Python combination.

## Fix

\`scripts/install\` and \`scripts/bin/sp-update\`: set
\`UV_PYTHON_INSTALL_DIR=/opt/sleepypod/python\` and \`UV_CACHE_DIR=/opt/sleepypod/uv-cache\` (chmod 0755) before invoking \`uv sync\`. Managed Python now lands in a world-readable location that \`dac\` can traverse + execute. Also \`chmod -R o+rX .venv\` after each sync as belt-and-suspenders against restrictive umask on individual venv files.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Pod 5, system python in range, uv uses it | works | works (env vars no-op) |
| Pod 4, uv downloads managed Python | **203/EXEC for User=dac modules** | **works** |
| Pod 3 with custom Python install | depends on HOME perms | always works |

\`UV_PYTHON_INSTALL_DIR\` is only consulted when uv decides to download. On pods where it uses system Python, this is a pure no-op.

## Test plan

- [ ] Fresh install on Pod 4: env-monitor + calibrator both reach \`active (running)\` without manual chmod.
- [ ] Fresh install on Pod 5 (no managed Python download): no regression, no spurious dirs created.
- [ ] \`sp-update\` mirror works the same way.
- [ ] Existing installs that already have a /home/root/-located Python aren't broken — uv will just download a fresh copy to /opt/sleepypod/python on next sync (one-time ~30MB cost, then cached).