### PR TITLE
feat(status): per-mount storage breakdown, drop duplicate disk row

### DIFF
--- a/src/components/status/HealthCircle.tsx
+++ b/src/components/status/HealthCircle.tsx
@@ -13,8 +13,6 @@ interface HealthCircleProps {
   sensorLabel?: string | null
   branch?: string
   commitHash?: string
-  diskPercent?: number
-  diskLabel?: string
   internetBlocked?: boolean
   wifiSsid?: string
   wifiSignal?: number
@@ -36,8 +34,6 @@ export function HealthCircle({
   sensorLabel,
   branch,
   commitHash,
-  diskPercent,
-  diskLabel,
   internetBlocked,
   wifiSsid,
   wifiSignal,
@@ -200,37 +196,7 @@ export function HealthCircle({
         </div>
       </>
 
-      {/* Row 4: Disk usage */}
-      {diskPercent !== undefined && (
-        <>
-          <div className="my-2.5 border-t border-zinc-800" />
-          <div className="space-y-1">
-            <div className="flex items-center justify-between text-[10px]">
-              <span className="text-zinc-500">{diskLabel ?? 'Disk'}</span>
-              <span
-                className={clsx(
-                  'font-medium',
-                  diskPercent > 90 ? 'text-red-400' : diskPercent > 75 ? 'text-amber-400' : 'text-zinc-500',
-                )}
-              >
-                {Math.round(diskPercent)}
-                %
-              </span>
-            </div>
-            <div className="h-1 w-full overflow-hidden rounded-full bg-zinc-800">
-              <div
-                className={clsx(
-                  'h-full rounded-full transition-all duration-500',
-                  diskPercent > 90 ? 'bg-red-400' : diskPercent > 75 ? 'bg-amber-400' : 'bg-sky-400',
-                )}
-                style={{ width: `${Math.min(diskPercent, 100)}%` }}
-              />
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Row 5: Hardware info — hidden by default */}
+      {/* Row 4: Hardware info — hidden by default */}
       {podVersion && (
         <>
           <div className="my-2.5 border-t border-zinc-800" />

--- a/src/components/status/StatusScreen.tsx
+++ b/src/components/status/StatusScreen.tsx
@@ -27,11 +27,6 @@ function formatMs(ms: number): string {
   return `${Math.round(ms)}ms`
 }
 
-function formatBytes(bytes: number): string {
-  const gb = bytes / (1024 * 1024 * 1024)
-  return `${gb.toFixed(1)} GB`
-}
-
 function dacMonitorStatus(status?: string): 'ok' | 'degraded' | 'error' | 'unknown' {
   if (!status) return 'unknown'
   if (status === 'not_initialized') return 'degraded'
@@ -70,7 +65,6 @@ export function StatusScreen() {
 
   // System info — less frequent
   const version = trpc.system.getVersion.useQuery({}, { refetchInterval: 60_000 })
-  const disk = trpc.system.getDiskUsage.useQuery({}, { refetchInterval: 30_000 })
   const internet = trpc.system.internetStatus.useQuery({}, { refetchInterval: POLL_INTERVAL })
   const wifi = trpc.system.wifiStatus.useQuery({}, { refetchInterval: POLL_INTERVAL })
   const logSources = trpc.system.getLogSources.useQuery({}, { refetchInterval: 30_000 })
@@ -93,7 +87,6 @@ export function StatusScreen() {
       utils.health.scheduler.invalidate(),
       utils.health.dacMonitor.invalidate(),
       utils.system.getVersion.invalidate(),
-      utils.system.getDiskUsage.invalidate(),
       utils.system.internetStatus.invalidate(),
       utils.system.wifiStatus.invalidate(),
       utils.system.getLogSources.invalidate(),
@@ -294,12 +287,6 @@ export function StatusScreen() {
           sensorLabel={deviceStatus.data?.sensorLabel ?? undefined}
           branch={version.data?.branch}
           commitHash={version.data?.commitHash}
-          diskPercent={disk.data?.usedPercent}
-          diskLabel={
-            disk.data && disk.data.totalBytes > 0
-              ? `${formatBytes(disk.data.usedBytes)} / ${formatBytes(disk.data.totalBytes)}`
-              : undefined
-          }
           internetBlocked={internet.data?.blocked}
           wifiSsid={wifi.data?.ssid ?? undefined}
           wifiSignal={wifi.data?.signal ?? undefined}

--- a/src/components/status/SystemInfoCard.tsx
+++ b/src/components/status/SystemInfoCard.tsx
@@ -4,39 +4,27 @@ import { trpc } from '@/src/utils/trpc'
 import { HardDrive, GitBranch, GitCommit, Calendar } from 'lucide-react'
 
 /**
- * SystemInfoCard — displays firmware/build version info and disk usage.
+ * SystemInfoCard — firmware/build version + per-mount storage breakdown.
  *
- * Wires into:
- * - system.getVersion → branch, commitHash, commitTitle, buildDate
- * - system.getDiskUsage → totalBytes, usedBytes, availableBytes, usedPercent
+ * Storage sections (Pod 5 layout — Pod 4 falls back gracefully when a mount
+ * is absent):
+ *   - eMMC                  → /persistent
+ *   - Biometrics tmpfs      → /persistent/biometrics (live RAW workspace)
+ *   - Biometrics archive    → /persistent/biometrics-archive (gzipped)
+ *
+ * DB size is intentionally omitted — it lives on eMMC and is rolled into that
+ * section's total.
  */
 export function SystemInfoCard() {
   const version = trpc.system.getVersion.useQuery({})
-  const disk = trpc.system.getDiskUsage.useQuery({})
+  const storage = trpc.system.getStorageBreakdown.useQuery({}, { refetchInterval: 30_000 })
 
-  const formatBytes = (bytes: number): string => {
-    if (bytes === 0) return '0 B'
-    const units = ['B', 'KB', 'MB', 'GB', 'TB']
-    const i = Math.floor(Math.log(bytes) / Math.log(1024))
-    const val = bytes / Math.pow(1024, i)
-    return `${val.toFixed(i > 1 ? 1 : 0)} ${units[i]}`
-  }
-
-  const isLoading = version.isLoading || disk.isLoading
+  const isLoading = version.isLoading || storage.isLoading
   const versionData = version.data
-  const diskData = disk.data
-
-  // Disk usage bar color based on usage percentage
-  const diskBarColor
-    = (diskData?.usedPercent ?? 0) >= 90
-      ? 'bg-red-500'
-      : (diskData?.usedPercent ?? 0) >= 75
-          ? 'bg-amber-500'
-          : 'bg-sky-500'
+  const storageData = storage.data
 
   return (
     <div className="rounded-2xl bg-zinc-900/80 p-3 sm:p-4">
-      {/* Header */}
       <div className="mb-2 flex items-center gap-2 sm:mb-3">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-sky-500/20">
           <HardDrive size={14} className="text-sky-400" />
@@ -53,7 +41,6 @@ export function SystemInfoCard() {
           )
         : (
             <div className="space-y-3">
-              {/* Version info rows */}
               {versionData && (
                 <div className="space-y-2">
                   <InfoRow
@@ -75,38 +62,115 @@ export function SystemInfoCard() {
                 </div>
               )}
 
-              {/* Disk usage */}
-              {diskData && diskData.totalBytes > 0 && (
-                <div className="border-t border-zinc-800 pt-3">
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="text-xs text-zinc-500">Disk Usage</span>
-                    <span className="text-xs tabular-nums text-zinc-400">
-                      {formatBytes(diskData.usedBytes)}
-                      {' / '}
-                      {formatBytes(diskData.totalBytes)}
-                    </span>
-                  </div>
-                  {/* Progress bar */}
-                  <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-800">
-                    <div
-                      className={`h-full rounded-full transition-all ${diskBarColor}`}
-                      style={{ width: `${Math.min(diskData.usedPercent, 100)}%` }}
+              {storageData && (
+                <div className="space-y-3 border-t border-zinc-800 pt-3">
+                  {storageData.emmc.totalBytes > 0 && (
+                    <DiskSection
+                      label="eMMC"
+                      sublabel="/persistent"
+                      totalBytes={storageData.emmc.totalBytes}
+                      usedBytes={storageData.emmc.usedBytes}
+                      availableBytes={storageData.emmc.availableBytes}
+                      usedPercent={storageData.emmc.usedPercent}
                     />
-                  </div>
-                  <div className="mt-1 flex justify-between">
-                    <span className="text-[10px] text-zinc-600">
-                      {diskData.usedPercent?.toFixed(1) ?? '0'}
-                      % used
-                    </span>
-                    <span className="text-[10px] text-zinc-600">
-                      {formatBytes(diskData.availableBytes)}
-                      {' free'}
-                    </span>
-                  </div>
+                  )}
+                  {storageData.biometricsTmpfs.totalBytes > 0 && (
+                    <DiskSection
+                      label="Biometrics tmpfs"
+                      sublabel="/persistent/biometrics"
+                      totalBytes={storageData.biometricsTmpfs.totalBytes}
+                      usedBytes={storageData.biometricsTmpfs.usedBytes}
+                      availableBytes={storageData.biometricsTmpfs.availableBytes}
+                      usedPercent={storageData.biometricsTmpfs.usedPercent}
+                    />
+                  )}
+                  {storageData.biometricsArchive.usedBytes > 0 && (
+                    <ArchiveSection
+                      usedBytes={storageData.biometricsArchive.usedBytes}
+                      fileCount={storageData.biometricsArchive.fileCount}
+                    />
+                  )}
                 </div>
               )}
             </div>
           )}
+    </div>
+  )
+}
+
+function DiskSection({
+  label,
+  sublabel,
+  totalBytes,
+  usedBytes,
+  availableBytes,
+  usedPercent,
+}: {
+  label: string
+  sublabel: string
+  totalBytes: number
+  usedBytes: number
+  availableBytes: number
+  usedPercent: number
+}) {
+  const barColor
+    = usedPercent >= 90
+      ? 'bg-red-500'
+      : usedPercent >= 75
+        ? 'bg-amber-500'
+        : 'bg-sky-500'
+
+  return (
+    <div>
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs text-zinc-400">{label}</span>
+          <span className="font-mono text-[10px] text-zinc-600">{sublabel}</span>
+        </div>
+        <span className="text-xs tabular-nums text-zinc-400">
+          {formatBytes(usedBytes)}
+          {' / '}
+          {formatBytes(totalBytes)}
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-800">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${Math.min(usedPercent, 100)}%` }}
+        />
+      </div>
+      <div className="mt-1 flex justify-between">
+        <span className="text-[10px] text-zinc-600">
+          {usedPercent.toFixed(1)}
+          % used
+        </span>
+        <span className="text-[10px] text-zinc-600">
+          {formatBytes(availableBytes)}
+          {' free'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function ArchiveSection({ usedBytes, fileCount }: { usedBytes: number, fileCount: number }) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs text-zinc-400">Biometrics archive</span>
+          <span className="font-mono text-[10px] text-zinc-600">/persistent/biometrics-archive</span>
+        </div>
+        <span className="text-xs tabular-nums text-zinc-400">
+          {formatBytes(usedBytes)}
+        </span>
+      </div>
+      <p className="mt-0.5 text-[10px] text-zinc-600">
+        {fileCount}
+        {' '}
+        gzipped session
+        {fileCount === 1 ? '' : 's'}
+      </p>
     </div>
   )
 }
@@ -138,6 +202,14 @@ function InfoRow({
       </div>
     </div>
   )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  const val = bytes / Math.pow(1024, i)
+  return `${val.toFixed(i > 1 ? 1 : 0)} ${units[i]}`
 }
 
 function formatBuildDate(dateStr: string): string {

--- a/src/server/routers/system.ts
+++ b/src/server/routers/system.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server'
 import { publicProcedure, router } from '@/src/server/trpc'
 import { execFile } from 'node:child_process'
 import { accessSync, constants } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
@@ -25,6 +25,50 @@ function resolveExec(name: string, candidates: string[]): string {
 
 const IPTABLES = resolveExec('iptables', ['/sbin/iptables', '/usr/sbin/iptables'])
 const IPTABLES_SAVE = resolveExec('iptables-save', ['/sbin/iptables-save', '/usr/sbin/iptables-save'])
+
+/**
+ * Run `df -B1 <path>` and return the parsed totals, or null if the mount
+ * is missing / df is unavailable (e.g. macOS dev).
+ */
+async function dfBreakdown(path: string): Promise<{
+  totalBytes: number
+  usedBytes: number
+  availableBytes: number
+  usedPercent: number
+} | null> {
+  try {
+    const { stdout } = await execFileAsync('df', ['-B1', path], { timeout: 5000 })
+    const line = stdout.trim().split('\n')[1]
+    const parts = line?.split(/\s+/) ?? []
+    const totalBytes = Number(parts[1]) || 0
+    const usedBytes = Number(parts[2]) || 0
+    const availableBytes = Number(parts[3]) || 0
+    const usedPercent = totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 10000) / 100 : 0
+    return { totalBytes, usedBytes, availableBytes, usedPercent }
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Sum the byte size + file count of a directory using `du -sb` (bytes).
+ * Returns null if the directory is missing or du is unavailable.
+ */
+async function archiveSize(path: string): Promise<{ usedBytes: number, fileCount: number } | null> {
+  try {
+    const [{ stdout: duOut }, entries] = await Promise.all([
+      execFileAsync('du', ['-sb', path], { timeout: 5000 }),
+      readdir(path, { withFileTypes: true }),
+    ])
+    const usedBytes = Number(duOut.trim().split(/\s+/)[0]) || 0
+    const fileCount = entries.filter(e => e.isFile()).length
+    return { usedBytes, fileCount }
+  }
+  catch {
+    return null
+  }
+}
 
 /**
  * Simple async mutex to serialize iptables mutations.
@@ -418,6 +462,50 @@ export const systemRouter = router({
       catch {
         // df unavailable (macOS dev environment)
         return { totalBytes: 0, usedBytes: 0, availableBytes: 0, usedPercent: 0 }
+      }
+    }),
+
+  /**
+   * Returns a per-mount storage breakdown for the System Info card:
+   * eMMC (/persistent), the live biometrics tmpfs (/persistent/biometrics),
+   * and the gzipped archive directory (/persistent/biometrics-archive).
+   *
+   * Each section is independent: a missing mount or directory yields zeros
+   * for that section without failing the whole call. macOS/dev returns
+   * zeros across the board.
+   */
+  getStorageBreakdown: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/system/storage-breakdown', protect: false, tags: ['System'] } })
+    .input(z.object({}))
+    .output(z.object({
+      emmc: z.object({
+        totalBytes: z.number(),
+        usedBytes: z.number(),
+        availableBytes: z.number(),
+        usedPercent: z.number(),
+      }),
+      biometricsTmpfs: z.object({
+        totalBytes: z.number(),
+        usedBytes: z.number(),
+        availableBytes: z.number(),
+        usedPercent: z.number(),
+      }),
+      biometricsArchive: z.object({
+        usedBytes: z.number(),
+        fileCount: z.number(),
+      }),
+    }))
+    .query(async () => {
+      const empty = { totalBytes: 0, usedBytes: 0, availableBytes: 0, usedPercent: 0 }
+      const [emmc, biometricsTmpfs, biometricsArchive] = await Promise.all([
+        dfBreakdown('/persistent'),
+        dfBreakdown('/persistent/biometrics'),
+        archiveSize('/persistent/biometrics-archive'),
+      ])
+      return {
+        emmc: emmc ?? empty,
+        biometricsTmpfs: biometricsTmpfs ?? empty,
+        biometricsArchive: biometricsArchive ?? { usedBytes: 0, fileCount: 0 },
       }
     }),
 


### PR DESCRIPTION
## Summary

\`HealthCircle\` and \`SystemInfoCard\` both rendered a root-filesystem disk bar — the inline row in HealthCircle was the lone storage signal before SystemInfoCard existed, and is now redundant. Drop the HealthCircle row (and its \`diskPercent\` / \`diskLabel\` props + StatusScreen plumbing) and expand SystemInfoCard with three per-mount sections instead of one:

- **eMMC** → \`/persistent\`
- **Biometrics tmpfs** → \`/persistent/biometrics\` (live RAW workspace, 500M tmpfs)
- **Biometrics archive** → \`/persistent/biometrics-archive\` (gzipped sessions, sized via \`du -sb\` + readdir)

DB size is intentionally omitted — it lives on eMMC and is already rolled into that section's total.

## What changed

- \`src/server/routers/system.ts\`: new \`getStorageBreakdown\` endpoint backed by \`df -B1 <mount>\` + \`du -sb <archive>\` helpers. Each mount/directory is independent — a missing one yields zeros for that section without failing the whole call (Pod 4 has no tmpfs / no archive yet, and macOS dev has none of them).
- \`src/components/status/SystemInfoCard.tsx\`: replaces the single Disk Usage block with eMMC + tmpfs DiskSection rows and an ArchiveSection (size + session count, no progress bar since archive size is open-ended).
- \`src/components/status/HealthCircle.tsx\`: drops the disk row + \`diskPercent\` / \`diskLabel\` props.
- \`src/components/status/StatusScreen.tsx\`: drops the \`getDiskUsage\` query, the local \`formatBytes\` helper, and the disk props on HealthCircle.
- \`getDiskUsage\` is kept for OpenAPI / external consumers that expect the existing shape.

## Test plan

- [ ] On a Pod 5: open Status screen → HealthCircle shows no disk row; SystemInfoCard shows three sections (eMMC, Biometrics tmpfs, Biometrics archive) with sane numbers
- [ ] On a Pod 4 (no tmpfs / no archive): SystemInfoCard hides the missing sections and only shows eMMC
- [ ] On macOS dev: card renders without errors (zeros for all sections is fine)
- [ ] Pull-to-refresh updates the storage breakdown
- [ ] \`pnpm tsc\`, \`pnpm lint\`, \`pnpm test\` all clean
- [ ] \`curl /api/system/storage-breakdown\` returns the expected nested shape on a real Pod