### PR TITLE
fix: Pod 3 install unblock — Volta pnpm shim + PrivateTmp for tempfile writes

### DIFF
--- a/modules/calibrator/sleepypod-calibrator.service
+++ b/modules/calibrator/sleepypod-calibrator.service
@@ -31,6 +31,10 @@ ReadOnlyPaths=/persistent
 ReadWritePaths=/persistent/sleepypod-data
 ProtectSystem=strict
 ProtectKernelTunables=true
+# Isolated /tmp — otherwise ProtectSystem=strict + narrow ReadWritePaths
+# hide host /tmp → Python tempfile.mkstemp() errors "No usable temporary
+# directory found". See piezo-processor.service for the full rationale.
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/environment-monitor/sleepypod-environment-monitor.service
+++ b/modules/environment-monitor/sleepypod-environment-monitor.service
@@ -29,6 +29,10 @@ ReadOnlyPaths=/persistent
 ReadWritePaths=/persistent/sleepypod-data
 ProtectSystem=strict
 ProtectKernelTunables=true
+# Isolated /tmp — otherwise ProtectSystem=strict + narrow ReadWritePaths
+# hide host /tmp → Python tempfile.mkstemp() errors "No usable temporary
+# directory found". See piezo-processor.service for the full rationale.
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/piezo-processor/sleepypod-piezo-processor.service
+++ b/modules/piezo-processor/sleepypod-piezo-processor.service
@@ -29,6 +29,13 @@ ReadOnlyPaths=/persistent
 ReadWritePaths=/persistent/sleepypod-data
 ProtectSystem=strict
 ProtectKernelTunables=true
+# Give the service its own isolated /tmp + /var/tmp namespace. Without
+# this, ProtectSystem=strict + the narrow ReadWritePaths hide the host
+# /tmp from the service → Python's tempfile.mkstemp() fails with
+# "No usable temporary directory found" → scipy/heartpy intermediate
+# computations crash → no vitals rows ever get written. Reported on
+# Pod 3 (Xcessive Overlord).
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/sleep-detector/sleepypod-sleep-detector.service
+++ b/modules/sleep-detector/sleepypod-sleep-detector.service
@@ -29,6 +29,10 @@ ReadOnlyPaths=/persistent
 ReadWritePaths=/persistent/sleepypod-data
 ProtectSystem=strict
 ProtectKernelTunables=true
+# Isolated /tmp — otherwise ProtectSystem=strict + narrow ReadWritePaths
+# hide host /tmp → Python tempfile.mkstemp() errors "No usable temporary
+# directory found". See piezo-processor.service for the full rationale.
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/install
+++ b/scripts/install
@@ -324,9 +324,21 @@ if [ ! -x /usr/local/bin/pnpm ]; then
   # Ensure pnpm ends up at /usr/local/bin/pnpm (npm global bin may be
   # elsewhere, e.g. under /home/root/.npm-global).
   NPM_BIN="$(npm config get prefix)/bin"
-  if [ ! -f "/usr/local/bin/pnpm" ] && [ -f "$NPM_BIN/pnpm" ]; then
+  if [ ! -x "/usr/local/bin/pnpm" ] && [ -x "$NPM_BIN/pnpm" ]; then
     ln -sf "$NPM_BIN/pnpm" /usr/local/bin/pnpm
   fi
+fi
+
+# Verify pnpm is now at the concrete path. Without this, a silently-failed
+# install (e.g. npm prefix points somewhere the symlink fallback above
+# didn't find) would let the script proceed and hit the Volta shim at
+# `pnpm install --frozen-lockfile` ~120 lines down with the same exit 126
+# this PR was meant to fix. Matches the Node verification pattern above.
+if [ ! -x /usr/local/bin/pnpm ]; then
+  echo "Error: pnpm not found at /usr/local/bin/pnpm after install." >&2
+  echo "  npm prefix: $(npm config get prefix 2>/dev/null || echo unknown)" >&2
+  echo "  Try: npm install -g pnpm, then re-run this installer." >&2
+  exit 1
 fi
 
 # Get the code in place

--- a/scripts/install
+++ b/scripts/install
@@ -311,11 +311,18 @@ if [ "$NODE_MAJOR" -lt "$NODE_WANTED" ]; then
   exit 1
 fi
 
-# Install pnpm if not present
-if ! command -v pnpm &>/dev/null; then
+# Install pnpm if not present at /usr/local/bin/pnpm. We check the
+# absolute path (not `command -v pnpm`) because Pod 3 firmware ships
+# Volta with a pnpm shim in ~/.volta/bin; the shim always reports "found"
+# via command -v but fails at exec time when Volta has no managed pnpm
+# installed. Checking for our concrete binary ensures we install it
+# regardless of any upstream shim — and since /usr/local/bin is forced
+# to the front of PATH (above), our pnpm wins at runtime.
+if [ ! -x /usr/local/bin/pnpm ]; then
   echo "Installing pnpm..."
   npm install -g pnpm
-  # Ensure pnpm is in PATH (npm global bin may differ from /usr/local/bin)
+  # Ensure pnpm ends up at /usr/local/bin/pnpm (npm global bin may be
+  # elsewhere, e.g. under /home/root/.npm-global).
   NPM_BIN="$(npm config get prefix)/bin"
   if [ ! -f "/usr/local/bin/pnpm" ] && [ -f "$NPM_BIN/pnpm" ]; then
     ln -sf "$NPM_BIN/pnpm" /usr/local/bin/pnpm


### PR DESCRIPTION
## Summary

Two related Pod 3 install fixes bundled for one v1.7.4 release.

### Fix 1 — Volta pnpm shim bypass

Pod 3 install at v1.7.3:

```
Volta error: Could not find executable "pnpm"
Failed line:    437
Failed command: CI=true pnpm install --frozen-lockfile --prod
```

`install:315`'s `command -v pnpm` found Volta's pnpm shim and skipped installing our own, so `/usr/local/bin/pnpm` never existed and the later `pnpm install` fell through to Volta → exit 126. Changed to check `[ -x /usr/local/bin/pnpm ]` so we always install our concrete binary regardless of upstream shims.

### Fix 2 — PrivateTmp on all 4 biometrics module units

Reported by the same Pod 3 user after the install succeeded (with a manual pnpm symlink workaround):

> "Biometrics don't save. I can see the waveforms but no stats."

Piezo-processor journal:

```
FileNotFoundError: [Errno 2] No usable temporary directory found in
  ['/tmp', '/var/tmp', '/usr/tmp', '/opt/sleepypod/modules/piezo-processor']
```

All 4 module units have `ProtectSystem=strict` + `ReadWritePaths=/persistent/sleepypod-data`, which makes the filesystem read-only except that one path — including `/tmp`. Python's `tempfile.mkstemp()` can't find anywhere to write, scipy/heartpy intermediate math crashes, no vitals rows ever get saved. Waveforms still show in the UI because piezo streams live via WebSocket without touching tempfile.

The user verified their own workaround:

> "I modified this line in the piezo service file to add /tmp and /var/tmp — this seems to have fixed that particular error. ... I think it's writing into the db now 🥳"

Shipping the cleaner systemd-native equivalent: `PrivateTmp=true` gives each service its own isolated /tmp + /var/tmp namespace (auto-cleaned on stop, not shared with host). Applied to all 4 modules — any could hit the same tempfile path under load.

## Why these together

Both are Pod 3-specific install issues from the same user session, both small, both targeted at the same install-reliability release. One CI + release cycle instead of two.

## Test plan

- [ ] Fresh install on Pod 3 (Volta present): pnpm step runs, service starts. Piezo-processor journal shows no `FileNotFoundError`. `vitals` row count increases over time while in bed.
- [ ] Pod 4 / Pod 5: no regression (PrivateTmp is a pure add, pnpm check change is benign when no Volta shim exists).
- [ ] `sp-update` still works (unchanged).

## Open: calibration UI "pending" — separate

The same Pod 3 user also reported calibration buttons stay in `pending` state. That's a separate bug (calibrator ↔ UI trigger pathway); the PrivateTmp fix here may unblock calibrator since it's the tempfile-heaviest module, but the UI trigger/ack handshake is its own investigation. Filing separately once v1.7.4 ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved installer reliability so the package manager is detected and installed more robustly, with clearer failure reporting if installation cannot be verified.

* **Bug Fixes**
  * Multiple services now run with isolated temporary directories, reducing interference with the host and improving runtime safety for temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->