### PR TITLE
fix(install): verify pnpm runs, not just has +x bit (addresses #465 CR nit)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -329,14 +329,16 @@ if [ ! -x /usr/local/bin/pnpm ]; then
   fi
 fi
 
-# Verify pnpm is now at the concrete path. Without this, a silently-failed
-# install (e.g. npm prefix points somewhere the symlink fallback above
-# didn't find) would let the script proceed and hit the Volta shim at
-# `pnpm install --frozen-lockfile` ~120 lines down with the same exit 126
-# this PR was meant to fix. Matches the Node verification pattern above.
-if [ ! -x /usr/local/bin/pnpm ]; then
-  echo "Error: pnpm not found at /usr/local/bin/pnpm after install." >&2
-  echo "  npm prefix: $(npm config get prefix 2>/dev/null || echo unknown)" >&2
+# Verify pnpm is now runnable at the concrete path. `[ -x ]` only checks
+# the file's execute bit — a broken pnpm (arch mismatch, corrupt install,
+# dangling symlink target) can still pass that test and then die at
+# `pnpm install` ~120 lines down. Exercising it via `pnpm --version`
+# catches all of those at the right spot. Matches the Node verification
+# pattern above (which runs `node -v`).
+if ! /usr/local/bin/pnpm --version >/dev/null 2>&1; then
+  echo "Error: /usr/local/bin/pnpm is not runnable after install." >&2
+  echo "  npm prefix:       $(npm config get prefix 2>/dev/null || echo unknown)" >&2
+  echo "  /usr/local/bin/pnpm: $(ls -la /usr/local/bin/pnpm 2>&1 || echo missing)" >&2
   echo "  Try: npm install -g pnpm, then re-run this installer." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Addresses the second-pass CR nit from #465: \`[ -x /usr/local/bin/pnpm ]\` only checks the execute bit, missing the "binary has +x but fails at runtime" class of failures (arch mismatch, corrupt install, dangling symlink target). Exercise the binary via \`pnpm --version\` to match the Node verification pattern.

Not urgent — v1.7.4 already works for the reported Pod 3 case, and the v1.7.2 ERR trap ensures any remaining failure modes surface with clear line/command info instead of silently descending into the Volta shim. This is cleanup + defense in depth.

## Test plan

- [ ] Fresh install on a pod with working pnpm: verification passes silently.
- [ ] Pre-stage a broken pnpm at /usr/local/bin/pnpm (e.g. empty file with +x): verification fails with the npm prefix + ls output + suggested-fix message.
- [ ] Pod 3/4/5: no behavior change when pnpm is healthy.