### PR TITLE
fix(hardware): preserve fresh mutations against stale DAC polls

### DIFF
--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm'
 import { db, biometricsDb } from '@/src/db'
 import { deviceState } from '@/src/db/schema'
 import { waterLevelReadings, flowReadings } from '@/src/db/biometrics-schema'
-import type { DeviceStatus } from './types'
+import type { DeviceStatus, Side } from './types'
 
 /**
  * Consumes status:updated events and writes current device state to the DB.
@@ -12,6 +12,36 @@ import type { DeviceStatus } from './types'
  * uses capacitance sensor data for accurate presence detection rather than
  * power-cycle heuristics.
  */
+
+// ── Mutation freshness ────────────────────────────────────────────────────
+// Manual mutations (setPower, setTemperature, setAlarm, scheduler power_off,
+// autoOffWatcher) write powered-state to device_state synchronously. The
+// firmware then needs ~1–3s to reflect the command in its status report,
+// during which a poll can carry stale data (e.g. setPower(true) writes
+// is_powered=1 but the next 1s-poll still reports targetLevel=0/
+// heatingDuration=0/currentLevel=0 — durationExpired is true → isNowPowered
+// is false → the fresh write gets clobbered). Mutations stamp this map so
+// upsertSide can skip the powered-state portion of the write inside the
+// freshness window. Observation fields (current temperature, water level)
+// still update normally.
+const MUTATION_FRESHNESS_MS = 5_000
+const recentMutations: Record<Side, number> = { left: 0, right: 0 }
+
+/** Mark a side as just-mutated; suppresses powered-state overwrite from
+ *  the next firmware poll(s) within the freshness window. */
+export function markSideMutated(side: Side): void {
+  recentMutations[side] = Date.now()
+}
+
+function isSideRecentlyMutated(side: Side): boolean {
+  return Date.now() - recentMutations[side] < MUTATION_FRESHNESS_MS
+}
+
+/** @internal — for tests only */
+export function _resetMutationStamps(): void {
+  recentMutations.left = 0
+  recentMutations.right = 0
+}
 /** Read alarm vibration state from DB (set by setAlarm/clearAlarm mutations). */
 export function getAlarmState(): { left: boolean, right: boolean } {
   try {
@@ -76,9 +106,15 @@ export class DeviceStateSync {
     const durationExpired = sideStatus.targetLevel === 0 && sideStatus.heatingDuration === 0
     const isNowPowered = durationExpired ? false : sideStatus.currentLevel !== 0
 
+    const skipPoweredFields = isSideRecentlyMutated(side)
+
     db.transaction((tx) => {
       const [prev] = tx
-        .select({ isPowered: deviceState.isPowered, poweredOnAt: deviceState.poweredOnAt })
+        .select({
+          isPowered: deviceState.isPowered,
+          poweredOnAt: deviceState.poweredOnAt,
+          targetTemperature: deviceState.targetTemperature,
+        })
         .from(deviceState)
         .where(eq(deviceState.side, side))
         .limit(1)
@@ -98,25 +134,32 @@ export class DeviceStateSync {
       // doesn't show a stale "warming to X°F" when the pod is actually neutral.
       const targetTemp = durationExpired ? null : sideStatus.targetTemperature
 
+      // If a mutation just landed, the firmware status is likely stale —
+      // preserve the mutation's powered-state fields and only refresh
+      // observation fields (currentTemperature, waterLevel).
+      const writeIsPowered = skipPoweredFields ? wasPowered : isNowPowered
+      const writePoweredOnAt = skipPoweredFields ? prev?.poweredOnAt ?? null : poweredOnAt
+      const writeTargetTemp = skipPoweredFields ? prev?.targetTemperature ?? null : targetTemp
+
       tx
         .insert(deviceState)
         .values({
           side,
           currentTemperature: sideStatus.currentTemperature,
-          targetTemperature: targetTemp,
-          isPowered: isNowPowered,
+          targetTemperature: writeTargetTemp,
+          isPowered: writeIsPowered,
           waterLevel: status.waterLevel,
-          poweredOnAt,
+          poweredOnAt: writePoweredOnAt,
           lastUpdated: now,
         })
         .onConflictDoUpdate({
           target: deviceState.side,
           set: {
             currentTemperature: sideStatus.currentTemperature,
-            targetTemperature: targetTemp,
-            isPowered: isNowPowered,
+            targetTemperature: writeTargetTemp,
+            isPowered: writeIsPowered,
             waterLevel: status.waterLevel,
-            poweredOnAt,
+            poweredOnAt: writePoweredOnAt,
             lastUpdated: now,
           },
         })

--- a/src/hardware/tests/deviceStateSync.test.ts
+++ b/src/hardware/tests/deviceStateSync.test.ts
@@ -240,4 +240,25 @@ describe('DeviceStateSync — mutation freshness window', () => {
     const row = readSide('right')
     expect(row?.is_powered).toBe(1)
   })
+
+  it('preserves null targetTemperature on a fresh power-off (no stale setpoint)', async () => {
+    // Caller (auto-off / setPower(false)) wrote isPowered=0, target=null.
+    // A stale firmware poll inside the freshness window must not resurrect
+    // the previous targetTemperature.
+    seedSide('right', false, null)
+    markSideMutated('right')
+
+    await sync.sync(status({
+      side: 'right',
+      currentTemperature: 80,
+      targetTemperature: 83, // firmware still reports yesterday's setpoint briefly
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(0)
+    expect(row?.target_temperature).toBeNull()
+  })
 })

--- a/src/hardware/tests/deviceStateSync.test.ts
+++ b/src/hardware/tests/deviceStateSync.test.ts
@@ -1,0 +1,243 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type BetterSqlite3 from 'better-sqlite3'
+import type { DeviceStatus } from '../types'
+
+vi.mock('@/src/db', async () => {
+  const BetterSqlite3 = (await import('better-sqlite3')).default
+  const { drizzle } = await import('drizzle-orm/better-sqlite3')
+  const schema = await import('@/src/db/schema')
+  const biometricsSchema = await import('@/src/db/biometrics-schema')
+  const primary = new BetterSqlite3(':memory:')
+  primary.pragma('foreign_keys = ON')
+  const bio = new BetterSqlite3(':memory:')
+  bio.pragma('foreign_keys = ON')
+  return {
+    db: drizzle(primary, { schema }),
+    biometricsDb: drizzle(bio, { schema: biometricsSchema }),
+    sqlite: primary,
+    biometricsSqlite: bio,
+    closeDatabase: vi.fn(),
+    closeBiometricsDatabase: vi.fn(),
+  }
+})
+
+import * as dbModule from '@/src/db'
+import { DeviceStateSync, markSideMutated, _resetMutationStamps } from '../deviceStateSync'
+
+const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
+  sqlite: BetterSqlite3.Database
+  biometricsSqlite: BetterSqlite3.Database
+}
+
+function resetSchema(): void {
+  ;(sqlite as any).exec(`
+    DROP TABLE IF EXISTS device_state;
+    CREATE TABLE device_state (
+      side TEXT PRIMARY KEY,
+      current_temperature REAL,
+      target_temperature REAL,
+      is_powered INTEGER NOT NULL DEFAULT 0,
+      is_alarm_vibrating INTEGER NOT NULL DEFAULT 0,
+      water_level TEXT DEFAULT 'unknown',
+      powered_on_at INTEGER,
+      last_updated INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+  `)
+  ;(biometricsSqlite as any).exec(`
+    DROP TABLE IF EXISTS water_level_readings;
+    DROP TABLE IF EXISTS flow_readings;
+    CREATE TABLE water_level_readings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp INTEGER NOT NULL,
+      level TEXT NOT NULL
+    );
+    CREATE TABLE flow_readings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp INTEGER NOT NULL,
+      left_flowrate_cd INTEGER,
+      right_flowrate_cd INTEGER,
+      left_pump_rpm INTEGER NOT NULL,
+      right_pump_rpm INTEGER NOT NULL
+    );
+  `)
+}
+
+function seedSide(side: 'left' | 'right', isPowered: boolean, targetTemp: number | null = null): void {
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO device_state (side, is_powered, target_temperature, powered_on_at, last_updated)
+       VALUES (?, ?, ?, ?, unixepoch())
+       ON CONFLICT(side) DO UPDATE SET
+         is_powered = excluded.is_powered,
+         target_temperature = excluded.target_temperature,
+         powered_on_at = excluded.powered_on_at,
+         last_updated = unixepoch()`
+    )
+    .run(side, isPowered ? 1 : 0, targetTemp, isPowered ? Math.floor(Date.now() / 1000) : null)
+}
+
+function readSide(side: 'left' | 'right') {
+  return (sqlite as any)
+    .prepare(`SELECT side, is_powered, target_temperature, current_temperature, powered_on_at FROM device_state WHERE side = ?`)
+    .get(side) as { side: string, is_powered: number, target_temperature: number | null, current_temperature: number | null, powered_on_at: number | null } | undefined
+}
+
+const status = (overrides: Partial<DeviceStatus['rightSide']> & { side?: 'left' | 'right' } = {}): DeviceStatus => {
+  const base: DeviceStatus['rightSide'] = {
+    currentTemperature: 75,
+    targetTemperature: 75,
+    currentLevel: 0,
+    targetLevel: 0,
+    heatingDuration: 0,
+  }
+  return {
+    leftSide: { ...base, ...(overrides.side === 'left' ? overrides : {}) },
+    rightSide: { ...base, ...(overrides.side !== 'left' ? overrides : {}) },
+    waterLevel: 'ok',
+    isPriming: false,
+    podVersion: 'H00' as DeviceStatus['podVersion'],
+    sensorLabel: 'test',
+  }
+}
+
+describe('DeviceStateSync — mutation freshness window', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('preserves isPowered=true after setPower mutation when stale poll reports neutral', async () => {
+    // Simulate setPower(right, true): mutation writes is_powered=1, target=83
+    seedSide('right', true, 83)
+    markSideMutated('right')
+
+    // Stale firmware status arrives ~1s later: targetLevel=0, heatingDuration=0,
+    // currentLevel=0 — the firmware hasn't picked up the new heat session yet.
+    await sync.sync(status({
+      side: 'right',
+      currentTemperature: 81,
+      targetTemperature: 75,
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(1)
+    expect(row?.target_temperature).toBe(83)
+    expect(row?.powered_on_at).not.toBeNull()
+    // Observation field should still update.
+    expect(row?.current_temperature).toBe(81)
+  })
+
+  it('preserves isPowered=false after power_off when stale poll reports residual heat', async () => {
+    seedSide('right', false, null)
+    markSideMutated('right')
+
+    // Stale firmware status: still showing currentLevel != 0 because the
+    // heater hadn't fully wound down yet.
+    await sync.sync(status({
+      side: 'right',
+      currentTemperature: 82,
+      targetTemperature: 0,
+      currentLevel: 5,
+      targetLevel: 5,
+      heatingDuration: 100,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(0)
+    expect(row?.target_temperature).toBeNull()
+  })
+
+  it('observation fields (currentTemperature, waterLevel) update inside the freshness window', async () => {
+    seedSide('right', true, 83)
+    markSideMutated('right')
+
+    await sync.sync(status({
+      side: 'right',
+      currentTemperature: 78,
+      targetTemperature: 0,
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    const row = readSide('right')
+    expect(row?.current_temperature).toBe(78)
+    // Powered-state fields preserved
+    expect(row?.is_powered).toBe(1)
+    expect(row?.target_temperature).toBe(83)
+  })
+
+  it('after the freshness window expires, sync resumes overwriting powered-state', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-02T20:00:00Z'))
+
+    seedSide('right', true, 83)
+    markSideMutated('right')
+
+    // First poll within window: skip
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+    expect(readSide('right')?.is_powered).toBe(1)
+
+    // Advance past freshness window (5s default)
+    vi.setSystemTime(new Date('2026-05-02T20:00:06Z'))
+
+    // Second poll, still showing neutral firmware status — should now reconcile
+    // since freshness window has expired.
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    expect(readSide('right')?.is_powered).toBe(0)
+  })
+
+  it('does not affect the opposite side', async () => {
+    seedSide('left', true, 80)
+    seedSide('right', false, null)
+    markSideMutated('right') // only right is fresh
+
+    // Firmware: left says neutral (stale-looking), right says heating.
+    // Without the gate, left would flip to false; with it, right is gated
+    // but left is not — left should reconcile to is_powered=false because
+    // its currentLevel=0 with no fresh mutation.
+    await sync.sync({
+      ...status(),
+      leftSide: { currentTemperature: 75, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+      rightSide: { currentTemperature: 75, targetTemperature: 75, currentLevel: 5, targetLevel: 5, heatingDuration: 100 },
+    })
+
+    expect(readSide('left')?.is_powered).toBe(0) // not fresh, reconciled to neutral
+    expect(readSide('right')?.is_powered).toBe(0) // fresh, preserved as off
+  })
+
+  it('without any mutation, sync writes the firmware-derived powered state directly', async () => {
+    // No mutation marker — normal sync behavior.
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 5,
+      targetLevel: 5,
+      heatingDuration: 100,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(1)
+  })
+})

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -17,6 +17,7 @@ import { encode as cborEncode } from 'cbor-x'
 import { fahrenheitToLevel, HardwareCommand } from '@/src/hardware/types'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { cancelAutoOffTimer } from '@/src/services/autoOffWatcher'
+import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { timeToDate } from './timeUtils'
 
 const HEARTBEAT_INTERVAL_MS_DEFAULT = 60_000
@@ -103,6 +104,7 @@ export class JobManager {
    * and skip. The DAC monitor's status poll will reconcile shortly after.
    */
   private async markSideOff(side: 'left' | 'right'): Promise<void> {
+    markSideMutated(side)
     try {
       await db
         .update(deviceState)
@@ -339,6 +341,7 @@ export class JobManager {
         console.log(`Skipping temp job temp-${sched.id} — ${sched.side} is not powered`)
         return
       }
+      markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
       await client.setTemperature(sched.side, sched.temperature)
@@ -371,6 +374,7 @@ export class JobManager {
       return
     }
     await this.withSideLock(sched.side, async () => {
+      markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
       await client.setPower(sched.side, true, sched.onTemperature)
@@ -438,6 +442,7 @@ export class JobManager {
         console.log(`Skipping alarm job alarm-${sched.id} — ${sched.side} is not powered`)
         return
       }
+      markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
       await client.setTemperature(sched.side, sched.alarmTemperature)
@@ -806,6 +811,7 @@ export class JobManager {
         fireDate,
         async () => {
           await this.withSideLock(side, async () => {
+            markSideMutated(side)
             const client = getSharedHardwareClient()
             await client.connect()
             await client.setTemperature(side, sp.temperature)

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -324,12 +324,19 @@ export const deviceRouter = router({
           const poweredOnAt = input.powered
             ? (prev?.isPowered ? prev.poweredOnAt : now)
             : null
+          // Always write the effective target (default 75°F when powering on
+          // without an explicit temperature; null when powering off). Without
+          // this, markSideMutated's freshness preservation could leave a stale
+          // setpoint visible past the mutation.
+          const targetTemperature = input.powered
+            ? (input.temperature ?? 75)
+            : null
           await db
             .update(deviceState)
             .set({
               isPowered: input.powered,
               poweredOnAt,
-              ...(input.temperature && { targetTemperature: input.temperature }),
+              targetTemperature,
               lastUpdated: now,
             })
             .where(eq(deviceState.side, input.side))

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -10,6 +10,7 @@ import { snoozeAlarm, cancelSnooze, getSnoozeStatus } from '@/src/hardware/snooz
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { HardwareCommand, fahrenheitToLevel } from '@/src/hardware/types'
 import { sendCommand } from '@/src/hardware/dacTransport'
+import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import {
   sideSchema,
   temperatureSchema,
@@ -214,6 +215,8 @@ export const deviceRouter = router({
         existing.resolve({ success: true }) // resolve the earlier promise immediately
       }
 
+      markSideMutated(input.side)
+
       // The DB is updated optimistically on every call for responsive UI.
       try {
         const now = new Date()
@@ -305,6 +308,7 @@ export const deviceRouter = router({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
+      markSideMutated(input.side)
       return withHardwareClient(async (client) => {
         await client.setPower(input.side, input.powered, input.temperature)
 
@@ -387,6 +391,7 @@ export const deviceRouter = router({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
+      markSideMutated(input.side)
       return withHardwareClient(async (client) => {
         cancelSnooze(input.side)
         await client.setAlarm(input.side, {
@@ -436,6 +441,7 @@ export const deviceRouter = router({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
+      markSideMutated(input.side)
       return withHardwareClient(async (client) => {
         await client.clearAlarm(input.side)
         cancelSnooze(input.side)

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -308,7 +308,6 @@ export const deviceRouter = router({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
-      markSideMutated(input.side)
       return withHardwareClient(async (client) => {
         await client.setPower(input.side, input.powered, input.temperature)
 
@@ -331,6 +330,10 @@ export const deviceRouter = router({
           const targetTemperature = input.powered
             ? (input.temperature ?? 75)
             : null
+          // Stamp freshness immediately before the DB write so the 5s guard
+          // covers this mutation. Stamping before the hardware roundtrip
+          // risks the window expiring while connect/setPower run.
+          markSideMutated(input.side)
           await db
             .update(deviceState)
             .set({

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -218,7 +218,12 @@ async function powerOffSide(side: Side): Promise<void> {
     // via a path that doesn't stamp through deviceStateSync.
     try {
       db.update(deviceState)
-        .set({ isPowered: false, poweredOnAt: null, lastUpdated: new Date() })
+        .set({
+          isPowered: false,
+          poweredOnAt: null,
+          targetTemperature: null,
+          lastUpdated: new Date(),
+        })
         .where(eq(deviceState.side, side))
         .run()
     }

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -14,6 +14,7 @@ import { db, biometricsDb } from '@/src/db'
 import { deviceSettings, sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
 import { sleepRecords } from '@/src/db/biometrics-schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 
 // ---------------------------------------------------------------------------
@@ -207,6 +208,7 @@ function isUserInBed(side: Side): boolean {
 /** Power off a side via the shared hardware client. */
 async function powerOffSide(side: Side): Promise<void> {
   try {
+    markSideMutated(side)
     const client = getSharedHardwareClient()
     await client.connect()
     await client.setPower(side, false)

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -208,7 +208,6 @@ function isUserInBed(side: Side): boolean {
 /** Power off a side via the shared hardware client. */
 async function powerOffSide(side: Side): Promise<void> {
   try {
-    markSideMutated(side)
     const client = getSharedHardwareClient()
     await client.connect()
     await client.setPower(side, false)
@@ -217,6 +216,11 @@ async function powerOffSide(side: Side): Promise<void> {
     // see a stale "powered on X hours ago" after the side comes back on later
     // via a path that doesn't stamp through deviceStateSync.
     try {
+      // Stamp freshness immediately before the DB write so the 5s guard
+      // protects this mutation from concurrent DAC polls — placing it before
+      // the slow hardware roundtrip risks the window expiring before the DB
+      // update lands.
+      markSideMutated(side)
       db.update(deviceState)
         .set({
           isPowered: false,


### PR DESCRIPTION
## Why

Live observation 2026-05-02: user clicked right-side ON via the UI at 23:05:54 UTC. The \`device.setPower\` mutation wrote \`device_state.is_powered=1, target_temperature=83\` synchronously and frank confirmed \`set_side right enabled (2700)\` at 23:07:15. **However**, for ~2 minutes the DB read back \`is_powered=0\` while the bed was actively heating. The pod UI showed "off" while the pump ran at 2000 RPM.

Root cause is at \`src/hardware/deviceStateSync.ts:upsertSide\`. The DacMonitor polls firmware every 1–2s and unconditionally upserts the derived powered state. The firmware needs a few seconds to reflect a fresh command — during that window it reports \`targetLevel=0, heatingDuration=0, currentLevel=0\` (stale), the sync computes \`isNowPowered=false\` via \`durationExpired\`, and clobbers the manual write.

Distinct from PR #495's scheduler races: this is a tRPC-mutation vs DAC-poll race. \`withSideLock\` only covers JobManager handlers.

## What

In-memory mutation-freshness map. Every powered-state mutation calls \`markSideMutated(side)\`; inside a 5s window, \`upsertSide\` preserves \`isPowered\` / \`poweredOnAt\` / \`targetTemperature\` from the prior row and only refreshes observation fields (\`currentTemperature\`, \`waterLevel\`). After the window expires, sync resumes normal reconciliation.

Mutations wired:
- tRPC: \`setPower\`, \`setTemperature\`, \`setAlarm\`, \`clearAlarm\`
- JobManager: \`runTemperatureJob\`, \`runPowerOnJob\`, \`runAlarmJob\`, \`markSideOff\`, run-once setpoint handlers
- \`autoOffWatcher.powerOffSide\`

No schema change — purely in-process state. Survives across imports because \`deviceStateSync.ts\` is a singleton-import module.

## Test plan

- [x] \`pnpm vitest run src/hardware/tests/deviceStateSync.test.ts\` — 6 new tests covering: fresh setPower preserves is_powered=1 vs stale-neutral poll; fresh power_off preserves is_powered=0 vs residual-heat poll; observation fields update inside the window; sync resumes overwriting after window expires; opposite side not affected; unmarked sides reconcile normally.
- [x] Full suite: 665 passed / 2 skipped across 46 files (was 659/2/45 — all delta is the new file).
- [x] \`tsc --noEmit\` clean. \`eslint\` clean.
- [ ] Pod-side smoke after deploy: click power on/off via UI, verify \`device_state\` reflects intent stably across the next 5+ DAC polls without flapping. Run \`watch -n1 'sqlite3 /persistent/sleepypod-data/sleepypod.db "SELECT side,is_powered,target_temperature,datetime(last_updated,\\"unixepoch\\") FROM device_state"'\`.

Closes sleepypod-core-22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents stale firmware polls from overwriting recently-changed device settings — preserves power state, powered-on timestamp, and target temperature for a short freshness window; ensures syncing one side doesn't flip the opposite side and respects fresh power-off behavior.

* **Tests**
  * Added comprehensive tests covering the mutation-freshness window, preservation behavior, and reconciliation after the window elapses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->