### PR TITLE
fix: cut v1.8.2 — pod 3 bedTemp/capSense v1 dialect

### DIFF
--- a/modules/common/dialect.py
+++ b/modules/common/dialect.py
@@ -1,0 +1,154 @@
+"""
+Inner-record dialect normalization for SleepyPod biometrics modules.
+
+Pod firmware emits two inner-record dialects depending on generation:
+
+  - v1 (Pod 3):  `bedTemp`, `capSense` — flat scalar keys per side
+                 (left/right.{out, cen, in}), integer centidegrees for
+                 temperatures, integer centipercent for humidity.
+
+  - v2 (Pod 4 / Pod 5):  `bedTemp2`, `capSense2` — nested per-side objects
+                 with `temps: [...]` arrays (bedTemp2) or `values: [...]`
+                 arrays (capSense2), float values in degrees C / raw units.
+
+The outer CBOR envelope (0xa2 {seq, data}) is identical across all pods —
+no envelope-level branching is needed.
+
+Dispatch is content-driven on the inner record's `type` field. Pod_GEN
+plumbing isn't required: the type tag IS the version marker (Eight Sleep
+deliberately renamed v1 → v2 when the schema changed).
+
+The canonical shape mirrors the SQLite DB row shape: scalar values per
+zone (no arrays), centidegrees integers for temperatures (matching the
+`bed_temp` table column types). v2 records are reduced to scalars at this
+boundary; v1 records map directly.
+
+Unknown record types pass through unchanged with a one-time warning log.
+"""
+
+import logging
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Float sentinel emitted by v2 firmware when a sensor is absent.
+NO_SENSOR_FLOAT = -327.68
+
+# Integer sentinel some v1 readings use (negative absolute zero).
+NO_SENSOR_INT = -32768
+
+# Track unknown record types seen so we only log each once per process.
+_unknown_types_seen: set[str] = set()
+
+
+def _is_sentinel_float(v) -> bool:
+    if v is None:
+        return True
+    if not isinstance(v, (int, float)):
+        return True
+    return abs(v - NO_SENSOR_FLOAT) < 0.01
+
+
+def _to_centidegrees(v) -> Optional[int]:
+    """Convert a float-degrees value to integer centidegrees, or None on sentinel."""
+    if _is_sentinel_float(v):
+        return None
+    return round(float(v) * 100)
+
+
+def _passthrough_centi(v) -> Optional[int]:
+    """v1 emits integer centidegrees natively — strip sentinels and pass through."""
+    if v is None:
+        return None
+    if not isinstance(v, (int, float)):
+        return None
+    iv = int(v)
+    if iv == NO_SENSOR_INT or abs(iv - NO_SENSOR_INT) < 1:
+        return None
+    return iv
+
+
+def normalize_bed_temp(rec: dict) -> Optional[dict]:
+    """
+    Reduce a `bedTemp` (v1) or `bedTemp2` (v2) record to the canonical
+    DB-row shape:
+
+        {
+          'ts': int,                                # unix seconds
+          'ambient_temp': int | None,               # centidegrees C
+          'mcu_temp': int | None,                   # centidegrees C
+          'humidity': int | None,                   # centipercent
+          'left_outer_temp', 'left_center_temp', 'left_inner_temp',
+          'right_outer_temp', 'right_center_temp', 'right_inner_temp':
+              int | None,                           # centidegrees C
+        }
+
+    Returns None if the record is not a bedTemp variant.
+    """
+    rtype = rec.get("type")
+    ts = int(rec.get("ts", 0))
+
+    if rtype == "bedTemp2":
+        # v2: float degrees, nested temps[] arrays
+        left = rec.get("left") or {}
+        right = rec.get("right") or {}
+        ltemps = left.get("temps") or []
+        rtemps = right.get("temps") or []
+
+        def _ambient():
+            la = left.get("amb") if not _is_sentinel_float(left.get("amb")) else None
+            ra = right.get("amb") if not _is_sentinel_float(right.get("amb")) else None
+            return la if la is not None else ra
+
+        def _humidity():
+            lh = left.get("hu") if not _is_sentinel_float(left.get("hu")) else None
+            rh = right.get("hu") if not _is_sentinel_float(right.get("hu")) else None
+            return lh if lh is not None else rh
+
+        return {
+            "ts": ts,
+            "ambient_temp": _to_centidegrees(_ambient()),
+            "mcu_temp": _to_centidegrees(rec.get("mcu")),
+            "humidity": _to_centidegrees(_humidity()),  # both percent and degrees use x100
+            "left_outer_temp": _to_centidegrees(ltemps[0] if len(ltemps) > 0 else None),
+            "left_center_temp": _to_centidegrees(ltemps[1] if len(ltemps) > 1 else None),
+            "left_inner_temp": _to_centidegrees(ltemps[2] if len(ltemps) > 2 else None),
+            "right_outer_temp": _to_centidegrees(rtemps[0] if len(rtemps) > 0 else None),
+            "right_center_temp": _to_centidegrees(rtemps[1] if len(rtemps) > 1 else None),
+            "right_inner_temp": _to_centidegrees(rtemps[2] if len(rtemps) > 2 else None),
+        }
+
+    if rtype == "bedTemp":
+        # v1: integer centidegrees natively, flat out/cen/in per side
+        left = rec.get("left") or {}
+        right = rec.get("right") or {}
+        return {
+            "ts": ts,
+            "ambient_temp": _passthrough_centi(rec.get("amb")),
+            "mcu_temp": _passthrough_centi(rec.get("mcu")),
+            "humidity": _passthrough_centi(rec.get("hu")),
+            "left_outer_temp": _passthrough_centi(left.get("out")),
+            "left_center_temp": _passthrough_centi(left.get("cen")),
+            "left_inner_temp": _passthrough_centi(left.get("in")),
+            "right_outer_temp": _passthrough_centi(right.get("out")),
+            "right_center_temp": _passthrough_centi(right.get("cen")),
+            "right_inner_temp": _passthrough_centi(right.get("in")),
+        }
+
+    return None
+
+
+def is_bed_temp_record(rec: dict) -> bool:
+    return rec.get("type") in ("bedTemp", "bedTemp2")
+
+
+def warn_unknown_type_once(rec: dict, pod_context: str = "") -> None:
+    """Log once per unique record type. Called by ingestion loops on records
+    they don't recognize, to surface firmware variance instead of silently
+    dropping data."""
+    rtype = rec.get("type")
+    if rtype is None or rtype in _unknown_types_seen:
+        return
+    _unknown_types_seen.add(rtype)
+    suffix = f" ({pod_context})" if pod_context else ""
+    log.warning("Unknown record type %r — passing through without normalization%s", rtype, suffix)

--- a/modules/common/test_dialect.py
+++ b/modules/common/test_dialect.py
@@ -1,0 +1,119 @@
+"""Tests for the inner-record dialect normalizer."""
+from common.dialect import normalize_bed_temp, is_bed_temp_record
+
+
+# Real fixtures captured from the pods (PR #437 RAW for Pod 3, local pod for v2).
+
+POD3_BED_TEMP_V1 = {
+    "type": "bedTemp",
+    "ts": 1776463233,
+    "amb": 2514, "mcu": 3428, "hu": 3956,
+    "left": {"side": 2334, "out": 2280, "cen": 2301, "in": 2359},
+    "right": {"side": 2417, "out": 2351, "cen": 2420, "in": 2396},
+}
+
+POD4_BED_TEMP_V2 = {
+    "type": "bedTemp2",
+    "ts": 1777349731,
+    "version": 1,
+    "mcu": 31.51,
+    "left": {"amb": 22.43, "hu": 51.99, "board": -327.68,
+             "temps": [24.01, 24.69, 23.67, -327.68]},
+    "right": {"amb": -327.68, "hu": -327.68, "board": -327.68,
+              "temps": [23.51, 27.89, 23.59, 22.94]},
+}
+
+
+class TestBedTempV1:
+    """Pod 3 bedTemp passes through as integer centidegrees."""
+
+    def test_top_level_scalars_passthrough(self):
+        c = normalize_bed_temp(POD3_BED_TEMP_V1)
+        assert c["ambient_temp"] == 2514
+        assert c["mcu_temp"] == 3428
+        assert c["humidity"] == 3956
+
+    def test_left_zones_from_flat_keys(self):
+        c = normalize_bed_temp(POD3_BED_TEMP_V1)
+        assert c["left_outer_temp"] == 2280
+        assert c["left_center_temp"] == 2301
+        assert c["left_inner_temp"] == 2359
+
+    def test_right_zones_from_flat_keys(self):
+        c = normalize_bed_temp(POD3_BED_TEMP_V1)
+        assert c["right_outer_temp"] == 2351
+        assert c["right_center_temp"] == 2420
+        assert c["right_inner_temp"] == 2396
+
+    def test_timestamp_preserved(self):
+        c = normalize_bed_temp(POD3_BED_TEMP_V1)
+        assert c["ts"] == 1776463233
+
+    def test_missing_zone_returns_none(self):
+        rec = {**POD3_BED_TEMP_V1, "left": {"out": 2280}}
+        c = normalize_bed_temp(rec)
+        assert c["left_outer_temp"] == 2280
+        assert c["left_center_temp"] is None
+        assert c["left_inner_temp"] is None
+
+    def test_int_sentinel_returns_none(self):
+        rec = {**POD3_BED_TEMP_V1, "amb": -32768}
+        c = normalize_bed_temp(rec)
+        assert c["ambient_temp"] is None
+
+
+class TestBedTempV2:
+    """Pod 4/5 bedTemp2 reduces float arrays to integer centidegrees."""
+
+    def test_left_ambient_from_nested(self):
+        c = normalize_bed_temp(POD4_BED_TEMP_V2)
+        assert c["ambient_temp"] == 2243  # 22.43 °C → 2243 cdC
+
+    def test_right_ambient_falls_back_when_left_sentinel(self):
+        rec = {**POD4_BED_TEMP_V2,
+               "left": {**POD4_BED_TEMP_V2["left"], "amb": -327.68},
+               "right": {**POD4_BED_TEMP_V2["right"], "amb": 22.5}}
+        c = normalize_bed_temp(rec)
+        assert c["ambient_temp"] == 2250
+
+    def test_temps_array_indexed_into_zones(self):
+        c = normalize_bed_temp(POD4_BED_TEMP_V2)
+        assert c["left_outer_temp"] == 2401
+        assert c["left_center_temp"] == 2469
+        assert c["left_inner_temp"] == 2367
+        assert c["right_outer_temp"] == 2351
+        assert c["right_center_temp"] == 2789
+        assert c["right_inner_temp"] == 2359
+
+    def test_mcu_converted_from_float(self):
+        c = normalize_bed_temp(POD4_BED_TEMP_V2)
+        assert c["mcu_temp"] == 3151
+
+    def test_float_sentinel_returns_none(self):
+        # Right side has all -327.68 → no usable readings
+        rec = {**POD4_BED_TEMP_V2,
+               "left": {**POD4_BED_TEMP_V2["left"], "amb": -327.68}}
+        c = normalize_bed_temp(rec)
+        # Falls through to right.amb which is also sentinel
+        assert c["ambient_temp"] is None
+
+    def test_short_temps_array_returns_none_for_missing_zones(self):
+        rec = {**POD4_BED_TEMP_V2,
+               "left": {**POD4_BED_TEMP_V2["left"], "temps": [24.01]}}
+        c = normalize_bed_temp(rec)
+        assert c["left_outer_temp"] == 2401
+        assert c["left_center_temp"] is None
+        assert c["left_inner_temp"] is None
+
+
+class TestDispatch:
+    def test_unknown_type_returns_none(self):
+        assert normalize_bed_temp({"type": "frzTemp"}) is None
+        assert normalize_bed_temp({"type": "piezo-dual"}) is None
+        assert normalize_bed_temp({"type": "log"}) is None
+
+    def test_is_bed_temp_record(self):
+        assert is_bed_temp_record({"type": "bedTemp"}) is True
+        assert is_bed_temp_record({"type": "bedTemp2"}) is True
+        assert is_bed_temp_record({"type": "frzTemp"}) is False
+        assert is_bed_temp_record({}) is False

--- a/modules/environment-monitor/main.py
+++ b/modules/environment-monitor/main.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import cbor2
 from common.raw_follower import RawFileFollower
+from common.dialect import normalize_bed_temp
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -45,9 +46,6 @@ SLEEPYPOD_DB = Path(os.environ.get(
 
 # Write at most once per 60s per record type
 DOWNSAMPLE_INTERVAL_S = 60
-
-# Hardware sentinel for "no sensor connected"
-NO_SENSOR = -327.68
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -88,50 +86,18 @@ def open_biometrics_db() -> sqlite3.Connection:
     return conn
 
 
-def _to_centidegrees(val) -> int | None:
-    """Convert a degrees-C float to centidegrees integer, or None if sentinel."""
-    if val is None or val == NO_SENSOR or abs(val - NO_SENSOR) < 0.01:
-        return None
-    return round(val * 100)
+def write_bed_temp(conn: sqlite3.Connection, ts: float, record: dict) -> bool:
+    """Normalize a bedTemp/bedTemp2 record and write to bed_temp table.
 
+    Dialect handling lives in common.dialect.normalize_bed_temp — this
+    function consumes the canonical row-shape and writes it.
 
-def _to_centipercent(val) -> int | None:
-    """Convert a percent float to centipercent integer, or None if sentinel."""
-    if val is None or val == NO_SENSOR or abs(val - NO_SENSOR) < 0.01:
-        return None
-    return round(val * 100)
-
-
-def _safe_temp(temps: list, idx: int) -> int | None:
-    """Extract a thermistor value from a temps array by index."""
-    if not isinstance(temps, list) or idx >= len(temps):
-        return None
-    return _to_centidegrees(temps[idx])
-
-
-def write_bed_temp(conn: sqlite3.Connection, ts: float, record: dict) -> None:
-    """Parse bedTemp2 record and write to bed_temp table.
-
-    bedTemp2 format:
-      mcu: float (MCU temp °C)
-      left:  {amb, hu, board, temps: [outer, center, inner, ?]}
-      right: {amb, hu, board, temps: [outer, center, inner, ?]}
+    Returns True on a successful insert, False if the record didn't match
+    a known dialect (caller should not advance the downsample cursor).
     """
-    left = record.get("left", {})
-    right = record.get("right", {})
-    left_temps = left.get("temps", [])
-    right_temps = right.get("temps", [])
-
-    # Use left ambient as the primary ambient reading (both sides share the room)
-    ambient = left.get("amb") if left.get("amb") != NO_SENSOR else right.get("amb")
-    # Average humidity from both sides (if available)
-    lhu = left.get("hu")
-    rhu = right.get("hu")
-    humidity = None
-    if lhu is not None and lhu != NO_SENSOR:
-        humidity = lhu
-    elif rhu is not None and rhu != NO_SENSOR:
-        humidity = rhu
+    canonical = normalize_bed_temp(record)
+    if canonical is None:
+        return False
 
     with conn:
         conn.execute(
@@ -142,17 +108,18 @@ def write_bed_temp(conn: sqlite3.Connection, ts: float, record: dict) -> None:
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 int(ts),
-                _to_centidegrees(ambient),
-                _to_centidegrees(record.get("mcu")),
-                _to_centipercent(humidity),
-                _safe_temp(left_temps, 0),
-                _safe_temp(left_temps, 1),
-                _safe_temp(left_temps, 2),
-                _safe_temp(right_temps, 0),
-                _safe_temp(right_temps, 1),
-                _safe_temp(right_temps, 2),
+                canonical["ambient_temp"],
+                canonical["mcu_temp"],
+                canonical["humidity"],
+                canonical["left_outer_temp"],
+                canonical["left_center_temp"],
+                canonical["left_inner_temp"],
+                canonical["right_outer_temp"],
+                canonical["right_center_temp"],
+                canonical["right_inner_temp"],
             ),
         )
+    return True
 
 
 def write_freezer_temp(conn: sqlite3.Connection, ts: float, record: dict) -> None:
@@ -236,8 +203,8 @@ def main() -> None:
 
             if rtype in ("bedTemp", "bedTemp2"):
                 if ts - last_bed_write >= DOWNSAMPLE_INTERVAL_S:
-                    write_bed_temp(db_conn, ts, record)
-                    last_bed_write = ts
+                    if write_bed_temp(db_conn, ts, record):
+                        last_bed_write = ts
 
             elif rtype == "frzTemp":
                 if ts - last_frz_write >= DOWNSAMPLE_INTERVAL_S:

--- a/src/streaming/normalizeFrame.ts
+++ b/src/streaming/normalizeFrame.ts
@@ -55,9 +55,9 @@ export interface WireFrzTemp {
   hs: number
 }
 
-/** bedTemp/bedTemp2 as the firmware writes it. */
-export interface WireBedTemp {
-  type: 'bedTemp' | 'bedTemp2'
+/** bedTemp2 (Pod 4 / Pod 5) — float degrees C, nested temps[] array per side. */
+export interface WireBedTemp2 {
+  type: 'bedTemp2'
   ts: number
   mcu?: number
   left: {
@@ -74,12 +74,31 @@ export interface WireBedTemp {
   }
 }
 
-/** capSense2 as the firmware writes it. */
+/** bedTemp (Pod 3, v1) — integer centidegrees, flat out/cen/in keys per side. */
+export interface WireBedTempV1 {
+  type: 'bedTemp'
+  ts: number
+  amb?: number // centidegrees
+  mcu?: number // centidegrees
+  hu?: number // centipercent
+  left: { side?: number, out?: number, cen?: number, in?: number }
+  right: { side?: number, out?: number, cen?: number, in?: number }
+}
+
+/** capSense2 (Pod 4 / Pod 5) — float values[] per side. */
 export interface WireCapSense2 {
   type: 'capSense2'
   ts: number
   left: { values: number[], status?: string } | number
   right: { values: number[], status?: string } | number
+}
+
+/** capSense (Pod 3, v1) — integer out/cen/in keys per side. */
+export interface WireCapSenseV1 {
+  type: 'capSense'
+  ts: number
+  left: { out?: number, cen?: number, in?: number, status?: string }
+  right: { out?: number, cen?: number, in?: number, status?: string }
 }
 
 // ---------------------------------------------------------------------------
@@ -111,8 +130,8 @@ function cdToC(v: unknown): number | null {
 
 export function normalizeFrame(rec: Record<string, unknown>): Record<string, unknown> {
   switch (rec.type) {
-    case 'bedTemp':
     case 'bedTemp2': {
+      // v2 (Pod 4 / Pod 5): floats in degrees, nested temps[] array.
       const left = (rec.left ?? {}) as Record<string, unknown>
       const right = (rec.right ?? {}) as Record<string, unknown>
       const leftTemps = (left.temps ?? []) as number[]
@@ -128,6 +147,45 @@ export function normalizeFrame(rec: Record<string, unknown>): Record<string, unk
         rightOuterTemp: safeNum(rightTemps[0]),
         rightCenterTemp: safeNum(rightTemps[1]),
         rightInnerTemp: safeNum(rightTemps[2]),
+      }
+    }
+    case 'bedTemp': {
+      // v1 (Pod 3): integer centidegrees, flat out/cen/in keys per side.
+      // Convert centidegrees → degrees C to match the canonical (v2) units.
+      const left = (rec.left ?? {}) as Record<string, unknown>
+      const right = (rec.right ?? {}) as Record<string, unknown>
+      return {
+        type: rec.type, ts: rec.ts,
+        ambientTemp: cdToC(rec.amb),
+        mcuTemp: cdToC(rec.mcu),
+        humidity: cdToC(rec.hu), // centipercent → percent (same /100 scale)
+        leftOuterTemp: cdToC(left.out),
+        leftCenterTemp: cdToC(left.cen),
+        leftInnerTemp: cdToC(left.in),
+        rightOuterTemp: cdToC(right.out),
+        rightCenterTemp: cdToC(right.cen),
+        rightInnerTemp: cdToC(right.in),
+      }
+    }
+    case 'capSense': {
+      // v1 (Pod 3): integer out/cen/in keys per side. Project into the same
+      // 6-slot paired-channel layout capSense2 uses so subscribers can read
+      // both. Missing slots stay as null to preserve zone position — never
+      // compact, or a partial frame would shift inner readings into outer
+      // slots and confuse downstream indexing.
+      const left = (rec.left ?? {}) as Record<string, unknown>
+      const right = (rec.right ?? {}) as Record<string, unknown>
+      const lOut = safeNum(left.out)
+      const lCen = safeNum(left.cen)
+      const lIn = safeNum(left.in)
+      const rOut = safeNum(right.out)
+      const rCen = safeNum(right.cen)
+      const rIn = safeNum(right.in)
+      return {
+        type: rec.type, ts: rec.ts,
+        left: [lOut, lOut, lCen, lCen, lIn, lIn],
+        right: [rOut, rOut, rCen, rCen, rIn, rIn],
+        status: left.status ?? right.status,
       }
     }
     case 'frzTemp':

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -185,6 +185,18 @@ function readRawRecord(
   return { data, nextOffset: pos }
 }
 
+/**
+ * Find the next outer-record marker (0xa2) at or after `from`. Returns the
+ * absolute buffer offset, or -1 if no marker exists in the remaining bytes.
+ *
+ * Used for resync after a malformed record — fast-forwarding to the next
+ * 0xa2 instead of advancing one byte at a time avoids log-spamming every
+ * null byte inside a partial piezo payload.
+ */
+function findNextRecordMarker(buf: Buffer, from: number): number {
+  return buf.indexOf(0xa2, from)
+}
+
 // ---------------------------------------------------------------------------
 // RAW file follower
 // ---------------------------------------------------------------------------
@@ -468,7 +480,9 @@ function handleSeek(ws: WebSocket, targetTs: number): void {
       }
       catch (e) {
         if (e instanceof RangeError) break // incomplete record
-        bufPos += 1 // skip malformed byte, try to resync
+        const next = findNextRecordMarker(seekBuffer, bufPos + 1)
+        if (next < 0) break // no marker in remaining bytes
+        bufPos = next
       }
     }
   }
@@ -639,9 +653,21 @@ export function startPiezoStreamServer(): WebSocketServer {
           if (e instanceof RangeError) {
             break // incomplete record — wait for more data
           }
-          // Malformed record — skip forward one byte and try to resync
-          console.warn('[sensorStream] Skipping malformed record:', (e as Error).message)
-          bufferPos += 1
+          // Malformed record — fast-forward to the next 0xa2 marker. Avoids
+          // log-spamming every byte inside a partial piezo payload (the v1
+          // 0x00 nulls that motivated this) and recovers in O(remaining bytes).
+          const next = findNextRecordMarker(fileBuffer, bufferPos + 1)
+          if (next < 0) {
+            // No marker in remaining bytes — drop what we have and wait for
+            // more data on the next poll.
+            console.warn('[sensorStream] Resync: no 0xa2 marker in remaining %d bytes (%s)',
+              fileBuffer.length - bufferPos, (e as Error).message)
+            bufferPos = fileBuffer.length
+            break
+          }
+          console.warn('[sensorStream] Resync: skipped %d bytes to next record (%s)',
+            next - bufferPos, (e as Error).message)
+          bufferPos = next
         }
       }
 

--- a/src/streaming/tests/normalizeFrame.test.ts
+++ b/src/streaming/tests/normalizeFrame.test.ts
@@ -97,6 +97,24 @@ const FIRMWARE_FIXTURES = {
     level: 'debug',
     msg: 'test message',
   },
+
+  // v1 (Pod 3) — captured from issue #437 attached RAW (PR #437)
+  bedTempV1: {
+    type: 'bedTemp',
+    ts: 1776463233,
+    amb: 2514, // centidegrees → 25.14 °C
+    mcu: 3428,
+    hu: 3956,
+    left: { side: 2334, out: 2280, cen: 2301, in: 2359 },
+    right: { side: 2417, out: 2351, cen: 2420, in: 2396 },
+  },
+
+  capSenseV1: {
+    type: 'capSense',
+    ts: 1776463227,
+    left: { out: 290, cen: 241, in: 339, status: 'good' },
+    right: { out: 372, cen: 498, in: 526, status: 'good' },
+  },
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +292,74 @@ describe('normalizeFrame', () => {
       expect(result.type).toBe('log')
       expect(result.msg).toBe('test message')
       expect(result.level).toBe('debug')
+    })
+  })
+
+  describe('bedTemp v1 (Pod 3)', () => {
+    it('converts integer centidegrees to degrees C', () => {
+      const result = normalizeFrame(FIRMWARE_FIXTURES.bedTempV1 as Record<string, unknown>)
+      expect(result.ambientTemp).toBeCloseTo(25.14)
+      expect(result.mcuTemp).toBeCloseTo(34.28)
+      expect(result.humidity).toBeCloseTo(39.56)
+    })
+
+    it('extracts per-zone thermistors from flat out/cen/in keys', () => {
+      const result = normalizeFrame(FIRMWARE_FIXTURES.bedTempV1 as Record<string, unknown>)
+      expect(result.leftOuterTemp).toBeCloseTo(22.80)
+      expect(result.leftCenterTemp).toBeCloseTo(23.01)
+      expect(result.leftInnerTemp).toBeCloseTo(23.59)
+      expect(result.rightOuterTemp).toBeCloseTo(23.51)
+      expect(result.rightCenterTemp).toBeCloseTo(24.20)
+      expect(result.rightInnerTemp).toBeCloseTo(23.96)
+    })
+
+    it('preserves type tag and timestamp', () => {
+      const result = normalizeFrame(FIRMWARE_FIXTURES.bedTempV1 as Record<string, unknown>)
+      expect(result.type).toBe('bedTemp')
+      expect(result.ts).toBe(1776463233)
+    })
+
+    it('returns null for missing zone keys', () => {
+      const partial = {
+        type: 'bedTemp', ts: 1776463233,
+        amb: 2514, mcu: 3428, hu: 3956,
+        left: { out: 2280 }, // no cen, no in
+        right: {},
+      }
+      const result = normalizeFrame(partial as Record<string, unknown>)
+      expect(result.leftOuterTemp).toBeCloseTo(22.80)
+      expect(result.leftCenterTemp).toBeNull()
+      expect(result.rightInnerTemp).toBeNull()
+    })
+  })
+
+  describe('capSense v1 (Pod 3)', () => {
+    it('projects flat out/cen/in into a values array', () => {
+      const result = normalizeFrame(FIRMWARE_FIXTURES.capSenseV1 as Record<string, unknown>)
+      expect(Array.isArray(result.left)).toBe(true)
+      expect(Array.isArray(result.right)).toBe(true)
+      // Per-zone values duplicated to mimic the capSense2 paired-channel layout
+      expect((result.left as number[])).toEqual([290, 290, 241, 241, 339, 339])
+      expect((result.right as number[])).toEqual([372, 372, 498, 498, 526, 526])
+    })
+
+    it('preserves status', () => {
+      const result = normalizeFrame(FIRMWARE_FIXTURES.capSenseV1 as Record<string, unknown>)
+      expect(result.status).toBe('good')
+    })
+
+    it('keeps zone positions stable when a field is missing', () => {
+      // If `out` is absent on a partial Pod 3 frame, the inner/center readings
+      // must NOT shift left into the outer slot — slot 0 stays null so
+      // subscribers indexing by zone aren't lied to.
+      const partial = {
+        type: 'capSense', ts: 1776463227,
+        left: { cen: 241, in: 339, status: 'good' },
+        right: { out: 372, cen: 498, in: 526, status: 'good' },
+      }
+      const result = normalizeFrame(partial as Record<string, unknown>)
+      expect((result.left as (number | null)[])).toEqual([null, null, 241, 241, 339, 339])
+      expect((result.right as (number | null)[])).toEqual([372, 372, 498, 498, 526, 526])
     })
   })
 })


### PR DESCRIPTION
## Summary

Promotes \`dev\` → \`main\` for v1.8.2.

- **#486** — Pod 3 firmware emits v1 inner records (\`bedTemp\`, \`capSense\`) that environment-monitor was silently dropping. Adds a content-keyed dialect normalizer at the CBOR-decode boundary so both v1 (Pod 3) and v2 (Pod 4 / Pod 5) reduce to a canonical row shape. Plus a streaming-parser resync fix that replaces 1-byte advancement with \`Buffer.indexOf(0xa2)\` fast-forward, killing the \`[sensorStream] Skipping malformed record: 0xa2 got 0x0\` log spam Oliver reported.

## Test plan

- [x] 14 new Python + 7 new TS test cases against real Pod 3 + Pod 4 RAW fixtures
- [x] Existing 46 TS + 57 Python tests pass (no regressions)
- [x] CI green on #486 (Lint, Typecheck, Unit Tests, build, CodeRabbit)
- [ ] Post-deploy on Oliver's Pod 3: \`bed_temp\` rows appearing every 60s with non-null left/right zone temps; iOS WebSocket frames for bedTemp/capSense include real values; no \`Skipping malformed record\` log spam.
- [ ] Post-deploy regression check on Pod 4: \`bed_temp\` continues writing with same shape as before.

Refs #395, supersedes #437.