### PR TITLE
fix(schedule): restore AI-powered custom curve

### DIFF
--- a/src/components/Schedule/AICurveWizard.tsx
+++ b/src/components/Schedule/AICurveWizard.tsx
@@ -1,0 +1,784 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  X,
+  Sparkles,
+  Copy,
+  Check,
+  Share2,
+  ClipboardPaste,
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  Trash2,
+  Plus,
+  Minus,
+  Save,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  generatePrompt,
+  parseAIResponse,
+  EXAMPLE_SUGGESTIONS,
+  loadTemplates,
+  saveTemplate,
+  deleteTemplate,
+} from '@/src/lib/sleepCurve/curvePrompt'
+import type { GeneratedCurve, CurveTemplate, ParseResult } from '@/src/lib/sleepCurve/curvePrompt'
+import { timeStringToMinutes } from '@/src/lib/sleepCurve/generate'
+import type { CurvePoint } from '@/src/lib/sleepCurve/types'
+import { CurveChart } from './CurveChart'
+import { PhaseLegend } from './PhaseLegend'
+
+interface AICurveWizardProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * Called when the user accepts a generated curve. The parent loads the
+   * set points + bedtime/wake into local editor state — the wizard does not
+   * write the schedule directly. The user reviews and presses Save in the
+   * parent editor to persist.
+   */
+  onApply: (config: {
+    setPoints: Array<{ time: string, temperature: number }>
+    bedtime: string
+    wakeTime: string
+  }) => void
+}
+
+type Step = 0 | 1 | 2 | 3
+
+const STEP_LABELS = ['Describe', 'Review', 'Import', 'Preview']
+
+export function AICurveWizard({ open, onClose, onApply }: AICurveWizardProps) {
+  const [step, setStep] = useState<Step>(0)
+  const [highestStep, setHighestStep] = useState<Step>(0)
+
+  // Step 1: Describe
+  const [preferences, setPreferences] = useState('')
+
+  // Step 2: Review
+  const [prompt, setPrompt] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  // Step 3: Import
+  const [jsonInput, setJsonInput] = useState('')
+  const [parseResult, setParseResult] = useState<ParseResult | null>(null)
+
+  // Step 4: Preview
+  const [curve, setCurve] = useState<GeneratedCurve | null>(null)
+  const [editablePoints, setEditablePoints] = useState<Array<{ time: string, tempF: number }>>([])
+  const [savedTemplates, setSavedTemplates] = useState<CurveTemplate[]>([])
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (open) {
+      setSavedTemplates(loadTemplates())
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      setStep(0)
+      setHighestStep(0)
+      setPreferences('')
+      setPrompt('')
+      setCopied(false)
+      setJsonInput('')
+      setParseResult(null)
+      setCurve(null)
+      setEditablePoints([])
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!jsonInput.trim()) {
+      setParseResult(null)
+      return
+    }
+    const timer = setTimeout(() => {
+      const result = parseAIResponse(jsonInput)
+      setParseResult(result)
+      if (result.success) {
+        setCurve(result.curve)
+        setEditablePoints(
+          Object.entries(result.curve.points)
+            .map(([time, tempF]) => ({ time, tempF }))
+            .sort((a, b) => a.time.localeCompare(b.time)),
+        )
+      }
+    }, 500)
+    return () => clearTimeout(timer)
+  }, [jsonInput])
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const goNext = useCallback(() => {
+    if (step === 0) {
+      const p = generatePrompt(preferences)
+      setPrompt(p)
+      const next: Step = 1
+      setStep(next)
+      setHighestStep(prev => Math.max(prev, next) as Step)
+    }
+    else if (step === 1) {
+      const next: Step = 2
+      setStep(next)
+      setHighestStep(prev => Math.max(prev, next) as Step)
+    }
+    else if (step === 2 && parseResult?.success) {
+      const next: Step = 3
+      setStep(next)
+      setHighestStep(prev => Math.max(prev, next) as Step)
+    }
+  }, [step, preferences, parseResult])
+
+  const goBack = useCallback(() => {
+    if (step > 0) setStep((step - 1) as Step)
+  }, [step])
+
+  const goToStep = useCallback((target: Step) => {
+    if (target <= highestStep) setStep(target)
+  }, [highestStep])
+
+  const handleSkipToImport = useCallback(() => {
+    setStep(2)
+    setHighestStep(prev => Math.max(prev, 2) as Step)
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(prompt)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+        return
+      }
+      catch { /* fall through */ }
+    }
+    const el = document.getElementById('ai-prompt-text')
+    if (el) {
+      const range = document.createRange()
+      range.selectNodeContents(el)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    }
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [prompt])
+
+  const handleShare = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ text: prompt })
+      }
+      catch { /* user cancelled */ }
+    }
+  }, [prompt])
+
+  const canShare = typeof navigator !== 'undefined' && !!navigator.share
+
+  const handlePaste = useCallback(async () => {
+    if (navigator.clipboard?.readText) {
+      try {
+        const text = await navigator.clipboard.readText()
+        setJsonInput(text)
+      }
+      catch { /* fall through */ }
+    }
+  }, [])
+
+  const handleLoadTemplate = useCallback((template: CurveTemplate) => {
+    setCurve(template)
+    setEditablePoints(
+      Object.entries(template.points)
+        .map(([time, tempF]) => ({ time, tempF }))
+        .sort((a, b) => a.time.localeCompare(b.time)),
+    )
+    setStep(3)
+    setHighestStep(3)
+  }, [])
+
+  const handleDeleteTemplate = useCallback((name: string) => {
+    deleteTemplate(name)
+    setSavedTemplates(loadTemplates())
+  }, [])
+
+  const handleSaveTemplate = useCallback(() => {
+    if (!curve) return
+    const pointsObj: Record<string, number> = {}
+    for (const p of editablePoints) pointsObj[p.time] = p.tempF
+    const updated: GeneratedCurve = { ...curve, points: pointsObj }
+    saveTemplate(updated)
+    setSavedTemplates(loadTemplates())
+  }, [curve, editablePoints])
+
+  const updatePoint = useCallback((idx: number, field: 'time' | 'tempF', value: string | number) => {
+    setEditablePoints((prev) => {
+      const next = [...prev]
+      if (field === 'time') next[idx] = { ...next[idx], time: value as string }
+      else next[idx] = { ...next[idx], tempF: Math.max(55, Math.min(110, value as number)) }
+      return next.sort((a, b) => a.time.localeCompare(b.time))
+    })
+  }, [])
+
+  const addPoint = useCallback(() => {
+    setEditablePoints((prev) => {
+      const last = prev[prev.length - 1]
+      const newTime = last ? incrementTime(last.time, 15) : '22:00'
+      return [...prev, { time: newTime, tempF: 78 }].sort((a, b) => a.time.localeCompare(b.time))
+    })
+  }, [])
+
+  const removePoint = useCallback((idx: number) => {
+    setEditablePoints((prev) => {
+      if (prev.length <= 3) return prev
+      return prev.filter((_, i) => i !== idx)
+    })
+  }, [])
+
+  const handleApply = useCallback(() => {
+    if (!curve || editablePoints.length < 3) return
+    onApply({
+      setPoints: editablePoints.map(p => ({ time: p.time, temperature: p.tempF })),
+      bedtime: curve.bedtime,
+      wakeTime: curve.wake,
+    })
+    onClose()
+  }, [curve, editablePoints, onApply, onClose])
+
+  const tempRange = useMemo(() => {
+    if (editablePoints.length === 0) return { min: 55, max: 110 }
+    const temps = editablePoints.map(p => p.tempF)
+    return { min: Math.min(...temps), max: Math.max(...temps) }
+  }, [editablePoints])
+
+  const chartData = useMemo(() => {
+    if (!curve || editablePoints.length < 2) return null
+    const btMin = timeStringToMinutes(curve.bedtime)
+
+    const withRelative = editablePoints.map((p) => {
+      let tMin = timeStringToMinutes(p.time) - btMin
+      if (tMin < -120) tMin += 24 * 60
+      return { ...p, minutesFromBedtime: tMin }
+    }).sort((a, b) => a.minutesFromBedtime - b.minutesFromBedtime)
+
+    const total = withRelative.length
+    const points: CurvePoint[] = withRelative.map((p, i) => {
+      const frac = i / (total - 1)
+      const phase = frac < 0.1
+        ? 'warmUp' as const
+        : frac < 0.25
+          ? 'coolDown' as const
+          : frac < 0.55
+            ? 'deepSleep' as const
+            : frac < 0.75
+              ? 'maintain' as const
+              : frac < 0.9
+                ? 'preWake' as const
+                : 'wake' as const
+      return { minutesFromBedtime: p.minutesFromBedtime, tempOffset: p.tempF - 80, phase }
+    })
+
+    return { points, bedtimeMinutes: btMin }
+  }, [curve, editablePoints])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[60] bg-black/60" onClick={onClose} />
+
+      <div className="fixed inset-x-0 bottom-0 z-[70] flex max-h-[90dvh] flex-col rounded-t-2xl bg-zinc-900 shadow-xl sm:inset-x-auto sm:inset-y-4 sm:left-1/2 sm:w-full sm:max-w-lg sm:-translate-x-1/2 sm:rounded-2xl">
+        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Sparkles size={16} className="text-cyan-400" />
+            <span className="text-sm font-semibold text-white">Custom AI Curve</span>
+          </div>
+          <button onClick={onClose} className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-800 text-zinc-400">
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="flex border-b border-zinc-800 px-4 py-2">
+          {STEP_LABELS.map((label, i) => (
+            <button
+              key={label}
+              onClick={() => goToStep(i as Step)}
+              disabled={i > highestStep}
+              className={cn(
+                'flex-1 py-1 text-[10px] font-medium uppercase tracking-wider transition-colors',
+                i === step ? 'text-cyan-400' : i <= highestStep ? 'text-zinc-500' : 'text-zinc-700',
+              )}
+            >
+              {i + 1}
+              .
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {step === 0 && (
+            <StepDescribe
+              preferences={preferences}
+              onPreferencesChange={setPreferences}
+              templates={savedTemplates}
+              onLoadTemplate={handleLoadTemplate}
+              onDeleteTemplate={handleDeleteTemplate}
+            />
+          )}
+          {step === 1 && (
+            <StepReview
+              prompt={prompt}
+              copied={copied}
+              onCopy={handleCopy}
+              canShare={canShare}
+              onShare={handleShare}
+            />
+          )}
+          {step === 2 && (
+            <StepImport
+              jsonInput={jsonInput}
+              onJsonInputChange={setJsonInput}
+              parseResult={parseResult}
+              onPaste={handlePaste}
+            />
+          )}
+          {step === 3 && curve && (
+            <StepPreview
+              curve={curve}
+              editablePoints={editablePoints}
+              tempRange={tempRange}
+              chartData={chartData}
+              onUpdatePoint={updatePoint}
+              onAddPoint={addPoint}
+              onRemovePoint={removePoint}
+              onSaveTemplate={handleSaveTemplate}
+              onApply={handleApply}
+            />
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-zinc-800 px-4 py-3">
+          <button
+            onClick={goBack}
+            disabled={step === 0}
+            className="flex items-center gap-1 text-xs text-zinc-400 disabled:opacity-30"
+          >
+            <ChevronLeft size={14} />
+            {' '}
+            Back
+          </button>
+
+          {step === 0 && (
+            <div className="flex gap-2">
+              <button
+                onClick={handleSkipToImport}
+                className="flex items-center gap-1 rounded-lg border border-zinc-800 px-4 py-2 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700"
+              >
+                <ClipboardPaste size={12} />
+                {' '}
+                Import
+              </button>
+              <button
+                onClick={goNext}
+                disabled={!preferences.trim()}
+                className="flex items-center gap-1 rounded-lg bg-cyan-500 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 disabled:opacity-40"
+              >
+                Generate
+                {' '}
+                <ChevronRight size={14} />
+              </button>
+            </div>
+          )}
+
+          {step > 0 && step < 3 && (
+            <button
+              onClick={goNext}
+              disabled={step === 2 && !parseResult?.success}
+              className="flex items-center gap-1 rounded-lg bg-cyan-500 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-cyan-600 disabled:opacity-40"
+            >
+              Next
+              {' '}
+              <ChevronRight size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function StepDescribe({
+  preferences,
+  onPreferencesChange,
+  templates,
+  onLoadTemplate,
+  onDeleteTemplate,
+}: {
+  preferences: string
+  onPreferencesChange: (v: string) => void
+  templates: CurveTemplate[]
+  onLoadTemplate: (t: CurveTemplate) => void
+  onDeleteTemplate: (name: string) => void
+}) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="mb-2 text-xs text-zinc-400">
+          Describe your sleep preferences in natural language. An AI will design a personalized temperature curve.
+        </p>
+        <textarea
+          value={preferences}
+          onChange={e => onPreferencesChange(e.target.value)}
+          placeholder="e.g., I run hot, bed at 11pm, wake at 6:30. Really cold first few hours..."
+          rows={4}
+          className="w-full rounded-xl border border-zinc-800 bg-zinc-800/50 px-3 py-2.5 text-sm text-white placeholder:text-zinc-600 focus:border-cyan-500/50 focus:outline-none"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500">Try an example</p>
+        {EXAMPLE_SUGGESTIONS.map(suggestion => (
+          <button
+            key={suggestion}
+            onClick={() => onPreferencesChange(suggestion)}
+            className="block w-full rounded-lg border border-zinc-800 px-3 py-2 text-left text-xs text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-300"
+          >
+            {suggestion}
+          </button>
+        ))}
+      </div>
+
+      {templates.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500">Saved Curves</p>
+          {templates.map(t => (
+            <div key={t.name} className="flex items-center gap-2 rounded-lg border border-zinc-800 px-3 py-2">
+              <button
+                onClick={() => onLoadTemplate(t)}
+                className="flex flex-1 items-center gap-2 text-left"
+              >
+                <span className="h-2 w-2 rounded-full bg-cyan-400" />
+                <span className="flex-1 text-xs font-medium text-zinc-300">{t.name}</span>
+                <span className="text-[10px] text-zinc-600">
+                  {t.bedtime}
+                  {' '}
+                  →
+                  {t.wake}
+                </span>
+              </button>
+              <button
+                onClick={() => onDeleteTemplate(t.name)}
+                className="flex h-6 w-6 items-center justify-center rounded text-zinc-600 hover:text-red-400"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StepReview({
+  prompt,
+  copied,
+  onCopy,
+  canShare,
+  onShare,
+}: {
+  prompt: string
+  copied: boolean
+  onCopy: () => void
+  canShare: boolean
+  onShare: () => void
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-zinc-400">
+        {canShare
+          ? 'Share this prompt to ChatGPT, Claude, or Gemini. Then paste the JSON response in the next step.'
+          : 'Select and copy this prompt, then paste it into ChatGPT, Claude, or Gemini. Paste the JSON response in the next step.'}
+      </p>
+
+      <div className="max-h-[40vh] overflow-y-auto rounded-xl border border-zinc-800 bg-zinc-950 p-3">
+        <pre id="ai-prompt-text" className="whitespace-pre-wrap text-[11px] leading-relaxed text-zinc-300 select-all">{prompt}</pre>
+      </div>
+
+      <div className="flex gap-2">
+        {canShare && (
+          <button
+            onClick={onShare}
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-cyan-500 px-4 py-3 text-sm font-semibold text-white transition-all hover:bg-cyan-600 active:scale-[0.98]"
+          >
+            <Share2 size={16} />
+            {' '}
+            Share Prompt
+          </button>
+        )}
+
+        <button
+          onClick={onCopy}
+          className={cn(
+            'flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-semibold transition-all',
+            canShare ? 'border border-zinc-800 bg-zinc-800/50 text-zinc-400' : 'flex-1',
+            copied
+              ? 'bg-emerald-500/20 text-emerald-400'
+              : !canShare
+                  ? 'bg-cyan-500 text-white hover:bg-cyan-600 active:scale-[0.98]'
+                  : '',
+          )}
+        >
+          {copied
+            ? (
+                <>
+                  <Check size={16} />
+                  {' '}
+                  Selected!
+                </>
+              )
+            : (
+                <>
+                  <Copy size={16} />
+                  {' '}
+                  {canShare ? 'Copy' : 'Select All'}
+                </>
+              )}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function StepImport({
+  jsonInput,
+  onJsonInputChange,
+  parseResult,
+  onPaste,
+}: {
+  jsonInput: string
+  onJsonInputChange: (v: string) => void
+  parseResult: ParseResult | null
+  onPaste: () => void
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-zinc-400">
+        Paste the AI&apos;s JSON response below. It will be validated automatically.
+      </p>
+
+      <textarea
+        value={jsonInput}
+        onChange={e => onJsonInputChange(e.target.value)}
+        placeholder='{"name": "...", "bedtime": "22:00", "wake": "07:00", "points": {...}, "reasoning": "..."}'
+        rows={8}
+        className="w-full rounded-xl border border-zinc-800 bg-zinc-800/50 px-3 py-2.5 font-mono text-xs text-white placeholder:text-zinc-600 focus:border-cyan-500/50 focus:outline-none"
+      />
+
+      <button
+        onClick={onPaste}
+        className="flex w-full items-center justify-center gap-2 rounded-xl border border-zinc-800 bg-zinc-800/50 px-4 py-2.5 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700"
+      >
+        <ClipboardPaste size={14} />
+        {' '}
+        Paste from Clipboard
+      </button>
+
+      {parseResult && (
+        parseResult.success
+          ? (
+              <div className="flex items-start gap-2 rounded-xl bg-emerald-500/10 px-3 py-2.5">
+                <Check size={14} className="mt-0.5 shrink-0 text-emerald-400" />
+                <div className="text-xs text-emerald-400">
+                  <span className="font-semibold">{parseResult.curve.name}</span>
+                  <span className="ml-1 text-emerald-400/70">
+                    —
+                    {' '}
+                    {Object.keys(parseResult.curve.points).length}
+                    {' '}
+                    set points,
+                    {' '}
+                    {parseResult.curve.bedtime}
+                    {' '}
+                    →
+                    {' '}
+                    {parseResult.curve.wake}
+                  </span>
+                </div>
+              </div>
+            )
+          : (
+              <div className="flex items-start gap-2 rounded-xl bg-red-500/10 px-3 py-2.5">
+                <AlertTriangle size={14} className="mt-0.5 shrink-0 text-red-400" />
+                <p className="text-xs text-red-400">{parseResult.error}</p>
+              </div>
+            )
+      )}
+    </div>
+  )
+}
+
+function StepPreview({
+  curve,
+  editablePoints,
+  tempRange,
+  chartData,
+  onUpdatePoint,
+  onAddPoint,
+  onRemovePoint,
+  onSaveTemplate,
+  onApply,
+}: {
+  curve: GeneratedCurve
+  editablePoints: Array<{ time: string, tempF: number }>
+  tempRange: { min: number, max: number }
+  chartData: { points: CurvePoint[], bedtimeMinutes: number } | null
+  onUpdatePoint: (idx: number, field: 'time' | 'tempF', value: string | number) => void
+  onAddPoint: () => void
+  onRemovePoint: (idx: number) => void
+  onSaveTemplate: () => void
+  onApply: () => void
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-white">{curve.name}</span>
+        <span className="rounded-full bg-zinc-800 px-2.5 py-1 text-[10px] font-medium text-zinc-400">
+          {curve.bedtime}
+          {' '}
+          →
+          {curve.wake}
+        </span>
+      </div>
+
+      {chartData && (
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-3">
+          <CurveChart
+            points={chartData.points}
+            bedtimeMinutes={chartData.bedtimeMinutes}
+            minTempF={tempRange.min}
+            maxTempF={tempRange.max}
+          />
+          <div className="mt-2">
+            <PhaseLegend />
+          </div>
+        </div>
+      )}
+
+      {curve.reasoning && (
+        <div className="rounded-xl border border-zinc-800 bg-zinc-800/30 px-3 py-2.5">
+          <p className="text-[11px] leading-relaxed text-zinc-400">{curve.reasoning}</p>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+            Set Points (
+            {editablePoints.length}
+            )
+          </p>
+          <button
+            onClick={onAddPoint}
+            className="flex items-center gap-1 text-[10px] text-cyan-400"
+          >
+            <Plus size={10} />
+            {' '}
+            Add
+          </button>
+        </div>
+
+        <div className="max-h-[30vh] overflow-y-auto rounded-xl border border-zinc-800">
+          {editablePoints.map((point, idx) => (
+            <div
+              key={`${point.time}-${idx}`}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2',
+                idx > 0 && 'border-t border-zinc-800/50',
+              )}
+            >
+              <input
+                type="time"
+                value={point.time}
+                onChange={e => onUpdatePoint(idx, 'time', e.target.value)}
+                className="w-20 rounded bg-zinc-800 px-2 py-1 text-xs text-white [color-scheme:dark]"
+              />
+
+              <div className="flex flex-1 items-center gap-2">
+                <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-zinc-800">
+                  <div
+                    className={cn(
+                      'absolute inset-y-0 left-0 rounded-full',
+                      point.tempF <= 74 ? 'bg-blue-500' : point.tempF <= 82 ? 'bg-violet-500' : 'bg-orange-500',
+                    )}
+                    style={{ width: `${((point.tempF - 55) / 55) * 100}%` }}
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => onUpdatePoint(idx, 'tempF', point.tempF - 1)}
+                  className="flex h-6 w-6 items-center justify-center rounded bg-zinc-800 text-zinc-400"
+                >
+                  <Minus size={10} />
+                </button>
+                <span className={cn(
+                  'w-10 text-center text-xs font-medium tabular-nums',
+                  point.tempF <= 74 ? 'text-blue-400' : point.tempF <= 82 ? 'text-zinc-300' : 'text-orange-400',
+                )}
+                >
+                  {point.tempF}
+                  °
+                </span>
+                <button
+                  onClick={() => onUpdatePoint(idx, 'tempF', point.tempF + 1)}
+                  className="flex h-6 w-6 items-center justify-center rounded bg-zinc-800 text-zinc-400"
+                >
+                  <Plus size={10} />
+                </button>
+              </div>
+
+              <button
+                onClick={() => onRemovePoint(idx)}
+                disabled={editablePoints.length <= 3}
+                className="flex h-6 w-6 items-center justify-center text-zinc-600 hover:text-red-400 disabled:opacity-30"
+              >
+                <Trash2 size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={onSaveTemplate}
+          className="flex items-center gap-1.5 rounded-xl border border-zinc-800 bg-zinc-800/50 px-4 py-3 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700"
+        >
+          <Save size={14} />
+          {' '}
+          Save
+        </button>
+
+        <button
+          onClick={onApply}
+          disabled={editablePoints.length < 3}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-cyan-500 px-4 py-3 text-sm font-semibold text-white transition-all hover:bg-cyan-600 active:scale-[0.98] disabled:opacity-60"
+        >
+          Use Curve
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function incrementTime(time: string, minutes: number): string {
+  const [h, m] = time.split(':').map(Number)
+  const total = (h * 60 + m + minutes) % (24 * 60)
+  return `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`
+}

--- a/src/components/Schedule/CurveEditor.tsx
+++ b/src/components/Schedule/CurveEditor.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Plus, Snowflake, Scale, Flame, X, Minus, Moon, Sun, Loader2 } from 'lucide-react'
+import { Plus, Snowflake, Scale, Flame, X, Minus, Moon, Sun, Loader2, Sparkles } from 'lucide-react'
 import clsx from 'clsx'
+import { AICurveWizard } from './AICurveWizard'
 import { CurveChart } from './CurveChart'
 import { SetPointCard } from './SetPointCard'
 import { SetPointEditor } from './SetPointEditor'
@@ -128,6 +129,7 @@ export function CurveEditor({
   const [editingId, setEditingId] = useState<number | null>(null)
   const [pendingConflict, setPendingConflict] = useState<DayOfWeek[] | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [aiWizardOpen, setAIWizardOpen] = useState(false)
   const idCounter = useRef(-1000)
 
   // Reset state when opening (avoid stale state from previous open)
@@ -153,6 +155,8 @@ export function CurveEditor({
     setPendingConflict(null)
 
     setSaveError(null)
+
+    setAIWizardOpen(false)
   }, [open, initialDays, initialSetPoints, initialBedtime, initialWake, initialMinTemp, initialMaxTemp])
 
   // Lock body scroll when open
@@ -231,6 +235,26 @@ export function CurveEditor({
   const handleEditorDelete = useCallback((id: number) => {
     handleDeletePoint(id)
   }, [handleDeletePoint])
+
+  const handleApplyAICurve = useCallback((config: {
+    setPoints: Array<{ time: string, temperature: number }>
+    bedtime: string
+    wakeTime: string
+  }) => {
+    const next: LocalSetPoint[] = config.setPoints.map((sp, i) => ({
+      localId: -(i + 1),
+      time: sp.time,
+      temperature: Math.round(Math.max(TEMP_FLOOR, Math.min(TEMP_CEIL, sp.temperature))),
+    }))
+    setPoints(next)
+    setBedtime(config.bedtime)
+    setWakeTime(config.wakeTime)
+    const temps = next.map(p => p.temperature)
+    if (temps.length > 0) {
+      setMinTemp(Math.min(...temps))
+      setMaxTemp(Math.max(...temps))
+    }
+  }, [])
 
   const handleApplyPreset = useCallback((preset: PresetDef) => {
     const bedtimeMinutes = timeStringToMinutes(bedtime)
@@ -404,7 +428,7 @@ export function CurveEditor({
                 <p className="text-center text-xs text-zinc-500">
                   Start from a preset or add set points manually
                 </p>
-                <div className="grid grid-cols-3 gap-2">
+                <div className="grid grid-cols-4 gap-2">
                   {PRESETS.map((preset) => {
                     const Icon = preset.icon
                     return (
@@ -419,6 +443,14 @@ export function CurveEditor({
                       </button>
                     )
                   })}
+                  <button
+                    type="button"
+                    onClick={() => setAIWizardOpen(true)}
+                    className="flex flex-col items-center gap-1 rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-2 py-3 text-cyan-400 active:scale-[0.97]"
+                  >
+                    <Sparkles size={16} />
+                    <span className="text-[11px] font-semibold">Custom AI</span>
+                  </button>
                 </div>
               </div>
             )
@@ -459,6 +491,13 @@ export function CurveEditor({
           Add Set Point
         </button>
       </div>
+
+      {/* Custom AI curve wizard */}
+      <AICurveWizard
+        open={aiWizardOpen}
+        onClose={() => setAIWizardOpen(false)}
+        onApply={handleApplyAICurve}
+      />
 
       {/* Per-point editor sheet */}
       <SetPointEditor

--- a/src/components/Schedule/PhaseLegend.tsx
+++ b/src/components/Schedule/PhaseLegend.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { Phase } from '@/src/lib/sleepCurve/types'
+import { phaseLabels, phaseColors } from '@/src/lib/sleepCurve/types'
+
+const displayPhases: Phase[] = ['warmUp', 'coolDown', 'deepSleep', 'preWake']
+
+export function PhaseLegend() {
+  return (
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+      {displayPhases.map(phase => (
+        <div key={phase} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: phaseColors[phase] }}
+          />
+          <span className="text-[10px] font-medium text-zinc-500">{phaseLabels[phase]}</span>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The AI-powered \"Custom AI\" curve option was removed from the web UI when the schedule editor was rebuilt around the new \`CurveEditor\` modal in #303 — \`AICurveWizard.tsx\` and \`CurvePresets.tsx\` were deleted as part of that refactor. Restore it as a 4th preset on the editor's empty-state preset row.

The wizard is reused largely as before (4-step copy/paste prompt → AI JSON → preview → use) but no longer writes the schedule itself: it now hands the generated set points + bedtime/wake back to the parent \`CurveEditor\`, which loads them into local state. The user reviews and clicks **Save** to persist via the standard \`useSchedule.saveCurve\` batch — same write path as the other presets.

## What changed

- Restored \`src/components/Schedule/AICurveWizard.tsx\` (slimmer surface — no tRPC, no \`side\`/\`selectedDays\` props)
- Restored \`src/components/Schedule/PhaseLegend.tsx\` (used by wizard preview chart)
- \`src/components/Schedule/CurveEditor.tsx\`: 4th preset \"Custom AI\" with Sparkles icon, opens wizard; \`handleApplyAICurve\` populates local set points + bedtime/wake/min-max temps

## Test plan

- [ ] Open Schedule → tap a day → \"New Curve\" → empty state shows 4 preset buttons (Hot Sleeper, Balanced, Cold Sleeper, **Custom AI**)
- [ ] Tap **Custom AI** → wizard opens at Describe step
- [ ] Type preferences → Generate → verify prompt rendered → Copy / Share works
- [ ] Paste a valid JSON response → preview chart renders → tap **Use Curve**
- [ ] Wizard closes; CurveEditor shows imported set points; chart preview matches
- [ ] Press **Save** → schedule persists for selected days
- [ ] Saved Curves: save a generated curve, reopen wizard → it appears under \"Saved Curves\" → load → preview repopulates
- [ ] Type-check (\`pnpm tsc\`), lint (\`pnpm lint\`), tests (\`pnpm test\`) all clean