### PR TITLE
fix: scheduler timezone correctness + reliability (#320)

### DIFF
--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -18,7 +18,7 @@ import { fahrenheitToLevel, HardwareCommand } from '@/src/hardware/types'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { cancelAutoOffTimer } from '@/src/services/autoOffWatcher'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
-import { timeToDate } from './timeUtils'
+import { timeToDate, nowInTimezone } from './timeUtils'
 
 const HEARTBEAT_INTERVAL_MS_DEFAULT = 60_000
 const HEARTBEAT_STALE_MS_DEFAULT = 90_000
@@ -35,6 +35,7 @@ interface JobManagerOptions {
 export class JobManager {
   private scheduler: Scheduler
   private reloadInProgress: Promise<void> | null = null
+  private reloadPending: boolean = false
   private sideLocks: Record<'left' | 'right', Promise<void>> = {
     left: Promise.resolve(),
     right: Promise.resolve(),
@@ -528,9 +529,12 @@ export class JobManager {
       await this.sendLedBrightness(dayBrightness)
     })
 
-    // Apply correct brightness immediately based on whether we're in the night window
-    const now = new Date()
-    const nowMinutes = now.getHours() * 60 + now.getMinutes()
+    // Apply correct brightness immediately based on whether we're in the night window.
+    // Use the configured scheduler timezone (which matches the cron jobs above) rather
+    // than the OS clock, which on embedded targets is often UTC and would flip the
+    // window for any user not on UTC.
+    const { hour: nowHour, minute: nowMinute } = nowInTimezone(this.scheduler.getTimezone())
+    const nowMinutes = nowHour * 60 + nowMinute
     const startMinutes = startHour * 60 + startMinute
     const endMinutes = endHour * 60 + endMinute
 
@@ -728,20 +732,29 @@ export class JobManager {
 
   /**
    * Reload all schedules (useful after database changes).
-   * Uses a mutex to prevent concurrent reloads which could cause race conditions.
+   *
+   * Uses a dirty-flag mutex so concurrent reload requests never drop DB
+   * changes. Naive coalescing (second caller awaits first and returns) is
+   * unsafe: caller A may have snapshotted the DB before caller B's write
+   * committed, so B's changes would be missed. Instead, if another reload
+   * is requested while one is in flight, we set a pending flag and the
+   * in-flight cycle loops to perform one more pass. All overlapping callers
+   * await the same final promise, so they all observe the latest DB state.
    */
   async reloadSchedules(): Promise<void> {
-    // If a reload is already in progress, wait for it to complete
     if (this.reloadInProgress) {
+      this.reloadPending = true
       await this.reloadInProgress
       return
     }
 
-    // Set the mutex and perform the reload
     this.reloadInProgress = (async () => {
       try {
-        this.scheduler.cancelRecurringJobs()
-        await this.loadSchedules()
+        do {
+          this.reloadPending = false
+          this.scheduler.cancelRecurringJobs()
+          await this.loadSchedules()
+        } while (this.reloadPending)
       }
       finally {
         this.reloadInProgress = null

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -9,6 +9,24 @@ import type {
 } from './types'
 
 /**
+ * Job types for which transient hardware failures should be retried.
+ * A failed set-point otherwise silently loses the user's target until the
+ * next scheduled point, potentially hours later.
+ */
+const HARDWARE_JOB_TYPES: ReadonlySet<JobType> = new Set([
+  JobType.TEMPERATURE,
+  JobType.POWER_ON,
+  JobType.POWER_OFF,
+  JobType.ALARM,
+  JobType.LED_BRIGHTNESS,
+  JobType.RUN_ONCE,
+  JobType.AWAY_MODE,
+])
+
+const HARDWARE_RETRY_ATTEMPTS = 3
+const HARDWARE_RETRY_BASE_DELAY_MS = 500
+
+/**
  * Job scheduler service for automated pod control
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -20,6 +38,14 @@ export class Scheduler extends EventEmitter {
   constructor(config: SchedulerConfig) {
     super()
     this.config = config
+  }
+
+  /**
+   * Read the currently configured timezone. Exposed so callers (e.g. JobManager)
+   * can convert wall-clock times to the user's zone without reaching into config.
+   */
+  getTimezone(): string {
+    return this.config.timezone
   }
 
   /**
@@ -42,7 +68,7 @@ export class Scheduler extends EventEmitter {
         rule: cronExpression,
       },
       async () => {
-        const result = await this.executeJob(id, handler)
+        const result = await this.executeJob(id, type, handler)
         this.emit('jobExecuted', id, result)
       }
     )
@@ -79,7 +105,7 @@ export class Scheduler extends EventEmitter {
     this.cancelJob(id)
 
     const job = schedule.scheduleJob(fireDate, async () => {
-      const result = await this.executeJob(id, handler)
+      const result = await this.executeJob(id, type, handler)
       this.emit('jobExecuted', id, result)
       this.jobs.delete(id)
     })
@@ -94,6 +120,7 @@ export class Scheduler extends EventEmitter {
       schedule: fireDate.toISOString(),
       job,
       metadata,
+      oneTime: true,
     }
 
     this.jobs.set(id, scheduledJob)
@@ -102,22 +129,42 @@ export class Scheduler extends EventEmitter {
   }
 
   /**
-   * Execute a job and handle errors
+   * Execute a job and handle errors. Hardware-category jobs get bounded retries
+   * with exponential backoff so a single transient failure doesn't strand the
+   * user's bed at the wrong temperature until the next scheduled point.
    */
   private async executeJob(
     id: string,
+    type: JobType,
     handler: () => Promise<void>
   ): Promise<JobExecutionResult> {
     const timestamp = new Date()
     this.inFlightJobs.add(id)
 
+    const maxAttempts = HARDWARE_JOB_TYPES.has(type) ? HARDWARE_RETRY_ATTEMPTS : 1
+    let lastError: unknown
+
     try {
-      await handler()
-      return { success: true, timestamp }
-    }
-    catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      this.emit('jobError', id, error as Error)
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          await handler()
+          return { success: true, timestamp }
+        }
+        catch (error) {
+          lastError = error
+          if (attempt < maxAttempts) {
+            const delay = HARDWARE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)
+            console.warn(
+              `Job ${id} attempt ${attempt}/${maxAttempts} failed, retrying in ${delay}ms:`,
+              error instanceof Error ? error.message : String(error),
+            )
+            await new Promise(resolve => setTimeout(resolve, delay))
+          }
+        }
+      }
+
+      const errorMessage = lastError instanceof Error ? lastError.message : String(lastError)
+      this.emit('jobError', id, lastError as Error)
       return { success: false, error: errorMessage, timestamp }
     }
     finally {
@@ -174,12 +221,13 @@ export class Scheduler extends EventEmitter {
   }
 
   /**
-   * Cancel all recurring (cron) jobs, preserving one-time run-once jobs.
-   * Used by reloadSchedules to avoid dropping active run-once sessions.
+   * Cancel all recurring (cron) jobs, preserving one-time fire-date jobs.
+   * Used by reloadSchedules to avoid dropping active one-shots (run-once
+   * sessions, away-mode start/return transitions) whose Date has not yet passed.
    */
   cancelRecurringJobs(): void {
     for (const [id, scheduledJob] of this.jobs.entries()) {
-      if (scheduledJob.type === JobType.RUN_ONCE) continue
+      if (scheduledJob.oneTime) continue
       scheduledJob.job.cancel()
       this.emit('jobCancelled', id)
       this.jobs.delete(id)
@@ -215,33 +263,24 @@ export class Scheduler extends EventEmitter {
   }
 
   /**
-   * Update scheduler configuration
+   * Update scheduler configuration.
+   *
+   * NOTE: Timezone changes require the caller to invoke a full reload
+   * (e.g. JobManager.reloadSchedules) because existing cron jobs are bound
+   * to their original tz at creation time and cannot be rebound in place
+   * without re-scheduling. Callers that change the timezone without
+   * following up with a reload will see stale jobs firing on the old zone.
+   * Use JobManager.updateTimezone for the safe path.
    */
   updateConfig(config: Partial<SchedulerConfig>): void {
-    // Store old timezone before updating config
     const oldTimezone = this.config.timezone
-
-    // Update config
     this.config = { ...this.config, ...config }
 
-    // Reschedule all jobs with new config if timezone changed
     if (config.timezone != null && config.timezone !== oldTimezone) {
-      this.rescheduleAllJobs()
-    }
-  }
-
-  /**
-   * Reschedule all jobs (useful after timezone change)
-   */
-  private rescheduleAllJobs(): void {
-    const jobs = Array.from(this.jobs.values())
-
-    for (const scheduledJob of jobs) {
-      // This would require storing the original handler
-      // For now, jobs need to be manually rescheduled
-      console.warn(
-        `Job ${scheduledJob.id} needs to be manually rescheduled after timezone change`
-      )
+      // Existing cron jobs still carry the old tz — cancel them now so
+      // they cannot fire on stale offsets before the caller reloads.
+      // One-time jobs (scheduled at absolute Date) are fine as-is.
+      this.cancelRecurringJobs()
     }
   }
 

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -44,6 +44,7 @@ vi.mock('@/src/db/schema', () => {
     deviceSettings: make('deviceSettings'),
     sideSettings: make('sideSettings'),
     runOnceSessions: make('runOnceSessions'),
+    deviceState: make('deviceState'),
   }
 })
 

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('@/src/db', () => {
+  // Minimal drizzle-shaped stub. Each .select().from(...) is a thenable
+  // that resolves to an empty row set on the next microtask. loadSchedules
+  // thus produces no jobs but still yields to the event loop, which is what
+  // the coalescing tests need.
+  const makeQuery = () => {
+    const promise: any = {
+      async then(resolve: (v: any) => void) {
+        await Promise.resolve()
+        resolve([])
+      },
+      where() { return promise },
+      limit() { return promise },
+    }
+    return promise
+  }
+  const fakeDb = {
+    select() {
+      return {
+        from() {
+          return makeQuery()
+        },
+      }
+    },
+    update() {
+      return { set: () => ({ where: () => ({ run: () => undefined }) }) }
+    },
+    transaction: (fn: any) => fn({ update: fakeDb.update }),
+  }
+  return { db: fakeDb }
+})
+
+vi.mock('@/src/db/schema', () => {
+  // Each "table" is just a tagged object so our fake .from() can distinguish them.
+  // The stub DB doesn't actually query them, so the shape doesn't matter beyond the name.
+  const make = (name: string) => ({ _: { name } })
+  return {
+    temperatureSchedules: make('temperatureSchedules'),
+    powerSchedules: make('powerSchedules'),
+    alarmSchedules: make('alarmSchedules'),
+    deviceSettings: make('deviceSettings'),
+    sideSettings: make('sideSettings'),
+    runOnceSessions: make('runOnceSessions'),
+  }
+})
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: () => ({
+    connect: vi.fn(async () => {}),
+    setTemperature: vi.fn(async () => {}),
+    setPower: vi.fn(async () => {}),
+    setAlarm: vi.fn(async () => {}),
+    startPriming: vi.fn(async () => {}),
+  }),
+}))
+
+vi.mock('@/src/hardware/dacTransport', () => ({
+  sendCommand: vi.fn(async () => {}),
+}))
+
+vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+vi.mock('@/src/services/autoOffWatcher', () => ({
+  cancelAutoOffTimer: vi.fn(),
+}))
+
+import { JobManager } from '../jobManager'
+
+/**
+ * Count reload cycles by spying on Scheduler.cancelRecurringJobs, which is
+ * called exactly once per reload cycle in runReloadCycle (and never by tests
+ * directly). This is robust regardless of how many DB selects happen inside
+ * each loadSchedules() pass.
+ */
+describe('JobManager.reloadSchedules coalescing', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    manager = new JobManager('UTC')
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  function spyReloadCount(): { count: () => number } {
+    const scheduler = manager.getScheduler()
+    let n = 0
+    const orig = scheduler.cancelRecurringJobs.bind(scheduler)
+    scheduler.cancelRecurringJobs = () => {
+      n++
+      orig()
+    }
+    return { count: () => n }
+  }
+
+  it('runs a follow-up reload when a second caller arrives while one is in flight', async () => {
+    const { count } = spyReloadCount()
+
+    const p1 = manager.reloadSchedules()
+    const p2 = manager.reloadSchedules()
+
+    await Promise.all([p1, p2])
+
+    // 1 cycle for caller A, 1 follow-up cycle triggered by caller B's pending flag
+    expect(count()).toBe(2)
+  })
+
+  it('collapses N concurrent callers into exactly 2 cycles', async () => {
+    const { count } = spyReloadCount()
+
+    const promises = [
+      manager.reloadSchedules(),
+      manager.reloadSchedules(),
+      manager.reloadSchedules(),
+      manager.reloadSchedules(),
+      manager.reloadSchedules(),
+    ]
+    await Promise.all(promises)
+
+    // Exactly 2: the initial cycle + one follow-up for all pending callers
+    expect(count()).toBe(2)
+  })
+
+  it('a single caller runs exactly one cycle', async () => {
+    const { count } = spyReloadCount()
+    await manager.reloadSchedules()
+    expect(count()).toBe(1)
+  })
+
+  it('sequential (non-overlapping) reloads each run a full cycle', async () => {
+    const { count } = spyReloadCount()
+    await manager.reloadSchedules()
+    await manager.reloadSchedules()
+    await manager.reloadSchedules()
+    expect(count()).toBe(3)
+  })
+
+  it('pending-flag drains: late-arriving second caller is not dropped', async () => {
+    const { count } = spyReloadCount()
+
+    // Caller A starts and we let its first cycle begin
+    const p1 = manager.reloadSchedules()
+    // Before p1 resolves, caller B arrives. Its request should trigger a second cycle.
+    const p2 = manager.reloadSchedules()
+
+    await p1
+    // After p1 resolves, the pending-flag-driven second cycle is also complete,
+    // so count should be 2 by the time p1 returns to caller A.
+    expect(count()).toBe(2)
+    await p2
+    expect(count()).toBe(2)
+  })
+})

--- a/src/scheduler/tests/scheduler.test.ts
+++ b/src/scheduler/tests/scheduler.test.ts
@@ -177,6 +177,116 @@ describe('Scheduler', () => {
       scheduler.updateConfig({ enabled: false })
       expect(scheduler.isEnabled()).toBe(false)
     })
+
+    it('cancels recurring jobs when timezone changes so stale offsets cannot fire', () => {
+      const handler = vi.fn(async () => {})
+      scheduler.scheduleJob('tz-old', JobType.TEMPERATURE, '0 0 * * *', handler)
+      expect(scheduler.getJob('tz-old')).toBeDefined()
+
+      scheduler.updateConfig({ timezone: 'America/New_York' })
+      expect(scheduler.getTimezone()).toBe('America/New_York')
+      // Recurring job must be dropped — caller is responsible for reloading
+      expect(scheduler.getJob('tz-old')).toBeUndefined()
+    })
+
+    it('preserves one-time jobs when timezone changes', () => {
+      const future = new Date(Date.now() + 60_000)
+      const handler = vi.fn(async () => {})
+      scheduler.scheduleOneTimeJob('once-keep', JobType.AWAY_MODE, future, handler)
+
+      scheduler.updateConfig({ timezone: 'America/New_York' })
+
+      expect(scheduler.getJob('once-keep')).toBeDefined()
+    })
+
+    it('is a no-op when timezone is unchanged', () => {
+      const handler = vi.fn(async () => {})
+      scheduler.scheduleJob('tz-keep', JobType.TEMPERATURE, '0 0 * * *', handler)
+      scheduler.updateConfig({ enabled: true, timezone: 'America/Los_Angeles' })
+      expect(scheduler.getJob('tz-keep')).toBeDefined()
+    })
+  })
+
+  describe('cancelRecurringJobs', () => {
+    it('preserves AWAY_MODE one-time jobs', () => {
+      const future = new Date(Date.now() + 60_000)
+      const handler = vi.fn(async () => {})
+
+      scheduler.scheduleJob('cron-temp', JobType.TEMPERATURE, '0 0 * * *', handler)
+      scheduler.scheduleOneTimeJob('away-start-left', JobType.AWAY_MODE, future, handler)
+      scheduler.scheduleOneTimeJob('runonce-1', JobType.RUN_ONCE, future, handler)
+
+      scheduler.cancelRecurringJobs()
+
+      expect(scheduler.getJob('cron-temp')).toBeUndefined()
+      expect(scheduler.getJob('away-start-left')).toBeDefined()
+      expect(scheduler.getJob('runonce-1')).toBeDefined()
+    })
+  })
+
+  describe('job retry for hardware failures', () => {
+    it('retries a failing hardware job up to 3 attempts', async () => {
+      const future = new Date(Date.now() + 30)
+      let calls = 0
+      const handler = vi.fn(async () => {
+        calls++
+        if (calls < 2) throw new Error('transient hw fail')
+      })
+
+      scheduler.scheduleOneTimeJob('retry-succeeds', JobType.TEMPERATURE, future, handler)
+
+      await new Promise((resolve) => {
+        scheduler.on('jobExecuted', (id, result) => {
+          if (id === 'retry-succeeds') {
+            expect(result.success).toBe(true)
+            expect(handler).toHaveBeenCalledTimes(2)
+            resolve(undefined)
+          }
+        })
+      })
+    })
+
+    it('does not retry non-hardware jobs', async () => {
+      const future = new Date(Date.now() + 30)
+      const handler = vi.fn(async () => {
+        throw new Error('fatal')
+      })
+
+      scheduler.scheduleOneTimeJob('no-retry', JobType.REBOOT, future, handler)
+
+      await new Promise((resolve) => {
+        scheduler.on('jobExecuted', (id, result) => {
+          if (id === 'no-retry') {
+            expect(result.success).toBe(false)
+            expect(handler).toHaveBeenCalledTimes(1)
+            resolve(undefined)
+          }
+        })
+      })
+    })
+
+    it('surfaces last error via jobError after exhausting retries', async () => {
+      const future = new Date(Date.now() + 30)
+      const handler = vi.fn(async () => {
+        throw new Error('always fails')
+      })
+      const errorListener = vi.fn()
+      scheduler.on('jobError', errorListener)
+
+      scheduler.scheduleOneTimeJob('retry-fails', JobType.POWER_ON, future, handler)
+
+      await new Promise((resolve) => {
+        scheduler.on('jobExecuted', (id, result) => {
+          if (id === 'retry-fails') {
+            expect(result.success).toBe(false)
+            expect(result.error).toBe('always fails')
+            expect(handler).toHaveBeenCalledTimes(3)
+            expect(errorListener).toHaveBeenCalledTimes(1)
+            resolve(undefined)
+          }
+        })
+      })
+    }, 10000)
   })
 
   describe('getNextInvocation', () => {

--- a/src/scheduler/tests/timeUtils.test.ts
+++ b/src/scheduler/tests/timeUtils.test.ts
@@ -83,7 +83,7 @@ describe('nowInTimezone', () => {
     const now = new Date('2026-04-01T14:30:00Z')
     // 10:30 EDT
     expect(nowInTimezone('America/New_York', now)).toEqual({ hour: 10, minute: 30 })
-    // 06:30 PDT
+    // 07:30 PDT (April → DST in effect, UTC-7)
     expect(nowInTimezone('America/Los_Angeles', now)).toEqual({ hour: 7, minute: 30 })
     // 14:30 UTC
     expect(nowInTimezone('UTC', now)).toEqual({ hour: 14, minute: 30 })

--- a/src/scheduler/tests/timeUtils.test.ts
+++ b/src/scheduler/tests/timeUtils.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { timeToDate, nowInTimezone } from '../timeUtils'
+
+describe('timeToDate', () => {
+  it('returns same-day instant when target time is later today in the zone', () => {
+    // Reference: 2026-04-01 14:00 UTC (which is 10:00 EDT / -04:00)
+    const ref = new Date('2026-04-01T14:00:00Z')
+    // 12:30 EDT is 16:30 UTC
+    const result = timeToDate('12:30', 'America/New_York', ref)
+    expect(result.toISOString()).toBe('2026-04-01T16:30:00.000Z')
+  })
+
+  it('rolls to tomorrow when target time already passed today in the zone', () => {
+    // Reference: 2026-04-01 14:00 UTC (10:00 EDT)
+    const ref = new Date('2026-04-01T14:00:00Z')
+    // 08:00 EDT has already passed -> 2026-04-02 08:00 EDT = 2026-04-02 12:00 UTC
+    const result = timeToDate('08:00', 'America/New_York', ref)
+    expect(result.toISOString()).toBe('2026-04-02T12:00:00.000Z')
+  })
+
+  it('uses the calendar date of the reference *in the target zone*', () => {
+    // Reference: 2026-04-01 02:00 UTC, which is still 2026-03-31 22:00 EDT
+    const ref = new Date('2026-04-01T02:00:00Z')
+    // 23:00 on 2026-03-31 EDT = 2026-04-01 03:00 UTC (later than ref, so same zone-day)
+    const result = timeToDate('23:00', 'America/New_York', ref)
+    expect(result.toISOString()).toBe('2026-04-01T03:00:00.000Z')
+  })
+
+  it('handles DST spring-forward gap by returning a valid instant past the gap', () => {
+    // US spring-forward 2026: 02:00 -> 03:00 local on 2026-03-08.
+    // 02:30 on that day does not exist in America/New_York.
+    // Reference: just before midnight local (prev day)
+    const ref = new Date('2026-03-08T06:00:00Z') // 01:00 EST
+    const result = timeToDate('02:30', 'America/New_York', ref)
+    // The old toLocaleString-based path produced an inconsistent offset here;
+    // with the formatToParts approach we get a single, well-defined instant.
+    // 02:30 in the pre-transition offset (-05:00) = 07:30 UTC.
+    // After our forward correction, the returned instant maps to 03:30 EDT = 07:30 UTC,
+    // i.e. the first valid local time after the skipped 02:30 slot.
+    expect(result.toISOString()).toBe('2026-03-08T07:30:00.000Z')
+    // Sanity: the returned Date is strictly after the reference (not a no-op).
+    expect(result.getTime()).toBeGreaterThan(ref.getTime())
+  })
+
+  it('handles DST fall-back by resolving to the first occurrence of the ambiguous time', () => {
+    // US fall-back 2026: 02:00 EDT -> 01:00 EST on 2026-11-01
+    // 01:30 local is ambiguous (occurs twice). We pick the pre-transition (EDT) instance.
+    const ref = new Date('2026-11-01T04:00:00Z') // 00:00 EDT
+    const result = timeToDate('01:30', 'America/New_York', ref)
+    // 01:30 EDT (-04:00) = 05:30 UTC
+    expect(result.toISOString()).toBe('2026-11-01T05:30:00.000Z')
+  })
+
+  it('handles UTC timezone correctly', () => {
+    const ref = new Date('2026-04-01T12:00:00Z')
+    const result = timeToDate('15:00', 'UTC', ref)
+    expect(result.toISOString()).toBe('2026-04-01T15:00:00.000Z')
+  })
+
+  it('rolls to tomorrow at midnight-edge correctly across DST start', () => {
+    // Reference: 2026-03-08 05:00 UTC = 2026-03-08 00:00 EST (just after midnight local)
+    // Request 00:00 -> should be equal to ref-ish; since adjusted <= ref (equal), rolls to tomorrow
+    const ref = new Date('2026-03-08T05:00:00Z')
+    const result = timeToDate('00:00', 'America/New_York', ref)
+    // Tomorrow 00:00 EDT (after DST kicked in mid-day) = 2026-03-09 00:00 EDT = 04:00 UTC
+    expect(result.toISOString()).toBe('2026-03-09T04:00:00.000Z')
+  })
+
+  it('throws on invalid time format', () => {
+    const ref = new Date('2026-04-01T12:00:00Z')
+    expect(() => timeToDate('abc', 'UTC', ref)).toThrow('Invalid time format')
+  })
+
+  it('throws on invalid timezone', () => {
+    const ref = new Date('2026-04-01T12:00:00Z')
+    expect(() => timeToDate('12:00', 'Not/A_Zone', ref)).toThrow()
+  })
+})
+
+describe('nowInTimezone', () => {
+  it('returns wall-clock hour/minute in the target zone, not the OS zone', () => {
+    // 2026-04-01 14:30 UTC
+    const now = new Date('2026-04-01T14:30:00Z')
+    // 10:30 EDT
+    expect(nowInTimezone('America/New_York', now)).toEqual({ hour: 10, minute: 30 })
+    // 06:30 PDT
+    expect(nowInTimezone('America/Los_Angeles', now)).toEqual({ hour: 7, minute: 30 })
+    // 14:30 UTC
+    expect(nowInTimezone('UTC', now)).toEqual({ hour: 14, minute: 30 })
+  })
+
+  it('correctly handles the day boundary in the target zone', () => {
+    // 2026-04-01 02:00 UTC = 2026-03-31 22:00 EDT (previous day)
+    const now = new Date('2026-04-01T02:00:00Z')
+    expect(nowInTimezone('America/New_York', now)).toEqual({ hour: 22, minute: 0 })
+  })
+
+  it('uses h23 cycle (0-23, not 1-24)', () => {
+    // 2026-04-01 04:00 UTC = 2026-04-01 00:00 EDT (midnight)
+    const now = new Date('2026-04-01T04:00:00Z')
+    expect(nowInTimezone('America/New_York', now)).toEqual({ hour: 0, minute: 0 })
+  })
+
+  it('throws on invalid timezone', () => {
+    expect(() => nowInTimezone('Not/A_Zone', new Date())).toThrow()
+  })
+})

--- a/src/scheduler/timeUtils.ts
+++ b/src/scheduler/timeUtils.ts
@@ -4,25 +4,118 @@
  */
 
 /**
+ * Resolve a wall-clock Y-M-D H:M in `timezone` to a UTC epoch ms.
+ * Uses Intl.DateTimeFormat.formatToParts to extract the timezone offset
+ * at that instant, which correctly handles DST boundaries:
+ *   - during spring-forward (non-existent local time), the returned instant
+ *     falls in the pre-transition offset, i.e. the next valid instant past
+ *     the gap (e.g. 02:30 -> 03:30 local on US DST start).
+ *   - during fall-back (ambiguous local time), the first occurrence is
+ *     returned (pre-transition offset), matching node-schedule's cron behavior.
+ */
+function zonedWallTimeToEpochMs(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timezone: string,
+): number {
+  // Start from a UTC guess, then measure the zone's offset at that instant
+  // and correct. One correction is enough when the target wall-clock exists;
+  // for the DST spring-forward gap the correction lands in the post-transition
+  // offset, which maps to the first valid instant after the gap.
+  const utcGuess = Date.UTC(year, month - 1, day, hour, minute)
+  const offsetAtGuess = getTimezoneOffsetMs(utcGuess, timezone)
+  return utcGuess - offsetAtGuess
+}
+
+/**
+ * Get the timezone's UTC offset in milliseconds at a given UTC instant.
+ * Positive for zones east of UTC, negative for zones west.
+ * Throws for invalid timezone identifiers.
+ */
+function getTimezoneOffsetMs(utcMs: number, timezone: string): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+  const parts = dtf.formatToParts(new Date(utcMs))
+  const get = (type: string) => {
+    const part = parts.find(p => p.type === type)
+    if (!part) throw new Error(`Invalid timezone: ${timezone}`)
+    return Number(part.value)
+  }
+  const asUtc = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour'), get('minute'), get('second'))
+  return asUtc - utcMs
+}
+
+/**
  * Convert an HH:mm time string to a Date for today or tomorrow.
  * If the resulting time is before `referenceDate`, it's assumed to be tomorrow.
  */
 export function timeToDate(time: string, timezone: string, referenceDate: Date): Date {
   const [hour, minute] = time.split(':').map(Number)
-  const dateStr = referenceDate.toLocaleDateString('en-CA', { timeZone: timezone })
-  const candidate = new Date(`${dateStr}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00Z`)
-
-  const utcStr = candidate.toLocaleString('en-US', { timeZone: 'UTC' })
-  const tzStr = candidate.toLocaleString('en-US', { timeZone: timezone })
-  const offset = new Date(utcStr).getTime() - new Date(tzStr).getTime()
-  if (isNaN(offset)) throw new Error(`Invalid timezone offset for: ${timezone}`)
-  const adjusted = new Date(candidate.getTime() + offset)
-
-  if (adjusted <= referenceDate) {
-    // Use calendar day increment instead of raw +24h (handles DST correctly)
-    const tomorrow = new Date(adjusted)
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    return tomorrow
+  if (Number.isNaN(hour) || Number.isNaN(minute)) {
+    throw new Error(`Invalid time format: "${time}"`)
   }
-  return adjusted
+
+  // Extract Y-M-D for the reference date in the target timezone
+  const dateParts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(referenceDate)
+  const get = (type: string) => {
+    const part = dateParts.find(p => p.type === type)
+    if (!part) throw new Error(`Invalid timezone: ${timezone}`)
+    return Number(part.value)
+  }
+  const year = get('year')
+  const month = get('month')
+  const day = get('day')
+
+  const todayMs = zonedWallTimeToEpochMs(year, month, day, hour, minute, timezone)
+  if (todayMs > referenceDate.getTime()) {
+    return new Date(todayMs)
+  }
+
+  // Otherwise, compute the same wall-clock on the next calendar day in the zone
+  const nextDay = new Date(Date.UTC(year, month - 1, day))
+  nextDay.setUTCDate(nextDay.getUTCDate() + 1)
+  const tomorrowMs = zonedWallTimeToEpochMs(
+    nextDay.getUTCFullYear(),
+    nextDay.getUTCMonth() + 1,
+    nextDay.getUTCDate(),
+    hour,
+    minute,
+    timezone,
+  )
+  return new Date(tomorrowMs)
+}
+
+/**
+ * Compute the current wall-clock hour + minute in a given timezone.
+ * Returns values suitable for comparison with scheduled HH:mm times.
+ */
+export function nowInTimezone(timezone: string, now: Date = new Date()): { hour: number, minute: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hourCycle: 'h23',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(now)
+  const get = (type: string) => {
+    const part = parts.find(p => p.type === type)
+    if (!part) throw new Error(`Invalid timezone: ${timezone}`)
+    return Number(part.value)
+  }
+  return { hour: get('hour'), minute: get('minute') }
 }

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -34,6 +34,12 @@ export interface ScheduledJob {
   schedule: string // Cron expression
   job: Job
   metadata?: Record<string, unknown>
+  /**
+   * True for jobs scheduled at an absolute fireDate (scheduleOneTimeJob).
+   * Preserved across cancelRecurringJobs reloads so in-flight one-shots
+   * (e.g. away-mode transitions) aren't silently dropped.
+   */
+  oneTime?: boolean
 }
 
 /**


### PR DESCRIPTION
Closes #320.

Focused fixes for the 6 findings filed against `src/scheduler/`. Each change is narrow — no drive-by refactors.

## Per-finding changes

- **LED night mode used OS clock (jobManager.ts:363-366)** — startup brightness now reads wall-clock hour/minute in the configured scheduler timezone via a new `nowInTimezone` helper. Previously `now.getHours()` reflected the OS zone (often UTC on embedded targets) and flipped the night window for any non-UTC user.
- **`rescheduleAllJobs` was a misleading no-op stub (scheduler.ts:236-246)** — removed. `updateConfig` now cancels recurring jobs when the timezone changes so stale-tz crons cannot fire; one-time (fire-date) jobs are preserved. `JobManager.updateTimezone` remains the safe public path (updateConfig → reload).
- **`timeToDate` wrong during DST spring-forward gap (timeUtils.ts:13-19)** — rewrote offset resolution using `Intl.DateTimeFormat.formatToParts`, eliminating the `toLocaleString` round-trip that silently produced wrong instants inside the skipped hour. The new path also handles fall-back consistently (first occurrence of the ambiguous wall-clock).
- **Reload coalescing dropped second caller's DB changes (jobManager.ts:564-583)** — replaced naive coalescing (second caller awaits, returns) with a dirty-flag pattern: if any caller arrives while a cycle is in flight, the cycle loops one more time so the late caller's DB write is always reflected. All overlapping callers await the same final promise.
- **`cancelRecurringJobs` orphaned away-mode one-time jobs (scheduler.ts:180-187)** — added `oneTime: boolean` flag to `ScheduledJob`, set by `scheduleOneTimeJob`. `cancelRecurringJobs` now skips every one-time job (both RUN_ONCE and AWAY_MODE transitions), not just the RUN_ONCE type.
- **No retry for transient hardware failures (scheduler.ts:107-126)** — `executeJob` now retries hardware-category jobs (TEMPERATURE / POWER_ON / POWER_OFF / ALARM / LED_BRIGHTNESS / RUN_ONCE / AWAY_MODE) up to 3 attempts with 500ms / 1000ms exponential backoff. Non-hardware jobs (REBOOT, PRIME, CALIBRATION) execute once as before. Final failure still surfaces `jobError`.

## Assumptions

- Retry policy: 3 attempts with 500ms base, 2x backoff. Hardcoded per the issue guidance ("2-3 attempts with backoff"); happy to make configurable in a follow-up.
- DST spring-forward gap resolution: returned instant corresponds to the first valid wall-clock past the gap (03:00 EDT for a 02:30 request on US DST start). Matches how node-schedule resolves such times for cron.
- Fall-back ambiguity: returns the first (pre-transition) occurrence of the ambiguous time. Matches node-schedule cron behavior.

## Test plan

New unit tests:

- [x] `src/scheduler/tests/timeUtils.test.ts` — 13 tests covering `timeToDate` + `nowInTimezone`, including DST spring-forward, fall-back, day-boundary-across-zones, UTC, invalid inputs.
- [x] `src/scheduler/tests/jobManager.test.ts` — 5 tests for reload-coalescing dirty-flag: single caller (1 cycle), 2 overlapping (2 cycles), 5 overlapping (2 cycles), 3 sequential (3 cycles), late-arriving caller drains.
- [x] Extended `src/scheduler/tests/scheduler.test.ts` — TZ-change cancel-then-preserve, `cancelRecurringJobs` AWAY_MODE preservation, hardware-job retry success on attempt 2, REBOOT does not retry, retry exhaustion surfaces `jobError`.

Gates:

- [x] `pnpm test` — 343 passed, 1 skipped, 0 failing across 24 files (pre-push hook also re-ran vitest on changed files and passed).
- [x] `pnpm tsc` — clean.
- [x] `pnpm lint` — clean for touched files (one unrelated pre-existing warning in `stryker.config.mjs`).

Manual verification not required for this PR — the issue findings are all reasoning-level bugs covered by the new unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LED night-mode initial brightness calculation to correctly use device timezone instead of system clock, preventing night/day window flipping on non-UTC devices.

* **Improvements**
  * Enhanced schedule reload efficiency by coalescing overlapping requests.
  * Added automatic retry logic for hardware-related operations.
  * Improved timezone and daylight saving time handling for job scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->