### PR TITLE
fix: install script integrity + systemd hardening (#319)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Source maps for debugging production crashes
-  productionBrowserSourceMaps: true,
+  // Keep production browser source maps off — serving .map files on LAN
+  // exposes TypeScript source, API route internals, and file paths.
+  // Use server-side-only source maps + a private error monitor for prod debugging.
+  productionBrowserSourceMaps: false,
   // Standalone output for cross-machine deploys (build on macOS, run on pod).
   // Turbopack bakes RELATIVE_ROOT_PATH at build time — without standalone,
   // the .next bundle only works on the machine that built it.

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -37,20 +37,31 @@ for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*; do
 done
 [ "$TEMP_CLEANED" -gt 0 ] && echo "Cleaned $TEMP_CLEANED stale temp entries."
 
-# 3. Prune old database backups (keep 3 most recent)
+# 3. Prune old database backups (keep 3 most recent of each kind).
+# Each backup set is a triplet — sleepypod.db.bak.<ts>, plus the matching
+# sleepypod.db-wal.bak.<ts> and sleepypod.db-shm.bak.<ts> sidecars created
+# by sp-update. Pruning only the .db files would leak WAL/SHM backups for
+# pruned timestamps.
 if [ -d "$DATA_DIR" ]; then
-  # `ls $DIR/glob | wc -l` dies under set -euo pipefail when the glob
-  # doesn't match (ls exits 1 on "no such file", pipefail propagates,
-  # set -e kills the command substitution). Use `find` instead: clean
-  # exit 0 whether or not matches exist.
-  BAK_COUNT=$(find "$DATA_DIR" -maxdepth 1 -name 'sleepypod.db.bak.*' -type f 2>/dev/null | wc -l)
-  BAK_COUNT=${BAK_COUNT:-0}
-  if [ "$BAK_COUNT" -gt 3 ]; then
-    PRUNE=$((BAK_COUNT - 3))
-    find "$DATA_DIR" -maxdepth 1 -name 'sleepypod.db.bak.*' -type f -printf '%T@ %p\n' 2>/dev/null \
-      | sort -rn | tail -n "$PRUNE" | awk '{print $2}' | xargs -r rm -f
-    echo "Pruned $PRUNE old DB backups (kept 3)."
-  fi
+  prune_bak_pattern() {
+    local pattern="$1"
+    # `ls $DIR/glob | wc -l` dies under set -euo pipefail when the glob
+    # doesn't match (ls exits 1 on "no such file", pipefail propagates,
+    # set -e kills the command substitution). Use `find` instead: clean
+    # exit 0 whether or not matches exist.
+    local count
+    count=$(find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f 2>/dev/null | wc -l)
+    count=${count:-0}
+    if [ "$count" -gt 3 ]; then
+      local prune=$((count - 3))
+      find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | tail -n "$prune" | awk '{print $2}' | xargs -r rm -f
+      echo "Pruned $prune old $pattern backups (kept 3)."
+    fi
+  }
+  prune_bak_pattern 'sleepypod.db.bak.*'
+  prune_bak_pattern 'sleepypod.db-wal.bak.*'
+  prune_bak_pattern 'sleepypod.db-shm.bak.*'
 fi
 
 # 4. Prune pnpm content-addressable store

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -119,6 +119,14 @@ ip6tables -P OUTPUT ACCEPT 2>/dev/null || true
 ip6tables -P FORWARD ACCEPT 2>/dev/null || true
 rm -f /etc/iptables/iptables.rules /etc/iptables/rules.v4 /etc/iptables/rules.v6
 
+# Remove the sleepypod system user (the group is kept in case dac is
+# still a member — removing it would orphan file ownership on any
+# databases preserved via --keep-data).
+if id sleepypod &>/dev/null; then
+  echo "Removing sleepypod system user..."
+  userdel sleepypod 2>/dev/null || true
+fi
+
 # Re-enable free-sleep if available
 for fs_svc in free-sleep.service free-sleep-stream.service; do
   if systemctl list-unit-files "$fs_svc" 2>/dev/null | grep -q "$fs_svc"; then

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -37,7 +37,18 @@ else
   }
   unblock_wan() {
     echo "Opening WAN access..."
-    SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
+    # Capture state verbatim. `|| true` would mask a failed save and
+    # quietly fall through on restore — silent data loss.
+    if ! SAVED_IPTABLES="$(iptables-save 2>&1)"; then
+      echo "Error: iptables-save failed — refusing to unblock WAN." >&2
+      echo "$SAVED_IPTABLES" >&2
+      SAVED_IPTABLES=""
+      return 1
+    fi
+    if [ -z "$SAVED_IPTABLES" ]; then
+      echo "Error: iptables-save produced no output — refusing to unblock WAN." >&2
+      return 1
+    fi
     iptables -F && iptables -X && iptables -t nat -F && iptables -t nat -X
     echo "WAN open."
   }
@@ -77,11 +88,11 @@ cleanup() {
       fi
       echo "Previous code restored."
     fi
-    if [ -f "$DATA_DIR/sleepypod.db.bak" ]; then
-      cp "$DATA_DIR/sleepypod.db.bak" "$DATA_DIR/sleepypod.db"
-      [ -f "$DATA_DIR/sleepypod.db-wal.bak" ] && cp "$DATA_DIR/sleepypod.db-wal.bak" "$DATA_DIR/sleepypod.db-wal"
-      [ -f "$DATA_DIR/sleepypod.db-shm.bak" ] && cp "$DATA_DIR/sleepypod.db-shm.bak" "$DATA_DIR/sleepypod.db-shm"
-      echo "Database restored."
+    if [ -n "${DB_BACKUP:-}" ] && [ -f "$DB_BACKUP" ]; then
+      cp "$DB_BACKUP" "$DATA_DIR/sleepypod.db"
+      [ -f "$DATA_DIR/sleepypod.db-wal.bak.${BACKUP_TS:-}" ] && cp "$DATA_DIR/sleepypod.db-wal.bak.${BACKUP_TS:-}" "$DATA_DIR/sleepypod.db-wal"
+      [ -f "$DATA_DIR/sleepypod.db-shm.bak.${BACKUP_TS:-}" ] && cp "$DATA_DIR/sleepypod.db-shm.bak.${BACKUP_TS:-}" "$DATA_DIR/sleepypod.db-shm"
+      echo "Database restored from $DB_BACKUP."
     fi
     systemctl start sleepypod.service 2>/dev/null || true
   elif [ "$exit_code" -ne 0 ]; then
@@ -125,11 +136,15 @@ tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . 2>/dev/null | tar xf - -C 
 systemctl stop sleepypod.service
 
 # Backup database (after stop so WAL/SHM are consistent)
+# Timestamped name so two rapid updates don't clobber the previous backup.
+# Matches scripts/install's naming; sp-maintenance prunes to 3 most recent.
+BACKUP_TS=$(date +%s)
+DB_BACKUP="$DATA_DIR/sleepypod.db.bak.$BACKUP_TS"
 if [ -f "$DATA_DIR/sleepypod.db" ]; then
-  cp "$DATA_DIR/sleepypod.db" "$DATA_DIR/sleepypod.db.bak"
-  [ -f "$DATA_DIR/sleepypod.db-wal" ] && cp "$DATA_DIR/sleepypod.db-wal" "$DATA_DIR/sleepypod.db-wal.bak"
-  [ -f "$DATA_DIR/sleepypod.db-shm" ] && cp "$DATA_DIR/sleepypod.db-shm" "$DATA_DIR/sleepypod.db-shm.bak"
-  echo "Database backed up."
+  cp "$DATA_DIR/sleepypod.db" "$DB_BACKUP"
+  [ -f "$DATA_DIR/sleepypod.db-wal" ] && cp "$DATA_DIR/sleepypod.db-wal" "$DATA_DIR/sleepypod.db-wal.bak.$BACKUP_TS"
+  [ -f "$DATA_DIR/sleepypod.db-shm" ] && cp "$DATA_DIR/sleepypod.db-shm" "$DATA_DIR/sleepypod.db-shm.bak.$BACKUP_TS"
+  echo "Database backed up to $DB_BACKUP."
 fi
 
 # Download code — try CI release first (includes pre-built .next), fall back to source tarball

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -90,8 +90,31 @@ cleanup() {
     fi
     if [ -n "${DB_BACKUP:-}" ] && [ -f "$DB_BACKUP" ]; then
       cp "$DB_BACKUP" "$DATA_DIR/sleepypod.db"
-      [ -f "$DATA_DIR/sleepypod.db-wal.bak.${BACKUP_TS:-}" ] && cp "$DATA_DIR/sleepypod.db-wal.bak.${BACKUP_TS:-}" "$DATA_DIR/sleepypod.db-wal"
-      [ -f "$DATA_DIR/sleepypod.db-shm.bak.${BACKUP_TS:-}" ] && cp "$DATA_DIR/sleepypod.db-shm.bak.${BACKUP_TS:-}" "$DATA_DIR/sleepypod.db-shm"
+      # Restore the WAL/SHM sidecars to a state consistent with the .db
+      # backup. If a backup sidecar exists, copy it; otherwise REMOVE any
+      # live sidecar — leaving a newer-than-DB sidecar would let SQLite
+      # replay post-rollback transactions on top of the rolled-back DB.
+      WAL_BAK="$DATA_DIR/sleepypod.db-wal.bak.${BACKUP_TS:-}"
+      SHM_BAK="$DATA_DIR/sleepypod.db-shm.bak.${BACKUP_TS:-}"
+      if [ -f "$WAL_BAK" ]; then
+        cp "$WAL_BAK" "$DATA_DIR/sleepypod.db-wal"
+      else
+        rm -f "$DATA_DIR/sleepypod.db-wal"
+      fi
+      if [ -f "$SHM_BAK" ]; then
+        cp "$SHM_BAK" "$DATA_DIR/sleepypod.db-shm"
+      else
+        rm -f "$DATA_DIR/sleepypod.db-shm"
+      fi
+      # The hardened systemd unit runs as User=sleepypod; ensure the
+      # restored files match the install-time ownership/mode (root:sleepypod
+      # 0660) so the service can read+write them.
+      chown root:sleepypod "$DATA_DIR/sleepypod.db" 2>/dev/null || true
+      chmod 0660 "$DATA_DIR/sleepypod.db" 2>/dev/null || true
+      [ -f "$DATA_DIR/sleepypod.db-wal" ] && chown root:sleepypod "$DATA_DIR/sleepypod.db-wal" 2>/dev/null || true
+      [ -f "$DATA_DIR/sleepypod.db-wal" ] && chmod 0660 "$DATA_DIR/sleepypod.db-wal" 2>/dev/null || true
+      [ -f "$DATA_DIR/sleepypod.db-shm" ] && chown root:sleepypod "$DATA_DIR/sleepypod.db-shm" 2>/dev/null || true
+      [ -f "$DATA_DIR/sleepypod.db-shm" ] && chmod 0660 "$DATA_DIR/sleepypod.db-shm" 2>/dev/null || true
       echo "Database restored from $DB_BACKUP."
     fi
     systemctl start sleepypod.service 2>/dev/null || true

--- a/scripts/install
+++ b/scripts/install
@@ -200,7 +200,7 @@ if ! flock -n 200; then
 fi
 
 # Check for required commands
-REQUIRED_CMDS=(curl systemctl ip groupadd usermod)
+REQUIRED_CMDS=(curl systemctl ip groupadd useradd userdel usermod)
 if [ "$INSTALL_LOCAL" = true ] && [ -n "$INSTALL_BRANCH" ]; then
   REQUIRED_CMDS+=(git)
 fi
@@ -616,6 +616,15 @@ echo "Creating systemd service..."
 # namespace setup (ProtectSystem=strict makes /etc read-only by default;
 # the runtime's checkAndRepairIptables() writes /etc/iptables/rules.v4).
 mkdir -p /etc/iptables
+
+# Only emit SupplementaryGroups=dac when the dac group exists — otherwise
+# systemd refuses to start the unit with "Failed to determine supplementary
+# group: No such file or directory".
+SUPP_GROUPS_LINE=""
+if getent group dac &>/dev/null; then
+  SUPP_GROUPS_LINE="SupplementaryGroups=dac"
+fi
+
 cat > /etc/systemd/system/sleepypod.service << EOF
 [Unit]
 Description=SleepyPod Core Service
@@ -629,7 +638,7 @@ Type=simple
 # else that needs root runs via ExecStartPre with the \`+\` prefix.
 User=sleepypod
 Group=sleepypod
-SupplementaryGroups=dac
+$SUPP_GROUPS_LINE
 UMask=0002
 WorkingDirectory=$INSTALL_DIR
 Environment="NODE_ENV=production"
@@ -640,7 +649,7 @@ Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
 # for /deviceinfo symlink creation (root-owned) and sp-maintenance
 # (journal vacuum, /tmp cleanup, pnpm store prune).
 ExecStartPre=+/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
-ExecStartPre=+$INSTALL_DIR/scripts/bin/sp-maintenance
+ExecStartPre=+/usr/local/bin/sp-maintenance
 Environment="PATH=/usr/local/bin:/usr/bin:/bin"
 ExecStart=/bin/sh -c 'if [ -f .next/standalone/server.js ]; then exec /usr/local/bin/node .next/standalone/server.js; else exec /usr/local/bin/pnpm start; fi'
 Restart=always
@@ -872,13 +881,19 @@ fi
 # files with 0644 between the initial fixup and the service restarts above.
 fix_db_permissions
 
-# Install CLI tools from scripts/bin/
+# Install CLI tools from scripts/bin/. /usr/local/bin is root-owned by
+# default — copies inherit current uid (root, since this script requires
+# sudo) but we chown/chmod explicitly so the file at the target path is
+# guaranteed root:root 0755 even if the source file under $INSTALL_DIR
+# has unusual ownership.
 if [ -d "$INSTALL_DIR/scripts/bin" ]; then
   echo "Installing CLI tools..."
   for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
     [ -f "$tool" ] || continue
-    cp "$tool" /usr/local/bin/
-    chmod +x "/usr/local/bin/$(basename "$tool")"
+    target="/usr/local/bin/$(basename "$tool")"
+    cp "$tool" "$target"
+    chown root:root "$target"
+    chmod 0755 "$target"
   done
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -94,7 +94,19 @@ SAVED_IPTABLES=""
 
 unblock_wan() {
   echo "Temporarily unblocking WAN access..."
-  SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
+  # Capture state verbatim. `|| true` would mask a failed save and
+  # quietly fall through to a minimal block_wan ruleset on restore —
+  # silent data loss. Fail loudly instead so the caller can bail.
+  if ! SAVED_IPTABLES="$(iptables-save 2>&1)"; then
+    echo "Error: iptables-save failed — refusing to unblock WAN." >&2
+    echo "$SAVED_IPTABLES" >&2
+    SAVED_IPTABLES=""
+    exit 1
+  fi
+  if [ -z "$SAVED_IPTABLES" ]; then
+    echo "Error: iptables-save produced no output — refusing to unblock WAN." >&2
+    exit 1
+  fi
   iptables -F
   iptables -X
   iptables -t nat -F
@@ -252,6 +264,23 @@ if id dac &>/dev/null; then
 else
   echo "Warning: user 'dac' not found — skipping group membership (not a Pod?)"
 fi
+
+# Create a dedicated system user for the Node.js service so it doesn't
+# run as UID 0. Membership:
+#   - sleepypod:  write access to $DATA_DIR (SQLite files)
+#   - dac:        read/write access to dac.sock (hardware control)
+# Runtime capabilities (CAP_NET_ADMIN, CAP_NET_RAW) are granted via the
+# service unit — they're only needed for iptables check/repair.
+if ! id sleepypod &>/dev/null; then
+  echo "Creating sleepypod system user..."
+  useradd --system --no-create-home --shell /usr/sbin/nologin \
+    --home-dir /nonexistent --gid sleepypod sleepypod
+fi
+# Add sleepypod to dac group (if dac exists) so it can reach dac.sock
+if id dac &>/dev/null; then
+  usermod -aG dac sleepypod
+fi
+
 mkdir -p "$DATA_DIR"
 chown root:sleepypod "$DATA_DIR"
 chmod 2770 "$DATA_DIR"
@@ -287,10 +316,47 @@ CURRENT_NODE_MAJOR=$(node -v 2>/dev/null | cut -d. -f1 | tr -d v || echo "0")
 if [ "$CURRENT_NODE_MAJOR" -lt "$NODE_WANTED" ]; then
   echo "Installing Node.js $NODE_FULL ($NODE_ARCH)..."
   NODE_TARBALL="node-v${NODE_FULL}-linux-${NODE_ARCH}.tar.gz"
-  NODE_URL="https://nodejs.org/dist/v${NODE_FULL}/${NODE_TARBALL}"
+  NODE_BASE_URL="https://nodejs.org/dist/v${NODE_FULL}"
+  NODE_URL="${NODE_BASE_URL}/${NODE_TARBALL}"
+
+  # Download tarball + SHASUMS256.txt to a scratch dir so we can verify
+  # integrity before extracting. A compromised CDN or MITM would otherwise
+  # install a backdoored binary silently (curl … | tar -xz has no checks).
+  NODE_TMP=$(mktemp -d)
+  if ! curl -fSL -o "$NODE_TMP/$NODE_TARBALL" "$NODE_URL"; then
+    echo "Error: Failed to download Node.js tarball from $NODE_URL" >&2
+    rm -rf "$NODE_TMP"
+    exit 1
+  fi
+  if ! curl -fSL -o "$NODE_TMP/SHASUMS256.txt" "$NODE_BASE_URL/SHASUMS256.txt"; then
+    echo "Error: Failed to download Node.js SHASUMS256.txt from $NODE_BASE_URL" >&2
+    rm -rf "$NODE_TMP"
+    exit 1
+  fi
+
+  # Verify with sha256sum (coreutils); fall back to shasum -a 256 (busybox/mac)
+  if command -v sha256sum &>/dev/null; then
+    NODE_HASH_CMD=(sha256sum --check --ignore-missing)
+  elif command -v shasum &>/dev/null; then
+    NODE_HASH_CMD=(shasum -a 256 --check --ignore-missing)
+  else
+    echo "Error: Neither sha256sum nor shasum available; cannot verify Node.js integrity." >&2
+    rm -rf "$NODE_TMP"
+    exit 1
+  fi
+
+  if ! (cd "$NODE_TMP" && "${NODE_HASH_CMD[@]}" SHASUMS256.txt) >/dev/null 2>&1; then
+    echo "Error: Node.js tarball SHA-256 verification failed." >&2
+    echo "  Expected hash from: $NODE_BASE_URL/SHASUMS256.txt" >&2
+    echo "  Tarball:            $NODE_URL" >&2
+    rm -rf "$NODE_TMP"
+    exit 1
+  fi
+  echo "Node.js tarball verified (SHA-256)."
 
   mkdir -p "$NODE_DIR"
-  curl -fSL "$NODE_URL" | tar -xz -C "$NODE_DIR"
+  tar -xz -C "$NODE_DIR" -f "$NODE_TMP/$NODE_TARBALL"
+  rm -rf "$NODE_TMP"
 
   # Symlink binaries into /usr/local/bin
   mkdir -p /usr/local/bin
@@ -512,13 +578,19 @@ if [ -f "$INSTALL_DIR/.env" ]; then
 else
   echo "Creating environment file..."
   touch "$INSTALL_DIR/.env"
-  chmod 600 "$INSTALL_DIR/.env"
+  chmod 640 "$INSTALL_DIR/.env"
   cat > "$INSTALL_DIR/.env" << EOF
 DATABASE_URL=file:$DATA_DIR/sleepypod.db
 BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db
 DAC_SOCK_PATH=$DAC_SOCK_PATH
 NODE_ENV=production
 EOF
+fi
+
+# Ensure the unprivileged service user can read .env (mode 640 + group owner).
+if [ -f "$INSTALL_DIR/.env" ] && id sleepypod &>/dev/null; then
+  chown root:sleepypod "$INSTALL_DIR/.env"
+  chmod 640 "$INSTALL_DIR/.env"
 fi
 
 # Initialize database with migrations (not destructive push)
@@ -530,8 +602,20 @@ fi
 # Database migrations run automatically on app startup (instrumentation.ts)
 echo "Database migrations will run on first startup."
 
+# Ensure the unprivileged service user can traverse /home/dac to reach
+# $INSTALL_DIR. Default /home/dac perms on some Pods are 0700 which
+# would block a service running as sleepypod. Chmod o+x grants
+# traverse-only (no read/list) so dac's privacy is preserved.
+if id dac &>/dev/null && [ -d /home/dac ]; then
+  chmod o+x /home/dac
+fi
+
 # Create systemd service
 echo "Creating systemd service..."
+# Ensure /etc/iptables exists so ReadWritePaths= below doesn't fail the
+# namespace setup (ProtectSystem=strict makes /etc read-only by default;
+# the runtime's checkAndRepairIptables() writes /etc/iptables/rules.v4).
+mkdir -p /etc/iptables
 cat > /etc/systemd/system/sleepypod.service << EOF
 [Unit]
 Description=SleepyPod Core Service
@@ -539,27 +623,58 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
+# Drop privileges: the Node.js app no longer runs as UID 0. It needs
+# group membership for dac.sock (dac) + data dir (sleepypod), and
+# CAP_NET_ADMIN/CAP_NET_RAW for runtime iptables check+repair. Anything
+# else that needs root runs via ExecStartPre with the \`+\` prefix.
+User=sleepypod
+Group=sleepypod
+SupplementaryGroups=dac
 UMask=0002
 WorkingDirectory=$INSTALL_DIR
 Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
-ExecStartPre=/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
-ExecStartPre=$INSTALL_DIR/scripts/bin/sp-maintenance
+# The \`+\` prefix runs ExecStartPre as root regardless of User=. Needed
+# for /deviceinfo symlink creation (root-owned) and sp-maintenance
+# (journal vacuum, /tmp cleanup, pnpm store prune).
+ExecStartPre=+/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
+ExecStartPre=+$INSTALL_DIR/scripts/bin/sp-maintenance
 Environment="PATH=/usr/local/bin:/usr/bin:/bin"
 ExecStart=/bin/sh -c 'if [ -f .next/standalone/server.js ]; then exec /usr/local/bin/node .next/standalone/server.js; else exec /usr/local/bin/pnpm start; fi'
 Restart=always
 RestartSec=10
 
-# Hardening (optional, doesn't interfere with dac.sock)
+# Capabilities — only what the runtime needs for iptables manipulation.
+# Bound everything else so a process compromise can't CAP_SYS_ADMIN etc.
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+
+# Hardening — doesn't interfere with dac.sock or iptables writes
 NoNewPrivileges=true
 RuntimeDirectory=dac
-ReadWritePaths=$DATA_DIR /persistent/deviceinfo /deviceinfo /run/dac
+# /etc/iptables is writable because checkAndRepairIptables() persists
+# rules to /etc/iptables/rules.v4 after auto-repairing missing rules.
+# ProtectHome is NOT set: INSTALL_DIR lives at /home/dac/sleepypod-core
+# and the service needs to read .next, node_modules, .env there.
+ReadWritePaths=$DATA_DIR /persistent/deviceinfo /deviceinfo /run/dac /etc/iptables
 ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+PrivateTmp=true
+PrivateDevices=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=false
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/lib/iptables-helpers
+++ b/scripts/lib/iptables-helpers
@@ -14,7 +14,19 @@ wan_is_blocked() {
 
 unblock_wan() {
   echo "Temporarily unblocking WAN access..."
-  SAVED_IPTABLES="$(iptables-save 2>/dev/null || true)"
+  # Capture state verbatim. `|| true` would mask a failed save and
+  # quietly fall through to a minimal block_wan ruleset on restore —
+  # silent data loss. Fail loudly instead so the caller can bail.
+  if ! SAVED_IPTABLES="$(iptables-save 2>&1)"; then
+    echo "Error: iptables-save failed — refusing to unblock WAN." >&2
+    echo "$SAVED_IPTABLES" >&2
+    SAVED_IPTABLES=""
+    return 1
+  fi
+  if [ -z "$SAVED_IPTABLES" ]; then
+    echo "Error: iptables-save produced no output — refusing to unblock WAN." >&2
+    return 1
+  fi
   iptables -F 2>/dev/null || true
   iptables -X 2>/dev/null || true
   iptables -t nat -F 2>/dev/null || true


### PR DESCRIPTION
Closes #319.

## Summary

Addresses the five security findings from the install/deploy pipeline audit.

### Per-finding fixes

- **Node.js tarball SHA-256 verification** (`scripts/install`) — downloads `SHASUMS256.txt` from the same `nodejs.org/dist/v${NODE_FULL}/` directory and verifies the tarball with `sha256sum --check --ignore-missing` (falls back to `shasum -a 256` where coreutils is absent) before extraction. Fails loud if hash mismatch, missing hash tools, or download failure.

- **Systemd service no longer runs as `User=root`** (`scripts/install`) — creates a dedicated `sleepypod` system user (member of `sleepypod` primary group, `dac` supplementary group for `dac.sock` access). The unit:
  - `User=sleepypod Group=sleepypod SupplementaryGroups=dac`
  - `AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW` — only what the runtime needs for `checkAndRepairIptables()` and internet-control routes
  - `CapabilityBoundingSet` locked to those two caps
  - `ExecStartPre=+...` prefix keeps root for the `dac.sock` symlink + `sp-maintenance` (journal vacuum / pnpm store prune)
  - Adds `ProtectKernelLogs`, `ProtectControlGroups`, `ProtectClock`, `ProtectHostname`, `PrivateTmp`, `PrivateDevices`, `RestrictNamespaces`, `RestrictRealtime`, `RestrictSUIDSGID`, `LockPersonality`, `RestrictAddressFamilies`, `SystemCallArchitectures=native`
  - `ReadWritePaths` expanded to include `/etc/iptables` (runtime persists rules there)
  - Notable omissions: `ProtectHome` (would hide `/home/dac/sleepypod-core`), `MemoryDenyWriteExecute` (breaks V8 JIT)

- **`productionBrowserSourceMaps` disabled** (`next.config.mjs`) — set to `false`. Use a private error monitor + server-side source maps for production debugging instead.

- **`iptables-save` failure no longer silently swallowed** (`scripts/install`, `scripts/lib/iptables-helpers`, `scripts/bin/sp-update` inline fallback) — captures stderr and refuses to unblock WAN if `iptables-save` fails or returns empty output (previous behavior was to fall through to a minimal `block_wan` ruleset on restore → silent data loss).

- **`sp-update` DB backup now timestamped** (`scripts/bin/sp-update`) — uses `sleepypod.db.bak.$(date +%s)` matching the install script + `sp-maintenance` pruning pattern (keeps 3 most recent). Two rapid updates no longer clobber the previous backup.

### Follow-on changes

- `sp-uninstall` removes the `sleepypod` user (group preserved for `--keep-data` file ownership).
- `.env` owner becomes `root:sleepypod` with mode `640` so the unprivileged service user can read it.
- `/home/dac` is made traversable (`o+x`) so the sleepypod service can reach `/home/dac/sleepypod-core`.
- `/etc/iptables` pre-created so namespace setup doesn't fail on missing directory.

### Assumptions

- `sp-update` does not rewrite the systemd unit file (existing behaviour). Users on existing installs need a re-run of the full installer to pick up the hardened unit. This matches how other install-time config (avahi service file, journald conf) is managed.
- The stale `scripts/install:822-824` file:line reference in the issue actually points at `scripts/bin/sp-update:129-131` — the install script already timestamps its backup. Fix applied to the real location.

## Test plan

- [ ] Fresh install on Pod 4 (`curl -fsSL ... | sudo bash`): Node.js tarball + SHASUMS256.txt download, sha256 verify passes, extraction succeeds, `id sleepypod` returns UID < 1000 with home `/nonexistent`.
- [ ] `systemctl show sleepypod.service -p User,AmbientCapabilities,CapabilityBoundingSet,ReadWritePaths` shows `sleepypod`, `cap_net_admin cap_net_raw`, and includes `/etc/iptables`.
- [ ] `systemctl status sleepypod.service` running healthy; endpoints respond at `http://<pod>:3000/`.
- [ ] `curl http://<pod>:3000/somepage.js.map` returns 404 (source maps gated).
- [ ] Simulated MITM on Node.js tarball (swap for corrupted file) — install aborts with `Node.js tarball SHA-256 verification failed`.
- [ ] `iptables-save` failure simulated (`chmod -x /sbin/iptables-save` then run `sp-update`) — script aborts with `iptables-save failed — refusing to unblock WAN`, WAN stays blocked.
- [ ] Two `sp-update` runs in a row — both create distinct `sleepypod.db.bak.<ts>` files; `sp-maintenance` prunes to 3 eventually.
- [ ] Runtime `iptablesCheck.ts` repair path still works (kill an mDNS rule then hit `/api/health.system` — auto-repair succeeds despite dropped root).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Service now runs as a dedicated unprivileged user with minimal capabilities instead of root.
  * Node.js installation now verifies checksums before extraction.

* **Bug Fixes**
  * Enhanced error handling during installation and updates to prevent silent failures.
  * Database restore process now uses timestamped backups for better recovery reliability.

* **Chores**
  * Production browser source maps disabled for reduced bundle size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->