### PR TITLE
fix(sleep-detector): validate RAW frame ts before persisting as wall-clock

### DIFF
--- a/modules/sleep-detector/main.py
+++ b/modules/sleep-detector/main.py
@@ -89,6 +89,12 @@ MOVEMENT_INTERVAL_S = 60
 PRESENCE_THRESHOLD = 1500
 # How often to reload calibration profiles (seconds)
 CALIBRATION_RELOAD_S = 60
+# Earliest ts considered a valid wall-clock timestamp (2020-01-01 UTC).
+# RAW frames very rarely arrive with a tiny relative ts (e.g. 3s after some
+# synthetic origin) before the firmware has a real wall-clock reference.
+# When that happens, we fall back to time.time() rather than persisting a
+# 1970-era entered_bed_at to sleep_records.
+MIN_VALID_WALL_CLOCK_TS = 1577836800.0  # 2020-01-01 00:00:00 UTC
 
 # Pump gating for movement scoring (#230)
 # Guard period after pump-off: 3 seconds = ~6 samples at 2 Hz capSense rate
@@ -137,6 +143,25 @@ def open_biometrics_db() -> sqlite3.Connection:
     conn.execute("PRAGMA busy_timeout=5000")
     conn.execute("PRAGMA synchronous=NORMAL")
     return conn
+
+
+def sanitize_ts(raw_ts) -> float:
+    """Coerce a RAW frame's `ts` field into a sane wall-clock timestamp.
+
+    Falls back to time.time() when:
+      - the field is missing or not a number
+      - the value is < 2020-01-01 epoch (firmware emitted a relative
+        timestamp before establishing wall-clock — directly persisting
+        this leads to entered_bed_at landing in 1970, observed once on
+        2026-03-21 in row id=30 of sleep_records).
+    """
+    try:
+        ts = float(raw_ts) if raw_ts is not None else time.time()
+    except (TypeError, ValueError):
+        return time.time()
+    if ts < MIN_VALID_WALL_CLOCK_TS:
+        return time.time()
+    return ts
 
 
 def write_sleep_record(conn: sqlite3.Connection, side: str,
@@ -704,7 +729,7 @@ def main() -> None:
             if rtype not in CAPSENSE_TYPES:
                 continue
 
-            ts = float(record.get("ts", time.time()))
+            ts = sanitize_ts(record.get("ts"))
             left.process(ts, record)
             right.process(ts, record)
 

--- a/modules/sleep-detector/main.py
+++ b/modules/sleep-detector/main.py
@@ -51,6 +51,7 @@ import os
 import sys
 import time
 import json
+import math
 import signal
 import logging
 import sqlite3
@@ -150,6 +151,7 @@ def sanitize_ts(raw_ts) -> float:
 
     Falls back to time.time() when:
       - the field is missing or not a number
+      - the value is NaN or +/-inf (CBOR-encoded IEEE 754 specials)
       - the value is < 2020-01-01 epoch (firmware emitted a relative
         timestamp before establishing wall-clock — directly persisting
         this leads to entered_bed_at landing in 1970, observed once on
@@ -158,6 +160,8 @@ def sanitize_ts(raw_ts) -> float:
     try:
         ts = float(raw_ts) if raw_ts is not None else time.time()
     except (TypeError, ValueError):
+        return time.time()
+    if not math.isfinite(ts):
         return time.time()
     if ts < MIN_VALID_WALL_CLOCK_TS:
         return time.time()

--- a/modules/sleep-detector/test_main.py
+++ b/modules/sleep-detector/test_main.py
@@ -75,3 +75,15 @@ class TestSanitizeTs:
     def test_handles_int_input(self):
         valid_int = 1777731963
         assert sanitize_ts(valid_int) == float(valid_int)
+
+    def test_substitutes_wall_clock_when_ts_is_nan(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(float("nan")) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_positive_inf(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(float("inf")) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_negative_inf(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(float("-inf")) == 1777731963.0

--- a/modules/sleep-detector/test_main.py
+++ b/modules/sleep-detector/test_main.py
@@ -1,0 +1,77 @@
+"""
+Tests for sleep-detector. Runs on developer Mac without pod-only deps —
+cbor2 / common.raw_follower / common.health are stubbed before importing main.
+"""
+
+import sys
+from unittest.mock import patch
+
+# Stub pod-only modules so `import main` works on dev machines.
+_stubs = {
+    "cbor2": type(sys)("cbor2"),
+    "common": type(sys)("common"),
+    "common.raw_follower": type(sys)("common.raw_follower"),
+    "common.calibration": type(sys)("common.calibration"),
+    "common.health": type(sys)("common.health"),
+}
+_stubs["common.raw_follower"].RawFileFollower = None
+_stubs["common.calibration"].CalibrationStore = None
+_stubs["common.calibration"].is_present_capsense_calibrated = lambda *a, **kw: False
+_stubs["common.calibration"].is_present_capsense2_calibrated = lambda *a, **kw: False
+_stubs["common.health"].report_health = lambda *a, **kw: None
+sys.modules.update(_stubs)
+
+from main import sanitize_ts, MIN_VALID_WALL_CLOCK_TS  # noqa: E402
+
+
+class TestSanitizeTs:
+    """sleep_records id=30 had entered_bed_at=3 (1970-01-01 00:00:03 UTC).
+    Root cause: a fresh RAW file post-restart can carry tiny relative ts
+    values; the prior code passed them straight through to
+    datetime.fromtimestamp() and persisted them as entered_bed_at."""
+
+    def test_passes_through_valid_wall_clock(self):
+        valid = 1777731963.0  # 2026-05-02 14:26 UTC
+        assert sanitize_ts(valid) == valid
+
+    def test_substitutes_wall_clock_when_ts_is_pre_2020_sentinel(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(3.0) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_zero(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(0) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_negative(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(-100) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_missing(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(None) == 1777731963.0
+
+    def test_substitutes_wall_clock_when_ts_is_not_a_number(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts("notanumber") == 1777731963.0
+
+    def test_threshold_boundary(self):
+        # Exactly at 2020-01-01 should be considered valid (>=).
+        assert sanitize_ts(MIN_VALID_WALL_CLOCK_TS) == MIN_VALID_WALL_CLOCK_TS
+
+    def test_just_below_threshold_is_replaced(self):
+        with patch("main.time.time", return_value=1777731963.0):
+            assert sanitize_ts(MIN_VALID_WALL_CLOCK_TS - 1) == 1777731963.0
+
+    def test_real_observed_bug_value(self):
+        """The exact value (ts=3) found in sleep_records id=30 on the pod
+        on 2026-03-21 — must be sanitized."""
+        sentinel_now = 1700000000.0  # arbitrary post-2020 wall-clock
+        with patch("main.time.time", return_value=sentinel_now):
+            result = sanitize_ts(3.0)
+            assert result == sentinel_now
+            # Sanity: result is a real wall-clock value, not 1970-era.
+            assert result >= MIN_VALID_WALL_CLOCK_TS
+
+    def test_handles_int_input(self):
+        valid_int = 1777731963
+        assert sanitize_ts(valid_int) == float(valid_int)


### PR DESCRIPTION
## Why

\`sleep_records\` row \`id=30\` in biometrics.db on the live pod has:

\`\`\`
entered_bed_at=3                  ← Unix epoch + 3s = 1970-01-01 00:00:03 UTC
left_bed_at=1774125695            ← 2026-03-21 20:41:35 UTC (real)
sleep_duration_seconds=1774125692 ← naively (left - entered) = 56+ years
present_intervals='[[3.0, 1774125695.0]]'
created_at=1774125815             ← real
\`\`\`

\`modules/sleep-detector/main.py:707\` reads \`ts = float(record.get("ts", time.time()))\` from the RAW frame and passes it directly to \`SideTracker.process()\`, which at line 545 does \`datetime.fromtimestamp(ts, tz=timezone.utc)\`. When a fresh RAW file follows a restart, the first frames can carry a tiny relative \`ts\` (≈3s) before firmware establishes a wall-clock reference. That value persists as \`entered_bed_at\` in 1970.

Bug occurred once on 2026-03-21 — only one row in the DB, but the code is unchanged so it can recur.

## What

Add \`sanitize_ts()\` at the dispatch point. Falls back to \`time.time()\` when:
- the field is missing or not a number
- the value is below \`MIN_VALID_WALL_CLOCK_TS = 1577836800.0\` (2020-01-01 UTC)

Replaces the inline \`float(record.get("ts", time.time()))\` so \`SideTracker.process()\` always receives a real wall-clock float.

## Test plan

- [x] \`pytest modules/sleep-detector/test_main.py -v\` — 10 cases:
  - Valid wall-clock passes through
  - The exact observed bug value (\`ts=3\`) gets sanitized
  - Zero, negative, missing, non-numeric → \`time.time()\`
  - Threshold boundary at 2020-01-01 UTC (inclusive)
  - Just-below threshold is replaced
  - Int input handled
- [x] \`tsc --noEmit\` clean (no TS code touched, but verified no import damage).
- [ ] After deploy: clean up the existing stale row on the pod once: \`sqlite3 /persistent/sleepypod-data/biometrics.db "DELETE FROM sleep_records WHERE id = 30"\`. (Not in this PR — manual cleanup.)
- [ ] Pod-side smoke: restart sleep-detector service, watch journal for "session started at <real timestamp>" — confirm the timestamp is current wall-clock, not 1970.

Closes sleepypod-core-23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sleep-detector now validates incoming timestamps and automatically replaces implausible entries (pre-2020, zero, negative, or non-numeric values) with the current system time.

* **Tests**
  * Added comprehensive unit tests for timestamp validation covering valid inputs, boundary conditions, and various invalid input types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->