### PR TITLE
fix(sp-update): atomic self-replace via install(1) instead of cp

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -262,11 +262,17 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   done
 fi
 
-# Install CLI tools from new source
+# Install CLI tools from new source.
+#
+# Use `install` (atomic mkstemp + rename) instead of `cp` — sp-update is
+# one of the sp-* tools being replaced here. `cp` truncates+writes into
+# the same inode, so the running bash reads garbage from its own script
+# after the overwrite ("line N: ): command not found" mid-run). `install`
+# stages new bytes at a fresh inode and renames over the path, so the
+# running process's open fd keeps pointing at the original content.
 if [ -d "$INSTALL_DIR/scripts/bin" ]; then
   for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-    cp "$tool" /usr/local/bin/
-    chmod +x "/usr/local/bin/$(basename "$tool")"
+    install -m 0755 "$tool" "/usr/local/bin/$(basename "$tool")"
   done
 fi
 


### PR DESCRIPTION
## Summary

\`sp-update\` is itself one of the \`sp-*\` tools the install loop overwrites. \`cp\` truncates+writes into the **same inode**, so the running bash reads garbage from its own script after the overwrite — fails partway through with \`line N: ): command not found\` mid-run, triggering the rollback path.

Reproduced today running \`sp-update dev\` against Pod 5 to test #491 cover-buttons:

\`\`\`
+ cbor2==5.9.0
/usr/local/bin/sp-update: line 272: ): command not found
Restoring saved iptables rules...
Update failed, rolling back...
Previous code restored.
Database restored.
\`\`\`

Latent bug — every prior sp-update has had this risk. We've been lucky on releases where the pre/post script byte-offsets happened to align on benign content. v1.9.0 widens script-length deltas enough to trip it.

## Fix

Swap \`cp\` for \`install -m 0755\`. \`install\` stages new bytes at a fresh inode and \`rename(2)\`s over the path. The running process's open fd keeps pointing at the **original** inode for the remainder of execution; the next \`sp-update\` invocation reads the new content from the new inode. Same atomic-replace pattern bash itself uses internally.

## Test plan

- [x] Patch applied locally; diff is the minimum viable change (\`cp X Y/\` + \`chmod +x Y\` collapsed into a single \`install -m 0755 X Y\`)
- [ ] On Pod 5: \`sp-update dev\` against this branch's tip succeeds, \`/opt/sleepypod/modules/cover-buttons\` lands, \`systemctl is-active sleepypod-cover-buttons\` is \`active\`. (Will run after this lands on dev.)
- [ ] No-op for any sp-update where script content didn't change between versions.