### PR TITLE
feat: ticket batch — install symlink, ci title gate, disk widget, export api, cover-buttons scripts, tmpfs RAW migration

### DIFF
--- a/.github/workflows/pr-title-gate.yml
+++ b/.github/workflows/pr-title-gate.yml
@@ -1,0 +1,38 @@
+name: PR Title Gate (main)
+
+# Fails if a PR targeting main has a title semantic-release can't act on.
+# Every PR to main is a release promotion; non-release-triggering titles
+# (Release:, chore:, docs:, bare Bump…) leave releases/latest pointing at
+# the previous tag because commit-analyzer logs "no release". v1.6.0 was
+# stale for 5 days because PR #452 squash-merged with title "Release:..".
+# Recovered via PR #453 with a conventional fix: empty commit. See ticket
+# sleepypod-core-10 for postmortem.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR title is release-triggering
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          # Allowed: feat / fix / perf / revert with optional (scope) and
+          # optional ! for breaking. Body-level "BREAKING CHANGE:" still
+          # works on top of any of these.
+          if [[ "$PR_TITLE" =~ ^(feat|fix|perf|revert)(\([^\)]+\))?!?:\ .+ ]]; then
+            echo "OK: '$PR_TITLE'"
+            exit 0
+          fi
+          echo "::error::PR title must start with feat: / fix: / perf: / revert: (optionally feat!: for breaking) to cut a release. Consider retitling."
+          echo "Got: '$PR_TITLE'"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,15 @@ ygg logs --follow                           # Live event stream
 - Use `ygg task` for cross-session work tracking; `ygg remember` for durable notes.
 - Do NOT use `bd` / beads.
 
+## PRs to `main`
+
+Every PR to `main` is a release promotion. Title MUST start with
+`feat:` / `fix:` / `perf:` / `revert:` (optional `(scope)`, optional `!`
+for breaking) — these are the only types semantic-release acts on. Other
+prefixes (`Release:`, `chore:`, `docs:`, bare `Bump…`) are blocked by
+`.github/workflows/pr-title-gate.yml` and would otherwise leave
+`releases/latest` stale.
+
 ## Session Completion
 
 Work is not complete until `git push` succeeds. Release held locks, run quality gates, rebase, push, verify `git status` shows up-to-date.

--- a/app/api/export/archive/route.ts
+++ b/app/api/export/archive/route.ts
@@ -1,0 +1,122 @@
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, readdir, rm, stat, symlink } from 'node:fs/promises'
+import { createWriteStream } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+
+const EXPORT_TOKEN = process.env.EXPORT_TOKEN
+const BIOMETRICS_DB_PATH = process.env.BIOMETRICS_DATABASE_URL?.replace('file:', '') ?? ''
+const RAW_DIR = process.env.RAW_DATA_DIR ?? '/persistent'
+
+const SAFE_FILENAME = /^[\w.-]+\.RAW$/i
+
+let inflight = false
+
+async function dumpSqlite(dbPath: string, outPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const out = createWriteStream(outPath)
+    const child = spawn('sqlite3', [dbPath, '.dump'])
+    child.stdout.pipe(out)
+    let stderr = ''
+    child.stderr.on('data', d => (stderr += d.toString()))
+    child.on('error', reject)
+    child.on('close', (code) => {
+      out.close(() => {
+        if (code === 0) resolve()
+        else reject(new Error(`sqlite3 .dump exited with ${code}: ${stderr}`))
+      })
+    })
+  })
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+
+  if (!EXPORT_TOKEN) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const token = url.searchParams.get('token')
+  if (!token || token !== EXPORT_TOKEN) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (inflight) {
+    return Response.json(
+      { error: 'Another export is in progress, retry later' },
+      { status: 429, headers: { 'Retry-After': '60' } },
+    )
+  }
+  inflight = true
+
+  const startTs = Number(url.searchParams.get('startTs') ?? '0')
+  const endTs = Number(url.searchParams.get('endTs') ?? String(Math.floor(Date.now() / 1000)))
+  const include = (url.searchParams.get('include') ?? 'raw,db')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+
+  let stagingDir: string | null = null
+  try {
+    stagingDir = await mkdtemp(path.join(tmpdir(), 'sp-export-'))
+
+    if (include.includes('db') && BIOMETRICS_DB_PATH) {
+      await dumpSqlite(BIOMETRICS_DB_PATH, path.join(stagingDir, 'biometrics.sql'))
+    }
+
+    if (include.includes('raw')) {
+      const rawStaged = path.join(stagingDir, 'raw')
+      await mkdir(rawStaged)
+      let entries: string[] = []
+      try {
+        entries = await readdir(RAW_DIR)
+      }
+      catch { /* RAW_DIR missing — ok, archive will have empty raw/ */ }
+      for (const name of entries) {
+        if (!SAFE_FILENAME.test(name)) continue
+        const full = path.join(RAW_DIR, name)
+        try {
+          const s = await stat(full)
+          const mtime = Math.floor(s.mtime.getTime() / 1000)
+          if (mtime < startTs || mtime > endTs) continue
+          await symlink(full, path.join(rawStaged, name))
+        }
+        catch { /* skip unreadable entry */ }
+      }
+    }
+
+    // -h dereferences symlinks so the archive contains real file contents
+    const tarChild = spawn('tar', ['-czhf', '-', '-C', stagingDir, '.'])
+    let tarStderr = ''
+    tarChild.stderr.on('data', d => (tarStderr += d.toString()))
+
+    const cleanup = () => {
+      const dir = stagingDir
+      stagingDir = null
+      if (dir) rm(dir, { recursive: true, force: true }).catch(() => {})
+      inflight = false
+    }
+    tarChild.on('close', (code) => {
+      if (code !== 0 && tarStderr) console.error('tar:', tarStderr)
+      cleanup()
+    })
+    tarChild.on('error', cleanup)
+
+    const stream = Readable.toWeb(tarChild.stdout) as ReadableStream<Uint8Array>
+    const filename = `sleepypod-export-${startTs}-${endTs}.tar.gz`
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'application/gzip',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    })
+  }
+  catch (error) {
+    if (stagingDir) await rm(stagingDir, { recursive: true, force: true }).catch(() => {})
+    inflight = false
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Export failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/adr/0018-tmpfs-raw-frames.md
+++ b/docs/adr/0018-tmpfs-raw-frames.md
@@ -1,0 +1,61 @@
+# ADR: tmpfs for live RAW frames + gzip cold archive on eMMC
+
+## Context
+
+Frankenfirmware writes ~1 GB/day of CBOR-encoded `*.RAW` frames into `/persistent` (eMMC). Three concerns drove a redesign:
+
+1. **eMMC wear** — cheap consumer eMMC TBW budgets survive years at 1 GB/day, but write-amplification (FTL block remap, garbage collection, partial-block updates) compresses that. The pod runs unattended for years; reducing live writes is cheap insurance.
+2. **Forensic window** — frank prunes RAW to ~24 h on disk by default. Several Pod 3 dialect bugs (#395, #486) were diagnosable only because reporters manually attached `.RAW` files to draft PRs. That workflow doesn't scale.
+3. **Take-my-data-with-me** — users with multiple weeks of biometric history have no path to extract or migrate it.
+
+`biometrics.db` (the *processed* HR/HRV/sleep-record metrics surfaced in the iOS/web app) already lives durably on disk and is unaffected. RAW is the upstream signal that sidecar processors consume and discard.
+
+## Decision
+
+Mount a **500 MB tmpfs at `/persistent/biometrics`**, redirect frankenfirmware's CWD there, and run an **archiver + pruner** that gzips RAW frames into `/persistent/biometrics-archive/` on eMMC.
+
+```
+frank → /persistent/biometrics/         (tmpfs, hot live RAW)
+           ↓ archiver every 15 min: gzip oldest, atomic rename
+        /persistent/biometrics-archive/<seqno>.RAW.gz
+           ↓ pruner every 15 min: drop oldest until df < 80%
+```
+
+### Firmware integration without a binary patch
+
+Frank is `cd /persistent && exec frankenfirmware`. The binary writes RAW with relative paths and updates `SEQNO.RAW` (sequence counter) in place. Three things made the migration safe without recompiling firmware:
+
+1. RAW filenames are relative (`%08lX.RAW`) — changing CWD redirects them.
+2. `SEQNO.RAW` is overwritten via `fopen("w")` truncate-write — verified empirically by inode stability (Pod 5: inode 13 unchanged since 2025-06-13). A symlink at `/persistent/biometrics/SEQNO.RAW → /persistent/SEQNO.RAW` lets writes pass through to the eMMC target.
+3. State subdirectories (`deviceinfo/`, `settings/`, `heat/`, `vector/`, `system-connections/`, `free-sleep-data/`) are also symlinked from tmpfs back to `/persistent` — firmware reads/writes them transparently.
+
+`PodConfiguration.json` uses an absolute path (`/persistent/PodConfiguration.json`) and is unaffected.
+
+The `frank.sh` patch is a single-line `cd` change with a timestamped backup and rollback path baked into `sp-uninstall`.
+
+## Volatility tradeoff
+
+tmpfs loses contents on reboot. The acceptable loss window is bounded by the archiver cadence:
+
+- **Clean reboot**: archiver runs on shutdown? No — it's a periodic timer, not an `OnShutdown` hook. Files newer than 15 min are unarchived. Same as unclean reboot.
+- **Unclean reboot**: up to ~30 min of live waveform lost (one rotation period the archiver hadn't picked up yet, plus the in-progress file the archiver intentionally skips while firmware is still writing it).
+- **`biometrics.db` rows are unaffected** — sidecar processors (piezo-processor, sleep-detector, environment-monitor) consume RAW frames as they stream and persist HR/HRV/BR/session rows to SQLite on the same `/persistent/sleepypod-data/` (eMMC) path. Vitals durability is unchanged.
+
+Loss of 30 min of upstream waveform is a worthwhile trade for years of eMMC wear avoidance plus an indefinitely growable cold archive (capped by the pruner at 80% disk).
+
+## Alternatives considered
+
+- **Overlayfs** with tmpfs upper layer over `/persistent`: would route ALL writes (DBs, settings, etc.) through tmpfs upper, breaking durability of everything else. Per-file routing isn't supported by overlayfs.
+- **LD_PRELOAD shim**: intercept `open()` for `*.RAW` and redirect. Hacky, fragile under firmware updates.
+- **inotify-watch + post-write move**: doesn't reduce eMMC writes (writes happen first, then move).
+- **Archiver-only, no tmpfs**: hits the cold-archive and disk-cap goals but doesn't reduce eMMC wear. Considered as a fallback if the firmware patch had been unsafe; not needed once `SEQNO.RAW` write-through was verified.
+
+## Rollback
+
+`scripts/bin/sp-uninstall` restores `frank.sh` from `frank.sh.bak-pre-tmpfs-*` (most recent), tears down mount unit + drop-ins + timers, and leaves the cold archive intact for forensics.
+
+## Refs
+
+- Ticket: sleepypod-core-19
+- GH issue: #493 (full design doc)
+- Live validation: Pod 5 fw a35aafa on 2026-05-04 — see PR #499

--- a/modules/biometrics-archiver/frank.service.d/sleepypod-biometrics-tmpfs.conf
+++ b/modules/biometrics-archiver/frank.service.d/sleepypod-biometrics-tmpfs.conf
@@ -1,0 +1,8 @@
+# Drop-in for /lib/systemd/system/frank.service installed by sleepypod's
+# biometrics-archiver module. Pulls in the tmpfs mount + prep service so
+# frankenfirmware finds /persistent/biometrics ready (mounted, with
+# symlinks) when frank.sh execs.
+[Unit]
+Wants=sleepypod-tmpfs-prep.service
+After=sleepypod-tmpfs-prep.service
+RequiresMountsFor=/persistent/biometrics

--- a/modules/biometrics-archiver/persistent-biometrics.mount
+++ b/modules/biometrics-archiver/persistent-biometrics.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sleepypod biometrics tmpfs (/persistent/biometrics)
+Documentation=https://github.com/sleepypod/core/tree/main/modules/biometrics-archiver
+RequiresMountsFor=/persistent
+Before=frank.service sleepypod.service sleepypod-piezo-processor.service sleepypod-sleep-detector.service sleepypod-environment-monitor.service sleepypod-cover-buttons.service
+
+[Mount]
+What=tmpfs
+Where=/persistent/biometrics
+Type=tmpfs
+Options=size=500M,mode=0755,nosuid,nodev
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/biometrics-archiver/sleepypod-biometrics-archiver
+++ b/modules/biometrics-archiver/sleepypod-biometrics-archiver
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Archive RAW files from the /persistent/biometrics tmpfs into a gzipped
+# cold archive on eMMC. Runs every 15 min via timer. Files newer than
+# KEEP_RECENT_MIN are left alone (firmware may still be writing them).
+#
+# Output: /persistent/biometrics-archive/<seqno>.RAW.gz, atomic via tmp
+# file + rename.
+set -euo pipefail
+
+TMPFS_DIR="/persistent/biometrics"
+ARCHIVE_DIR="/persistent/biometrics-archive"
+KEEP_RECENT_MIN="${KEEP_RECENT_MIN:-15}"
+GZIP_LEVEL="${GZIP_LEVEL:-6}"
+
+mkdir -p "$ARCHIVE_DIR"
+
+if ! mountpoint -q "$TMPFS_DIR"; then
+  echo "archiver: $TMPFS_DIR is not a tmpfs mount — skipping" >&2
+  exit 0
+fi
+
+archived=0
+removed=0
+failed=0
+
+while IFS= read -r -d '' src; do
+  base=$(basename "$src")
+  dst="$ARCHIVE_DIR/$base.gz"
+
+  if [ -f "$dst" ]; then
+    rm -f "$src"
+    removed=$((removed + 1))
+    continue
+  fi
+
+  tmp="$dst.tmp.$$"
+  if gzip -"$GZIP_LEVEL" -c "$src" > "$tmp"; then
+    mv -f "$tmp" "$dst"
+    rm -f "$src"
+    archived=$((archived + 1))
+  else
+    rm -f "$tmp"
+    failed=$((failed + 1))
+    echo "archiver: failed to gzip $base" >&2
+  fi
+done < <(find "$TMPFS_DIR" -maxdepth 1 -type f -name '*.RAW' -mmin "+$KEEP_RECENT_MIN" -print0)
+
+echo "archiver: archived=$archived removed=$removed failed=$failed"

--- a/modules/biometrics-archiver/sleepypod-biometrics-archiver.service
+++ b/modules/biometrics-archiver/sleepypod-biometrics-archiver.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sleepypod biometrics RAW archiver (gzip oldest from tmpfs to eMMC)
+Documentation=https://github.com/sleepypod/core/tree/main/modules/biometrics-archiver
+Requires=persistent-biometrics.mount
+After=persistent-biometrics.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sleepypod-biometrics-archiver
+Nice=10
+IOSchedulingClass=idle

--- a/modules/biometrics-archiver/sleepypod-biometrics-archiver.timer
+++ b/modules/biometrics-archiver/sleepypod-biometrics-archiver.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run sleepypod biometrics RAW archiver every 15 min
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Persistent=true
+Unit=sleepypod-biometrics-archiver.service
+
+[Install]
+WantedBy=timers.target

--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Prune oldest gzipped RAW archives until /persistent disk usage falls
+# below TARGET_USED_PCT. Runs every 15 min after archiver. Never touches
+# files outside /persistent/biometrics-archive/.
+set -euo pipefail
+
+ARCHIVE_DIR="/persistent/biometrics-archive"
+TARGET_USED_PCT="${TARGET_USED_PCT:-80}"
+
+mkdir -p "$ARCHIVE_DIR"
+
+pruned=0
+while :; do
+  used_pct=$(df --output=pcent /persistent | tail -1 | tr -dc '0-9')
+  used_pct=${used_pct:-0}
+  if [ "$used_pct" -le "$TARGET_USED_PCT" ]; then
+    break
+  fi
+
+  oldest=$(find "$ARCHIVE_DIR" -maxdepth 1 -type f -name '*.RAW.gz' -printf '%T@ %p\n' 2>/dev/null \
+    | sort -n | head -1 | awk '{print $2}')
+  if [ -z "$oldest" ]; then
+    echo "pruner: $used_pct% used but archive is empty — nothing to prune" >&2
+    break
+  fi
+
+  rm -f "$oldest"
+  pruned=$((pruned + 1))
+done
+
+used_pct=$(df --output=pcent /persistent | tail -1 | tr -dc '0-9')
+echo "pruner: pruned=$pruned used_pct=$used_pct%"

--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner.service
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Sleepypod biometrics archive pruner (keep /persistent < 80%)
+Documentation=https://github.com/sleepypod/core/tree/main/modules/biometrics-archiver
+After=sleepypod-biometrics-archiver.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sleepypod-biometrics-pruner
+Nice=10
+IOSchedulingClass=idle

--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner.timer
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run sleepypod biometrics archive pruner every 15 min
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=15min
+Persistent=true
+Unit=sleepypod-biometrics-pruner.service
+
+[Install]
+WantedBy=timers.target

--- a/modules/biometrics-archiver/sleepypod-tmpfs-prep
+++ b/modules/biometrics-archiver/sleepypod-tmpfs-prep
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Prepare /persistent/biometrics tmpfs after mount: place symlinks for the
+# state files frankenfirmware accesses by relative path so the firmware
+# can run with cwd=/persistent/biometrics without losing persistence.
+#
+# - SEQNO.RAW: firmware overwrites in place via fopen("w") — symlink writes
+#   pass through to the eMMC target. Verified empirically: same inode for
+#   /persistent/SEQNO.RAW across many days, mtime advancing.
+# - settings/heat/vector/system-connections/free-sleep-data/deviceinfo/
+#   sleepypod-data: state directories the firmware reads (and rarely
+#   writes); symlinks transparently expose the on-disk content.
+# - alarm.cbr/uptime.log: misc small state files.
+#
+# Idempotent: safe to run on every frank.service start. Tmpfs is empty
+# after every mount, so we re-stage every time.
+set -euo pipefail
+
+TMPFS_DIR="/persistent/biometrics"
+SOURCE_DIR="/persistent"
+
+if ! mountpoint -q "$TMPFS_DIR"; then
+  echo "tmpfs-prep: $TMPFS_DIR is not a tmpfs mount — refusing to stage" >&2
+  exit 1
+fi
+
+# Subdirectories: symlink target dirs live on eMMC.
+for name in deviceinfo settings heat vector system-connections free-sleep-data sleepypod-data; do
+  src="$SOURCE_DIR/$name"
+  dst="$TMPFS_DIR/$name"
+  if [ -e "$src" ] && [ ! -L "$dst" ]; then
+    ln -sfn "$src" "$dst"
+  fi
+done
+
+# State files that firmware reads/writes through cwd. Symlinks pass
+# writes through to eMMC.
+for name in SEQNO.RAW alarm.cbr uptime.log; do
+  src="$SOURCE_DIR/$name"
+  dst="$TMPFS_DIR/$name"
+  if [ -f "$src" ] && [ ! -L "$dst" ]; then
+    ln -sfn "$src" "$dst"
+  fi
+done
+
+echo "tmpfs-prep: staged $(ls -1 "$TMPFS_DIR" | wc -l) entries in $TMPFS_DIR"

--- a/modules/biometrics-archiver/sleepypod-tmpfs-prep.service
+++ b/modules/biometrics-archiver/sleepypod-tmpfs-prep.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Stage symlinks in /persistent/biometrics tmpfs for frankenfirmware
+Documentation=https://github.com/sleepypod/core/tree/main/modules/biometrics-archiver
+Requires=persistent-biometrics.mount
+After=persistent-biometrics.mount
+Before=frank.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/sleepypod-tmpfs-prep
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/cover-buttons/sleepypod-cover-buttons.service
+++ b/modules/cover-buttons/sleepypod-cover-buttons.service
@@ -15,7 +15,7 @@ RestartSec=10
 
 # Environment — override via /etc/sleepypod/modules/cover-buttons.env
 EnvironmentFile=-/etc/sleepypod/modules/cover-buttons.env
-Environment="RAW_DATA_DIR=/persistent"
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 

--- a/modules/environment-monitor/sleepypod-environment-monitor.service
+++ b/modules/environment-monitor/sleepypod-environment-monitor.service
@@ -15,7 +15,7 @@ RestartSec=10
 
 # Environment — override via /etc/sleepypod/modules/environment-monitor.env
 EnvironmentFile=-/etc/sleepypod/modules/environment-monitor.env
-Environment="RAW_DATA_DIR=/persistent"
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 

--- a/modules/piezo-processor/sleepypod-piezo-processor.service
+++ b/modules/piezo-processor/sleepypod-piezo-processor.service
@@ -15,7 +15,7 @@ RestartSec=10
 
 # Environment — override via /etc/sleepypod/modules/piezo-processor.env
 EnvironmentFile=-/etc/sleepypod/modules/piezo-processor.env
-Environment="RAW_DATA_DIR=/persistent"
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 

--- a/modules/sleep-detector/sleepypod-sleep-detector.service
+++ b/modules/sleep-detector/sleepypod-sleep-detector.service
@@ -15,7 +15,7 @@ RestartSec=10
 
 # Environment — override via /etc/sleepypod/modules/sleep-detector.env
 EnvironmentFile=-/etc/sleepypod/modules/sleep-detector.env
-Environment="RAW_DATA_DIR=/persistent"
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 

--- a/scripts/bin/sp-freesleep
+++ b/scripts/bin/sp-freesleep
@@ -2,7 +2,7 @@
 set -euo pipefail
 echo "Switching to free-sleep..."
 systemctl stop sleepypod.service 2>/dev/null || true
-for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
+for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator sleepypod-cover-buttons; do
   systemctl stop "$svc.service" 2>/dev/null || true
   systemctl disable "$svc.service" 2>/dev/null || true
 done

--- a/scripts/bin/sp-sleepypod
+++ b/scripts/bin/sp-sleepypod
@@ -11,7 +11,7 @@ if command -v fuser &>/dev/null; then
   sleep 1
 fi
 systemctl restart sleepypod.service
-for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator; do
+for svc in sleepypod-piezo-processor sleepypod-sleep-detector sleepypod-environment-monitor sleepypod-calibrator sleepypod-cover-buttons; do
   systemctl enable "$svc.service" 2>/dev/null || true
   systemctl restart "$svc.service" 2>/dev/null || true
 done

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -58,6 +58,33 @@ for svc in "${SERVICES[@]}"; do
   systemctl disable "$svc" 2>/dev/null || true
   rm -f "/etc/systemd/system/$svc"
 done
+
+# Restore frank.sh from the most recent pre-tmpfs backup BEFORE the mount
+# is torn down — otherwise frank's cwd disappears mid-restart.
+if ls /opt/eight/bin/frank.sh.bak-pre-tmpfs-* >/dev/null 2>&1; then
+  newest_backup=$(ls -1t /opt/eight/bin/frank.sh.bak-pre-tmpfs-* | head -1)
+  echo "Restoring frank.sh from $newest_backup"
+  cp -p "$newest_backup" /opt/eight/bin/frank.sh
+  systemctl restart frank.service 2>/dev/null || true
+fi
+
+# Tear down biometrics-archiver: timers, prep service, mount unit.
+for u in sleepypod-biometrics-archiver.timer sleepypod-biometrics-pruner.timer \
+         sleepypod-tmpfs-prep.service persistent-biometrics.mount; do
+  systemctl stop "$u" 2>/dev/null || true
+  systemctl disable "$u" 2>/dev/null || true
+done
+rm -f /etc/systemd/system/sleepypod-biometrics-archiver.service \
+      /etc/systemd/system/sleepypod-biometrics-archiver.timer \
+      /etc/systemd/system/sleepypod-biometrics-pruner.service \
+      /etc/systemd/system/sleepypod-biometrics-pruner.timer \
+      /etc/systemd/system/sleepypod-tmpfs-prep.service \
+      /etc/systemd/system/persistent-biometrics.mount
+rm -rf /etc/systemd/system/frank.service.d
+rm -f /usr/local/bin/sleepypod-tmpfs-prep \
+      /usr/local/bin/sleepypod-biometrics-archiver \
+      /usr/local/bin/sleepypod-biometrics-pruner
+
 systemctl daemon-reload
 
 # Remove CLI tools

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -51,6 +51,7 @@ SERVICES=(
   sleepypod-sleep-detector.service
   sleepypod-environment-monitor.service
   sleepypod-calibrator.service
+  sleepypod-cover-buttons.service
 )
 for svc in "${SERVICES[@]}"; do
   systemctl stop "$svc" 2>/dev/null || true

--- a/scripts/install
+++ b/scripts/install
@@ -590,15 +590,22 @@ if [ -f "$INSTALL_DIR/.env" ]; then
   grep -q "^BIOMETRICS_DATABASE_URL=" "$INSTALL_DIR/.env" && \
     sed -i "s|^BIOMETRICS_DATABASE_URL=.*|BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db|" "$INSTALL_DIR/.env" || \
     echo "BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db" >> "$INSTALL_DIR/.env"
+
+  # Generate EXPORT_TOKEN once if missing — preserved across upgrades.
+  if ! grep -q "^EXPORT_TOKEN=" "$INSTALL_DIR/.env"; then
+    echo "EXPORT_TOKEN=$(head -c 24 /dev/urandom | base64 | tr -d '+/=' )" >> "$INSTALL_DIR/.env"
+  fi
 else
   echo "Creating environment file..."
   touch "$INSTALL_DIR/.env"
   chmod 640 "$INSTALL_DIR/.env"
+  EXPORT_TOKEN_VAL="$(head -c 24 /dev/urandom | base64 | tr -d '+/=' )"
   cat > "$INSTALL_DIR/.env" << EOF
 DATABASE_URL=file:$DATA_DIR/sleepypod.db
 BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db
 DAC_SOCK_PATH=$DAC_SOCK_PATH
 NODE_ENV=production
+EXPORT_TOKEN=$EXPORT_TOKEN_VAL
 EOF
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -963,6 +963,33 @@ if [ -d "$ARCHIVER_SRC" ]; then
 
   systemctl enable --now sleepypod-biometrics-archiver.timer
   systemctl enable --now sleepypod-biometrics-pruner.timer
+
+  # One-time migration: gzip + relocate any pre-tmpfs RAW files at
+  # /persistent root (firmware now writes to /persistent/biometrics, so
+  # files at the old location are stranded). Idempotent — runs only if
+  # there are .RAW files at root, skips SEQNO.RAW.
+  shopt -s nullglob
+  stranded=( /persistent/*.RAW )
+  shopt -u nullglob
+  archived=0
+  for src in "${stranded[@]}"; do
+    base=$(basename "$src")
+    [ "$base" = "SEQNO.RAW" ] && continue
+    dst="/persistent/biometrics-archive/$base.gz"
+    if [ -f "$dst" ]; then
+      rm -f "$src"
+      archived=$((archived + 1))
+      continue
+    fi
+    if gzip -c "$src" > "$dst.tmp.$$"; then
+      mv -f "$dst.tmp.$$" "$dst"
+      rm -f "$src"
+      archived=$((archived + 1))
+    else
+      rm -f "$dst.tmp.$$"
+    fi
+  done
+  [ "$archived" -gt 0 ] && echo "Archived $archived stranded pre-tmpfs RAW files"
 fi
 
 # Re-fix DB permissions after all services restarted with new UMask.

--- a/scripts/install
+++ b/scripts/install
@@ -899,6 +899,72 @@ else
   install_module "cover-buttons"
 fi
 
+# ============================================================================
+# Biometrics archiver — tmpfs RAW writes + gzip cold archive on eMMC.
+# ============================================================================
+# Frankenfirmware writes ~1 GB/day of *.RAW frames. Move them to a 500 MB
+# tmpfs at /persistent/biometrics so wear stays off eMMC; archiver gzips
+# files older than 15 min into /persistent/biometrics-archive/, pruner
+# keeps /persistent < 80% full. SEQNO.RAW + persistent state subdirs are
+# symlinked from tmpfs back to /persistent so the firmware sees its
+# state without code changes. See modules/biometrics-archiver/README.
+ARCHIVER_SRC="$INSTALL_DIR/modules/biometrics-archiver"
+if [ -d "$ARCHIVER_SRC" ]; then
+  echo "Installing biometrics-archiver (tmpfs + cold archive)..."
+
+  # Scripts
+  for s in sleepypod-tmpfs-prep sleepypod-biometrics-archiver sleepypod-biometrics-pruner; do
+    install -m 0755 "$ARCHIVER_SRC/$s" "/usr/local/bin/$s"
+  done
+
+  # Systemd units
+  install -m 0644 "$ARCHIVER_SRC/persistent-biometrics.mount"      /etc/systemd/system/
+  install -m 0644 "$ARCHIVER_SRC/sleepypod-tmpfs-prep.service"     /etc/systemd/system/
+  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-archiver.service" /etc/systemd/system/
+  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-archiver.timer"   /etc/systemd/system/
+  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-pruner.service"   /etc/systemd/system/
+  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-pruner.timer"     /etc/systemd/system/
+
+  # frank.service drop-in: pull in mount + prep before frankenfirmware execs
+  mkdir -p /etc/systemd/system/frank.service.d
+  install -m 0644 "$ARCHIVER_SRC/frank.service.d/sleepypod-biometrics-tmpfs.conf" \
+    /etc/systemd/system/frank.service.d/sleepypod-biometrics-tmpfs.conf
+
+  systemctl daemon-reload
+
+  # Bring up the mount + symlinks BEFORE patching frank.sh so the cd
+  # target exists when frank restarts.
+  systemctl enable --now persistent-biometrics.mount
+  systemctl enable --now sleepypod-tmpfs-prep.service
+
+  # Patch /opt/eight/bin/frank.sh idempotently. The original is a 12-line
+  # firmware shim that does `cd /persistent && exec frankenfirmware`. We
+  # need cwd=/persistent/biometrics so RAW frames land in tmpfs.
+  if [ -f /opt/eight/bin/frank.sh ]; then
+    if ! grep -q 'cd /persistent/biometrics' /opt/eight/bin/frank.sh; then
+      backup="/opt/eight/bin/frank.sh.bak-pre-tmpfs-$(date -u +%Y%m%dT%H%M%SZ)"
+      cp -p /opt/eight/bin/frank.sh "$backup"
+      echo "Backed up frank.sh to $backup"
+      sed -i 's|cd /persistent &&|cd /persistent/biometrics \&\&|' /opt/eight/bin/frank.sh
+      echo "Patched frank.sh: cwd -> /persistent/biometrics"
+      systemctl restart frank.service
+    else
+      echo "frank.sh already patched — skipping"
+    fi
+  else
+    echo "Warning: /opt/eight/bin/frank.sh not found — skipping patch (not a Pod?)"
+  fi
+
+  # Restart sleepypod modules so they pick up RAW_DATA_DIR=/persistent/biometrics
+  for u in sleepypod-piezo-processor sleepypod-sleep-detector \
+           sleepypod-environment-monitor sleepypod-cover-buttons; do
+    systemctl restart "$u.service" 2>/dev/null || true
+  done
+
+  systemctl enable --now sleepypod-biometrics-archiver.timer
+  systemctl enable --now sleepypod-biometrics-pruner.timer
+fi
+
 # Re-fix DB permissions after all services restarted with new UMask.
 # On upgrades, old services (without UMask=0002) may have recreated WAL/SHM
 # files with 0644 between the initial fixup and the service restarts above.

--- a/scripts/install
+++ b/scripts/install
@@ -377,6 +377,21 @@ if [ "$NODE_MAJOR" -lt "$NODE_WANTED" ]; then
   exit 1
 fi
 
+# Ensure /usr/local/bin/node exists. The systemd unit hardcodes this
+# path (see ExecStart below), but on Pod 3 firmware Node ships
+# preinstalled via Volta at ~/.volta/bin/node — when the version check
+# above passes we skip the tarball install and would otherwise leave
+# /usr/local/bin/node missing. Symlink the resolved node binary so the
+# service can exec it. Matches the pnpm pattern below.
+if [ ! -x /usr/local/bin/node ]; then
+  RESOLVED_NODE="$(command -v node || true)"
+  if [ -n "$RESOLVED_NODE" ] && [ -x "$RESOLVED_NODE" ]; then
+    mkdir -p /usr/local/bin
+    ln -sf "$RESOLVED_NODE" /usr/local/bin/node
+    echo "Symlinked /usr/local/bin/node -> $RESOLVED_NODE"
+  fi
+fi
+
 # Install pnpm if not present at /usr/local/bin/pnpm. We check the
 # absolute path (not `command -v pnpm`) because Pod 3 firmware ships
 # Volta with a pnpm shim in ~/.volta/bin; the shim always reports "found"

--- a/src/components/status/StatusScreen.tsx
+++ b/src/components/status/StatusScreen.tsx
@@ -5,6 +5,7 @@ import { trpc } from '@/src/utils/trpc'
 import { PullToRefresh } from '@/src/components/PullToRefresh/PullToRefresh'
 import { HealthCircle } from './HealthCircle'
 import { HealthStatusCard } from './HealthStatusCard'
+import { SystemInfoCard } from './SystemInfoCard'
 import { UpdateCard } from './UpdateCard'
 import { WaterModal } from './WaterModal'
 import { CalibrationModal } from './CalibrationModal'
@@ -307,6 +308,9 @@ export function StatusScreen() {
           isPriming={deviceStatus.data?.isPriming ?? false}
           onWaterClick={() => setWaterModalOpen(true)}
         />
+
+        {/* System info — branch/commit/build date + full disk usage */}
+        <SystemInfoCard />
 
         {/* Internet access toggle */}
         <InternetToggleCard />


### PR DESCRIPTION
## Summary

| Ticket | Commit | What |
|---|---|---|
| #17 | 7700cbf | Register `sleepypod-cover-buttons.service` in sp-uninstall / sp-sleepypod / sp-freesleep iteration lists |
| #14 | 8c489fd | Symlink `/usr/local/bin/node` when node is preinstalled at a non-standard path (Pod 3 Volta case) |
| #10 | 30efa90 | New `pr-title-gate.yml` workflow — fails any PR to main whose title isn't `feat/fix/perf/revert` |
| #16 | 0115fb5 | Re-mount orphaned `SystemInfoCard` on status page so the disk widget is visible again |
| #20 | a23d5e6 | New `GET /api/export/archive` route — token-gated tar.gz of biometrics db + raw window |
| #19 | 09a44a1 + 180a498 + 9a0dde5 | tmpfs at `/persistent/biometrics` (500 MB) + gzip cold archive on eMMC; frank.sh cd patch with timestamped backup; archiver/pruner timers; one-time stranded-RAW migration; ADR 0018 |

#22 / #23 / #24 / #15 already merged in #496 / #497 / #498 / #491 — they're awaiting on-pod verification, no code changes here.

## #19 — design rationale

Frankenfirmware string analysis showed `%08lX.RAW` filenames and `SEQNO.RAW` are relative to cwd; `/persistent/PodConfiguration.json` is absolute. The load-bearing fact that made the symlink architecture safe: `/persistent/SEQNO.RAW` inode 13 has been continuous since 2025-06-13, mtime advancing → firmware uses `fopen("w")` truncate-write, NOT rename-replace → symlink writes pass through to the eMMC inode. Without that, the migration would require recompiling firmware.

External validation: Discord community thread (terchrng + Masticore) independently arrived at the same plan — `mkdir /persistent/biometrics`, patch frank.sh cd, `mount -t tmpfs -o size=500M`, restart frank. PR #499 ships that plus the archiver/pruner/uninstall/idempotency the chat plan was missing.

## Live-validated on Pod 5 (fw a35aafa)

**Initial cutover** (2026-05-04 00:17 UTC):
1. Mounted tmpfs at `/persistent/biometrics` ✓
2. Staged symlinks: SEQNO.RAW + 9 state files/dirs back to /persistent ✓
3. Backed up frank.sh → `frank.sh.bak-pre-tmpfs-20260504T001651Z` + patched cd target ✓
4. Restarted frank → new RAW `02C6D44D.RAW` landed in tmpfs (`df` confirmed `tmpfs` filesystem) ✓
5. SEQNO.RAW write-through verified: inode 13 unchanged, content advanced to new seqno ✓
6. Restarted sleepypod modules with `RAW_DATA_DIR=/persistent/biometrics` (via drop-ins) → all 4 modules' fds attached to tmpfs RAW ✓
7. End-to-end pipeline confirmed: piezo emitting real vitals at 00:39:57 (`HR=67.4 HRV=70.9 BR=22.4 q=0.44`), both sides ✓
8. One-time migration archived 129 stranded pre-tmpfs RAW files at root (529 MB freed) ✓

**8h 30m later** (2026-05-05 05:30 UTC, after one full sleep cycle):

| | |
|---|---|
| frank cwd | `/persistent/biometrics` (patch persisted) |
| frank fd | `/persistent/biometrics/02CC61F4.RAW` (live tmpfs write) |
| seq advance from cutover | `02C6D44D` → `02CC61F4` (full sleep cycle of data, zero eMMC writes for live RAW) |
| tmpfs | 8.1 MB / 500 MB (2%) — comfortably below cap |
| /persistent eMMC | 818 MB / 15 GB (6%) |
| cold archive | **239 gzipped files, 609 MB total** |
| services | frank + sleepypod + 5 modules all active |
| timers | archiver + pruner firing every 15 min on schedule |
| live vitals | HR 57–72, BR ~19, both sides — real sleeping data |

**Survived an `sp-update` pulling main** (which doesn't have this PR yet). The drop-ins at `/etc/systemd/system/sleepypod-*.service.d/biometrics-tmpfs.conf` overlaid main's `RAW_DATA_DIR=/persistent` with `/persistent/biometrics`; frank.sh patch + tmpfs mount untouched by sp-update. Confirms the install/upgrade flow is robust.

## Test plan

Local:
- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean (1 pre-existing warning in stryker config)
- [x] `pnpm test --run` — 724 passed, 2 skipped
- [x] `bash -n` syntax-check on install / sp-uninstall / 3 archiver scripts

On-pod (post-merge or via `./scripts/install --branch feat/tickets-10-14-16-17-20-batch`):
- [ ] #17 — `sp-freesleep` then `sp-sleepypod` cycles `sleepypod-cover-buttons` correctly
- [ ] #14 — re-run installer on Pod 3, confirm `/usr/local/bin/node` exists and `systemctl start sleepypod` works
- [ ] #10 — open a dummy PR to main with title `Release: foo`, confirm CI fails; retitle to `fix: foo`, confirm pass
- [ ] #16 — load `http://<pod>:3000/en/status`, see SystemInfoCard with disk usage rendered
- [ ] #20 — `grep EXPORT_TOKEN /home/dac/sleepypod-core/.env` returns a value; `curl "http://<pod>:3000/api/export/archive?token=<value>"` streams tar.gz; `curl` without token returns 401
- [x] #19 — live-validated on Pod 5 across 8h 30m + one sp-update from main; second-pod fresh-install flow still TODO

## Rollback

`scripts/bin/sp-uninstall` restores frank.sh from the most recent `frank.sh.bak-pre-tmpfs-*` backup, tears down the mount + units + drop-ins + scripts. Cold archive at `/persistent/biometrics-archive/` is preserved for forensics.

## Out of scope

- iOS Export button for #20 — separate repo / SwiftUI scope
- Tests for the export route — pending live behavior confirmation