### PR TITLE
fix: calibrator OOM on Pod 3 + force .venv refresh on upgrades

### DIFF
--- a/modules/calibrator/sleepypod-calibrator.service
+++ b/modules/calibrator/sleepypod-calibrator.service
@@ -20,8 +20,12 @@ Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 Environment="CALIBRATION_HOUR=6"
 
-# Resource limits (calibration is bursty but short-lived)
-MemoryMax=256M
+# Resource limits (calibration loads up to 6h of sensor data into numpy
+# arrays for scipy processing — 500Hz piezo × 6h easily exceeds a few
+# hundred MB). 256M was tripping systemd's kill at ~6s into capacitance
+# calibration on Pod 3 (status=9/KILL). 1G is conservative vs total
+# Pod RAM (~6GB) and leaves plenty of headroom.
+MemoryMax=1G
 CPUQuota=25%
 
 # Sandboxing

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -240,6 +240,12 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       mkdir -p "$MODULES_DEST/$mod"
       cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
       rm -rf "$MODULES_DEST/$mod/venv"
+      # Also wipe .venv so OTAs pick up the shared UV_PYTHON_INSTALL_DIR
+      # set above — otherwise a pre-v1.7.3 venv's bin/python symlink keeps
+      # pointing at /home/root/.local/share/uv/… and User=dac modules fail
+      # to exec. uv's content-addressable cache means this is a cheap
+      # re-link, not a full re-download.
+      rm -rf "$MODULES_DEST/$mod/.venv"
       if command -v uv &>/dev/null; then
         (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
           || echo "Warning: uv sync failed for module $mod"

--- a/scripts/install
+++ b/scripts/install
@@ -705,6 +705,15 @@ else
     # Remove orphaned venv/ from pre-uv installs
     rm -rf "$dest/venv"
 
+    # Also wipe any existing .venv. An upgraded install from pre-v1.7.3
+    # would otherwise retain a .venv whose bin/python symlink points at
+    # /home/root/.local/share/uv/… (root-only, mode 0700) and User=dac
+    # services (calibrator, environment-monitor) would still fail 203/EXEC
+    # even though we've since set UV_PYTHON_INSTALL_DIR. Fresh recreation
+    # is cheap: uv's content-addressable cache reuses the managed Python
+    # and wheels, only the venv metadata is re-linked.
+    rm -rf "$dest/.venv"
+
     # Create Python environment with uv (no ensurepip/pyexpat needed).
     # No --python flag: let uv pick from requires-python in pyproject.toml.
     # If system python3 is in range it's used; otherwise uv downloads a


### PR DESCRIPTION
## Summary

Two Pod 3 fixes reported by Xcessive Overlord after v1.7.5.

### 1. Calibrator SIGKILLed at 6s

`MemoryMax=256M` trips systemd's kill as scipy loads 6h of 500Hz piezo data (~864MB worst case) into numpy arrays. Raised to **1G** — well within Pod RAM headroom and matches how much memory the work actually needs.

### 2. User=dac modules still 203/EXEC after upgrade from pre-v1.7.3

The #463 fix set \`UV_PYTHON_INSTALL_DIR=/opt/sleepypod/python\` but existing \`.venv/\` dirs from older installs retain the symlink into \`/home/root/.local/share/uv/…\` (mode 0700, root-only). uv reuses the venv rather than recreating it against the new shared Python. User=dac services (calibrator, env-monitor) still fail to execve.

Install + sp-update now \`rm -rf .venv\` before \`uv sync\`. Cheap — uv's wheel cache means this is a re-link, not a re-download.

## Validates the workaround

Reporter changed calibrator's unit to \`User=root\` to get past this. With the venv refresh, their upgrade can stay on \`User=dac\` and stop running scipy as root.

## Test plan

- [ ] Fresh install on Pod 3: calibrator completes full capacitance pass (no SIGKILL) with MemoryMax=1G.
- [ ] Upgrade via sp-update from a pre-v1.7.3 install: \`readlink -f /opt/sleepypod/modules/calibrator/.venv/bin/python\` points under \`/opt/sleepypod/python\`, not \`/home/root\`.
- [ ] Pod 4/5: no regression.

## Not in this PR

- "No piezo records available" — calibrator sees empty while piezo-processor works. Need RAW file layout investigation.
- UI chart x-axis showing ~24h instead of configured window — frontend bug.

Will file separately if user confirms the above two fixes work end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased memory allocation for the calibrator service to prevent out-of-memory errors during extended sensor data processing.
  * Fixed virtual environment initialization to ensure proper service execution with correct user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->