### PR TITLE
fix(piezo): suppress phantom presence from asymmetric pump-coupling

### DIFF
--- a/modules/piezo-processor/main.py
+++ b/modules/piezo-processor/main.py
@@ -65,6 +65,17 @@ PUMP_ENERGY_MULTIPLIER = 10.0
 PUMP_CORRELATION_MIN = 0.5
 PUMP_GUARD_S = 5.0
 
+# Per-side pump activity threshold (frzHealth pump RPM). When one side's
+# pump is running and the opposite side's is idle, observed live on
+# 2026-05-02: a heating cycle on right with left idle drove pump@2000RPM
+# coupling into the right piezo and produced phantom HR/HRV/BR. The
+# existing PumpGate (broadband-symmetric energy spike) does not catch
+# asymmetric pump activity because min/max ratio is small.
+ASYMMETRIC_PUMP_RPM_MIN = 50          # pump considered "running" above this
+ASYMMETRIC_PUMP_GUARD_S = 5.0         # trailing guard after own-side pump-off
+ASYMMETRIC_PRESENCE_STD_FACTOR = 4.0  # raise enter_threshold by this factor
+ASYMMETRIC_PRESENCE_ACR_THRESHOLD = 0.6  # require strong autocorr to enter
+
 # HR band: 0.8 Hz preserves fundamental of 48+ BPM; 8.5 Hz per PMC7582983
 HR_BAND = (0.8, 8.5)
 
@@ -158,6 +169,68 @@ def _bandpass(sig: np.ndarray, lo: float, hi: float, fs: float,
 # ---------------------------------------------------------------------------
 # Pump gating — streaming adaptation (Shin et al. IEEE TBME 2009)
 # ---------------------------------------------------------------------------
+
+class FrzHealthPumpState:
+    """Tracks per-side pump RPM from frzHealth records.
+
+    Used by SideProcessor to suppress phantom presence detection when
+    only the same side's pump is running (asymmetric pump-coupling
+    artifact). Trailing guard period mirrors the post-pump-off ringing
+    in the piezo channel.
+    """
+
+    def __init__(self):
+        self._pump_rpm = {"left": 0.0, "right": 0.0}
+        # monotonic seconds when each side's pump last turned off
+        self._pump_off_at = {"left": 0.0, "right": 0.0}
+        self._was_active = {"left": False, "right": False}
+
+    def update(self, record: dict) -> None:
+        if record.get("type") != "frzHealth":
+            return
+        for side in ("left", "right"):
+            data = record.get(side)
+            if not isinstance(data, dict):
+                continue
+            rpm = 0.0
+            for key in ("pumpRpm", "pump_rpm", "pumpRPM", "rpm"):
+                val = data.get(key)
+                if val is not None:
+                    try:
+                        rpm = float(val)
+                    except (TypeError, ValueError):
+                        rpm = 0.0
+                    break
+            if rpm == 0:
+                for key in ("pumpDuty", "pump_duty", "duty"):
+                    val = data.get(key)
+                    if val is not None:
+                        try:
+                            rpm = ASYMMETRIC_PUMP_RPM_MIN + 1.0 if float(val) > 0 else 0.0
+                        except (TypeError, ValueError):
+                            rpm = 0.0
+                        break
+
+            now_active = rpm >= ASYMMETRIC_PUMP_RPM_MIN
+            if self._was_active[side] and not now_active:
+                self._pump_off_at[side] = time.monotonic()
+            self._pump_rpm[side] = rpm
+            self._was_active[side] = now_active
+
+    def is_side_pump_active(self, side: str) -> bool:
+        """Pump active = currently running OR within the trailing guard window."""
+        if self._pump_rpm[side] >= ASYMMETRIC_PUMP_RPM_MIN:
+            return True
+        return time.monotonic() - self._pump_off_at[side] < ASYMMETRIC_PUMP_GUARD_S
+
+    def is_asymmetric_for(self, side: str) -> bool:
+        """Own pump active, opposite pump idle (and outside its own guard).
+        This is the configuration that produces phantom presence: pump
+        vibration on the powered side without competing signal on the
+        other side to balance/reject."""
+        other = "right" if side == "left" else "left"
+        return self.is_side_pump_active(side) and not self.is_side_pump_active(other)
+
 
 class PumpGate:
     """Detects pump activity from dual-channel energy spikes.
@@ -631,7 +704,8 @@ def compute_hrv(samples: np.ndarray,
 # ---------------------------------------------------------------------------
 
 class SideProcessor:
-    def __init__(self, side: str, db_conn: sqlite3.Connection):
+    def __init__(self, side: str, db_conn: sqlite3.Connection,
+                 pump_state: Optional[FrzHealthPumpState] = None):
         self.side = side
         self.db = db_conn
         self._hr_buf: deque = deque(maxlen=HR_WINDOW_S * SAMPLE_RATE)
@@ -643,6 +717,7 @@ class SideProcessor:
         self._other: Optional['SideProcessor'] = None  # set after both sides created
         self._last_med_std: float = 0.0  # cached for cross-channel comparison
         self._last_acr_qual: float = 0.0
+        self._pump_state = pump_state
 
     def ingest(self, samples: np.ndarray) -> None:
         self._hr_buf.extend(samples)
@@ -689,6 +764,29 @@ class SideProcessor:
         # Cache AFTER suppression so the other side sees post-suppression values
         self._last_med_std = med_std
         self._last_acr_qual = acr_qual
+
+        # Asymmetric pump-coupling guard: when own-side pump is active and the
+        # opposite side's pump is idle, motor vibration couples into the same-
+        # side piezo channel and produces broadband energy with periodic-looking
+        # autocorrelation in the cardiac band. The existing PumpGate (broadband-
+        # symmetric spike) does not catch this asymmetric case. While the gate
+        # is active, require BOTH significantly elevated energy AND strong
+        # autocorrelation to enter PRESENT — pure pump coupling rarely produces
+        # both because cardiac periodicity dominates only with a real person.
+        if (self._pump_state is not None
+                and self._pump_state.is_asymmetric_for(self.side)
+                and self._presence.state == PresenceDetector.ABSENT):
+            asymmetric_std_threshold = (
+                self._presence.enter_threshold * ASYMMETRIC_PRESENCE_STD_FACTOR
+            )
+            if not (med_std > asymmetric_std_threshold
+                    and acr_qual > ASYMMETRIC_PRESENCE_ACR_THRESHOLD):
+                log.debug(
+                    "%s: pump-coupling guard suppressed presence "
+                    "(med_std=%.0f, acr=%.2f, own-pump-active, other-idle)",
+                    self.side, med_std, acr_qual,
+                )
+                return
 
         present = self._presence.update(med_std, acr_qual)
 
@@ -742,8 +840,9 @@ def main() -> None:
 
     db_conn = open_biometrics_db()
     pump_gate = PumpGate()
-    left = SideProcessor("left", db_conn)
-    right = SideProcessor("right", db_conn)
+    pump_state = FrzHealthPumpState()
+    left = SideProcessor("left", db_conn, pump_state=pump_state)
+    right = SideProcessor("right", db_conn, pump_state=pump_state)
     left._other = right
     right._other = left
     follower = RawFileFollower(RAW_DATA_DIR, _shutdown, poll_interval=0.01)
@@ -752,7 +851,14 @@ def main() -> None:
 
     try:
         for record in follower.read_records():
-            if record.get("type") != "piezo-dual":
+            rtype = record.get("type")
+
+            # Track per-side pump state for the asymmetric pump-coupling guard
+            if rtype == "frzHealth":
+                pump_state.update(record)
+                continue
+
+            if rtype != "piezo-dual":
                 continue
 
             # Each record contains ~500 int32 samples per channel

--- a/modules/piezo-processor/test_main.py
+++ b/modules/piezo-processor/test_main.py
@@ -905,6 +905,18 @@ class TestFrzHealthPumpState:
         assert ps.is_side_pump_active("left") is True
         assert ps.is_side_pump_active("right") is True
 
+    def test_pumpRPM_uppercase_variant(self):
+        """Firmware may emit pumpRPM (all-caps RPM); main.py:196 lists it
+        but only the lowercase variants were exercised before."""
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRPM": 2000},
+            "right": {"pumpRPM": 0},
+        })
+        assert ps.is_side_pump_active("left") is True
+        assert ps.is_side_pump_active("right") is False
+
     def test_pumpDuty_fallback(self):
         ps = FrzHealthPumpState()
         ps.update({

--- a/modules/piezo-processor/test_main.py
+++ b/modules/piezo-processor/test_main.py
@@ -32,6 +32,9 @@ from main import (  # noqa: E402
     compute_breathing_rate,
     compute_hrv,
     subharmonic_summation_hr,
+    FrzHealthPumpState,
+    ASYMMETRIC_PUMP_GUARD_S,
+    ASYMMETRIC_PUMP_RPM_MIN,
     HRTracker,
     PresenceDetector,
     PumpGate,
@@ -851,3 +854,144 @@ class TestIntegration:
 
         # At least one of these should indicate "nobody home"
         assert not present or hr is None or score < 0.15
+
+
+# ===================================================================
+# FrzHealthPumpState — asymmetric pump-coupling guard
+# ===================================================================
+
+class TestFrzHealthPumpState:
+    """Tracks per-side pump RPM from frzHealth records and identifies
+    asymmetric pump-on configurations (own pump active, other idle) that
+    cause phantom presence on Pod 3. Bug observed live 2026-05-02:
+    right-side heating with pump@2000RPM produced 23 vitals rows in
+    30 min with no occupant."""
+
+    def test_ignores_non_frzhealth_records(self):
+        ps = FrzHealthPumpState()
+        ps.update({"type": "piezo-dual", "left": {"pumpRpm": 5000}, "right": {"pumpRpm": 5000}})
+        assert ps.is_side_pump_active("left") is False
+        assert ps.is_side_pump_active("right") is False
+
+    def test_marks_pump_active_above_threshold(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN + 100},
+        })
+        assert ps.is_side_pump_active("left") is False
+        assert ps.is_side_pump_active("right") is True
+
+    def test_below_threshold_is_idle(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN - 1},
+            "right": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN - 1},
+        })
+        assert ps.is_side_pump_active("left") is False
+        assert ps.is_side_pump_active("right") is False
+
+    def test_alternative_field_names(self):
+        """Different firmware versions emit pumpRpm / pump_rpm / rpm /
+        pumpDuty. The state tracker must read all of them."""
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pump_rpm": 2000},
+            "right": {"rpm": 2000},
+        })
+        assert ps.is_side_pump_active("left") is True
+        assert ps.is_side_pump_active("right") is True
+
+    def test_pumpDuty_fallback(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpDuty": 50},
+            "right": {"pumpDuty": 0},
+        })
+        assert ps.is_side_pump_active("left") is True
+        assert ps.is_side_pump_active("right") is False
+
+    def test_is_asymmetric_true_when_only_own_side_running(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 2000},
+        })
+        # The exact live observation: right is heating, left is off.
+        assert ps.is_asymmetric_for("right") is True
+        assert ps.is_asymmetric_for("left") is False
+
+    def test_is_asymmetric_false_when_both_running(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 2000},
+            "right": {"pumpRpm": 2000},
+        })
+        # Both pumps on → balanced; broadband PumpGate handles this case.
+        # Asymmetric guard should not fire.
+        assert ps.is_asymmetric_for("left") is False
+        assert ps.is_asymmetric_for("right") is False
+
+    def test_is_asymmetric_false_when_both_idle(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 0},
+        })
+        assert ps.is_asymmetric_for("left") is False
+        assert ps.is_asymmetric_for("right") is False
+
+    def test_guard_period_after_pump_off(self):
+        """After own-side pump turns off, ringing in piezo continues for
+        a few seconds — keep the gate active during that trailing window."""
+        ps = FrzHealthPumpState()
+        # Pump on
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 2000},
+        })
+        assert ps.is_side_pump_active("right") is True
+
+        # Pump off — should still be "active" within guard
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 0},
+        })
+        assert ps.is_side_pump_active("right") is True
+        assert ps.is_asymmetric_for("right") is True
+
+    def test_guard_period_expires(self):
+        ps = FrzHealthPumpState()
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 2000},
+        })
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 0},
+        })
+        # Force guard expiry
+        ps._pump_off_at["right"] = time.monotonic() - ASYMMETRIC_PUMP_GUARD_S - 1
+        assert ps.is_side_pump_active("right") is False
+
+    def test_handles_malformed_record_safely(self):
+        ps = FrzHealthPumpState()
+        # No left/right keys
+        ps.update({"type": "frzHealth"})
+        # Wrong types
+        ps.update({"type": "frzHealth", "left": "not a dict", "right": [1, 2, 3]})
+        # Non-numeric rpm
+        ps.update({"type": "frzHealth", "left": {"pumpRpm": "abc"}, "right": {"pumpRpm": None}})
+        assert ps.is_side_pump_active("left") is False
+        assert ps.is_side_pump_active("right") is False


### PR DESCRIPTION
## Why

Live observation 2026-05-02 14:50 PDT (after the user clicked "right side ON"): with no occupant, the biometrics DB recorded **23 vitals rows + 30 movement rows for right in 30 min**. HR/HRV/BR looked plausible because pump vibration (right pump @ 2000 RPM, left pump idle) sits in the cardiac band 0.8–8.5 Hz.

Both writers are properly presence-gated. The bug is in piezo's \`PresenceDetector\`. The existing \`PumpGate\` (\`modules/piezo-processor/main.py:163\`) only detects **symmetric** L+R energy spikes (ratio>0.5 + 10× baseline). Single-side pump activity has a small min/max ratio, so the detector falls through and the asymmetric vibration is treated as a real signal.

This is the same class of bug as PRs #228 (cross-channel presence rejection) and #230 (capSense2 pump gating) — but for the piezo signal path.

## What

Add \`FrzHealthPumpState\` that consumes \`frzHealth\` records and tracks per-side pump RPM (mirroring sleep-detector's \`PumpGateCapSense.update_pump_state\`).

\`SideProcessor._maybe_write\` consults it just before \`PresenceDetector.update\`. When own-side pump is active **and** opposite-side pump is idle (the configuration that produces phantom presence), require BOTH:
- \`med_std > enter_threshold * 4\` (significantly elevated energy), AND
- \`acr_qual > 0.6\` (strong cardiac periodicity)

Either condition alone (the default OR-gate behavior) admits coupling artifacts. Pure pump coupling rarely produces both, while real-occupant cardiac signal does.

A 5s trailing guard catches residual piezo ringing after pump-off. Multiple firmware field-name spellings supported: \`pumpRpm\`, \`pump_rpm\`, \`rpm\`, \`pumpDuty\`.

## Test plan

- [x] \`pytest modules/piezo-processor/test_main.py -v\` — 11 new \`TestFrzHealthPumpState\` cases covering: ignores non-frzHealth records, threshold boundary, alternative field names, pumpDuty fallback, asymmetric detection (true/false matrix), trailing guard, malformed-record safety. Full suite: 68 passed (was 57; +11 new).
- [x] \`tsc --noEmit\` clean (no TS code touched but verified no import damage).
- [ ] Pod-side smoke after deploy: clear bed, click right ON for 10 minutes, verify zero new vitals rows for right and no new sleep_records open. \`watch -n5 'sqlite3 /persistent/sleepypod-data/biometrics.db "SELECT side,COUNT(*) FROM vitals WHERE timestamp > strftime(\"%s\",\"now\",\"-5 minutes\") GROUP BY side"'\`. Expected: zero counts on the heating side when bed is empty.
- [ ] Pod-side regression check: real-occupant on the heating side should still produce vitals. Confirm with one user lying down for 5 min — vitals should write normally.

Closes sleepypod-core-24.

Refs: PR #228 (cross-channel rejection — same class), PR #230 (capSense2 pump gating — same class).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Implemented per-side pump state tracking to monitor pump activity and asymmetry
- Added asymmetric pump-coupling suppression logic that intelligently filters signal transitions based on pump status and signal quality metrics
- Enhanced vitals generation with improved filtering for more reliable data

**Tests**
- Added comprehensive test coverage for pump state tracking, asymmetry detection, and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->