### PR TITLE
fix(scheduler): serialize per-side jobs + add liveness heartbeat

### DIFF
--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -8,6 +8,7 @@ import {
   deviceSettings,
   sideSettings,
   runOnceSessions,
+  deviceState,
 } from '@/src/db/schema'
 import { and, eq, gt } from 'drizzle-orm'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
@@ -18,20 +19,104 @@ import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus
 import { cancelAutoOffTimer } from '@/src/services/autoOffWatcher'
 import { timeToDate } from './timeUtils'
 
+const HEARTBEAT_INTERVAL_MS_DEFAULT = 60_000
+const HEARTBEAT_STALE_MS_DEFAULT = 90_000
+const HEARTBEAT_RELOAD_COOLDOWN_MS = 300_000
+
+interface JobManagerOptions {
+  heartbeatIntervalMs?: number
+  heartbeatStaleMs?: number
+}
+
 /**
  * Job manager - orchestrates all scheduled tasks
  */
 export class JobManager {
   private scheduler: Scheduler
   private reloadInProgress: Promise<void> | null = null
+  private sideLocks: Record<'left' | 'right', Promise<void>> = {
+    left: Promise.resolve(),
+    right: Promise.resolve(),
+  }
 
-  constructor(timezone: string) {
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private readonly heartbeatIntervalMs: number
+  private readonly heartbeatStaleMs: number
+  private lastHeartbeatReloadAt = 0
+
+  constructor(timezone: string, options: JobManagerOptions = {}) {
     this.scheduler = new Scheduler({
       timezone,
       enabled: true,
     })
 
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS_DEFAULT
+    this.heartbeatStaleMs = options.heartbeatStaleMs ?? HEARTBEAT_STALE_MS_DEFAULT
+
     this.setupEventListeners()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-side serialization
+  //
+  // Power-off, power-on, temperature, alarm, and run-once temp handlers all
+  // mutate the same hardware side. node-schedule fires same-minute jobs in
+  // parallel inside the event loop, which previously let a `temperature` job
+  // win the race against a same-minute `power_off` (the temp's setTemperature
+  // command landed last and re-enabled heat). Wrapping the handlers in a
+  // per-side mutex serializes them; combined with power_off updating
+  // device_state.isPowered before sending hardware, any temp/alarm that
+  // acquires the lock after power_off observes isPowered=false and skips.
+  // ---------------------------------------------------------------------------
+  private async withSideLock<T>(side: 'left' | 'right', fn: () => Promise<T>): Promise<T> {
+    const prev = this.sideLocks[side]
+    let release!: () => void
+    this.sideLocks[side] = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    try {
+      await prev
+      return await fn()
+    }
+    finally {
+      release()
+    }
+  }
+
+  /**
+   * Read the current powered state for a side from device_state.
+   * Returns false if no row exists (treat as off).
+   */
+  private async isSidePowered(side: 'left' | 'right'): Promise<boolean> {
+    const [row] = await db
+      .select({ isPowered: deviceState.isPowered })
+      .from(deviceState)
+      .where(eq(deviceState.side, side))
+      .limit(1)
+    return row?.isPowered ?? false
+  }
+
+  /**
+   * Synchronously mark a side as powered off in device_state. Called by
+   * power_off handlers BEFORE sending the hardware command so concurrent
+   * temp/alarm jobs that acquire the side lock after see isPowered=false
+   * and skip. The DAC monitor's status poll will reconcile shortly after.
+   */
+  private async markSideOff(side: 'left' | 'right'): Promise<void> {
+    try {
+      await db
+        .update(deviceState)
+        .set({
+          isPowered: false,
+          poweredOnAt: null,
+          targetTemperature: null,
+          lastUpdated: new Date(),
+        })
+        .where(eq(deviceState.side, side))
+    }
+    catch (e) {
+      console.warn(`[jobManager] markSideOff failed for ${side}:`, e instanceof Error ? e.message : e)
+    }
   }
 
   /**
@@ -150,6 +235,75 @@ export class JobManager {
     await this.loadRunOnceSessions()
 
     console.log(`Loaded ${this.scheduler.getJobs().length} scheduled jobs`)
+
+    this.startHeartbeat()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Liveness heartbeat
+  //
+  // node-schedule's internal cron loop has been observed to silently stop
+  // firing jobs while the host process keeps running (status 200 on tRPC,
+  // no exception, just no fires). On 2026-05-02 this caused the 17:00 UTC
+  // power-off jobs to be missed entirely, leaving the bed heating until the
+  // user noticed. The heartbeat scans for jobs whose nextInvocation() has
+  // slipped into the past and, if any are stale, forces a reloadSchedules()
+  // to re-register fresh node-schedule timers. Cooldown prevents spinning
+  // on a persistent failure.
+  // ---------------------------------------------------------------------------
+  startHeartbeat(): void {
+    if (this.heartbeatTimer) return
+    this.heartbeatTimer = setInterval(() => {
+      void this.checkLiveness()
+    }, this.heartbeatIntervalMs)
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  /**
+   * Detect overdue jobs and force a schedule reload if any are found.
+   * Public so health endpoints / tests can trigger an on-demand check.
+   * Returns the list of stale job IDs found this tick (empty if healthy).
+   */
+  async checkLiveness(): Promise<string[]> {
+    const now = Date.now()
+    const stale: string[] = []
+    for (const job of this.scheduler.getJobs()) {
+      if (job.type === JobType.RUN_ONCE) continue
+      const next = this.scheduler.getNextInvocation(job.id)
+      if (!next) continue
+      const nextMs = next.getTime()
+      if (nextMs < now - this.heartbeatStaleMs) {
+        stale.push(job.id)
+      }
+    }
+    if (stale.length === 0) return stale
+
+    const cooldownLeft = HEARTBEAT_RELOAD_COOLDOWN_MS - (now - this.lastHeartbeatReloadAt)
+    if (cooldownLeft > 0) {
+      console.warn(
+        `[scheduler] ${stale.length} jobs overdue past nextRun by >${this.heartbeatStaleMs}ms `
+        + `(examples: ${stale.slice(0, 3).join(', ')}). Reload cooldown active for ${Math.round(cooldownLeft / 1000)}s.`
+      )
+      return stale
+    }
+    console.warn(
+      `[scheduler] ${stale.length} jobs overdue past nextRun by >${this.heartbeatStaleMs}ms `
+      + `(examples: ${stale.slice(0, 3).join(', ')}). Forcing reloadSchedules().`
+    )
+    this.lastHeartbeatReloadAt = now
+    try {
+      await this.reloadSchedules()
+    }
+    catch (e) {
+      console.error('[scheduler] heartbeat-triggered reload failed:', e instanceof Error ? e.message : e)
+    }
+    return stale
   }
 
   /**
@@ -165,26 +319,34 @@ export class JobManager {
       `temp-${sched.id}`,
       JobType.TEMPERATURE,
       cron,
-      async () => {
-        if (await this.hasActiveRunOnceSession(sched.side)) {
-          console.log(`Skipping recurring temp job temp-${sched.id} — run-once session active for ${sched.side}`)
-          return
-        }
-        const client = getSharedHardwareClient()
-        await client.connect()
-        try {
-          await client.setTemperature(sched.side, sched.temperature)
-          broadcastMutationStatus(sched.side, {
-            targetTemperature: sched.temperature,
-            targetLevel: fahrenheitToLevel(sched.temperature),
-          })
-        }
-        finally {
-          // shared client — don't disconnect
-        }
-      },
+      () => this.runTemperatureJob(sched),
       { scheduleId: sched.id, side: sched.side }
     )
+  }
+
+  /**
+   * Execute a temperature job's body. Exposed so tests can drive the handler
+   * directly without going through cron timing. Same gating + side-lock as
+   * the registered scheduler handler.
+   */
+  async runTemperatureJob(sched: typeof temperatureSchedules.$inferSelect): Promise<void> {
+    if (await this.hasActiveRunOnceSession(sched.side)) {
+      console.log(`Skipping recurring temp job temp-${sched.id} — run-once session active for ${sched.side}`)
+      return
+    }
+    await this.withSideLock(sched.side, async () => {
+      if (!(await this.isSidePowered(sched.side))) {
+        console.log(`Skipping temp job temp-${sched.id} — ${sched.side} is not powered`)
+        return
+      }
+      const client = getSharedHardwareClient()
+      await client.connect()
+      await client.setTemperature(sched.side, sched.temperature)
+      broadcastMutationStatus(sched.side, {
+        targetTemperature: sched.temperature,
+        targetLevel: fahrenheitToLevel(sched.temperature),
+      })
+    })
   }
 
   /**
@@ -198,28 +360,27 @@ export class JobManager {
       `power-on-${sched.id}`,
       JobType.POWER_ON,
       cron,
-      async () => {
-        if (await this.hasActiveRunOnceSession(sched.side)) {
-          console.log(`Skipping recurring power-on job — run-once session active for ${sched.side}`)
-          return
-        }
-        const client = getSharedHardwareClient()
-        await client.connect()
-        try {
-          await client.setPower(sched.side, true, sched.onTemperature)
-          cancelAutoOffTimer(sched.side)
-          const onTemp = sched.onTemperature ?? 75
-          broadcastMutationStatus(sched.side, {
-            targetTemperature: onTemp,
-            targetLevel: fahrenheitToLevel(onTemp),
-          })
-        }
-        finally {
-          // shared client — don't disconnect
-        }
-      },
+      () => this.runPowerOnJob(sched),
       { scheduleId: sched.id, side: sched.side }
     )
+  }
+
+  async runPowerOnJob(sched: typeof powerSchedules.$inferSelect): Promise<void> {
+    if (await this.hasActiveRunOnceSession(sched.side)) {
+      console.log(`Skipping recurring power-on job — run-once session active for ${sched.side}`)
+      return
+    }
+    await this.withSideLock(sched.side, async () => {
+      const client = getSharedHardwareClient()
+      await client.connect()
+      await client.setPower(sched.side, true, sched.onTemperature)
+      cancelAutoOffTimer(sched.side)
+      const onTemp = sched.onTemperature ?? 75
+      broadcastMutationStatus(sched.side, {
+        targetTemperature: onTemp,
+        targetLevel: fahrenheitToLevel(onTemp),
+      })
+    })
   }
 
   /**
@@ -233,23 +394,26 @@ export class JobManager {
       `power-off-${sched.id}`,
       JobType.POWER_OFF,
       cron,
-      async () => {
-        if (await this.hasActiveRunOnceSession(sched.side)) {
-          console.log(`Skipping recurring power-off job — run-once session active for ${sched.side}`)
-          return
-        }
-        const client = getSharedHardwareClient()
-        await client.connect()
-        try {
-          await client.setPower(sched.side, false)
-          broadcastMutationStatus(sched.side, { targetLevel: 0 })
-        }
-        finally {
-          // shared client — don't disconnect
-        }
-      },
+      () => this.runPowerOffJob(sched),
       { scheduleId: sched.id, side: sched.side }
     )
+  }
+
+  async runPowerOffJob(sched: typeof powerSchedules.$inferSelect): Promise<void> {
+    if (await this.hasActiveRunOnceSession(sched.side)) {
+      console.log(`Skipping recurring power-off job — run-once session active for ${sched.side}`)
+      return
+    }
+    await this.withSideLock(sched.side, async () => {
+      // Mark off in DB BEFORE hardware so any temp/alarm job that acquires
+      // the side lock after this one observes isPowered=false and skips its
+      // setTemperature command.
+      await this.markSideOff(sched.side)
+      const client = getSharedHardwareClient()
+      await client.connect()
+      await client.setPower(sched.side, false)
+      broadcastMutationStatus(sched.side, { targetLevel: 0 })
+    })
   }
 
   /**
@@ -263,31 +427,31 @@ export class JobManager {
       `alarm-${sched.id}`,
       JobType.ALARM,
       cron,
-      async () => {
-        const client = getSharedHardwareClient()
-        await client.connect()
-        try {
-          // Set alarm temperature first
-          await client.setTemperature(sched.side, sched.alarmTemperature)
-
-          // Trigger alarm
-          await client.setAlarm(sched.side, {
-            vibrationIntensity: sched.vibrationIntensity,
-            vibrationPattern: sched.vibrationPattern,
-            duration: sched.duration,
-          })
-          broadcastMutationStatus(sched.side, {
-            targetTemperature: sched.alarmTemperature,
-            targetLevel: fahrenheitToLevel(sched.alarmTemperature),
-            isAlarmVibrating: true,
-          })
-        }
-        finally {
-          // shared client — don't disconnect
-        }
-      },
+      () => this.runAlarmJob(sched),
       { scheduleId: sched.id, side: sched.side }
     )
+  }
+
+  async runAlarmJob(sched: typeof alarmSchedules.$inferSelect): Promise<void> {
+    await this.withSideLock(sched.side, async () => {
+      if (!(await this.isSidePowered(sched.side))) {
+        console.log(`Skipping alarm job alarm-${sched.id} — ${sched.side} is not powered`)
+        return
+      }
+      const client = getSharedHardwareClient()
+      await client.connect()
+      await client.setTemperature(sched.side, sched.alarmTemperature)
+      await client.setAlarm(sched.side, {
+        vibrationIntensity: sched.vibrationIntensity,
+        vibrationPattern: sched.vibrationPattern,
+        duration: sched.duration,
+      })
+      broadcastMutationStatus(sched.side, {
+        targetTemperature: sched.alarmTemperature,
+        targetLevel: fahrenheitToLevel(sched.alarmTemperature),
+        isAlarmVibrating: true,
+      })
+    })
   }
 
   /**
@@ -641,18 +805,15 @@ export class JobManager {
         JobType.RUN_ONCE,
         fireDate,
         async () => {
-          const client = getSharedHardwareClient()
-          await client.connect()
-          try {
+          await this.withSideLock(side, async () => {
+            const client = getSharedHardwareClient()
+            await client.connect()
             await client.setTemperature(side, sp.temperature)
             broadcastMutationStatus(side, {
               targetTemperature: sp.temperature,
               targetLevel: fahrenheitToLevel(sp.temperature),
             })
-          }
-          finally {
-            // shared client — don't disconnect
-          }
+          })
         },
         { sessionId, side, index: i },
       )
@@ -683,16 +844,18 @@ export class JobManager {
           .set({ status: 'completed' })
           .where(eq(runOnceSessions.id, sessionId))
 
-        // Power off the side at wake time
-        try {
-          const client = getSharedHardwareClient()
-          await client.connect()
-          await client.setPower(side, false)
-          broadcastMutationStatus(side, { targetLevel: 0 })
-        }
-        catch (e) {
-          console.warn(`[runOnce] Failed to power off ${side} at wake:`, e)
-        }
+        await this.withSideLock(side, async () => {
+          await this.markSideOff(side)
+          try {
+            const client = getSharedHardwareClient()
+            await client.connect()
+            await client.setPower(side, false)
+            broadcastMutationStatus(side, { targetLevel: 0 })
+          }
+          catch (e) {
+            console.warn(`[runOnce] Failed to power off ${side} at wake:`, e)
+          }
+        })
 
         console.log(`Run-once session ${sessionId} completed — ${side} powered off`)
       },
@@ -785,6 +948,7 @@ export class JobManager {
    * Gracefully shutdown
    */
   async shutdown(): Promise<void> {
+    this.stopHeartbeat()
     this.removeEventListeners()
     await this.scheduler.shutdown()
   }

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -1,0 +1,410 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type BetterSqlite3 from 'better-sqlite3'
+
+// ── Hardware mocks ────────────────────────────────────────────────────────
+type AnyAsync = (...args: any[]) => Promise<void>
+const setTemperature = vi.fn<AnyAsync>()
+const setPower = vi.fn<AnyAsync>()
+const setAlarm = vi.fn<AnyAsync>()
+const connect = vi.fn<() => Promise<void>>()
+setTemperature.mockResolvedValue(undefined)
+setPower.mockResolvedValue(undefined)
+setAlarm.mockResolvedValue(undefined)
+connect.mockResolvedValue(undefined)
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: () => ({ connect, setTemperature, setPower, setAlarm }),
+}))
+
+vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+vi.mock('@/src/services/autoOffWatcher', () => ({
+  cancelAutoOffTimer: vi.fn(),
+}))
+
+// In-memory primary DB seeded with the schema the JobManager reads
+vi.mock('@/src/db', async () => {
+  const BetterSqlite3 = (await import('better-sqlite3')).default
+  const { drizzle } = await import('drizzle-orm/better-sqlite3')
+  const schema = await import('@/src/db/schema')
+  const primary = new BetterSqlite3(':memory:')
+  primary.pragma('foreign_keys = ON')
+  return {
+    db: drizzle(primary, { schema }),
+    biometricsDb: null,
+    sqlite: primary,
+    biometricsSqlite: null,
+    closeDatabase: vi.fn(),
+    closeBiometricsDatabase: vi.fn(),
+  }
+})
+
+import * as dbModule from '@/src/db'
+import { JobManager } from '../jobManager'
+const { sqlite } = dbModule as typeof dbModule & { sqlite: BetterSqlite3.Database }
+
+function resetSchema(): void {
+  ;(sqlite as any).exec(`
+    DROP TABLE IF EXISTS device_state;
+    DROP TABLE IF EXISTS run_once_sessions;
+
+    CREATE TABLE device_state (
+      side TEXT PRIMARY KEY,
+      current_temperature REAL,
+      target_temperature REAL,
+      is_powered INTEGER NOT NULL DEFAULT 0,
+      is_alarm_vibrating INTEGER NOT NULL DEFAULT 0,
+      water_level TEXT DEFAULT 'unknown',
+      powered_on_at INTEGER,
+      last_updated INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE run_once_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      set_points TEXT NOT NULL,
+      wake_time TEXT NOT NULL,
+      started_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      expires_at INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+  `)
+}
+
+function seedSidePowered(side: 'left' | 'right', isPowered: boolean): void {
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO device_state (side, is_powered, target_temperature)
+       VALUES (?, ?, ?)
+       ON CONFLICT(side) DO UPDATE SET is_powered = excluded.is_powered, target_temperature = excluded.target_temperature`
+    )
+    .run(side, isPowered ? 1 : 0, isPowered ? 80 : null)
+}
+
+function readSide(side: 'left' | 'right') {
+  return (sqlite as any)
+    .prepare(`SELECT side, is_powered, target_temperature FROM device_state WHERE side = ?`)
+    .get(side) as { side: string, is_powered: number, target_temperature: number | null } | undefined
+}
+
+const tempSched = (side: 'left' | 'right', temperature: number) => ({
+  id: 1,
+  side,
+  dayOfWeek: 'saturday' as const,
+  time: '10:00',
+  temperature,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+const alarmSched = (side: 'left' | 'right') => ({
+  id: 1,
+  side,
+  dayOfWeek: 'saturday' as const,
+  time: '09:00',
+  alarmTemperature: 88,
+  vibrationIntensity: 100,
+  vibrationPattern: 'rise' as const,
+  duration: 10,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+const powerSched = (side: 'left' | 'right') => ({
+  id: 1,
+  side,
+  dayOfWeek: 'saturday' as const,
+  onTime: '22:00',
+  offTime: '10:00',
+  onTemperature: 89,
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+describe('JobManager — job ordering and gating', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    setAlarm.mockClear()
+    connect.mockClear()
+    manager = new JobManager('America/Los_Angeles', {
+      heartbeatIntervalMs: 60_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  describe('temperature gating by isPowered', () => {
+    it('fires setTemperature when side is powered', async () => {
+      seedSidePowered('left', true)
+
+      await manager.runTemperatureJob(tempSched('left', 75))
+
+      expect(setTemperature).toHaveBeenCalledOnce()
+      expect(setTemperature).toHaveBeenCalledWith('left', 75)
+    })
+
+    it('skips setTemperature when side is not powered', async () => {
+      seedSidePowered('left', false)
+
+      await manager.runTemperatureJob(tempSched('left', 75))
+
+      expect(setTemperature).not.toHaveBeenCalled()
+    })
+
+    it('skips setTemperature when side has no device_state row', async () => {
+      // No row inserted at all
+      await manager.runTemperatureJob(tempSched('right', 80))
+
+      expect(setTemperature).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('alarm gating by isPowered', () => {
+    it('fires alarm + temperature when side is powered', async () => {
+      seedSidePowered('right', true)
+
+      await manager.runAlarmJob(alarmSched('right'))
+
+      expect(setTemperature).toHaveBeenCalledWith('right', 88)
+      expect(setAlarm).toHaveBeenCalledOnce()
+    })
+
+    it('skips alarm + temperature when side is not powered', async () => {
+      seedSidePowered('right', false)
+
+      await manager.runAlarmJob(alarmSched('right'))
+
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(setAlarm).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('powerOff state synchronization', () => {
+    it('marks device_state.isPowered=false BEFORE sending setPower(false)', async () => {
+      seedSidePowered('left', true)
+
+      // Capture is_powered at the moment setPower is invoked.
+      let isPoweredAtSetPower: number | undefined
+      setPower.mockImplementationOnce(async () => {
+        const row = readSide('left')
+        isPoweredAtSetPower = row?.is_powered
+      })
+
+      await manager.runPowerOffJob(powerSched('left'))
+
+      expect(setPower).toHaveBeenCalledWith('left', false)
+      expect(isPoweredAtSetPower).toBe(0)
+    })
+
+    it('clears target_temperature on power off', async () => {
+      seedSidePowered('left', true)
+
+      await manager.runPowerOffJob(powerSched('left'))
+
+      const row = readSide('left')
+      expect(row?.is_powered).toBe(0)
+      expect(row?.target_temperature).toBeNull()
+    })
+  })
+
+  describe('per-side mutex serializes concurrent jobs (same-minute race)', () => {
+    it('temperature job dispatched concurrently with power_off does not re-enable heat', async () => {
+      // The bug: at HH:MM both fire. Without the lock, setTemperature(80)
+      // landed last and re-enabled the side. With the lock + isPowered gate,
+      // power_off updates DB→false then sends setPower(false); temp picks up
+      // the lock after, sees isPowered=false, skips setTemperature.
+      seedSidePowered('left', true)
+
+      // Make hardware setPower take a beat so the temp handler queues
+      // behind it on the lock instead of completing first.
+      setPower.mockImplementationOnce(async () => {
+        await new Promise(r => setTimeout(r, 25))
+      })
+
+      const power = manager.runPowerOffJob(powerSched('left'))
+      const temp = manager.runTemperatureJob(tempSched('left', 80))
+      await Promise.all([power, temp])
+
+      expect(setPower).toHaveBeenCalledTimes(1)
+      expect(setPower).toHaveBeenCalledWith('left', false)
+      expect(setTemperature).not.toHaveBeenCalled()
+
+      const row = readSide('left')
+      expect(row?.is_powered).toBe(0)
+    })
+
+    it('temp job that wins the lock first still ends with side off after power_off runs second', async () => {
+      seedSidePowered('left', true)
+
+      // Even when the temp handler beats power_off into the lock, power_off
+      // claims the next slot, marks DB off, sends setPower(false). Final
+      // hardware state is off and DB reflects that.
+      const temp = manager.runTemperatureJob(tempSched('left', 80))
+      const power = manager.runPowerOffJob(powerSched('left'))
+      await Promise.all([temp, power])
+
+      expect(setTemperature).toHaveBeenCalledWith('left', 80)
+      expect(setPower).toHaveBeenLastCalledWith('left', false)
+
+      const row = readSide('left')
+      expect(row?.is_powered).toBe(0)
+      expect(row?.target_temperature).toBeNull()
+    })
+
+    it('serializes — second handler does not start until first releases', async () => {
+      seedSidePowered('left', true)
+
+      const order: string[] = []
+      setPower.mockImplementation(async () => {
+        order.push('power-off-start')
+        await new Promise(r => setTimeout(r, 30))
+        order.push('power-off-end')
+      })
+      setTemperature.mockImplementation(async () => {
+        order.push('temp-start')
+        await new Promise(r => setTimeout(r, 5))
+        order.push('temp-end')
+      })
+
+      const a = manager.runPowerOffJob(powerSched('left'))
+      const b = manager.runTemperatureJob(tempSched('left', 80))
+      await Promise.all([a, b])
+
+      // power-off ran first end-to-end before temp started (or skipped).
+      // The temp will skip because power_off cleared isPowered, but the
+      // serialization holds: no overlap between starts/ends.
+      const powerStart = order.indexOf('power-off-start')
+      const powerEnd = order.indexOf('power-off-end')
+      const tempStart = order.indexOf('temp-start')
+      expect(powerStart).toBeGreaterThanOrEqual(0)
+      expect(powerEnd).toBeGreaterThan(powerStart)
+      // temp-start must NOT appear between power-off-start and power-off-end.
+      if (tempStart !== -1) {
+        expect(tempStart).toBeGreaterThan(powerEnd)
+      }
+    })
+
+    it('different sides run in parallel — left lock does not block right', async () => {
+      seedSidePowered('left', true)
+      seedSidePowered('right', true)
+
+      const order: string[] = []
+      setTemperature.mockImplementation(async (side: string) => {
+        order.push(`${side}-start`)
+        await new Promise(r => setTimeout(r, 25))
+        order.push(`${side}-end`)
+      })
+
+      const start = Date.now()
+      await Promise.all([
+        manager.runTemperatureJob(tempSched('left', 80)),
+        manager.runTemperatureJob(tempSched('right', 80)),
+      ])
+      const elapsed = Date.now() - start
+
+      // Both ran in parallel — total time should be ~25ms not ~50ms.
+      expect(elapsed).toBeLessThan(45)
+      // Interleaved starts confirm parallelism.
+      expect(order[0]).toMatch(/-start$/)
+      expect(order[1]).toMatch(/-start$/)
+    })
+  })
+})
+
+describe('JobManager — liveness heartbeat', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    manager = new JobManager('America/Los_Angeles', {
+      heartbeatIntervalMs: 1_000_000, // never auto-fires; we drive it manually
+      heartbeatStaleMs: 50,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('reports no stale jobs when next invocations are in the future', async () => {
+    const scheduler = manager.getScheduler()
+    scheduler.scheduleJob('test-future', 'temperature' as any, '0 0 * * *', async () => {})
+
+    const stale = await manager.checkLiveness()
+    expect(stale).toEqual([])
+  })
+
+  it('detects a job whose nextInvocation is older than the stale threshold', async () => {
+    const scheduler = manager.getScheduler()
+    scheduler.scheduleJob('test-past', 'temperature' as any, '0 0 * * *', async () => {})
+
+    // Spy: force the job to report a nextInvocation in the past.
+    const job = scheduler.getJob('test-past')
+    if (!job) throw new Error('expected test-past to be registered')
+    const fakePast = new Date(Date.now() - 5_000)
+    vi.spyOn(scheduler, 'getNextInvocation').mockImplementation(id =>
+      id === 'test-past' ? (fakePast as any) : null
+    )
+
+    // Track whether reload fires.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+
+    const stale = await manager.checkLiveness()
+
+    expect(stale).toContain('test-past')
+    expect(reloadSpy).toHaveBeenCalledOnce()
+
+    // Cleanup so afterEach shutdown doesn't trip on the cancelled job.
+    job.job.cancel()
+  })
+
+  it('respects reload cooldown — second stale tick within window does not reload again', async () => {
+    const scheduler = manager.getScheduler()
+    scheduler.scheduleJob('test-past', 'temperature' as any, '0 0 * * *', async () => {})
+
+    const fakePast = new Date(Date.now() - 5_000)
+    vi.spyOn(scheduler, 'getNextInvocation').mockImplementation(id =>
+      id === 'test-past' ? (fakePast as any) : null
+    )
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+
+    await manager.checkLiveness()
+    await manager.checkLiveness()
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores RUN_ONCE jobs (they auto-remove after firing)', async () => {
+    const scheduler = manager.getScheduler()
+    const future = new Date(Date.now() + 60_000)
+    scheduler.scheduleOneTimeJob('runonce-1', 'run_once' as any, future, async () => {})
+
+    // Pretend the run_once is overdue — heartbeat must still ignore it.
+    vi.spyOn(scheduler, 'getNextInvocation').mockImplementation(() => new Date(Date.now() - 5_000) as any)
+
+    const stale = await manager.checkLiveness()
+    expect(stale).toEqual([])
+  })
+
+  it('startHeartbeat is idempotent', () => {
+    manager.startHeartbeat()
+    manager.startHeartbeat()
+    manager.stopHeartbeat()
+    // No throw, no leaked timer — afterEach shutdown will catch any leak.
+  })
+})


### PR DESCRIPTION
## Why

On 2026-05-02 the pod kept both sides heating well past their scheduled 10:00 PDT OFF. Investigation surfaced two distinct bugs in the in-process scheduler.

## Bug 1 — same-minute job race

At 16:00 UTC (right's 09:00 PDT off) three jobs fired simultaneously: \`power-off-18\`, \`temp-1069\`, \`alarm-24\`. node-schedule has no ordering guarantee between same-minute fires; the temperature/alarm \`setTemperature\` command landed *after* \`setLevel(0)\`, leaving the side heating at 80°F. firmware persists last setpoint, so the bed stayed on for the rest of the day.

## Bug 2 — silent scheduler stall

After 16:30 UTC, node-schedule's internal timers stopped firing for ~3.5 hours. The process kept serving tRPC, but the journal shows no \`Job executed\` lines between \`temp-1053 (16:30:00 UTC)\` and \`prime-prereboot (20:05:00 UTC)\`. The 17:00 UTC OFFs were missed entirely. A subsequent \`reloadSchedules()\` (triggered by an inbound mutation at 18:31 UTC) re-registered the cron jobs but does not replay missed past triggers.

## What

1. **Per-side mutex** on hardware-command handlers (\`runTemperatureJob\`, \`runPowerOnJob\`, \`runPowerOffJob\`, \`runAlarmJob\`, run-once temp/cleanup). Same-side jobs serialize; different-side jobs still run in parallel.
2. **\`device_state.isPowered\` gate.** Temp and alarm handlers read \`is_powered\` inside the lock and skip the setTemperature command when the side is off (handles user-initiated off + post-power_off state).
3. **Synchronous DB-first power_off.** \`runPowerOffJob\` writes \`is_powered=false\`/\`target_temperature=null\` to \`device_state\` *before* sending \`setPower(false)\`, so any temp/alarm that acquires the lock after sees the new state and skips. Closes the same-minute race even if temp lands first into the lock — power_off then claims it second and ends with hardware off.
4. **Liveness heartbeat** (\`startHeartbeat\` / \`checkLiveness\`). Every 60s, scan registered jobs for any whose \`nextInvocation()\` has slipped >90s into the past. If found, log a warning and force \`reloadSchedules()\` (5-minute cooldown to avoid loops on persistent failure). RUN_ONCE jobs are excluded.

Handler bodies were extracted from inline closures into named methods (\`runTemperatureJob\`, etc.) to keep the cron registration readable and let tests drive them directly.

## Test plan

- [x] \`pnpm vitest run src/scheduler\` — 16 new tests in \`src/scheduler/tests/jobOrdering.test.ts\` cover: gating both directions, DB-write-before-hardware ordering, target_temperature clearing, race scenarios (temp before / after power_off), serialization timing, parallel different-side jobs, heartbeat detection, cooldown, RUN_ONCE exclusion, idempotent start.
- [x] Full suite green: 659 passed / 2 skipped across 45 files.
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint src/\` clean.
- [ ] Pod-side smoke after deploy: at the next configured \`offTime\`, verify only \`setPower(false)\` reaches frank (no follow-on \`set_side enabled\`). \`journalctl -u sleepypod -f | grep -E "Job executed|setPower|setTemperature"\`.
- [ ] Pod-side liveness check: \`curl /api/trpc/health.scheduler\` should still report \`healthy:true\` after deploy; \`[scheduler] N jobs overdue\` should not appear in steady-state journal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable heartbeat timing and liveness detection for stale jobs

* **Bug Fixes**
  * Improved power state synchronization between database and hardware
  * Fixed temperature and alarm jobs executing on unpowered sides
  * Enhanced per-side job serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->