### PR TITLE
fix: hardware transport timeouts + retry backoff (#321)

### DIFF
--- a/src/hardware/dacTransport.ts
+++ b/src/hardware/dacTransport.ts
@@ -201,6 +201,23 @@ class SocketListener {
 
 const SEPARATOR = Buffer.from('\n\n')
 const RESPONSE_DELAY_MS = 10
+const DEFAULT_MESSAGE_RESPONSE_TIMEOUT_MS = 30_000
+
+function messageResponseTimeoutMs(): number {
+  const raw = process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_MESSAGE_RESPONSE_TIMEOUT_MS
+}
+
+export class MessageResponseTimeoutError extends Error {
+  public constructor(timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms waiting for firmware response`)
+    this.name = 'MessageResponseTimeoutError'
+  }
+}
 
 class DacTransport {
   public constructor(
@@ -213,12 +230,26 @@ class DacTransport {
     return this.sequentialQueue.exec(async () => {
       const requestBytes = Buffer.concat([Buffer.from(message), SEPARATOR])
       await this.write(requestBytes)
-      const resp = await this.messageStream.readMessage()
 
-      if (RESPONSE_DELAY_MS > 0) {
-        await wait(RESPONSE_DELAY_MS)
+      const timeoutMs = messageResponseTimeoutMs()
+      let timeout: NodeJS.Timeout | undefined
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new MessageResponseTimeoutError(timeoutMs)),
+          timeoutMs,
+        )
+      })
+
+      try {
+        const resp = await Promise.race([this.messageStream.readMessage(), timeoutPromise])
+        if (RESPONSE_DELAY_MS > 0) {
+          await wait(RESPONSE_DELAY_MS)
+        }
+        return resp.toString()
       }
-      return resp.toString()
+      finally {
+        if (timeout) clearTimeout(timeout)
+      }
     })
   }
 
@@ -265,12 +296,27 @@ class DacServer {
 // ─── Connection timeout ──────────────────────────────────────────────────────
 
 const CONNECTION_TIMEOUT_MS = 25_000
+const RECONNECT_INITIAL_DELAY_MS = 1_000
+const RECONNECT_MAX_DELAY_MS = 60_000
+const RECONNECT_MAX_ATTEMPTS = 10
 
 class ConnectionTimeoutError extends Error {
   public constructor() {
     super('Timed out waiting for frankenfirmware connection')
     this.name = 'ConnectionTimeoutError'
   }
+}
+
+export class ConnectionRetriesExhaustedError extends Error {
+  public constructor(attempts: number) {
+    super(`Gave up connecting to frankenfirmware after ${attempts} attempts`)
+    this.name = 'ConnectionRetriesExhaustedError'
+  }
+}
+
+export function backoffDelayMs(attempt: number): number {
+  const exponential = RECONNECT_INITIAL_DELAY_MS * 2 ** attempt
+  return Math.min(exponential, RECONNECT_MAX_DELAY_MS)
 }
 
 function withTimeout<T>(promise: Promise<T>, onTimeout: () => Error): Promise<T> {
@@ -328,6 +374,7 @@ export async function connectDac(socketPath: string): Promise<void> {
   }
 
   connectPromise = (async () => {
+    let timeoutAttempts = 0
     while (true) {
       if (!dacServer) {
         dacServer = await DacServer.start(socketPath)
@@ -341,6 +388,14 @@ export async function connectDac(socketPath: string): Promise<void> {
       catch (error) {
         if (error instanceof ConnectionTimeoutError) {
           await shutdown()
+          timeoutAttempts += 1
+          if (timeoutAttempts >= RECONNECT_MAX_ATTEMPTS) {
+            console.error(`[DAC] giving up after ${timeoutAttempts} connection timeouts`)
+            throw new ConnectionRetriesExhaustedError(timeoutAttempts)
+          }
+          const delay = backoffDelayMs(timeoutAttempts - 1)
+          console.warn(`[DAC] reconnect attempt ${timeoutAttempts} in ${delay}ms`)
+          await wait(delay)
           continue
         }
         await shutdown()

--- a/src/hardware/tests/dacTransport.test.ts
+++ b/src/hardware/tests/dacTransport.test.ts
@@ -13,7 +13,14 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { Socket } from 'net'
 import { promises as fs } from 'fs'
-import { connectDac, sendCommand, disconnectDac, isDacConnected } from '../dacTransport'
+import {
+  connectDac,
+  sendCommand,
+  disconnectDac,
+  isDacConnected,
+  MessageResponseTimeoutError,
+  backoffDelayMs,
+} from '../dacTransport'
 
 function createTestSocketPath(): string {
   return `/tmp/test-dac-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`
@@ -190,5 +197,76 @@ describe('dacTransport', () => {
 
     await disconnectDac()
     expect(isDacConnected()).toBe(false)
+  })
+
+  describe('response timeout', () => {
+    const originalTimeout = process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS
+
+    beforeEach(() => {
+      process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS = '150'
+    })
+
+    afterEach(() => {
+      if (originalTimeout === undefined) {
+        delete process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS
+      }
+      else {
+        process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS = originalTimeout
+      }
+    })
+
+    test('rejects with MessageResponseTimeoutError when firmware hangs', async () => {
+      const connectPromise = connectDac(socketPath)
+
+      await new Promise(r => setTimeout(r, 200))
+      mockFranken = await connectAsFrankenfirmware(socketPath)
+      // Intentionally do not wire up handleCommands — firmware is "hung"
+
+      await connectPromise
+
+      await expect(sendCommand('14')).rejects.toBeInstanceOf(MessageResponseTimeoutError)
+    })
+
+    test('queue drains after timeout — next command succeeds (no deadlock)', async () => {
+      const connectPromise = connectDac(socketPath)
+
+      await new Promise(r => setTimeout(r, 200))
+      mockFranken = await connectAsFrankenfirmware(socketPath)
+
+      await connectPromise
+
+      // First request: firmware ignores it (no handler attached yet)
+      const firstResult = sendCommand('14')
+      await expect(firstResult).rejects.toBeInstanceOf(MessageResponseTimeoutError)
+
+      // Now firmware becomes responsive. The queue must not be stuck.
+      handleCommands(mockFranken)
+      const response = await sendCommand('0')
+      expect(response).toBe('READY')
+    })
+  })
+
+  describe('reconnect backoff', () => {
+    test('backoffDelayMs grows exponentially and caps at 60s', () => {
+      expect(backoffDelayMs(0)).toBe(1_000)
+      expect(backoffDelayMs(1)).toBe(2_000)
+      expect(backoffDelayMs(2)).toBe(4_000)
+      expect(backoffDelayMs(3)).toBe(8_000)
+      expect(backoffDelayMs(4)).toBe(16_000)
+      expect(backoffDelayMs(5)).toBe(32_000)
+      // Cap: 2^6 * 1000 = 64_000 but max is 60_000
+      expect(backoffDelayMs(6)).toBe(60_000)
+      expect(backoffDelayMs(10)).toBe(60_000)
+      expect(backoffDelayMs(100)).toBe(60_000)
+    })
+
+    test('backoffDelayMs is monotonically non-decreasing', () => {
+      let prev = 0
+      for (let i = 0; i < 15; i++) {
+        const delay = backoffDelayMs(i)
+        expect(delay).toBeGreaterThanOrEqual(prev)
+        prev = delay
+      }
+    })
   })
 })


### PR DESCRIPTION
Closes #321.

## Findings addressed

- **No response timeout in `dacTransport.ts:212-222` (queue deadlock)**
  `sendMessage()` now races `readMessage()` with a 30s timeout. When firmware
  hangs, the promise rejects with a new exported `MessageResponseTimeoutError`
  instead of blocking the sequential queue forever. Next command can proceed.

- **`connectDac` retry loop runs forever with no backoff or limit**
  Reconnect now uses exponential backoff (1s → 2s → 4s → ... capped at 60s)
  between attempts and stops after `RECONNECT_MAX_ATTEMPTS` (10) consecutive
  timeouts, throwing a new exported `ConnectionRetriesExhaustedError`. The
  existing caller in `dacMonitor.instance.ts` already catches connection
  failures and logs them, so the degraded-mode signal is surfaced via that
  existing path rather than a new event bus (keeps the change scoped).

- **Timeout surfaced as a proper error**
  `MessageResponseTimeoutError` and `ConnectionRetriesExhaustedError` are
  named, exported classes so consumers can `instanceof`-discriminate.

## Out of scope (noted in issue but not in this PR's task)

The three remaining findings — busy-wait race in the internal `MessageStream`,
shell-injection hardening in `iptablesCheck.ts`, and the unsafe cast in
`dacMonitor.instance.ts:184` — are intentionally left for a follow-up to keep
this PR focused and reviewable. They do not overlap with the deadlock/backoff
fix.

## Assumptions

- 30s matches the timeout already used by the standalone `messageStream.ts`.
- Max 10 retry attempts with 60s cap = up to ~9 minutes of retries before
  giving up; fail-fast is preferable to log storms for permanent firmware
  outages.
- Test seam: `DAC_MESSAGE_RESPONSE_TIMEOUT_MS` env var lets tests use a short
  timeout without waiting 30s. Defaults to 30_000 in prod.

## Test plan

- Added unit tests in `src/hardware/tests/dacTransport.test.ts`:
  - `rejects with MessageResponseTimeoutError when firmware hangs` — hung
    firmware triggers timeout rejection.
  - `queue drains after timeout — next command succeeds (no deadlock)` —
    verifies post-timeout the sequential queue accepts new commands.
  - `backoffDelayMs grows exponentially and caps at 60s` — covers
    1s/2s/4s/8s/16s/32s/60s curve including the cap.
  - `backoffDelayMs is monotonically non-decreasing`.
- [x] `pnpm test` — 322 passed, 1 skipped.
- [x] `pnpm tsc` — clean.
- [x] `pnpm lint` — clean (1 pre-existing warning in `stryker.config.mjs`, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hardware communication now enforces response deadlines with configurable timeout settings for improved reliability
  * Added automatic reconnection with exponential backoff strategy to handle intermittent device connectivity issues
  * Improved error handling provides clearer feedback when connection or response timeouts occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->