### PR TITLE
fix: cut v1.7.5 — pnpm runtime verification

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -329,14 +329,16 @@ if [ ! -x /usr/local/bin/pnpm ]; then
   fi
 fi
 
-# Verify pnpm is now at the concrete path. Without this, a silently-failed
-# install (e.g. npm prefix points somewhere the symlink fallback above
-# didn't find) would let the script proceed and hit the Volta shim at
-# `pnpm install --frozen-lockfile` ~120 lines down with the same exit 126
-# this PR was meant to fix. Matches the Node verification pattern above.
-if [ ! -x /usr/local/bin/pnpm ]; then
-  echo "Error: pnpm not found at /usr/local/bin/pnpm after install." >&2
-  echo "  npm prefix: $(npm config get prefix 2>/dev/null || echo unknown)" >&2
+# Verify pnpm is now runnable at the concrete path. `[ -x ]` only checks
+# the file's execute bit — a broken pnpm (arch mismatch, corrupt install,
+# dangling symlink target) can still pass that test and then die at
+# `pnpm install` ~120 lines down. Exercising it via `pnpm --version`
+# catches all of those at the right spot. Matches the Node verification
+# pattern above (which runs `node -v`).
+if ! /usr/local/bin/pnpm --version >/dev/null 2>&1; then
+  echo "Error: /usr/local/bin/pnpm is not runnable after install." >&2
+  echo "  npm prefix:       $(npm config get prefix 2>/dev/null || echo unknown)" >&2
+  echo "  /usr/local/bin/pnpm: $(ls -la /usr/local/bin/pnpm 2>&1 || echo missing)" >&2
   echo "  Try: npm install -g pnpm, then re-run this installer." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Promotes #469 to main for **v1.7.5**. Single \`fix:\` commit addressing the second-pass CR nit from #465: replace \`[ -x /usr/local/bin/pnpm ]\` with an actual \`pnpm --version\` invocation so the post-install verification catches \"binary exists with +x but fails at runtime\" cases (arch mismatch, corrupt install, dangling symlink target) instead of letting them leak to the downstream \`pnpm install\` call.

## Merge instruction

**Use "Create a merge commit" — DO NOT SQUASH.**

## Test plan

- [ ] Pod 3/4/5 fresh install: verification passes silently, service starts normally.
- [ ] If pnpm is broken (corrupt binary): script exits at the verify step with npm prefix + ls output + suggested fix.