### PR TITLE
fix(piezo+build): symmetric pump-coupling phantom vitals + propagate build failures

### DIFF
--- a/modules/piezo-processor/main.py
+++ b/modules/piezo-processor/main.py
@@ -65,16 +65,16 @@ PUMP_ENERGY_MULTIPLIER = 10.0
 PUMP_CORRELATION_MIN = 0.5
 PUMP_GUARD_S = 5.0
 
-# Per-side pump activity threshold (frzHealth pump RPM). When one side's
-# pump is running and the opposite side's is idle, observed live on
-# 2026-05-02: a heating cycle on right with left idle drove pump@2000RPM
-# coupling into the right piezo and produced phantom HR/HRV/BR. The
-# existing PumpGate (broadband-symmetric energy spike) does not catch
-# asymmetric pump activity because min/max ratio is small.
-ASYMMETRIC_PUMP_RPM_MIN = 50          # pump considered "running" above this
-ASYMMETRIC_PUMP_GUARD_S = 5.0         # trailing guard after own-side pump-off
-ASYMMETRIC_PRESENCE_STD_FACTOR = 4.0  # raise enter_threshold by this factor
-ASYMMETRIC_PRESENCE_ACR_THRESHOLD = 0.6  # require strong autocorr to enter
+# Per-side pump activity threshold (frzHealth pump RPM). PumpGate catches
+# broadband-symmetric energy spikes but misses two steady-state coupling
+# modes: asymmetric (one pump on, observed 2026-05-02 Pod 3 — pump@2000RPM
+# on right with left idle drove phantom HR/HRV/BR) and symmetric (both
+# pumps on, observed 2026-05-05 Pod 5 — 1940/2004 rpm beat at 64/min lands
+# in the cardiac band). Both are caught by the guard below.
+PUMP_ACTIVE_RPM_MIN = 50          # pump considered "running" above this
+PUMP_OFF_GUARD_S = 5.0            # trailing guard after own-side pump-off
+PUMP_COUPLING_STD_FACTOR = 4.0    # raise enter_threshold by this factor
+PUMP_COUPLING_ACR_THRESHOLD = 0.6 # require strong autocorr to enter
 
 # HR band: 0.8 Hz preserves fundamental of 48+ BPM; 8.5 Hz per PMC7582983
 HR_BAND = (0.8, 8.5)
@@ -259,12 +259,12 @@ class FrzHealthPumpState:
                     val = data.get(key)
                     if val is not None:
                         try:
-                            rpm = ASYMMETRIC_PUMP_RPM_MIN + 1.0 if float(val) > 0 else 0.0
+                            rpm = PUMP_ACTIVE_RPM_MIN + 1.0 if float(val) > 0 else 0.0
                         except (TypeError, ValueError):
                             rpm = 0.0
                         break
 
-            now_active = rpm >= ASYMMETRIC_PUMP_RPM_MIN
+            now_active = rpm >= PUMP_ACTIVE_RPM_MIN
             if self._was_active[side] and not now_active:
                 self._pump_off_at[side] = time.monotonic()
             self._pump_rpm[side] = rpm
@@ -272,9 +272,9 @@ class FrzHealthPumpState:
 
     def is_side_pump_active(self, side: str) -> bool:
         """Pump active = currently running OR within the trailing guard window."""
-        if self._pump_rpm[side] >= ASYMMETRIC_PUMP_RPM_MIN:
+        if self._pump_rpm[side] >= PUMP_ACTIVE_RPM_MIN:
             return True
-        return time.monotonic() - self._pump_off_at[side] < ASYMMETRIC_PUMP_GUARD_S
+        return time.monotonic() - self._pump_off_at[side] < PUMP_OFF_GUARD_S
 
     def is_asymmetric_for(self, side: str) -> bool:
         """Own pump active, opposite pump idle (and outside its own guard).
@@ -285,13 +285,9 @@ class FrzHealthPumpState:
         return self.is_side_pump_active(side) and not self.is_side_pump_active(other)
 
     def is_symmetric_active(self) -> bool:
-        """Both sides' pumps active. Two pumps at slightly different RPMs
-        (e.g. Pod 5 live: 1940 / 2004) produce a beat frequency that lands
-        in the cardiac band (here 64/min), generating phantom HR/HRV/BR
-        on both sides simultaneously. The broadband PumpGate catches
-        sudden symmetric spikes but NOT steady-state both-on heating —
-        observed live on Pod 5 emitting bilateral vitals with no
-        occupant. Mirror of is_asymmetric_for, for the both-on case."""
+        """Both pumps active. RPM mismatch (Pod 5 live: 1940/2004) produces
+        a beat frequency in the cardiac band, generating bilateral phantom
+        vitals. PumpGate catches symmetric spikes but not steady-state."""
         return self.is_side_pump_active("left") and self.is_side_pump_active("right")
 
 
@@ -830,45 +826,27 @@ class SideProcessor:
         self._last_med_std = med_std
         self._last_acr_qual = acr_qual
 
-        # Pump-coupling guard. Two configurations produce phantom presence:
-        #
-        #  1. Asymmetric (own-pump-on, other-pump-off): motor vibration
-        #     couples into the same-side piezo and produces broadband
-        #     energy with periodic-looking autocorrelation in the cardiac
-        #     band. Cross-channel rejection above can't help because the
-        #     opposite side has no competing signal.
-        #
-        #  2. Symmetric (both-pumps-on): two pumps at slightly different
-        #     RPMs create a beat frequency in the cardiac band (Pod 5
-        #     live: 1940/2004 rpm → 64/min beat), producing bilateral
-        #     phantom HR/HRV/BR. The broadband PumpGate catches sudden
-        #     symmetric spikes (ramps) but not steady-state both-on
-        #     heating, and cross-channel rejection sees both sides as
-        #     "real signal" and stays out of the way.
-        #
-        # In both cases, while the gate is active we require BOTH
-        # significantly elevated energy AND strong autocorrelation to
-        # enter PRESENT — pump coupling rarely produces both because
-        # cardiac periodicity dominates only with a real person.
-        pump_coupling = (
-            self._pump_state is not None
-            and self._presence.state == PresenceDetector.ABSENT
-            and (self._pump_state.is_asymmetric_for(self.side)
-                 or self._pump_state.is_symmetric_active())
-        )
-        if pump_coupling:
-            std_threshold = (
-                self._presence.enter_threshold * ASYMMETRIC_PRESENCE_STD_FACTOR
-            )
-            if not (med_std > std_threshold
-                    and acr_qual > ASYMMETRIC_PRESENCE_ACR_THRESHOLD):
-                mode = "symmetric" if self._pump_state.is_symmetric_active() else "asymmetric"
-                log.debug(
-                    "%s: pump-coupling guard suppressed presence "
-                    "(med_std=%.0f, acr=%.2f, mode=%s)",
-                    self.side, med_std, acr_qual, mode,
-                )
-                return
+        # Pump-coupling guard. PumpGate handles symmetric spikes (ramps)
+        # but misses two steady-state modes: asymmetric (own-pump-on with
+        # opposite idle — vibration couples into same-side piezo, no
+        # competing signal for cross-channel rejection) and symmetric
+        # (both pumps on at mismatched RPMs — beat frequency lands in the
+        # cardiac band, both sides look "real"). In both, require elevated
+        # energy AND strong autocorrelation to enter PRESENT; coupling
+        # rarely produces both, only a real person does.
+        if self._pump_state is not None and self._presence.state == PresenceDetector.ABSENT:
+            symmetric = self._pump_state.is_symmetric_active()
+            asymmetric = self._pump_state.is_asymmetric_for(self.side)
+            if symmetric or asymmetric:
+                std_threshold = self._presence.enter_threshold * PUMP_COUPLING_STD_FACTOR
+                if not (med_std > std_threshold and acr_qual > PUMP_COUPLING_ACR_THRESHOLD):
+                    log.debug(
+                        "%s: pump-coupling guard suppressed presence "
+                        "(med_std=%.0f, acr=%.2f, mode=%s)",
+                        self.side, med_std, acr_qual,
+                        "symmetric" if symmetric else "asymmetric",
+                    )
+                    return
 
         present = self._presence.update(med_std, acr_qual)
 

--- a/modules/piezo-processor/main.py
+++ b/modules/piezo-processor/main.py
@@ -284,6 +284,16 @@ class FrzHealthPumpState:
         other = "right" if side == "left" else "left"
         return self.is_side_pump_active(side) and not self.is_side_pump_active(other)
 
+    def is_symmetric_active(self) -> bool:
+        """Both sides' pumps active. Two pumps at slightly different RPMs
+        (e.g. Pod 5 live: 1940 / 2004) produce a beat frequency that lands
+        in the cardiac band (here 64/min), generating phantom HR/HRV/BR
+        on both sides simultaneously. The broadband PumpGate catches
+        sudden symmetric spikes but NOT steady-state both-on heating —
+        observed live on Pod 5 emitting bilateral vitals with no
+        occupant. Mirror of is_asymmetric_for, for the both-on case."""
+        return self.is_side_pump_active("left") and self.is_side_pump_active("right")
+
 
 class PumpGate:
     """Detects pump activity from dual-channel energy spikes.
@@ -820,26 +830,43 @@ class SideProcessor:
         self._last_med_std = med_std
         self._last_acr_qual = acr_qual
 
-        # Asymmetric pump-coupling guard: when own-side pump is active and the
-        # opposite side's pump is idle, motor vibration couples into the same-
-        # side piezo channel and produces broadband energy with periodic-looking
-        # autocorrelation in the cardiac band. The existing PumpGate (broadband-
-        # symmetric spike) does not catch this asymmetric case. While the gate
-        # is active, require BOTH significantly elevated energy AND strong
-        # autocorrelation to enter PRESENT — pure pump coupling rarely produces
-        # both because cardiac periodicity dominates only with a real person.
-        if (self._pump_state is not None
-                and self._pump_state.is_asymmetric_for(self.side)
-                and self._presence.state == PresenceDetector.ABSENT):
-            asymmetric_std_threshold = (
+        # Pump-coupling guard. Two configurations produce phantom presence:
+        #
+        #  1. Asymmetric (own-pump-on, other-pump-off): motor vibration
+        #     couples into the same-side piezo and produces broadband
+        #     energy with periodic-looking autocorrelation in the cardiac
+        #     band. Cross-channel rejection above can't help because the
+        #     opposite side has no competing signal.
+        #
+        #  2. Symmetric (both-pumps-on): two pumps at slightly different
+        #     RPMs create a beat frequency in the cardiac band (Pod 5
+        #     live: 1940/2004 rpm → 64/min beat), producing bilateral
+        #     phantom HR/HRV/BR. The broadband PumpGate catches sudden
+        #     symmetric spikes (ramps) but not steady-state both-on
+        #     heating, and cross-channel rejection sees both sides as
+        #     "real signal" and stays out of the way.
+        #
+        # In both cases, while the gate is active we require BOTH
+        # significantly elevated energy AND strong autocorrelation to
+        # enter PRESENT — pump coupling rarely produces both because
+        # cardiac periodicity dominates only with a real person.
+        pump_coupling = (
+            self._pump_state is not None
+            and self._presence.state == PresenceDetector.ABSENT
+            and (self._pump_state.is_asymmetric_for(self.side)
+                 or self._pump_state.is_symmetric_active())
+        )
+        if pump_coupling:
+            std_threshold = (
                 self._presence.enter_threshold * ASYMMETRIC_PRESENCE_STD_FACTOR
             )
-            if not (med_std > asymmetric_std_threshold
+            if not (med_std > std_threshold
                     and acr_qual > ASYMMETRIC_PRESENCE_ACR_THRESHOLD):
+                mode = "symmetric" if self._pump_state.is_symmetric_active() else "asymmetric"
                 log.debug(
                     "%s: pump-coupling guard suppressed presence "
-                    "(med_std=%.0f, acr=%.2f, own-pump-active, other-idle)",
-                    self.side, med_std, acr_qual,
+                    "(med_std=%.0f, acr=%.2f, mode=%s)",
+                    self.side, med_std, acr_qual, mode,
                 )
                 return
 

--- a/modules/piezo-processor/test_main.py
+++ b/modules/piezo-processor/test_main.py
@@ -1093,10 +1093,35 @@ class TestFrzHealthPumpState:
             "left": {"pumpRpm": 2000},
             "right": {"pumpRpm": 2000},
         })
-        # Both pumps on → balanced; broadband PumpGate handles this case.
-        # Asymmetric guard should not fire.
+        # Both pumps on → not asymmetric. The symmetric case is caught
+        # by is_symmetric_active() instead — see test below.
         assert ps.is_asymmetric_for("left") is False
         assert ps.is_asymmetric_for("right") is False
+        assert ps.is_symmetric_active() is True
+
+    def test_is_symmetric_active_only_when_both_running(self):
+        ps = FrzHealthPumpState()
+        # Both off
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 0},
+        })
+        assert ps.is_symmetric_active() is False
+        # Asymmetric (right only)
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 0},
+            "right": {"pumpRpm": 2000},
+        })
+        assert ps.is_symmetric_active() is False
+        # Both on (Pod 5 live: 1940 / 2004 → beat 64/min in cardiac band)
+        ps.update({
+            "type": "frzHealth",
+            "left": {"pumpRpm": 1940},
+            "right": {"pumpRpm": 2004},
+        })
+        assert ps.is_symmetric_active() is True
 
     def test_is_asymmetric_false_when_both_idle(self):
         ps = FrzHealthPumpState()

--- a/modules/piezo-processor/test_main.py
+++ b/modules/piezo-processor/test_main.py
@@ -33,8 +33,8 @@ from main import (  # noqa: E402
     compute_hrv,
     subharmonic_summation_hr,
     FrzHealthPumpState,
-    ASYMMETRIC_PUMP_GUARD_S,
-    ASYMMETRIC_PUMP_RPM_MIN,
+    PUMP_OFF_GUARD_S,
+    PUMP_ACTIVE_RPM_MIN,
     HRTracker,
     PresenceDetector,
     PumpGate,
@@ -1026,7 +1026,7 @@ class TestFrzHealthPumpState:
         ps.update({
             "type": "frzHealth",
             "left": {"pumpRpm": 0},
-            "right": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN + 100},
+            "right": {"pumpRpm": PUMP_ACTIVE_RPM_MIN + 100},
         })
         assert ps.is_side_pump_active("left") is False
         assert ps.is_side_pump_active("right") is True
@@ -1035,8 +1035,8 @@ class TestFrzHealthPumpState:
         ps = FrzHealthPumpState()
         ps.update({
             "type": "frzHealth",
-            "left": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN - 1},
-            "right": {"pumpRpm": ASYMMETRIC_PUMP_RPM_MIN - 1},
+            "left": {"pumpRpm": PUMP_ACTIVE_RPM_MIN - 1},
+            "right": {"pumpRpm": PUMP_ACTIVE_RPM_MIN - 1},
         })
         assert ps.is_side_pump_active("left") is False
         assert ps.is_side_pump_active("right") is False
@@ -1167,7 +1167,7 @@ class TestFrzHealthPumpState:
             "right": {"pumpRpm": 0},
         })
         # Force guard expiry
-        ps._pump_off_at["right"] = time.monotonic() - ASYMMETRIC_PUMP_GUARD_S - 1
+        ps._pump_off_at["right"] = time.monotonic() - PUMP_OFF_GUARD_S - 1
         assert ps.is_side_pump_active("right") is False
 
     def test_handles_malformed_record_safely(self):

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/generate-git-info.mjs && lingui compile",
-    "build": "next build && node scripts/strip-turbopack-external-hashes.mjs && cp -r .next/static .next/standalone/.next/static && { if [ -d public ]; then cp -r public .next/standalone/public; fi; }",
+    "build": "next build && node scripts/strip-turbopack-external-hashes.mjs && cp -r .next/static .next/standalone/.next/static && { [ ! -d public ] || cp -r public .next/standalone/public || true; }",
     "dev": "next dev",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
Two related fixes — surfaced together by tonight's Pod 5 deploy.

## (1) symmetric pump-coupling phantom HR/BR — sleepypod-core-25

**Why.** Live observation 2026-05-05 05:30 UTC on Pod 5 fw a35aafa: both pumps running steady-state (left 1940 rpm, right 2004 rpm), no occupant. \`piezo-processor\` emitted bilateral vitals over hours:

\`\`\`
05:26:48 right HR=71.9 HRV=0.0  BR=19.9 q=0.23
05:27:49 right HR=57.6 HRV=83.1 BR=22.3 q=0.28
06:50:32 left  HR=49.8 HRV=10.2 BR=17.5 q=0.79  ← high quality, no human
06:51:32 right HR=49.3 HRV=17.7 BR=19.6 q=0.18
\`\`\`

`2004 - 1940 = 64` cycles/min — two pumps at slightly different RPMs create a beat in resting-HR range. HRV swinging 0 → 99 between adjacent windows is also incompatible with a real heartbeat.

**Why the existing guards miss it.** PR #498 fixed the asymmetric case (one pump on, the other idle) and relied on the broadband \`PumpGate\` to catch the symmetric case. PumpGate detects sudden symmetric *spikes* (ramps) but not steady-state both-on heating. Cross-channel rejection at \`main.py:800-817\` also stays out of the way because both sides have similar pump-coupling energy and each sees the other as legitimate competing signal.

**Fix.** Add \`FrzHealthPumpState.is_symmetric_active()\` (true when both sides' pumps are active, with the same trailing guard semantics as \`is_asymmetric_for\`) and extend the pump-coupling guard in \`SideProcessor.process\` to fire on either configuration. Same enter-threshold + autocorr requirement as the asymmetric path.

## (2) build script || true masks failures — found tonight during sp-update

The chained build:

\`\`\`
next build && cp -r .next/static .next/standalone/.next/static && [ -d public ] && cp -r public .next/standalone/public || true
\`\`\`

Trailing \`|| true\` covered the WHOLE chain, not just the public copy. A failed \`next build\` returned exit 0 anyway, sp-update reported "Update complete!", and sleepypod crashlooped with \`Could not find a production build in the '.next' directory\`. Pod 5 hit this when turbopack didn't finish (likely OOM mid-build) and the partial \`.next/\` had no \`BUILD_ID\`.

Restructure so \`|| true\` scopes only to the public copy (the only legitimately-optional step):

\`\`\`
next build && cp -r .next/static .next/standalone/.next/static && { [ ! -d public ] || cp -r public .next/standalone/public || true; }
\`\`\`

Verified across 6 branches with a synthetic test: build/static failures now propagate; public copy failures still tolerated.

## Test plan

- [x] \`pytest test_main.py\` — 76 passed, 0 failed
- [x] \`pytest test_main.py::TestFrzHealthPumpState\` — 13 passed (12 existing + 1 new)
- [x] Synthetic shell test for the build chain — 6/6 cases pass
- [ ] Live Pod 5 verification: both pumps on, no occupant for 10 min → 0 vitals rows for both sides (pending sp-update)
- [ ] CI build still produces \`.next/\` correctly (CI is the existing happy path; will validate via the dev-release workflow on this PR)

## Refs

- sleepypod-core-25 (this ticket)
- PR #498 (asymmetric case — Pod 3)
- PR #228 (cross-channel rejection foundation)
- PR #230 (capSense2 pump gating)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for symmetric pump activity state to distinguish when both pumps are running simultaneously.
  * Improved presence detection suppression during pump operation with a unified, symmetric-aware guard mechanism using refined energy and correlation thresholds.

* **Tests**
  * Expanded test coverage for symmetric and asymmetric pump scenarios, including mixed-pump operation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->