### PR TITLE
fix: cut v1.7.3 — uv-managed Python in shared dir for User=dac modules

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -221,6 +221,13 @@ fi
 if [ -d "$INSTALL_DIR/modules" ]; then
   MODULES_DEST="/opt/sleepypod/modules"
   mkdir -p "$MODULES_DEST"
+  # Match the install script's shared uv cache + Python install dir so
+  # User=dac modules can execute the managed Python (otherwise it lives
+  # under root's home at 0700 and the .venv symlink fails with 203/EXEC).
+  export UV_PYTHON_INSTALL_DIR="/opt/sleepypod/python"
+  export UV_CACHE_DIR="/opt/sleepypod/uv-cache"
+  mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+  chmod 0755 /opt/sleepypod "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" 2>/dev/null || true
   if [ -d "$INSTALL_DIR/modules/common" ]; then
     mkdir -p "$MODULES_DEST/common"
     cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
@@ -236,6 +243,7 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       if command -v uv &>/dev/null; then
         (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
           || echo "Warning: uv sync failed for module $mod"
+        chmod -R o+rX "$MODULES_DEST/$mod/.venv" 2>/dev/null || true
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then

--- a/scripts/install
+++ b/scripts/install
@@ -643,6 +643,18 @@ MODULES_DEST="/opt/sleepypod/modules"
 mkdir -p "$MODULES_DEST"
 mkdir -p /etc/sleepypod/modules
 
+# Shared world-readable cache for uv-managed Python interpreters. Without
+# this, uv defaults to ~/.local/share/uv which (running as root via sudo)
+# is /root/.local/share/uv — mode 0700, unreadable by `dac` user. Modules
+# whose unit has User=dac (calibrator, environment-monitor) then fail to
+# even execve the .venv/bin/python symlink → systemd status 203/EXEC.
+# Reported on a Pod 4 install where uv downloaded cpython-3.10.20.
+UV_PYTHON_INSTALL_DIR="/opt/sleepypod/python"
+UV_CACHE_DIR="/opt/sleepypod/uv-cache"
+mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+chmod 0755 /opt/sleepypod "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
+export UV_PYTHON_INSTALL_DIR UV_CACHE_DIR
+
 # Install uv (Rust-based Python package manager — bypasses broken ensurepip/pyexpat on Yocto)
 if ! command -v uv &>/dev/null; then
   echo "Installing uv..."
@@ -675,11 +687,16 @@ else
     # Create Python environment with uv (no ensurepip/pyexpat needed).
     # No --python flag: let uv pick from requires-python in pyproject.toml.
     # If system python3 is in range it's used; otherwise uv downloads a
-    # compatible managed interpreter.
+    # compatible managed interpreter into UV_PYTHON_INSTALL_DIR (set above
+    # to /opt/sleepypod/python so User=dac modules can execute it).
     (cd "$dest" && uv sync --frozen) || {
       echo "Warning: uv sync failed for module $name"
       return
     }
+
+    # Ensure non-root service users (User=dac on calibrator + env-monitor)
+    # can read the venv dir + traverse the managed-Python symlink target.
+    chmod -R o+rX "$dest/.venv" 2>/dev/null || true
 
     # Install systemd service
     if [ -f "$dest/$service" ]; then


### PR DESCRIPTION
## Summary

Promotes #463 from dev to main to cut **v1.7.3**.

### Bug fixed

Pod 4 v1.7.2 install completes but \`User=dac\` modules (env-monitor, calibrator) crash-loop with systemd 203/EXEC. Root cause: uv installs managed Python under \`/home/root/.local/share/uv/\` (mode 0700); \`dac\` user can't traverse → permission denied on execve.

### Fix

Set \`UV_PYTHON_INSTALL_DIR=/opt/sleepypod/python\` and \`UV_CACHE_DIR=/opt/sleepypod/uv-cache\` (chmod 0755) before \`uv sync\` in both install + sp-update. Plus \`chmod -R o+rX .venv\` after sync.

Validated end-to-end with the affected user: after the equivalent chmod workaround, env-monitor reaches \`active\` and ingests RAW frames cleanly.

## Merge instruction

**Use "Create a merge commit" — DO NOT SQUASH.** Single \`fix:\` commit needs to stay parseable for semantic-release.

## Test plan

- [ ] Pod 4 user re-runs canonical install; env-monitor + calibrator both reach \`active\` without manual chmod.
- [ ] Pod 5: no regression.