### PR TITLE
fix(biometrics): piezo quality scoring — calibration q=0 + vitals_quality writer

### DIFF
--- a/modules/common/calibration.py
+++ b/modules/common/calibration.py
@@ -444,8 +444,11 @@ class PiezoCalibrator:
             "baseline_mean_range": round(best_mean_range, 2),
         }
 
-        # Quality: very low baseline range = clean baseline
-        quality = max(0.0, min(1.0, 1.0 - (best_mean_range / 50000)))
+        # Quality: how cleanly the baseline sits below the presence threshold.
+        # Self-scaling against threshold (rather than a fixed constant) keeps the
+        # metric meaningful regardless of ADC range — raw int32 piezo values run
+        # in the 1e8–1e9 range, where a fixed 50k denominator clamps to 0.
+        quality = max(0.0, min(1.0, 1.0 - (best_mean_range / max(threshold, 1.0))))
 
         return CalibrationResult(
             params=params,

--- a/modules/piezo-processor/main.py
+++ b/modules/piezo-processor/main.py
@@ -111,6 +111,7 @@ def write_vitals(conn: sqlite3.Connection, side: str, ts: datetime,
                  flags: Optional[list] = None,
                  hr_raw: Optional[float] = None) -> None:
     ts_unix = int(ts.timestamp())
+    now_unix = int(time.time())
     flags_json = json.dumps(flags) if flags else None
     with conn:
         cur = conn.execute(
@@ -120,7 +121,7 @@ def write_vitals(conn: sqlite3.Connection, side: str, ts: datetime,
         conn.execute(
             "INSERT INTO vitals_quality (vitals_id, side, timestamp, quality_score, flags, hr_raw, created_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (cur.lastrowid, side, ts_unix, quality_score, flags_json, hr_raw, ts_unix),
+            (cur.lastrowid, side, ts_unix, quality_score, flags_json, hr_raw, now_unix),
         )
 
 

--- a/modules/piezo-processor/main.py
+++ b/modules/piezo-processor/main.py
@@ -28,6 +28,7 @@ Signal processing pipeline (per side):
 
 import os
 import sys
+import json
 import time
 import signal
 import logging
@@ -105,12 +106,21 @@ def open_biometrics_db() -> sqlite3.Connection:
 
 def write_vitals(conn: sqlite3.Connection, side: str, ts: datetime,
                  heart_rate: Optional[float], hrv: Optional[float],
-                 breathing_rate: Optional[float]) -> None:
+                 breathing_rate: Optional[float],
+                 quality_score: float,
+                 flags: Optional[list] = None,
+                 hr_raw: Optional[float] = None) -> None:
     ts_unix = int(ts.timestamp())
+    flags_json = json.dumps(flags) if flags else None
     with conn:
-        conn.execute(
+        cur = conn.execute(
             "INSERT INTO vitals (side, timestamp, heart_rate, hrv, breathing_rate) VALUES (?, ?, ?, ?, ?)",
             (side, ts_unix, heart_rate, hrv, breathing_rate),
+        )
+        conn.execute(
+            "INSERT INTO vitals_quality (vitals_id, side, timestamp, quality_score, flags, hr_raw, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (cur.lastrowid, side, ts_unix, quality_score, flags_json, hr_raw, ts_unix),
         )
 
 
@@ -698,9 +708,23 @@ class SideProcessor:
 
         if hr is not None or hrv is not None or br is not None:
             ts = datetime.now(timezone.utc)
-            write_vitals(self.db, self.side, ts, hr, hrv, br)
-            log.info("vitals %s — HR=%.1f HRV=%.1f BR=%.1f", self.side,
-                     hr or 0, hrv or 0, br or 0)
+            snr = max(0.0, min(1.0, acr_qual))
+            hr_conf = max(0.0, min(1.0, hr_score)) if hr is not None else 0.0
+            quality = round(0.55 * snr + 0.45 * hr_conf, 3)
+            flags = []
+            if hr is None:
+                flags.append("no_hr")
+            if hrv is None:
+                flags.append("no_hrv")
+            if br is None:
+                flags.append("no_br")
+            if med_std < self._presence.enter_threshold:
+                flags.append("low_signal")
+            write_vitals(self.db, self.side, ts, hr, hrv, br,
+                         quality_score=quality, flags=flags or None,
+                         hr_raw=hr_raw)
+            log.info("vitals %s — HR=%.1f HRV=%.1f BR=%.1f q=%.2f", self.side,
+                     hr or 0, hrv or 0, br or 0, quality)
 
         self._last_write = now
 


### PR DESCRIPTION
## Summary

Two issues found while spot-checking biometrics on Pod 4 against the deployed dev tip:

- **Piezo calibration always reports `quality_score=0.0`.** The formula in `modules/common/calibration.py` divided `baseline_mean_range` by a hardcoded `50000`, but the int32 ADC produces p2p values around 2.8e7 — so `1 - mean/50000` always clamped to 0. Switched to scaling against the run's own `presence_threshold` so the metric self-calibrates to the pod's actual signal scale and stays meaningful as a "baseline-to-cutoff headroom" measure.
- **`vitals_quality` table has been empty since #323 shipped the schema.** The piezo-processor never wrote to it. Added the writer: each `vitals` insert now also writes a paired `vitals_quality` row in the same transaction, with `quality_score = 0.55 × autocorr_qual + 0.45 × hr_score` and flags for any missing measurement (`no_hr`, `no_hrv`, `no_br`, `low_signal`).

Pod 4 numbers post-fix (projected): baseline_mean_range 2.87e7 / threshold 1.49e9 → q ≈ 0.98 on next daily calibration.

## Test plan

- [x] `pytest modules/piezo-processor/test_main.py` — 57/57 pass
- [x] tsc + eslint + drizzle-kit (pre-push hook)
- [ ] After merge & deploy: verify next daily piezo calibration writes a non-zero quality_score
- [ ] After deploy: verify `SELECT COUNT(*) FROM vitals_quality WHERE timestamp > strftime('%s','now')-3600` is non-zero on Pod 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calibration quality scoring now adapts dynamically to signal range, improving consistency across different device conditions
  * Signal-quality metadata now recorded with vital signs, including confidence indicators for missing metrics and low-signal detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->