### PR TITLE
feat(cover-buttons): syslog observability for TTC button presses

### DIFF
--- a/modules/cover-buttons/main.py
+++ b/modules/cover-buttons/main.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+SleepyPod cover-buttons module.
+
+Tails /persistent/*.RAW for `buttonEvent` CBOR records emitted by the TTC
+cover (top/middle/bottom buttons on each side) and logs each press to the
+systemd journal. Pure observability — no DB writes, no action dispatch.
+
+Wire schema (sparse — only sides/buttons that fired are present):
+
+    { "type": "buttonEvent", "ts": 1777357840,
+      "left":  { "top": 1, "bottom": 1 },
+      "right": { "top": 1 } }
+"""
+
+import os
+import sys
+import time
+import signal
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from common.raw_follower import RawFileFollower
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+RAW_DATA_DIR = Path(os.environ.get("RAW_DATA_DIR", "/persistent"))
+SLEEPYPOD_DB = Path(os.environ.get("DATABASE_URL", "file:/persistent/sleepypod-data/sleepypod.db").replace("file:", ""))
+
+VALID_SIDES = ("left", "right")
+VALID_BUTTONS = ("top", "middle", "bottom")
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [cover-buttons] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Shutdown handling
+# ---------------------------------------------------------------------------
+
+_shutdown = threading.Event()
+
+def _on_signal(signum, frame):
+    log.info("Received signal %d, shutting down...", signum)
+    _shutdown.set()
+
+signal.signal(signal.SIGTERM, _on_signal)
+signal.signal(signal.SIGINT, _on_signal)
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+def report_health(status: str, message: str) -> None:
+    """Write module health to sleepypod.db system_health table."""
+    try:
+        conn = sqlite3.connect(str(SLEEPYPOD_DB), timeout=2.0)
+        try:
+            with conn:
+                conn.execute(
+                    """INSERT INTO system_health (component, status, message, last_checked)
+                       VALUES ('cover-buttons', ?, ?, ?)
+                       ON CONFLICT(component) DO UPDATE SET
+                         status=excluded.status,
+                         message=excluded.message,
+                         last_checked=excluded.last_checked""",
+                    (status, message, int(time.time())),
+                )
+        finally:
+            conn.close()
+    except Exception as e:
+        log.warning("Could not write health status: %s", e)
+
+# ---------------------------------------------------------------------------
+# Press extraction
+# ---------------------------------------------------------------------------
+
+def iter_presses(record):
+    """Yield (side, button, count, ts) tuples from a buttonEvent record.
+
+    Skips malformed records (non-dict side payloads, unknown button keys)
+    without raising. Non-buttonEvent records yield nothing.
+    """
+    if record.get("type") != "buttonEvent":
+        return
+    ts = record.get("ts")
+    for side in VALID_SIDES:
+        side_payload = record.get(side)
+        if side_payload is None:
+            continue
+        if not isinstance(side_payload, dict):
+            log.debug("schema mismatch: %s payload is %s, not dict",
+                      side, type(side_payload).__name__)
+            continue
+        for button, count in side_payload.items():
+            if button not in VALID_BUTTONS:
+                log.debug("schema mismatch: unknown button key %r on %s",
+                          button, side)
+                continue
+            try:
+                count_int = int(count)
+            except (TypeError, ValueError):
+                log.debug("schema mismatch: non-integer count %r for %s.%s",
+                          count, side, button)
+                continue
+            if count_int <= 0:
+                continue
+            yield side, button, count_int, ts
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    log.info("Starting cover-buttons (raw_dir=%s)", RAW_DATA_DIR)
+
+    follower = RawFileFollower(RAW_DATA_DIR, _shutdown, poll_interval=0.1)
+
+    report_health("healthy", "cover-buttons started")
+
+    try:
+        for record in follower.read_records():
+            if record.get("type") != "buttonEvent":
+                continue
+            for side, button, count, ts in iter_presses(record):
+                for _ in range(count):
+                    log.info("press: side=%s button=%s count=1 ts=%s",
+                             side, button, ts)
+
+    except Exception as e:
+        log.exception("Fatal error in main loop: %s", e)
+        report_health("down", str(e))
+        sys.exit(1)
+    finally:
+        log.info("Shutdown complete")
+
+    report_health("down", "cover-buttons stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/cover-buttons/main.py
+++ b/modules/cover-buttons/main.py
@@ -4,7 +4,9 @@ SleepyPod cover-buttons module.
 
 Tails /persistent/*.RAW for `buttonEvent` CBOR records emitted by the TTC
 cover (top/middle/bottom buttons on each side) and logs each press to the
-systemd journal. Pure observability — no DB writes, no action dispatch.
+systemd journal. No biometrics-data writes and no action dispatch — only
+the standard system_health lifecycle markers (start / fatal / stopped)
+that match the other Python sidecars.
 
 Wire schema (sparse — only sides/buttons that fired are present):
 

--- a/modules/cover-buttons/main.py
+++ b/modules/cover-buttons/main.py
@@ -91,10 +91,11 @@ def report_health(status: str, message: str) -> None:
 def iter_presses(record):
     """Yield (side, button, count, ts) tuples from a buttonEvent record.
 
-    Skips malformed records (non-dict side payloads, unknown button keys)
-    without raising. Non-buttonEvent records yield nothing.
+    Skips malformed records (non-dict records, non-dict side payloads,
+    unknown button keys) without raising. Non-buttonEvent records yield
+    nothing. Corrupt RAW frames must not tear down the service.
     """
-    if record.get("type") != "buttonEvent":
+    if not isinstance(record, dict) or record.get("type") != "buttonEvent":
         return
     ts = record.get("ts")
     for side in VALID_SIDES:
@@ -133,8 +134,6 @@ def main() -> None:
 
     try:
         for record in follower.read_records():
-            if record.get("type") != "buttonEvent":
-                continue
             for side, button, count, ts in iter_presses(record):
                 for _ in range(count):
                     log.info("press: side=%s button=%s count=1 ts=%s",

--- a/modules/cover-buttons/manifest.json
+++ b/modules/cover-buttons/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "cover-buttons",
+  "version": "1.0.0",
+  "description": "TTC cover button press observability — logs top/middle/bottom presses to syslog",
+  "provides": [],
+  "writes": [],
+  "service": "sleepypod-cover-buttons.service",
+  "language": "python",
+  "minVersion": "1.0.0"
+}

--- a/modules/cover-buttons/pyproject.toml
+++ b/modules/cover-buttons/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "cover-buttons"
+version = "0.1.0"
+requires-python = ">=3.9,<3.11"
+dependencies = [
+    "cbor2>=5.9.0",
+]

--- a/modules/cover-buttons/sleepypod-cover-buttons.service
+++ b/modules/cover-buttons/sleepypod-cover-buttons.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=SleepyPod Cover Buttons (TTC button press observability)
+Documentation=https://github.com/sleepypod/core/tree/main/modules/cover-buttons
+After=network.target sleepypod.service
+Wants=sleepypod.service
+
+[Service]
+Type=simple
+User=root
+UMask=0002
+WorkingDirectory=/opt/sleepypod/modules/cover-buttons
+ExecStart=/opt/sleepypod/modules/cover-buttons/.venv/bin/python main.py
+Restart=always
+RestartSec=10
+
+# Environment — override via /etc/sleepypod/modules/cover-buttons.env
+EnvironmentFile=-/etc/sleepypod/modules/cover-buttons.env
+Environment="RAW_DATA_DIR=/persistent"
+Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
+Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
+
+# Resource limits
+MemoryMax=64M
+CPUQuota=20%
+
+# Sandboxing
+NoNewPrivileges=true
+ReadOnlyPaths=/persistent
+ReadWritePaths=/persistent/sleepypod-data
+ProtectSystem=strict
+ProtectKernelTunables=true
+# Isolated /tmp — otherwise ProtectSystem=strict + narrow ReadWritePaths
+# hide host /tmp → Python tempfile.mkstemp() errors "No usable temporary
+# directory found". See piezo-processor.service for the full rationale.
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/cover-buttons/test_main.py
+++ b/modules/cover-buttons/test_main.py
@@ -1,0 +1,87 @@
+"""Tests for cover-buttons press extraction.
+
+Stub out the cbor2 / common.raw_follower imports so main.py loads on a
+developer Mac without the on-pod runtime. We only exercise iter_presses.
+"""
+
+import sys
+
+_stubs = {
+    "cbor2": type(sys)("cbor2"),
+    "common": type(sys)("common"),
+    "common.raw_follower": type(sys)("common.raw_follower"),
+}
+_stubs["common.raw_follower"].RawFileFollower = None
+sys.modules.update(_stubs)
+
+from main import iter_presses  # noqa: E402
+
+
+def test_real_sample_two_buttons_left():
+    rec = {"type": "buttonEvent", "ts": 1777357840,
+           "left": {"top": 1, "bottom": 1}}
+    out = sorted(iter_presses(rec))
+    assert out == sorted([
+        ("left", "top", 1, 1777357840),
+        ("left", "bottom", 1, 1777357840),
+    ])
+
+
+def test_real_sample_second_capture():
+    rec = {"type": "buttonEvent", "ts": 1777343118,
+           "left": {"top": 1, "bottom": 1}}
+    out = sorted(iter_presses(rec))
+    assert out == sorted([
+        ("left", "top", 1, 1777343118),
+        ("left", "bottom", 1, 1777343118),
+    ])
+
+
+def test_real_sample_single_button():
+    rec = {"type": "buttonEvent", "ts": 1777388681,
+           "left": {"top": 1}}
+    out = list(iter_presses(rec))
+    assert out == [("left", "top", 1, 1777388681)]
+
+
+def test_non_dict_side_skipped():
+    rec = {"type": "buttonEvent", "ts": 0, "left": "garbage"}
+    assert list(iter_presses(rec)) == []
+
+
+def test_unknown_button_key_skipped():
+    rec = {"type": "buttonEvent", "ts": 0, "left": {"weird": 1}}
+    assert list(iter_presses(rec)) == []
+
+
+def test_non_buttonevent_filtered_out():
+    rec = {"type": "piezo-dual", "ts": 0, "left": {"top": 1}}
+    assert list(iter_presses(rec)) == []
+
+
+def test_both_sides_yielded():
+    rec = {"type": "buttonEvent", "ts": 100,
+           "left": {"top": 1}, "right": {"middle": 1, "bottom": 1}}
+    out = sorted(iter_presses(rec))
+    assert out == sorted([
+        ("left", "top", 1, 100),
+        ("right", "middle", 1, 100),
+        ("right", "bottom", 1, 100),
+    ])
+
+
+def test_zero_count_skipped():
+    rec = {"type": "buttonEvent", "ts": 0, "left": {"top": 0}}
+    assert list(iter_presses(rec)) == []
+
+
+def test_count_greater_than_one_preserved():
+    rec = {"type": "buttonEvent", "ts": 50, "left": {"top": 3}}
+    out = list(iter_presses(rec))
+    assert out == [("left", "top", 3, 50)]
+
+
+def test_missing_side_ok():
+    rec = {"type": "buttonEvent", "ts": 0, "right": {"top": 1}}
+    out = list(iter_presses(rec))
+    assert out == [("right", "top", 1, 0)]

--- a/modules/cover-buttons/test_main.py
+++ b/modules/cover-buttons/test_main.py
@@ -59,6 +59,13 @@ def test_non_buttonevent_filtered_out():
     assert list(iter_presses(rec)) == []
 
 
+def test_non_dict_record_skipped():
+    # RawFileFollower yields decoded CBOR — corrupt frames can be lists,
+    # strings, ints, None. Service must not crash.
+    for bad in [None, [], "buttonEvent", 42, b"buttonEvent"]:
+        assert list(iter_presses(bad)) == []
+
+
 def test_both_sides_yielded():
     rec = {"type": "buttonEvent", "ts": 100,
            "left": {"top": 1}, "right": {"middle": 1, "bottom": 1}}

--- a/modules/cover-buttons/uv.lock
+++ b/modules/cover-buttons/uv.lock
@@ -1,0 +1,63 @@
+version = 1
+revision = 3
+requires-python = ">=3.9, <3.11"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "cbor2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cb/09939728be094d155b5d4ac262e39877875f5f7e36eea66beb359f647bd0/cbor2-5.9.0.tar.gz", hash = "sha256:85c7a46279ac8f226e1059275221e6b3d0e370d2bb6bd0500f9780781615bcea", size = 111231, upload-time = "2026-03-22T15:56:50.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/bf/12b337e5354e47f6378da18989480c0c1e2cc5fe9b865e6fab45d6332aa6/cbor2-5.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:55bea0dd9a7d354e35f4e5fe58ceab393e76962713749dc3a0a64a0e5d19545e", size = 70577, upload-time = "2026-03-22T15:55:54.174Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7b/74c524ce81c1ddc6c44b4865028ffb7d3a8e7ae653b1061650375a28cbb1/cbor2-5.9.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3095dc49e75572841a9534cbfdabc2a17487ea4ee33341436abc4a7ac7245a3a", size = 261074, upload-time = "2026-03-22T15:55:55.654Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/97/c496c71422b2ca18ff2acc5f49e8c45cd7294b7df1359eccec78021b428e/cbor2-5.9.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25bec7beb2089465382b1be72e78667fe9090598800826559c3e3008cf0db743", size = 255498, upload-time = "2026-03-22T15:55:57.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/40/9bd7e66dba7aea674a440e004faea406de42c49aeac23453954b67768532/cbor2-5.9.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cc5efec69055c3c470997935d95762be7e4bfd1248d88fb1a33bb7e0f45712e9", size = 255683, upload-time = "2026-03-22T15:55:58.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d1/fa3e158dbe4c08091495b720c604624b285bc272afdbcfac2150725d955b/cbor2-5.9.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:420d2490c7836c81151b4bd591c35cffc55391e33e7e333c50fda391bcea7d31", size = 250798, upload-time = "2026-03-22T15:55:59.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/16/3186084b441c4b0caebfaaa2c66a57bde82ceaacd469570c77c8030b6b95/cbor2-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:d1a21c006760f95acd9509cc5a7d15d6fc82e58f721f94fa9039b4e77189a6e5", size = 69436, upload-time = "2026-03-22T15:56:01.466Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1f/57d00cd13e0f9391bcd616795aa78409210a7464570fe21e3b9cd42eb5a7/cbor2-5.9.0-cp310-cp310-win_arm64.whl", hash = "sha256:08388ea54195738602b4c4999966bcaef6f0b17d293c9658658409d9fff96f57", size = 65312, upload-time = "2026-03-22T15:56:02.804Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/f052f558e29f90ed29f9a42263232f6f059fd7bbf1b5d27e3867f9356375/cbor2-5.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1da96ce5d852fe3d342c1eb2c202a52d1c97edfddc9230f1be7e02674662bf26", size = 70582, upload-time = "2026-03-22T15:56:40.441Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fb/91fa1b15b525577ec20a8904f22d8e97eb81164f6663705539e89acdde8f/cbor2-5.9.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65f8eac3268c608533f326f0fd9010ab1b2a8a917b05edaf3853116336821669", size = 260147, upload-time = "2026-03-22T15:56:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/4013441f8fccca0c5bff043c6ff8b86fde03c5da8b41a22694d49af02b3e/cbor2-5.9.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f797532d13469f2193e5c16e827d8df7a8c33674b19be755790b54ab231e6a73", size = 254507, upload-time = "2026-03-22T15:56:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/26/b96e357ca8554a5458939bc9a7a6f83a494ce15470c96d02f79188fa81c7/cbor2-5.9.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fbdcf4d74acbeb7672e6413e81cd2c1ced1a4a8cf949484ac54e9af5265c3c72", size = 254592, upload-time = "2026-03-22T15:56:44.402Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/06/db0fcac41763153e20aca5a096ee3727bfc591d7825daa5bad493bb99b6d/cbor2-5.9.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:53cfa49e0df9c639beb871d480de098eedc81eb63ff29f2dc922720d7577b676", size = 249671, upload-time = "2026-03-22T15:56:45.581Z" },
+    { url = "https://files.pythonhosted.org/packages/25/9e/484d2b68f2e720add45e3d0d61976fe2abd86dea31ec13038fb630097ef1/cbor2-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:f29e5c3abcc91c1aeefecde0e057bf33f1655588d3065c6560c30ceb3be6f333", size = 69511, upload-time = "2026-03-22T15:56:46.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/b6653d28c6ebb42402c2d22044108ee59ff4d064eae435ce20894a4847ec/cbor2-5.9.0-cp39-cp39-win_arm64.whl", hash = "sha256:d8524a8c142c3cc228e635f8a97499a6c0b18ca91382e8276565658035cdcb6d", size = 65375, upload-time = "2026-03-22T15:56:47.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/b83492b096fbef26e9cb62c1a4bf2d3cef579ea7b33138c6c37c4ae66f67/cbor2-5.9.0-py3-none-any.whl", hash = "sha256:27695cbd70c90b8de5c4a284642c2836449b14e2c2e07e3ffe0744cb7669a01b", size = 24627, upload-time = "2026-03-22T15:56:48.847Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/fe/5d7f37d51ec21cccf9ae14a42a674907b8385779e639482f83c6eff1bcee/cbor2-6.0.1.tar.gz", hash = "sha256:46a745c296ec336fe83fa7905b77b4faa243eb32bb84fab1cfdb0e4636d1985b", size = 84191, upload-time = "2026-04-28T21:23:37.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/2e/80711ed51bc703d91650bf0bb01d0901a136df1bd46f6c5acce757f45628/cbor2-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e08983e898c9ed663d896bd3c9b70b79d220976b077ee6407614ad8bb742a9c5", size = 401847, upload-time = "2026-04-28T21:22:31.221Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5d/1ee9433098a282457dcb4342c3de1493a195b0f155493bd0e3c58bdd856f/cbor2-6.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:68448f04972484cd6edb50a816198ed3a7ccc1cbbcceab90e4e6ac04abc68a84", size = 448992, upload-time = "2026-04-28T21:22:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/696741927f550c39d749c01f2b326d936f7d4b625049e9bd447d0737b836/cbor2-6.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0c019daa823c46edf111aea7e600cc4de5825695c0088b35bb1388bd2ea9734b", size = 459109, upload-time = "2026-04-28T21:22:34.754Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/99/2521f3180695e239c904dfe153987cdf51faeacf59d88845d653223b99ce/cbor2-6.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5edd913cfe8e3e25b2c9fff5fb3f519222212f751fc3cf7e4ef492146115c50e", size = 515180, upload-time = "2026-04-28T21:22:36.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ab/f460a518d0a5634100a9eace551b2f345bbfb322d238f89bdf43c5316ca5/cbor2-6.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3969d41449a42887a716a5b3ab3335fc6a9c67cb2e95164d0fd126641a1e96e6", size = 525486, upload-time = "2026-04-28T21:22:38.379Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/53/8723adacead95b4428fab81bd1d629e260129301eb1d0f82358c52560caa/cbor2-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:16c6f9852630f687fbf3fe0565218844d92fd2a0bcad9babf041d8881d2022a1", size = 288714, upload-time = "2026-04-28T21:22:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/522865bde8831819f28763f995b39fe67289ef99486c6254917e10304b67/cbor2-6.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:6e06ce3f551979fbd3632df0f2062674f8aadc4231e84041f02f6e7155f149a9", size = 281087, upload-time = "2026-04-28T21:22:41.045Z" },
+]
+
+[[package]]
+name = "cover-buttons"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "cbor2", version = "5.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cbor2", version = "6.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cbor2", specifier = ">=5.9.0" }]

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -235,7 +235,7 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   if ! command -v uv &>/dev/null; then
     echo "Warning: uv not found — biometrics modules not synced. Re-run the full installer."
   fi
-  for mod in piezo-processor sleep-detector environment-monitor calibrator; do
+  for mod in piezo-processor sleep-detector environment-monitor calibrator cover-buttons; do
     if [ -d "$INSTALL_DIR/modules/$mod" ]; then
       mkdir -p "$MODULES_DEST/$mod"
       cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"

--- a/scripts/install
+++ b/scripts/install
@@ -750,6 +750,7 @@ else
   install_module "sleep-detector"
   install_module "environment-monitor"
   install_module "calibrator"
+  install_module "cover-buttons"
 fi
 
 # Re-fix DB permissions after all services restarted with new UMask.
@@ -890,5 +891,6 @@ echo "  Config:         $INSTALL_DIR/.env"
 echo "  Module logs:    journalctl -u sleepypod-piezo-processor.service"
 echo "                  journalctl -u sleepypod-sleep-detector.service"
 echo "                  journalctl -u sleepypod-environment-monitor.service"
+echo "                  journalctl -u sleepypod-cover-buttons.service"
 echo "  App logs:       journalctl -u sleepypod.service"
 echo ""


### PR DESCRIPTION
## Summary

Refs `sleepypod-core-15` (minimum bar). Tails `/persistent/*.RAW` for `buttonEvent` CBOR records (top/middle/bottom × left/right) and emits a one-liner per press to the systemd journal. **No biometrics-data writes; no action dispatch; no UI.** Observability only — visibility for the broader cover-button trigger work that's still queued.

`system_health` writes are kept (3 inserts per service lifecycle: started / fatal / stopped) — same convention as piezo-processor / sleep-detector / environment-monitor — so the StatusScreen system-services card can surface whether the module is running.

## Schema

Sparse — only sides/buttons that fired are present:

```json
{ "type": "buttonEvent", "ts": 1777357840,
  "left":  { "top": 1, "bottom": 1 },
  "right": { "top": 1 } }
```

Discovered by sniffing real Pod 5 RAW (3 historical samples confirmed in `/persistent/*.RAW`).

## Test plan

- [x] `pytest modules/cover-buttons/test_main.py` — 11 passed (incl. non-dict record + non-dict side payload + unknown button key + zero count + count > 1 + missing-side cases)
- [x] `pnpm tsc --noEmit` clean, `pnpm lint` clean
- [ ] Deploy to Pod 5 + verify `journalctl -u sleepypod-cover-buttons` shows a press log within ~1s of physically pressing a button

## Out of scope (in `sleepypod-core-15`)

- `tap_gestures` table widening to `trigger_gestures` enum
- Equipment cap module (`src/hardware/equipment.ts`)
- Action dispatch through `gestureActionHandler`
- Settings UI for button → action mapping
- `buttonEvent` in `ALL_SENSOR_TYPES` for WebSocket broadcast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cover button monitoring service that logs top/middle/bottom button presses and reports service health with graceful shutdown handling.

* **Tests**
  * Added tests covering button event parsing, filtering, and invalid-input handling.

* **Chores**
  * Installer and update scripts now include the new cover-buttons module and its systemd service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->