### PR TITLE
feat(mqtt): backend bridge, schema, tRPC router, ADR 0019

### DIFF
--- a/docs/adr/0019-mqtt-bridge.md
+++ b/docs/adr/0019-mqtt-bridge.md
@@ -34,10 +34,15 @@ the user's broker. The Pod is a single tenant on someone else's bus.
   envelope. Connection failures are non-fatal — the bridge logs and retries
   without blocking the Pod's primary tRPC startup path.
 - `keepalive` 30 s. Topic prefix configurable; default `sleepypod`.
-- TLS optional. When enabled we set `rejectUnauthorized: false` so users
-  with self-signed broker certs (the common HA case) work out of the box.
-  Stricter cert-pinning is deferred until protectedProcedure-style auth
-  lands.
+- TLS optional. `mqttTlsEnabled` switches the connection to `mqtts://` /
+  TLS sockets but leaves mqtt.js's default `rejectUnauthorized: true` in
+  place — strict cert verification on by default. Self-signed-cert
+  deployments (the common HA case) opt in via a separate
+  `mqttTlsInsecure` column or `MQTT_TLS_INSECURE` env, both off by
+  default. The two-flag split keeps "encrypted but MITM-able" out of
+  the easy path; an operator who wants insecure TLS has to set it
+  explicitly. Stricter cert-pinning is deferred until
+  protectedProcedure-style auth lands.
 
 ### LAN-only default
 
@@ -83,6 +88,12 @@ exposed beyond the SQLite row.
   them outside the bridge entirely).
 - Reconsider whether the row should hold the password at all, vs deriving
   it from a credential service called at bridge start.
+- Replace the bridge's `appRouter.createCaller({})` with a dedicated
+  least-privilege bridge context. With every procedure currently
+  `publicProcedure`, the empty-context caller is correct — but once auth
+  lands, an empty context becomes a privilege-escalation channel where
+  any MQTT subscriber on `cmd/*` can drive admin-only routes. Tracked
+  inline at the call site in `src/streaming/mqttBridge.ts`.
 
 ### Configuration precedence: DB > env > default
 
@@ -131,8 +142,9 @@ duration, side enum) lives on the procedure and is enforced once.
   leave it disabled.
 - Adds the `mqtt` npm package to runtime deps (~200 KB). Bridge module is
   lazy in spirit: it only opens the connection when configured.
-- The `device_settings` row gains seven nullable columns. Migration
-  `0007_round_hardball.sql`.
+- The `device_settings` row gains eight nullable columns. Migrations
+  `0007_round_hardball.sql` (initial seven) and `0008_flashy_wallow.sql`
+  (`mqtt_tls_insecure`).
 - Plaintext credential storage is a known compromise; tracked above.
 
 ## Refs

--- a/docs/adr/0019-mqtt-bridge.md
+++ b/docs/adr/0019-mqtt-bridge.md
@@ -1,0 +1,142 @@
+# ADR 0019: MQTT bridge for Home Assistant integration
+
+## Context
+
+The Pod runs a tRPC HTTP API on port 3000 and a WebSocket sensor stream on
+3001. Both are great for the iOS / web app but neither is what smart-home
+hubs speak. Home Assistant in particular ships a first-class MQTT
+integration with a discovery convention — Pod owners running HA today have
+to script `rest_command` blocks against tRPC, which does not surface in HA's
+device UI and breaks every time we touch a route.
+
+Adding a single MQTT bridge that publishes state and accepts commands gets
+us:
+
+1. **Native HA UX** — climate cards per side, sensors for biometrics and
+   water level, switches for priming. No YAML scripting.
+2. **Generic interop** — anything that speaks MQTT (Node-RED, openHAB, raw
+   `mosquitto_sub`) can read and command the Pod with no Pod-specific code.
+3. **No new transport in the iOS app** — the existing tRPC path stays the
+   primary control plane. MQTT is an additive surface.
+
+## Decision
+
+Run an in-process MQTT *client* (not a broker) that connects outbound to
+the user's broker. The Pod is a single tenant on someone else's bus.
+
+### Transport
+
+- One persistent `mqtt.MqttClient` per process, started from
+  `instrumentation.ts` after the piezo stream server.
+- LWT publishes `offline` retained on `<prefix>/<device-id>/availability`;
+  on `connect` we replace it with `online`.
+- `reconnectPeriod` 5 s with the library's built-in exponential backoff
+  envelope. Connection failures are non-fatal — the bridge logs and retries
+  without blocking the Pod's primary tRPC startup path.
+- `keepalive` 30 s. Topic prefix configurable; default `sleepypod`.
+- TLS optional. When enabled we set `rejectUnauthorized: false` so users
+  with self-signed broker certs (the common HA case) work out of the box.
+  Stricter cert-pinning is deferred until protectedProcedure-style auth
+  lands.
+
+### LAN-only default
+
+The broker URL defaults to *unset*. The bridge stays dormant until either
+`device_settings.mqtt_url` or `MQTT_URL` is provided. We do not ship a
+default broker, do not autodiscover one, and do not punch a hole in
+`iptables` for outbound MQTT. The user opts in.
+
+When enabled, traffic flows Pod → user-supplied broker. The broker is
+expected to be on the same LAN; no public broker is recommended. The pod
+already runs WAN-blocked behind the iptables LAN-only policy; opening MQTT
+to the public internet is the operator's choice.
+
+### Credentials: plaintext in `device_settings`
+
+The bridge reads username/password from `device_settings.mqtt_username` and
+`device_settings.mqtt_password`. Both columns are plaintext.
+
+We considered three alternatives and rejected each:
+
+1. **Keychain / OS secret store** — the Pod's Yocto image has no secret
+   service running. Wiring one up just for MQTT credentials adds a
+   meaningful surface (D-Bus, Avahi exclusions, install-time bootstrap)
+   for one route's worth of secret material.
+2. **Encrypted at rest with a Pod-derived key** — without a tamper-resistant
+   key store the "key" is just another file on the same eMMC; the
+   encryption is theatre.
+3. **Hashed credential round-trip via a protected tRPC procedure** — would
+   require landing real auth on tRPC first, which is its own multi-week
+   project. We have no `protectedProcedure` today; everything is
+   `publicProcedure` because the Pod is LAN-isolated.
+
+The threat model that justifies plaintext: an attacker who has read access
+to `/persistent/sleepypod.dev.db` already has full control of the Pod.
+Protecting the broker password against that attacker buys nothing. The
+Settings UI never returns the stored password — `getSettings` reports
+`passwordSet` and `updateSettings` accepts write-only — so it is not
+exposed beyond the SQLite row.
+
+**Revisit when** `protectedProcedure` lands. At that point we should:
+
+- Move credentials behind an authenticated read endpoint (or stop reading
+  them outside the bridge entirely).
+- Reconsider whether the row should hold the password at all, vs deriving
+  it from a credential service called at bridge start.
+
+### Configuration precedence: DB > env > default
+
+Each MQTT field on `device_settings` is nullable. Resolution at bridge
+start picks the first non-null source per field:
+
+```
+device_settings.mqtt_<field>  >  process.env.MQTT_<FIELD>  >  hard default
+```
+
+This lets a headless deployment ship secrets via env (e.g. systemd
+`EnvironmentFile`) while a UI-driven setup writes to the DB. The Settings
+UI gets per-field source attribution from `mqtt.getSettings` so it can
+render "Set in environment" hints next to fields the operator can't change
+without sshing in.
+
+### HA discovery
+
+On `connect` we publish retained discovery payloads under
+`homeassistant/<comp>/<device-id>/<entity>/config` for:
+
+- `climate` per side — current/target temperature, mode (`off|heat`),
+  command topics that round-trip through `cmd/set-temperature` and
+  `cmd/set-power`.
+- `sensor` for water level, per-side heart rate, breathing rate, HRV.
+
+Discovery prefix is overridable via `MQTT_HA_DISCOVERY_PREFIX` for users
+who run a non-default HA install.
+
+### Command routing through tRPC
+
+Commands arriving on `cmd/<verb>` are dispatched to the same `appRouter`
+procedures the iOS app calls (`device.setTemperature`, `setPower`,
+`setAlarm`, `clearAlarm`, `startPriming`). The bridge does *no* input
+validation of its own — Zod input schemas on the procedures are the single
+source of truth. A malformed payload throws inside the caller and the error
+is logged; we do not surface command failures back over MQTT in v1.
+
+This matters: it means the bridge cannot accidentally diverge from the iOS
+app's safety envelope. Every constraint (temperature range, alarm
+duration, side enum) lives on the procedure and is enforced once.
+
+## Consequences
+
+- One outbound TCP connection per Pod when enabled. No effect on Pods that
+  leave it disabled.
+- Adds the `mqtt` npm package to runtime deps (~200 KB). Bridge module is
+  lazy in spirit: it only opens the connection when configured.
+- The `device_settings` row gains seven nullable columns. Migration
+  `0007_round_hardball.sql`.
+- Plaintext credential storage is a known compromise; tracked above.
+
+## Refs
+
+- Epic: sleepypod-core-26
+- Backend ticket: sleepypod-core-27
+- Settings UI ticket: sleepypod-core-28

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -21,6 +21,7 @@ import { startBiometricsRetention, stopBiometricsRetention } from '@/src/db/rete
 import { getDacMonitor, shutdownDacMonitor } from '@/src/hardware/dacMonitor.instance'
 import { startPiezoStreamServer, shutdownPiezoStreamServer } from '@/src/streaming/piezoStream'
 import { startBonjourAnnouncement, stopBonjourAnnouncement } from '@/src/streaming/bonjourAnnounce'
+import { startMqttBridge, shutdownMqttBridge } from '@/src/streaming/mqttBridge'
 import { initializeKeepalives, shutdownKeepalives } from '@/src/services/temperatureKeepalive'
 import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
 
@@ -67,6 +68,14 @@ async function gracefulShutdown(signal: string): Promise<void> {
   }
   catch (error) {
     console.error('Error shutting down piezo stream server:', error)
+  }
+
+  // Step 2b: Shutdown MQTT bridge (publish offline + close client cleanly)
+  try {
+    await shutdownMqttBridge()
+  }
+  catch (error) {
+    console.error('Error shutting down MQTT bridge:', error)
   }
 
   // Step 3: Stop Bonjour announcement
@@ -289,6 +298,17 @@ export async function initializeScheduler(): Promise<void> {
     catch (error) {
       console.warn(
         'WARNING: Piezo stream server failed to start:',
+        error instanceof Error ? error.message : error
+      )
+    }
+
+    // Start MQTT bridge (non-blocking; no-op when disabled in settings/env)
+    try {
+      await startMqttBridge()
+    }
+    catch (error) {
+      console.warn(
+        'WARNING: MQTT bridge failed to start:',
         error instanceof Error ? error.message : error
       )
     }

--- a/src/db/migrations/0007_round_hardball.sql
+++ b/src/db/migrations/0007_round_hardball.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `device_settings` ADD `mqtt_enabled` integer;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_url` text;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_username` text;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_password` text;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_topic_prefix` text;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_ha_discovery` integer;--> statement-breakpoint
+ALTER TABLE `device_settings` ADD `mqtt_tls_enabled` integer;

--- a/src/db/migrations/0008_flashy_wallow.sql
+++ b/src/db/migrations/0008_flashy_wallow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `device_settings` ADD `mqtt_tls_insecure` integer;

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,846 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "675e4c64-8540-4148-aabf-6c739012b34b",
+  "prevId": "6dfe13f3-b76e-4404-9841-773e6129ec00",
+  "tables": {
+    "alarm_schedules": {
+      "name": "alarm_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_intensity": {
+          "name": "vibration_intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_pattern": {
+          "name": "vibration_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rise'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alarm_temperature": {
+          "name": "alarm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_alarm_schedules_side_day": {
+          "name": "idx_alarm_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_settings": {
+      "name": "device_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'F'"
+        },
+        "reboot_daily": {
+          "name": "reboot_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reboot_time": {
+          "name": "reboot_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'03:00'"
+        },
+        "prime_pod_daily": {
+          "name": "prime_pod_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prime_pod_time": {
+          "name": "prime_pod_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'14:00'"
+        },
+        "led_night_mode_enabled": {
+          "name": "led_night_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "led_day_brightness": {
+          "name": "led_day_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "led_night_brightness": {
+          "name": "led_night_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "led_night_start_time": {
+          "name": "led_night_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'22:00'"
+        },
+        "led_night_end_time": {
+          "name": "led_night_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'07:00'"
+        },
+        "global_max_on_hours": {
+          "name": "global_max_on_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_enabled": {
+          "name": "mqtt_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_url": {
+          "name": "mqtt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_username": {
+          "name": "mqtt_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_password": {
+          "name": "mqtt_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_topic_prefix": {
+          "name": "mqtt_topic_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_ha_discovery": {
+          "name": "mqtt_ha_discovery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_tls_enabled": {
+          "name": "mqtt_tls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_state": {
+      "name": "device_state",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_temperature": {
+          "name": "current_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_temperature": {
+          "name": "target_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_powered": {
+          "name": "is_powered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_alarm_vibrating": {
+          "name": "is_alarm_vibrating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "water_level": {
+          "name": "water_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "powered_on_at": {
+          "name": "powered_on_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "power_schedules": {
+      "name": "power_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_time": {
+          "name": "on_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "off_time": {
+          "name": "off_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_temperature": {
+          "name": "on_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_power_schedules_side_day": {
+          "name": "idx_power_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_once_sessions": {
+      "name": "run_once_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_points": {
+          "name": "set_points",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_run_once_side_status": {
+          "name": "idx_run_once_side_status",
+          "columns": [
+            "side",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "side_settings": {
+      "name": "side_settings",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "away_mode": {
+          "name": "away_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_on": {
+          "name": "always_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_enabled": {
+          "name": "auto_off_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_minutes": {
+          "name": "auto_off_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "away_start": {
+          "name": "away_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "away_return": {
+          "name": "away_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_health": {
+      "name": "system_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "component": {
+          "name": "component",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "system_health_component_unique": {
+          "name": "system_health_component_unique",
+          "columns": [
+            "component"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tap_gestures": {
+      "name": "tap_gestures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tap_type": {
+          "name": "tap_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature_change": {
+          "name": "temperature_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_amount": {
+          "name": "temperature_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_behavior": {
+          "name": "alarm_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_snooze_duration": {
+          "name": "alarm_snooze_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_inactive_behavior": {
+          "name": "alarm_inactive_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uq_tap_side_type": {
+          "name": "uq_tap_side_type",
+          "columns": [
+            "side",
+            "tap_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temperature_schedules": {
+      "name": "temperature_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_temp_schedules_side_day_time": {
+          "name": "idx_temp_schedules_side_day_time",
+          "columns": [
+            "side",
+            "day_of_week",
+            "time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/0008_snapshot.json
+++ b/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,853 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bfd61d6c-c349-409a-851a-6a9893c16722",
+  "prevId": "675e4c64-8540-4148-aabf-6c739012b34b",
+  "tables": {
+    "alarm_schedules": {
+      "name": "alarm_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_intensity": {
+          "name": "vibration_intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_pattern": {
+          "name": "vibration_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rise'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alarm_temperature": {
+          "name": "alarm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_alarm_schedules_side_day": {
+          "name": "idx_alarm_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_settings": {
+      "name": "device_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'F'"
+        },
+        "reboot_daily": {
+          "name": "reboot_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reboot_time": {
+          "name": "reboot_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'03:00'"
+        },
+        "prime_pod_daily": {
+          "name": "prime_pod_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prime_pod_time": {
+          "name": "prime_pod_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'14:00'"
+        },
+        "led_night_mode_enabled": {
+          "name": "led_night_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "led_day_brightness": {
+          "name": "led_day_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "led_night_brightness": {
+          "name": "led_night_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "led_night_start_time": {
+          "name": "led_night_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'22:00'"
+        },
+        "led_night_end_time": {
+          "name": "led_night_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'07:00'"
+        },
+        "global_max_on_hours": {
+          "name": "global_max_on_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_enabled": {
+          "name": "mqtt_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_url": {
+          "name": "mqtt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_username": {
+          "name": "mqtt_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_password": {
+          "name": "mqtt_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_topic_prefix": {
+          "name": "mqtt_topic_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_ha_discovery": {
+          "name": "mqtt_ha_discovery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_tls_enabled": {
+          "name": "mqtt_tls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_tls_insecure": {
+          "name": "mqtt_tls_insecure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_state": {
+      "name": "device_state",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_temperature": {
+          "name": "current_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_temperature": {
+          "name": "target_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_powered": {
+          "name": "is_powered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_alarm_vibrating": {
+          "name": "is_alarm_vibrating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "water_level": {
+          "name": "water_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "powered_on_at": {
+          "name": "powered_on_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "power_schedules": {
+      "name": "power_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_time": {
+          "name": "on_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "off_time": {
+          "name": "off_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_temperature": {
+          "name": "on_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_power_schedules_side_day": {
+          "name": "idx_power_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_once_sessions": {
+      "name": "run_once_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_points": {
+          "name": "set_points",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_run_once_side_status": {
+          "name": "idx_run_once_side_status",
+          "columns": [
+            "side",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "side_settings": {
+      "name": "side_settings",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "away_mode": {
+          "name": "away_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_on": {
+          "name": "always_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_enabled": {
+          "name": "auto_off_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_minutes": {
+          "name": "auto_off_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "away_start": {
+          "name": "away_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "away_return": {
+          "name": "away_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_health": {
+      "name": "system_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "component": {
+          "name": "component",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "system_health_component_unique": {
+          "name": "system_health_component_unique",
+          "columns": [
+            "component"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tap_gestures": {
+      "name": "tap_gestures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tap_type": {
+          "name": "tap_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature_change": {
+          "name": "temperature_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_amount": {
+          "name": "temperature_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_behavior": {
+          "name": "alarm_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_snooze_duration": {
+          "name": "alarm_snooze_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_inactive_behavior": {
+          "name": "alarm_inactive_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uq_tap_side_type": {
+          "name": "uq_tap_side_type",
+          "columns": [
+            "side",
+            "tap_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temperature_schedules": {
+      "name": "temperature_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_temp_schedules_side_day_time": {
+          "name": "idx_temp_schedules_side_day_time",
+          "columns": [
+            "side",
+            "day_of_week",
+            "time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778211700223,
       "tag": "0007_round_hardball",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778214991769,
+      "tag": "0008_flashy_wallow",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777089654456,
       "tag": "0006_yummy_squadron_sinister",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1778211700223,
+      "tag": "0007_round_hardball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,6 +30,17 @@ export const deviceSettings = sqliteTable('device_settings', {
   // hours with no run-once or always-on override, autoOffWatcher forces it
   // off. NULL = disabled. Independent of per-side bed-exit auto-off.
   globalMaxOnHours: integer('global_max_on_hours'),
+  // MQTT bridge configuration. NULL on every field falls back to the
+  // matching MQTT_* env var; a non-null value overrides the env. Plaintext
+  // credentials per ADR 0019 — pod runs LAN-isolated and there is no auth
+  // middleware to gate a hashed-credential round-trip yet.
+  mqttEnabled: integer('mqtt_enabled', { mode: 'boolean' }),
+  mqttUrl: text('mqtt_url'),
+  mqttUsername: text('mqtt_username'),
+  mqttPassword: text('mqtt_password'),
+  mqttTopicPrefix: text('mqtt_topic_prefix'),
+  mqttHaDiscovery: integer('mqtt_ha_discovery', { mode: 'boolean' }),
+  mqttTlsEnabled: integer('mqtt_tls_enabled', { mode: 'boolean' }),
   createdAt: integer('created_at', { mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -41,6 +41,10 @@ export const deviceSettings = sqliteTable('device_settings', {
   mqttTopicPrefix: text('mqtt_topic_prefix'),
   mqttHaDiscovery: integer('mqtt_ha_discovery', { mode: 'boolean' }),
   mqttTlsEnabled: integer('mqtt_tls_enabled', { mode: 'boolean' }),
+  // When true, accept self-signed broker certs (sets rejectUnauthorized:false).
+  // Defaults to NULL (env fallback MQTT_TLS_INSECURE, then false). Off-by-default
+  // per ADR 0019 — tlsEnabled alone keeps strict cert verification.
+  mqttTlsInsecure: integer('mqtt_tls_insecure', { mode: 'boolean' }),
   createdAt: integer('created_at', { mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),

--- a/src/server/routers/app.ts
+++ b/src/server/routers/app.ts
@@ -11,6 +11,7 @@ import { rawRouter } from './raw'
 import { calibrationRouter } from './calibration'
 import { waterLevelRouter } from './waterLevel'
 import { runOnceRouter } from './runOnce'
+import { mqttRouter } from './mqtt'
 
 export const appRouter = router({
   healthcheck: publicProcedure
@@ -33,6 +34,7 @@ export const appRouter = router({
   calibration: calibrationRouter,
   waterLevel: waterLevelRouter,
   runOnce: runOnceRouter,
+  mqtt: mqttRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/mqtt.ts
+++ b/src/server/routers/mqtt.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod'
+import { TRPCError } from '@trpc/server'
+import { eq } from 'drizzle-orm'
+import { publicProcedure, router } from '@/src/server/trpc'
+import { db } from '@/src/db'
+import { deviceSettings } from '@/src/db/schema'
+import {
+  getBridgeStatus,
+  resolveConfig,
+  shutdownMqttBridge,
+  startMqttBridge,
+  testConnection,
+} from '@/src/streaming/mqttBridge'
+
+const sourceSchema = z.enum(['db', 'env', 'default'])
+
+const settingsSchema = z.object({
+  enabled: z.object({ value: z.boolean(), source: sourceSchema }),
+  url: z.object({ value: z.string().nullable(), source: sourceSchema }),
+  username: z.object({ value: z.string().nullable(), source: sourceSchema }),
+  // Password is write-only; getSettings reports `passwordSet` instead so the
+  // UI can render "•••" without leaking the value.
+  passwordSet: z.boolean(),
+  passwordSource: sourceSchema,
+  topicPrefix: z.object({ value: z.string(), source: sourceSchema }),
+  haDiscovery: z.object({ value: z.boolean(), source: sourceSchema }),
+  tlsEnabled: z.object({ value: z.boolean(), source: sourceSchema }),
+})
+
+const updateInputSchema = z
+  .object({
+    enabled: z.boolean().nullable().optional(),
+    url: z.string().url().nullable().optional(),
+    username: z.string().nullable().optional(),
+    // null clears the stored password; undefined leaves it untouched.
+    password: z.string().nullable().optional(),
+    topicPrefix: z.string().min(1).max(64).regex(/^[a-zA-Z0-9_/-]+$/).nullable().optional(),
+    haDiscovery: z.boolean().nullable().optional(),
+    tlsEnabled: z.boolean().nullable().optional(),
+  })
+  .strict()
+
+/**
+ * MQTT bridge configuration router.
+ *
+ * Settings UI calls these endpoints. Writes always target device_settings
+ * (singleton row id=1); the bridge resolves DB > env > default at start and
+ * after every settings update. Password is write-only: getSettings reports
+ * whether one is set but never returns the value.
+ */
+export const mqttRouter = router({
+  /**
+   * Resolved bridge configuration with per-field source attribution.
+   *
+   * The Settings UI uses `source` to render "Set in environment" hints next
+   * to fields the operator can't override via the UI alone.
+   */
+  getSettings: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/mqtt/settings', protect: false, tags: ['MQTT'] } })
+    .input(z.object({}))
+    .output(settingsSchema)
+    .query(async () => {
+      const { config, sources } = await resolveConfig()
+      const passwordSet = config.password !== null && config.password.length > 0
+      // When no password is set anywhere, sources.password is whichever layer
+      // was checked last — surface that as 'default' so the UI doesn't claim
+      // a password came from env when none exists at all.
+      const passwordSource = passwordSet ? sources.password : 'default'
+      return {
+        enabled: { value: config.enabled, source: sources.enabled },
+        url: { value: config.url, source: sources.url },
+        username: { value: config.username, source: sources.username },
+        passwordSet,
+        passwordSource,
+        topicPrefix: { value: config.topicPrefix, source: sources.topicPrefix },
+        haDiscovery: { value: config.haDiscovery, source: sources.haDiscovery },
+        tlsEnabled: { value: config.tlsEnabled, source: sources.tlsEnabled },
+      }
+    }),
+
+  /**
+   * Persist a partial update to device_settings and restart the bridge so
+   * the new config takes effect. `null` clears a field (falls back to env).
+   */
+  updateSettings: publicProcedure
+    .meta({ openapi: { method: 'PATCH', path: '/mqtt/settings', protect: false, tags: ['MQTT'] } })
+    .input(updateInputSchema)
+    .output(z.object({ success: z.boolean() }))
+    .mutation(async ({ input }) => {
+      try {
+        const updates: Record<string, unknown> = { updatedAt: new Date() }
+        if ('enabled' in input) updates.mqttEnabled = input.enabled ?? null
+        if ('url' in input) updates.mqttUrl = input.url ?? null
+        if ('username' in input) updates.mqttUsername = input.username ?? null
+        if ('password' in input) updates.mqttPassword = input.password ?? null
+        if ('topicPrefix' in input) updates.mqttTopicPrefix = input.topicPrefix ?? null
+        if ('haDiscovery' in input) updates.mqttHaDiscovery = input.haDiscovery ?? null
+        if ('tlsEnabled' in input) updates.mqttTlsEnabled = input.tlsEnabled ?? null
+
+        await db.update(deviceSettings).set(updates).where(eq(deviceSettings.id, 1))
+      }
+      catch (err) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to update MQTT settings: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          cause: err,
+        })
+      }
+
+      // Restart so the resolved config is picked up. Failures are logged
+      // inside the bridge — surface them via getStatus rather than failing
+      // the mutation, since the row was persisted successfully.
+      try {
+        await shutdownMqttBridge()
+        await startMqttBridge()
+      }
+      catch (err) {
+        console.warn('[mqtt] restart after settings update failed:', err instanceof Error ? err.message : err)
+      }
+
+      return { success: true }
+    }),
+
+  /**
+   * Try to connect to the supplied broker without persisting anything.
+   * Used by the Settings UI's "Test connection" button.
+   */
+  testConnection: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/mqtt/test-connection', protect: false, tags: ['MQTT'] } })
+    .input(z.object({
+      url: z.string().url(),
+      username: z.string().nullable().optional(),
+      password: z.string().nullable().optional(),
+      tlsEnabled: z.boolean().optional(),
+    }).strict())
+    .output(z.object({ success: z.boolean(), error: z.string().optional() }))
+    .mutation(async ({ input }) => {
+      return testConnection({
+        url: input.url,
+        username: input.username ?? null,
+        password: input.password ?? null,
+        tlsEnabled: input.tlsEnabled ?? false,
+      })
+    }),
+
+  /**
+   * Live bridge status for the Settings UI to render an indicator without
+   * scraping logs.
+   */
+  getStatus: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/mqtt/status', protect: false, tags: ['MQTT'] } })
+    .input(z.object({}))
+    .output(z.object({
+      runState: z.enum(['stopped', 'starting', 'connected', 'reconnecting', 'errored']),
+      connected: z.boolean(),
+      lastError: z.string().nullable(),
+      deviceId: z.string(),
+      topicPrefix: z.string().nullable(),
+    }))
+    .query(() => getBridgeStatus()),
+})

--- a/src/server/routers/mqtt.ts
+++ b/src/server/routers/mqtt.ts
@@ -15,16 +15,24 @@ import {
 const sourceSchema = z.enum(['db', 'env', 'default'])
 
 const settingsSchema = z.object({
-  enabled: z.object({ value: z.boolean(), source: sourceSchema }),
-  url: z.object({ value: z.string().nullable(), source: sourceSchema }),
-  username: z.object({ value: z.string().nullable(), source: sourceSchema }),
-  // Password is write-only; getSettings reports `passwordSet` instead so the
+  enabled: z.boolean(),
+  url: z.string().nullable(),
+  username: z.string().nullable(),
+  // Password is write-only; getSettings reports `passwordIsSet` instead so the
   // UI can render "•••" without leaking the value.
-  passwordSet: z.boolean(),
-  passwordSource: sourceSchema,
-  topicPrefix: z.object({ value: z.string(), source: sourceSchema }),
-  haDiscovery: z.object({ value: z.boolean(), source: sourceSchema }),
-  tlsEnabled: z.object({ value: z.boolean(), source: sourceSchema }),
+  passwordIsSet: z.boolean(),
+  topicPrefix: z.string(),
+  haDiscovery: z.boolean(),
+  tlsEnabled: z.boolean(),
+  sources: z.object({
+    enabled: sourceSchema,
+    url: sourceSchema,
+    username: sourceSchema,
+    password: sourceSchema,
+    topicPrefix: sourceSchema,
+    haDiscovery: sourceSchema,
+    tlsEnabled: sourceSchema,
+  }),
 })
 
 const updateInputSchema = z
@@ -61,20 +69,28 @@ export const mqttRouter = router({
     .output(settingsSchema)
     .query(async () => {
       const { config, sources } = await resolveConfig()
-      const passwordSet = config.password !== null && config.password.length > 0
+      const passwordIsSet = config.password !== null && config.password.length > 0
       // When no password is set anywhere, sources.password is whichever layer
       // was checked last — surface that as 'default' so the UI doesn't claim
       // a password came from env when none exists at all.
-      const passwordSource = passwordSet ? sources.password : 'default'
+      const passwordSource = passwordIsSet ? sources.password : 'default'
       return {
-        enabled: { value: config.enabled, source: sources.enabled },
-        url: { value: config.url, source: sources.url },
-        username: { value: config.username, source: sources.username },
-        passwordSet,
-        passwordSource,
-        topicPrefix: { value: config.topicPrefix, source: sources.topicPrefix },
-        haDiscovery: { value: config.haDiscovery, source: sources.haDiscovery },
-        tlsEnabled: { value: config.tlsEnabled, source: sources.tlsEnabled },
+        enabled: config.enabled,
+        url: config.url,
+        username: config.username,
+        passwordIsSet,
+        topicPrefix: config.topicPrefix,
+        haDiscovery: config.haDiscovery,
+        tlsEnabled: config.tlsEnabled,
+        sources: {
+          enabled: sources.enabled,
+          url: sources.url,
+          username: sources.username,
+          password: passwordSource,
+          topicPrefix: sources.topicPrefix,
+          haDiscovery: sources.haDiscovery,
+          tlsEnabled: sources.tlsEnabled,
+        },
       }
     }),
 
@@ -107,16 +123,18 @@ export const mqttRouter = router({
         })
       }
 
-      // Restart so the resolved config is picked up. Failures are logged
-      // inside the bridge — surface them via getStatus rather than failing
-      // the mutation, since the row was persisted successfully.
-      try {
-        await shutdownMqttBridge()
-        await startMqttBridge()
-      }
-      catch (err) {
-        console.warn('[mqtt] restart after settings update failed:', err instanceof Error ? err.message : err)
-      }
+      // Restart so the resolved config is picked up. Fire-and-forget — a
+      // misconfigured broker should not stall the mutation while mqtt.js
+      // exhausts its CONNECT_TIMEOUT_MS. Errors surface via getStatus.
+      void (async () => {
+        try {
+          await shutdownMqttBridge()
+          await startMqttBridge()
+        }
+        catch (err) {
+          console.warn('[mqtt] restart after settings update failed:', err instanceof Error ? err.message : err)
+        }
+      })()
 
       return { success: true }
     }),
@@ -133,7 +151,7 @@ export const mqttRouter = router({
       password: z.string().nullable().optional(),
       tlsEnabled: z.boolean().optional(),
     }).strict())
-    .output(z.object({ success: z.boolean(), error: z.string().optional() }))
+    .output(z.object({ ok: z.boolean(), error: z.string().optional() }))
     .mutation(async ({ input }) => {
       return testConnection({
         url: input.url,
@@ -156,6 +174,8 @@ export const mqttRouter = router({
       lastError: z.string().nullable(),
       deviceId: z.string(),
       topicPrefix: z.string().nullable(),
+      messagesPublished: z.number(),
+      lastPublishAt: z.string().nullable(),
     }))
     .query(() => getBridgeStatus()),
 })

--- a/src/server/routers/tests/mqtt.test.ts
+++ b/src/server/routers/tests/mqtt.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for the MQTT router — getSettings shape, updateSettings field
+ * discrimination + fire-and-forget restart, getStatus / testConnection
+ * passthrough. The bridge module is fully mocked so no real socket is opened.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Hoisted mocks for the bridge — the router calls these and we need to
+// observe arguments / return values per test.
+const bridgeMock = vi.hoisted(() => ({
+  resolveConfig: vi.fn(),
+  testConnection: vi.fn(),
+  getBridgeStatus: vi.fn(),
+  startMqttBridge: vi.fn(),
+  shutdownMqttBridge: vi.fn(),
+}))
+
+// Hoisted DB mock — we capture the `set(updates)` argument from
+// db.update(deviceSettings).set(...).where(...). The setSpy is typed via the
+// generic so `mock.calls[N][0]` is `Record<string, unknown>` at the call sites.
+const dbMock = vi.hoisted(() => {
+  const setSpy = vi.fn<(updates: Record<string, unknown>) => { where: ReturnType<typeof vi.fn> }>(
+    () => ({ where: vi.fn(async () => undefined) }),
+  )
+  const update = vi.fn(() => ({ set: setSpy }))
+  return { update, setSpy }
+})
+
+vi.mock('@/src/streaming/mqttBridge', () => bridgeMock)
+
+vi.mock('@/src/db', () => ({
+  db: { update: dbMock.update },
+  biometricsDb: {},
+}))
+
+const { mqttRouter } = await import('@/src/server/routers/mqtt')
+
+const caller = mqttRouter.createCaller({})
+
+beforeEach(() => {
+  bridgeMock.resolveConfig.mockReset()
+  bridgeMock.testConnection.mockReset()
+  bridgeMock.getBridgeStatus.mockReset()
+  bridgeMock.startMqttBridge.mockReset().mockResolvedValue(undefined)
+  bridgeMock.shutdownMqttBridge.mockReset().mockResolvedValue(undefined)
+  dbMock.update.mockClear()
+  dbMock.setSpy.mockClear()
+})
+
+describe('mqtt.getSettings', () => {
+  it('returns the flat shape with a single sources map', async () => {
+    bridgeMock.resolveConfig.mockResolvedValue({
+      config: {
+        enabled: true,
+        url: 'mqtt://broker:1883',
+        username: 'u',
+        password: 'p',
+        topicPrefix: 'sp',
+        haDiscovery: true,
+        tlsEnabled: false,
+        tlsInsecure: false,
+      },
+      sources: {
+        enabled: 'db',
+        url: 'db',
+        username: 'env',
+        password: 'db',
+        topicPrefix: 'default',
+        haDiscovery: 'default',
+        tlsEnabled: 'default',
+        tlsInsecure: 'default',
+      },
+    })
+
+    const result = await caller.getSettings({})
+
+    // Flat shape — top-level fields are the resolved config minus password
+    // (replaced by passwordIsSet) and minus tlsInsecure (router-internal).
+    expect(result).toEqual({
+      enabled: true,
+      url: 'mqtt://broker:1883',
+      username: 'u',
+      passwordIsSet: true,
+      topicPrefix: 'sp',
+      haDiscovery: true,
+      tlsEnabled: false,
+      sources: {
+        enabled: 'db',
+        url: 'db',
+        username: 'env',
+        password: 'db',
+        topicPrefix: 'default',
+        haDiscovery: 'default',
+        tlsEnabled: 'default',
+      },
+    })
+    // The router never leaks the password field itself.
+    expect(result).not.toHaveProperty('password')
+  })
+
+  it('passwordIsSet is false and source is "default" when password is null', async () => {
+    bridgeMock.resolveConfig.mockResolvedValue({
+      config: {
+        enabled: false, url: null, username: null, password: null,
+        topicPrefix: 'sp', haDiscovery: true, tlsEnabled: false, tlsInsecure: false,
+      },
+      // resolveConfig may report password source as 'env' if MQTT_PASSWORD was
+      // checked; the router collapses absent passwords to 'default' so the UI
+      // doesn't claim the value came from somewhere it didn't.
+      sources: {
+        enabled: 'default', url: 'default', username: 'default', password: 'env',
+        topicPrefix: 'default', haDiscovery: 'default', tlsEnabled: 'default', tlsInsecure: 'default',
+      },
+    })
+
+    const result = await caller.getSettings({})
+
+    expect(result.passwordIsSet).toBe(false)
+    expect(result.sources.password).toBe('default')
+  })
+
+  it('passwordIsSet is false when password resolves to an empty string', async () => {
+    bridgeMock.resolveConfig.mockResolvedValue({
+      config: {
+        enabled: false, url: null, username: null, password: '',
+        topicPrefix: 'sp', haDiscovery: true, tlsEnabled: false, tlsInsecure: false,
+      },
+      sources: {
+        enabled: 'default', url: 'default', username: 'default', password: 'db',
+        topicPrefix: 'default', haDiscovery: 'default', tlsEnabled: 'default', tlsInsecure: 'default',
+      },
+    })
+
+    const result = await caller.getSettings({})
+
+    expect(result.passwordIsSet).toBe(false)
+    expect(result.sources.password).toBe('default')
+  })
+
+  it('passwordIsSet is true and password source is preserved when a password is present', async () => {
+    bridgeMock.resolveConfig.mockResolvedValue({
+      config: {
+        enabled: false, url: null, username: null, password: 'secret',
+        topicPrefix: 'sp', haDiscovery: true, tlsEnabled: false, tlsInsecure: false,
+      },
+      sources: {
+        enabled: 'default', url: 'default', username: 'default', password: 'env',
+        topicPrefix: 'default', haDiscovery: 'default', tlsEnabled: 'default', tlsInsecure: 'default',
+      },
+    })
+
+    const result = await caller.getSettings({})
+
+    expect(result.passwordIsSet).toBe(true)
+    expect(result.sources.password).toBe('env')
+  })
+})
+
+describe('mqtt.updateSettings — field discrimination', () => {
+  it('only writes fields present in the input — undefined keys are left untouched', async () => {
+    await caller.updateSettings({ url: 'mqtt://broker:1883' })
+
+    expect(dbMock.setSpy).toHaveBeenCalledTimes(1)
+    const updates = dbMock.setSpy.mock.calls[0][0]
+
+    expect(updates).toHaveProperty('mqttUrl', 'mqtt://broker:1883')
+    expect(updates).toHaveProperty('updatedAt')
+    expect(updates.updatedAt).toBeInstanceOf(Date)
+
+    // Every other mqtt* column must be absent — undefined keys leave stored
+    // values alone, matching ADR 0019's PATCH semantics.
+    expect(updates).not.toHaveProperty('mqttEnabled')
+    expect(updates).not.toHaveProperty('mqttUsername')
+    expect(updates).not.toHaveProperty('mqttPassword')
+    expect(updates).not.toHaveProperty('mqttTopicPrefix')
+    expect(updates).not.toHaveProperty('mqttHaDiscovery')
+    expect(updates).not.toHaveProperty('mqttTlsEnabled')
+  })
+
+  it('null clears a field (password → mqttPassword: null)', async () => {
+    await caller.updateSettings({ password: null })
+
+    const updates = dbMock.setSpy.mock.calls[0][0]
+    expect(updates).toHaveProperty('mqttPassword', null)
+  })
+
+  it('null clears a boolean field (enabled → mqttEnabled: null)', async () => {
+    await caller.updateSettings({ enabled: null })
+
+    const updates = dbMock.setSpy.mock.calls[0][0]
+    expect(updates).toHaveProperty('mqttEnabled', null)
+  })
+
+  it('writes every field when each is present in the input', async () => {
+    await caller.updateSettings({
+      enabled: true,
+      url: 'mqtt://broker:1883',
+      username: 'u',
+      password: 'p',
+      topicPrefix: 'sp',
+      haDiscovery: false,
+      tlsEnabled: true,
+    })
+
+    const updates = dbMock.setSpy.mock.calls[0][0]
+    expect(updates).toMatchObject({
+      mqttEnabled: true,
+      mqttUrl: 'mqtt://broker:1883',
+      mqttUsername: 'u',
+      mqttPassword: 'p',
+      mqttTopicPrefix: 'sp',
+      mqttHaDiscovery: false,
+      mqttTlsEnabled: true,
+    })
+  })
+})
+
+describe('mqtt.updateSettings — restart is fire-and-forget', () => {
+  it('mutation resolves before bridge restart awaits', async () => {
+    // shutdownMqttBridge never resolves in this test — if the mutation awaited
+    // it the call would hang forever. Resolution proves fire-and-forget.
+    bridgeMock.shutdownMqttBridge.mockImplementation(() => new Promise(() => { /* never */ }))
+    bridgeMock.startMqttBridge.mockImplementation(() => new Promise(() => { /* never */ }))
+
+    const result = await caller.updateSettings({ enabled: true })
+
+    expect(result).toEqual({ success: true })
+    // Restart was kicked off but startMqttBridge can't have run yet because
+    // shutdown is still pending — confirms shutdown→start is awaited
+    // sequentially inside the IIFE while the mutation returned immediately.
+    expect(bridgeMock.shutdownMqttBridge).toHaveBeenCalledTimes(1)
+    expect(bridgeMock.startMqttBridge).not.toHaveBeenCalled()
+  })
+
+  it('mutation still resolves when the bridge restart throws', async () => {
+    bridgeMock.shutdownMqttBridge.mockRejectedValue(new Error('shutdown boom'))
+
+    const result = await caller.updateSettings({ enabled: false })
+
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('mqtt.getStatus', () => {
+  it('passes through getBridgeStatus()', async () => {
+    bridgeMock.getBridgeStatus.mockReturnValue({
+      runState: 'connected',
+      connected: true,
+      lastError: null,
+      deviceId: 'sleepypod-test',
+      topicPrefix: 'sp',
+      messagesPublished: 17,
+      lastPublishAt: '2026-04-01T00:00:00.000Z',
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(bridgeMock.getBridgeStatus).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      runState: 'connected',
+      connected: true,
+      lastError: null,
+      deviceId: 'sleepypod-test',
+      topicPrefix: 'sp',
+      messagesPublished: 17,
+      lastPublishAt: '2026-04-01T00:00:00.000Z',
+    })
+  })
+})
+
+describe('mqtt.testConnection', () => {
+  it('passes input through to bridge.testConnection and returns its result', async () => {
+    bridgeMock.testConnection.mockResolvedValue({ ok: true })
+
+    const result = await caller.testConnection({
+      url: 'mqtt://broker:1883',
+      username: 'u',
+      password: 'p',
+      tlsEnabled: true,
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(bridgeMock.testConnection).toHaveBeenCalledTimes(1)
+    expect(bridgeMock.testConnection).toHaveBeenCalledWith({
+      url: 'mqtt://broker:1883',
+      username: 'u',
+      password: 'p',
+      tlsEnabled: true,
+    })
+  })
+
+  it('normalises optional fields — missing username/password become null, tlsEnabled defaults to false', async () => {
+    bridgeMock.testConnection.mockResolvedValue({ ok: false, error: 'connect timeout' })
+
+    const result = await caller.testConnection({ url: 'mqtt://broker:1883' })
+
+    expect(result).toEqual({ ok: false, error: 'connect timeout' })
+    expect(bridgeMock.testConnection).toHaveBeenCalledWith({
+      url: 'mqtt://broker:1883',
+      username: null,
+      password: null,
+      tlsEnabled: false,
+    })
+  })
+})

--- a/src/streaming/mqttBridge.ts
+++ b/src/streaming/mqttBridge.ts
@@ -65,6 +65,7 @@ export interface ResolvedMqttConfig {
   topicPrefix: string
   haDiscovery: boolean
   tlsEnabled: boolean
+  tlsInsecure: boolean
 }
 
 export interface ResolvedMqttSources {
@@ -75,6 +76,7 @@ export interface ResolvedMqttSources {
   topicPrefix: ConfigSource
   haDiscovery: ConfigSource
   tlsEnabled: ConfigSource
+  tlsInsecure: ConfigSource
 }
 
 function envBool(value: string | undefined): boolean | null {
@@ -97,6 +99,7 @@ export async function resolveConfig(): Promise<{
   const envEnabled = envBool(process.env.MQTT_ENABLED)
   const envHaDiscovery = envBool(process.env.MQTT_HA_DISCOVERY)
   const envTls = envBool(process.env.MQTT_TLS)
+  const envTlsInsecure = envBool(process.env.MQTT_TLS_INSECURE)
 
   const pick = <T>(dbVal: T | null | undefined, envVal: T | null, fallback: T): { value: T, source: ConfigSource } => {
     if (dbVal !== null && dbVal !== undefined) return { value: dbVal, source: 'db' }
@@ -111,6 +114,7 @@ export async function resolveConfig(): Promise<{
   const topicPrefix = pick<string>(row?.mqttTopicPrefix ?? null, process.env.MQTT_TOPIC_PREFIX ?? null, DEFAULT_TOPIC_PREFIX)
   const haDiscovery = pick<boolean>(row?.mqttHaDiscovery ?? null, envHaDiscovery, true)
   const tlsEnabled = pick<boolean>(row?.mqttTlsEnabled ?? null, envTls, false)
+  const tlsInsecure = pick<boolean>(row?.mqttTlsInsecure ?? null, envTlsInsecure, false)
 
   return {
     config: {
@@ -121,6 +125,7 @@ export async function resolveConfig(): Promise<{
       topicPrefix: topicPrefix.value,
       haDiscovery: haDiscovery.value,
       tlsEnabled: tlsEnabled.value,
+      tlsInsecure: tlsInsecure.value,
     },
     sources: {
       enabled: enabled.source,
@@ -130,6 +135,7 @@ export async function resolveConfig(): Promise<{
       topicPrefix: topicPrefix.source,
       haDiscovery: haDiscovery.source,
       tlsEnabled: tlsEnabled.source,
+      tlsInsecure: tlsInsecure.source,
     },
   }
 }
@@ -161,6 +167,8 @@ interface BridgeState {
   publishTimer: ReturnType<typeof setInterval> | null
   unsubscribeFrame: (() => void) | null
   resolved: ResolvedMqttConfig | null
+  messagesPublished: number
+  lastPublishAt: Date | null
 }
 
 const state: BridgeState = {
@@ -170,6 +178,8 @@ const state: BridgeState = {
   publishTimer: null,
   unsubscribeFrame: null,
   resolved: null,
+  messagesPublished: 0,
+  lastPublishAt: null,
 }
 
 export interface BridgeStatus {
@@ -178,6 +188,8 @@ export interface BridgeStatus {
   lastError: string | null
   deviceId: string
   topicPrefix: string | null
+  messagesPublished: number
+  lastPublishAt: string | null
 }
 
 export function getBridgeStatus(): BridgeStatus {
@@ -187,6 +199,8 @@ export function getBridgeStatus(): BridgeStatus {
     lastError: state.lastError,
     deviceId: deviceId(),
     topicPrefix: state.resolved?.topicPrefix ?? null,
+    messagesPublished: state.messagesPublished,
+    lastPublishAt: state.lastPublishAt?.toISOString() ?? null,
   }
 }
 
@@ -207,7 +221,12 @@ function safePublish(t: string, payload: string | Buffer, opts: IClientPublishOp
   if (!c || !c.connected) return
   try {
     c.publish(t, payload, opts, (err?: Error | null) => {
-      if (err) console.warn(`[mqtt] publish ${t} failed:`, err.message)
+      if (err) {
+        console.warn(`[mqtt] publish ${t} failed:`, err.message)
+        return
+      }
+      state.messagesPublished += 1
+      state.lastPublishAt = new Date()
     })
   }
   catch (err) {
@@ -392,6 +411,10 @@ async function publishState(): Promise<void> {
 // Command dispatch
 // ---------------------------------------------------------------------------
 
+// TODO: empty context is fine while every procedure is publicProcedure. Once
+// protectedProcedure lands (see ADR 0019 follow-ups), this becomes a privilege
+// escalation channel — MQTT commands would bypass auth. Replace with a
+// dedicated bridge context that asserts least-privilege.
 const caller = appRouter.createCaller({})
 
 interface CommandPayload {
@@ -451,11 +474,15 @@ export interface TestConnectionInput {
 }
 
 export interface TestConnectionResult {
-  success: boolean
+  ok: boolean
   error?: string
 }
 
 export async function testConnection(input: TestConnectionInput): Promise<TestConnectionResult> {
+  // Test connection respects MQTT_TLS_INSECURE so a "Test" button surfaces
+  // the same cert-trust outcome the running bridge would see. tlsEnabled on
+  // its own does not relax cert verification — mqtt.js defaults to strict.
+  const tlsInsecure = envBool(process.env.MQTT_TLS_INSECURE) === true
   return new Promise((resolve) => {
     let settled = false
     const finalize = (result: TestConnectionResult) => {
@@ -474,7 +501,7 @@ export async function testConnection(input: TestConnectionInput): Promise<TestCo
       clientId: `sleepypod-test-${Math.random().toString(16).slice(2, 10)}`,
       ...(input.username ? { username: input.username } : {}),
       ...(input.password ? { password: input.password } : {}),
-      ...(input.tlsEnabled ? { rejectUnauthorized: false } : {}),
+      ...(input.tlsEnabled && tlsInsecure ? { rejectUnauthorized: false } : {}),
     }
 
     let c: MqttClient
@@ -482,13 +509,13 @@ export async function testConnection(input: TestConnectionInput): Promise<TestCo
       c = mqtt.connect(input.url, opts)
     }
     catch (err) {
-      resolve({ success: false, error: err instanceof Error ? err.message : String(err) })
+      resolve({ ok: false, error: err instanceof Error ? err.message : String(err) })
       return
     }
 
-    c.once('connect', () => finalize({ success: true }))
-    c.once('error', (err: Error) => finalize({ success: false, error: err.message }))
-    setTimeout(() => finalize({ success: false, error: 'connect timeout' }), TEST_CONNECT_TIMEOUT_MS + 500)
+    c.once('connect', () => finalize({ ok: true }))
+    c.once('error', (err: Error) => finalize({ ok: false, error: err.message }))
+    setTimeout(() => finalize({ ok: false, error: 'connect timeout' }), TEST_CONNECT_TIMEOUT_MS + 500)
   })
 }
 
@@ -532,7 +559,10 @@ export async function startMqttBridge(): Promise<void> {
     },
     ...(config.username ? { username: config.username } : {}),
     ...(config.password ? { password: config.password } : {}),
-    ...(config.tlsEnabled ? { rejectUnauthorized: false } : {}),
+    // tlsEnabled on its own keeps mqtt.js default rejectUnauthorized:true.
+    // Self-signed-cert deployments must opt in via mqttTlsInsecure /
+    // MQTT_TLS_INSECURE — see ADR 0019.
+    ...(config.tlsEnabled && config.tlsInsecure ? { rejectUnauthorized: false } : {}),
   }
 
   const client: MqttClient = mqtt.connect(config.url, opts)

--- a/src/streaming/mqttBridge.ts
+++ b/src/streaming/mqttBridge.ts
@@ -1,0 +1,643 @@
+/**
+ * MQTT bridge — exposes the Pod on a user-supplied MQTT broker so Home
+ * Assistant (or any generic MQTT consumer) can read state and issue
+ * commands without touching the tRPC HTTP API.
+ *
+ * Lifecycle (managed by instrumentation.ts):
+ *   1. startMqttBridge()    — resolve config, connect, publish HA discovery,
+ *                             start state-mirror loop, subscribe to cmd/*
+ *   2. shutdownMqttBridge() — publish offline retained, end client cleanly
+ *
+ * Configuration precedence per field: device_settings row > MQTT_* env > default.
+ * If the resolved row leaves both NULL the field falls back to env, and finally
+ * to a fixed default. Sources are surfaced via getResolvedConfig() so the
+ * Settings UI can show why a value is what it is.
+ *
+ * Topic layout (configurable prefix; default "sleepypod"):
+ *   <prefix>/<device-id>/availability                — LWT (online | offline)
+ *   <prefix>/<device-id>/state/device-status         — full deviceStatus mirror
+ *   <prefix>/<device-id>/state/<side>/climate        — per-side temperature/mode
+ *   <prefix>/<device-id>/state/water-level           — low | ok | unknown
+ *   <prefix>/<device-id>/state/biometrics/<side>     — latest HR/HRV/BR summary
+ *   <prefix>/<device-id>/cmd/set-temperature         — JSON {side, temperature, duration?}
+ *   <prefix>/<device-id>/cmd/set-power               — JSON {side, powered, temperature?}
+ *   <prefix>/<device-id>/cmd/set-alarm               — JSON {side, vibrationIntensity, vibrationPattern, duration}
+ *   <prefix>/<device-id>/cmd/clear-alarm             — JSON {side}
+ *   <prefix>/<device-id>/cmd/start-priming           — JSON {} (or empty payload)
+ *
+ * Commands route through the existing tRPC procedures via createCaller, so the
+ * Zod input schemas are the single source of truth for argument validation —
+ * the bridge never reimplements business logic.
+ *
+ * TODO: depends on the `mqtt` npm package owned by sleepypod-core-28
+ * (frontend agent). The @ts-ignore on the import resolves once that lands.
+ */
+
+import os from 'node:os'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- mqtt dep landed by sleepypod-core-28; resolves once frontend PR merges
+import mqtt, { type IClientOptions, type IClientPublishOptions, type MqttClient } from 'mqtt'
+import { eq, desc } from 'drizzle-orm'
+import { db, biometricsDb } from '@/src/db'
+import { deviceSettings, deviceState } from '@/src/db/schema'
+import { vitals } from '@/src/db/biometrics-schema'
+import { appRouter } from '@/src/server/routers/app'
+import { onServerFrame } from './piezoStream'
+import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
+
+// ---------------------------------------------------------------------------
+// Configuration resolution
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TOPIC_PREFIX = 'sleepypod'
+const STATE_PUBLISH_INTERVAL_MS = 30_000
+const RECONNECT_PERIOD_MS = 5_000
+const CONNECT_TIMEOUT_MS = 10_000
+const TEST_CONNECT_TIMEOUT_MS = 5_000
+
+export type ConfigSource = 'db' | 'env' | 'default'
+
+export interface ResolvedMqttConfig {
+  enabled: boolean
+  url: string | null
+  username: string | null
+  password: string | null
+  topicPrefix: string
+  haDiscovery: boolean
+  tlsEnabled: boolean
+}
+
+export interface ResolvedMqttSources {
+  enabled: ConfigSource
+  url: ConfigSource
+  username: ConfigSource
+  password: ConfigSource
+  topicPrefix: ConfigSource
+  haDiscovery: ConfigSource
+  tlsEnabled: ConfigSource
+}
+
+function envBool(value: string | undefined): boolean | null {
+  if (value === undefined) return null
+  return value === '1' || value.toLowerCase() === 'true'
+}
+
+export async function resolveConfig(): Promise<{
+  config: ResolvedMqttConfig
+  sources: ResolvedMqttSources
+}> {
+  let row: typeof deviceSettings.$inferSelect | undefined
+  try {
+    [row] = await db.select().from(deviceSettings).limit(1)
+  }
+  catch (err) {
+    console.warn('[mqtt] failed to read device_settings — falling back to env:', err instanceof Error ? err.message : err)
+  }
+
+  const envEnabled = envBool(process.env.MQTT_ENABLED)
+  const envHaDiscovery = envBool(process.env.MQTT_HA_DISCOVERY)
+  const envTls = envBool(process.env.MQTT_TLS)
+
+  const pick = <T>(dbVal: T | null | undefined, envVal: T | null, fallback: T): { value: T, source: ConfigSource } => {
+    if (dbVal !== null && dbVal !== undefined) return { value: dbVal, source: 'db' }
+    if (envVal !== null && envVal !== undefined) return { value: envVal, source: 'env' }
+    return { value: fallback, source: 'default' }
+  }
+
+  const enabled = pick<boolean>(row?.mqttEnabled ?? null, envEnabled, false)
+  const url = pick<string | null>(row?.mqttUrl ?? null, process.env.MQTT_URL ?? null, null)
+  const username = pick<string | null>(row?.mqttUsername ?? null, process.env.MQTT_USERNAME ?? null, null)
+  const password = pick<string | null>(row?.mqttPassword ?? null, process.env.MQTT_PASSWORD ?? null, null)
+  const topicPrefix = pick<string>(row?.mqttTopicPrefix ?? null, process.env.MQTT_TOPIC_PREFIX ?? null, DEFAULT_TOPIC_PREFIX)
+  const haDiscovery = pick<boolean>(row?.mqttHaDiscovery ?? null, envHaDiscovery, true)
+  const tlsEnabled = pick<boolean>(row?.mqttTlsEnabled ?? null, envTls, false)
+
+  return {
+    config: {
+      enabled: enabled.value,
+      url: url.value,
+      username: username.value,
+      password: password.value,
+      topicPrefix: topicPrefix.value,
+      haDiscovery: haDiscovery.value,
+      tlsEnabled: tlsEnabled.value,
+    },
+    sources: {
+      enabled: enabled.source,
+      url: url.source,
+      username: username.source,
+      password: password.source,
+      topicPrefix: topicPrefix.source,
+      haDiscovery: haDiscovery.source,
+      tlsEnabled: tlsEnabled.source,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Device identity
+// ---------------------------------------------------------------------------
+
+function deviceId(): string {
+  const override = process.env.MQTT_DEVICE_ID
+  if (override && override.trim().length > 0) return slugify(override)
+  return slugify(os.hostname() || 'sleepypod')
+}
+
+function slugify(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9-_]/g, '-').replace(/^-+|-+$/g, '') || 'sleepypod'
+}
+
+// ---------------------------------------------------------------------------
+// Bridge state
+// ---------------------------------------------------------------------------
+
+type BridgeRunState = 'stopped' | 'starting' | 'connected' | 'reconnecting' | 'errored'
+
+interface BridgeState {
+  client: MqttClient | null
+  runState: BridgeRunState
+  lastError: string | null
+  publishTimer: ReturnType<typeof setInterval> | null
+  unsubscribeFrame: (() => void) | null
+  resolved: ResolvedMqttConfig | null
+}
+
+const state: BridgeState = {
+  client: null,
+  runState: 'stopped',
+  lastError: null,
+  publishTimer: null,
+  unsubscribeFrame: null,
+  resolved: null,
+}
+
+export interface BridgeStatus {
+  runState: BridgeRunState
+  connected: boolean
+  lastError: string | null
+  deviceId: string
+  topicPrefix: string | null
+}
+
+export function getBridgeStatus(): BridgeStatus {
+  return {
+    runState: state.runState,
+    connected: state.client?.connected === true,
+    lastError: state.lastError,
+    deviceId: deviceId(),
+    topicPrefix: state.resolved?.topicPrefix ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Publishing helpers
+// ---------------------------------------------------------------------------
+
+const RETAINED_QOS_0: IClientPublishOptions = { qos: 0, retain: true }
+const VOLATILE_QOS_0: IClientPublishOptions = { qos: 0, retain: false }
+
+function topic(...parts: string[]): string {
+  const prefix = state.resolved?.topicPrefix ?? DEFAULT_TOPIC_PREFIX
+  return [prefix, deviceId(), ...parts].join('/')
+}
+
+function safePublish(t: string, payload: string | Buffer, opts: IClientPublishOptions): void {
+  const c = state.client
+  if (!c || !c.connected) return
+  try {
+    c.publish(t, payload, opts, (err?: Error | null) => {
+      if (err) console.warn(`[mqtt] publish ${t} failed:`, err.message)
+    })
+  }
+  catch (err) {
+    console.warn(`[mqtt] publish ${t} threw:`, err instanceof Error ? err.message : err)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HA discovery
+// ---------------------------------------------------------------------------
+
+interface HaDiscoveryDevice {
+  identifiers: string[]
+  name: string
+  manufacturer: string
+  model: string
+  sw_version?: string
+}
+
+function haDevice(): HaDiscoveryDevice {
+  const id = deviceId()
+  return {
+    identifiers: [id],
+    name: `Sleepypod ${id}`,
+    manufacturer: 'Sleepypod',
+    model: 'Pod',
+  }
+}
+
+function publishHaDiscovery(): void {
+  if (!state.resolved?.haDiscovery) return
+  const id = deviceId()
+  const dev = haDevice()
+  const availability = topic('availability')
+  const haPrefix = process.env.MQTT_HA_DISCOVERY_PREFIX || 'homeassistant'
+
+  const climate = (side: 'left' | 'right') => ({
+    name: `${side === 'left' ? 'Left' : 'Right'} side`,
+    unique_id: `${id}_${side}_climate`,
+    availability_topic: availability,
+    payload_available: 'online',
+    payload_not_available: 'offline',
+    current_temperature_topic: topic('state', side, 'climate'),
+    current_temperature_template: '{{ value_json.currentTemperature }}',
+    temperature_state_topic: topic('state', side, 'climate'),
+    temperature_state_template: '{{ value_json.targetTemperature }}',
+    mode_state_topic: topic('state', side, 'climate'),
+    mode_state_template: '{{ value_json.mode }}',
+    temperature_command_topic: topic('cmd', 'set-temperature'),
+    temperature_command_template: `{ "side": "${side}", "temperature": {{ value | int }} }`,
+    mode_command_topic: topic('cmd', 'set-power'),
+    mode_command_template: `{ "side": "${side}", "powered": {{ "true" if value == "heat" else "false" }} }`,
+    modes: ['off', 'heat'],
+    min_temp: 55,
+    max_temp: 110,
+    temp_step: 1,
+    temperature_unit: 'F',
+    device: dev,
+  })
+
+  const sensor = (objectId: string, name: string, stateTopic: string, template: string, unit?: string) => {
+    const cfg: Record<string, unknown> = {
+      name,
+      unique_id: `${id}_${objectId}`,
+      availability_topic: availability,
+      payload_available: 'online',
+      payload_not_available: 'offline',
+      state_topic: stateTopic,
+      value_template: template,
+      device: dev,
+    }
+    if (unit) cfg.unit_of_measurement = unit
+    return cfg
+  }
+
+  safePublish(
+    `${haPrefix}/climate/${id}/left/config`,
+    JSON.stringify(climate('left')),
+    RETAINED_QOS_0,
+  )
+  safePublish(
+    `${haPrefix}/climate/${id}/right/config`,
+    JSON.stringify(climate('right')),
+    RETAINED_QOS_0,
+  )
+  safePublish(
+    `${haPrefix}/sensor/${id}/water_level/config`,
+    JSON.stringify(sensor('water_level', 'Water level', topic('state', 'water-level'), '{{ value_json.level }}')),
+    RETAINED_QOS_0,
+  )
+  for (const side of ['left', 'right'] as const) {
+    safePublish(
+      `${haPrefix}/sensor/${id}/${side}_heart_rate/config`,
+      JSON.stringify(sensor(`${side}_heart_rate`, `${side === 'left' ? 'Left' : 'Right'} heart rate`,
+        topic('state', 'biometrics', side), '{{ value_json.heartRate }}', 'bpm')),
+      RETAINED_QOS_0,
+    )
+    safePublish(
+      `${haPrefix}/sensor/${id}/${side}_breathing_rate/config`,
+      JSON.stringify(sensor(`${side}_breathing_rate`, `${side === 'left' ? 'Left' : 'Right'} breathing rate`,
+        topic('state', 'biometrics', side), '{{ value_json.breathingRate }}', 'br/min')),
+      RETAINED_QOS_0,
+    )
+    safePublish(
+      `${haPrefix}/sensor/${id}/${side}_hrv/config`,
+      JSON.stringify(sensor(`${side}_hrv`, `${side === 'left' ? 'Left' : 'Right'} HRV`,
+        topic('state', 'biometrics', side), '{{ value_json.hrv }}', 'ms')),
+      RETAINED_QOS_0,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State publication
+// ---------------------------------------------------------------------------
+
+async function publishState(): Promise<void> {
+  if (!state.client?.connected) return
+
+  const monitor = getDacMonitorIfRunning()
+  const status = monitor?.getLastStatus()
+
+  if (status) {
+    safePublish(topic('state', 'device-status'), JSON.stringify({
+      ts: Date.now(),
+      leftSide: status.leftSide,
+      rightSide: status.rightSide,
+      waterLevel: status.waterLevel,
+      isPriming: status.isPriming,
+      podVersion: status.podVersion,
+    }), RETAINED_QOS_0)
+
+    safePublish(topic('state', 'water-level'), JSON.stringify({
+      ts: Date.now(),
+      level: status.waterLevel,
+    }), RETAINED_QOS_0)
+  }
+
+  try {
+    const sides = await db.select().from(deviceState)
+    for (const row of sides) {
+      const mode = row.isPowered ? 'heat' : 'off'
+      safePublish(topic('state', row.side, 'climate'), JSON.stringify({
+        ts: row.lastUpdated.getTime(),
+        currentTemperature: row.currentTemperature,
+        targetTemperature: row.targetTemperature,
+        isPowered: row.isPowered,
+        isAlarmVibrating: row.isAlarmVibrating,
+        mode,
+        waterLevel: row.waterLevel,
+      }), RETAINED_QOS_0)
+    }
+  }
+  catch (err) {
+    console.warn('[mqtt] device_state publish failed:', err instanceof Error ? err.message : err)
+  }
+
+  for (const side of ['left', 'right'] as const) {
+    try {
+      const [latest] = await biometricsDb
+        .select()
+        .from(vitals)
+        .where(eq(vitals.side, side))
+        .orderBy(desc(vitals.timestamp))
+        .limit(1)
+      if (latest) {
+        safePublish(topic('state', 'biometrics', side), JSON.stringify({
+          ts: latest.timestamp.getTime(),
+          heartRate: latest.heartRate,
+          hrv: latest.hrv,
+          breathingRate: latest.breathingRate,
+        }), RETAINED_QOS_0)
+      }
+    }
+    catch (err) {
+      console.warn(`[mqtt] biometrics publish (${side}) failed:`, err instanceof Error ? err.message : err)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command dispatch
+// ---------------------------------------------------------------------------
+
+const caller = appRouter.createCaller({})
+
+interface CommandPayload {
+  side?: unknown
+  temperature?: unknown
+  duration?: unknown
+  powered?: unknown
+  vibrationIntensity?: unknown
+  vibrationPattern?: unknown
+}
+
+function parsePayload(buf: Buffer): CommandPayload {
+  const text = buf.toString('utf-8').trim()
+  if (text.length === 0) return {}
+  try {
+    const parsed = JSON.parse(text)
+    return typeof parsed === 'object' && parsed !== null ? parsed as CommandPayload : {}
+  }
+  catch {
+    return {}
+  }
+}
+
+async function handleCommand(verb: string, payload: CommandPayload): Promise<void> {
+  // Each branch hands the payload straight to the tRPC procedure — its Zod
+  // schema rejects malformed input. No client-side validation duplicated here.
+  switch (verb) {
+    case 'set-temperature':
+      await caller.device.setTemperature(payload as never)
+      return
+    case 'set-power':
+      await caller.device.setPower(payload as never)
+      return
+    case 'set-alarm':
+      await caller.device.setAlarm(payload as never)
+      return
+    case 'clear-alarm':
+      await caller.device.clearAlarm(payload as never)
+      return
+    case 'start-priming':
+      await caller.device.startPriming({})
+      return
+    default:
+      console.warn(`[mqtt] unknown command verb: ${verb}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test connection (used by tRPC mqtt.testConnection)
+// ---------------------------------------------------------------------------
+
+export interface TestConnectionInput {
+  url: string
+  username?: string | null
+  password?: string | null
+  tlsEnabled?: boolean
+}
+
+export interface TestConnectionResult {
+  success: boolean
+  error?: string
+}
+
+export async function testConnection(input: TestConnectionInput): Promise<TestConnectionResult> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finalize = (result: TestConnectionResult) => {
+      if (settled) return
+      settled = true
+      try {
+        c.end(true)
+      }
+      catch { /* ignore */ }
+      resolve(result)
+    }
+
+    const opts: IClientOptions = {
+      reconnectPeriod: 0,
+      connectTimeout: TEST_CONNECT_TIMEOUT_MS,
+      clientId: `sleepypod-test-${Math.random().toString(16).slice(2, 10)}`,
+      ...(input.username ? { username: input.username } : {}),
+      ...(input.password ? { password: input.password } : {}),
+      ...(input.tlsEnabled ? { rejectUnauthorized: false } : {}),
+    }
+
+    let c: MqttClient
+    try {
+      c = mqtt.connect(input.url, opts)
+    }
+    catch (err) {
+      resolve({ success: false, error: err instanceof Error ? err.message : String(err) })
+      return
+    }
+
+    c.once('connect', () => finalize({ success: true }))
+    c.once('error', (err: Error) => finalize({ success: false, error: err.message }))
+    setTimeout(() => finalize({ success: false, error: 'connect timeout' }), TEST_CONNECT_TIMEOUT_MS + 500)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export async function startMqttBridge(): Promise<void> {
+  if (state.runState !== 'stopped') return
+
+  state.runState = 'starting'
+  state.lastError = null
+
+  const { config } = await resolveConfig()
+  state.resolved = config
+
+  if (!config.enabled) {
+    console.log('[mqtt] disabled (set mqtt_enabled=true in device_settings or MQTT_ENABLED=true)')
+    state.runState = 'stopped'
+    return
+  }
+  if (!config.url) {
+    console.warn('[mqtt] enabled but no URL configured — set mqtt_url in device_settings or MQTT_URL')
+    state.runState = 'errored'
+    state.lastError = 'no broker URL configured'
+    return
+  }
+
+  const id = deviceId()
+  const availabilityTopic = topic('availability')
+  const opts: IClientOptions = {
+    clientId: `sleepypod-${id}-${Math.random().toString(16).slice(2, 10)}`,
+    reconnectPeriod: RECONNECT_PERIOD_MS,
+    connectTimeout: CONNECT_TIMEOUT_MS,
+    keepalive: 30,
+    will: {
+      topic: availabilityTopic,
+      payload: Buffer.from('offline'),
+      qos: 0,
+      retain: true,
+    },
+    ...(config.username ? { username: config.username } : {}),
+    ...(config.password ? { password: config.password } : {}),
+    ...(config.tlsEnabled ? { rejectUnauthorized: false } : {}),
+  }
+
+  const client: MqttClient = mqtt.connect(config.url, opts)
+  state.client = client
+
+  client.on('connect', () => {
+    state.runState = 'connected'
+    state.lastError = null
+    console.log(`[mqtt] connected to ${config.url} (deviceId=${id}, prefix=${config.topicPrefix})`)
+    safePublish(availabilityTopic, 'online', RETAINED_QOS_0)
+    publishHaDiscovery()
+    client.subscribe(topic('cmd', '+'), { qos: 0 }, (err: Error | null) => {
+      if (err) console.warn('[mqtt] subscribe cmd/* failed:', err.message)
+    })
+    void publishState()
+  })
+
+  client.on('reconnect', () => {
+    state.runState = 'reconnecting'
+    console.log('[mqtt] reconnecting…')
+  })
+
+  client.on('error', (err: Error) => {
+    state.lastError = err.message
+    console.warn('[mqtt] client error:', err.message)
+  })
+
+  client.on('close', () => {
+    if (state.runState === 'connected') state.runState = 'reconnecting'
+  })
+
+  client.on('message', (incomingTopic: string, payload: Buffer) => {
+    const cmdPrefix = topic('cmd') + '/'
+    if (!incomingTopic.startsWith(cmdPrefix)) return
+    const verb = incomingTopic.slice(cmdPrefix.length)
+    const parsed = parsePayload(payload)
+    void handleCommand(verb, parsed).catch((err) => {
+      console.warn(`[mqtt] command ${verb} failed:`, err instanceof Error ? err.message : err)
+    })
+  })
+
+  state.publishTimer = setInterval(() => {
+    void publishState()
+  }, STATE_PUBLISH_INTERVAL_MS)
+
+  // React to live status frames so HA sees temperature changes immediately
+  // rather than waiting for the periodic re-publish.
+  state.unsubscribeFrame = onServerFrame((frame) => {
+    if (frame.type !== 'deviceStatus') return
+    if (!state.client?.connected) return
+    safePublish(topic('state', 'device-status'), JSON.stringify(frame), RETAINED_QOS_0)
+  })
+}
+
+export async function shutdownMqttBridge(): Promise<void> {
+  if (state.runState === 'stopped' && !state.client) return
+  console.log('[mqtt] shutting down…')
+
+  if (state.publishTimer) {
+    clearInterval(state.publishTimer)
+    state.publishTimer = null
+  }
+  if (state.unsubscribeFrame) {
+    try {
+      state.unsubscribeFrame()
+    }
+    catch { /* ignore */ }
+    state.unsubscribeFrame = null
+  }
+
+  const c = state.client
+  state.client = null
+  state.runState = 'stopped'
+  if (!c) return
+
+  // Best-effort retained-offline so HA reflects the pod going down.
+  try {
+    if (c.connected) {
+      await new Promise<void>((resolve) => {
+        c.publish(topic('availability'), 'offline', RETAINED_QOS_0, () => resolve())
+        setTimeout(resolve, VOLATILE_QOS_0.qos === 0 ? 500 : 1000)
+      })
+    }
+  }
+  catch { /* ignore */ }
+
+  await new Promise<void>((resolve) => {
+    try {
+      c.end(false, {}, () => resolve())
+      setTimeout(resolve, 1500)
+    }
+    catch {
+      resolve()
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Internal hooks for unit tests
+// ---------------------------------------------------------------------------
+
+export const __test__ = {
+  resolveConfig,
+  deviceId,
+  slugify,
+  parsePayload,
+  state,
+}

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -778,8 +778,23 @@ export function onServerFrame(cb: ServerFrameListener): () => void {
 /**
  * Broadcast a JSON message to all connected WS clients that are subscribed
  * to the given sensor type. Used by dacMonitor to push device status frames.
+ *
+ * Also fans out to in-process server-side listeners (onServerFrame) for every
+ * frame type. The MQTT bridge subscribes here to mirror deviceStatus frames
+ * to HA without waiting on the 30 s timer; previously this path only fired
+ * inside the file-decoder loop and was gated to frzHealth, so frames produced
+ * by broadcastFrame() (deviceStatus, etc.) never reached server listeners.
  */
 export function broadcastFrame(frame: Record<string, unknown>): void {
+  if (serverFrameListeners.size > 0) {
+    for (const cb of serverFrameListeners) {
+      try {
+        cb(frame)
+      }
+      catch { /* consumer error */ }
+    }
+  }
+
   const server = wss
   if (!server || server.clients.size === 0) return
 

--- a/src/streaming/tests/__stubs__/mqtt.ts
+++ b/src/streaming/tests/__stubs__/mqtt.ts
@@ -1,0 +1,50 @@
+/**
+ * Test-only stub for the `mqtt` npm package.
+ *
+ * The package is added by sleepypod-core-28 (frontend PR). On this branch it
+ * isn't installed yet, so vite's import-analysis fails to resolve the literal
+ * `import mqtt from 'mqtt'` in src/streaming/mqttBridge.ts at transform time —
+ * before any vi.mock factory can intercept it.
+ *
+ * vitest.config.mts aliases `mqtt` to this stub so the bridge module loads in
+ * tests. Tests then layer vi.mock('mqtt', ...) on top to control behaviour.
+ *
+ * No real socket is ever opened — `connect` is a noop that returns a stub
+ * client wired to throw on use, surfacing any test that accidentally relies
+ * on real network IO.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+
+export type IClientOptions = Record<string, unknown>
+export type IClientPublishOptions = Record<string, unknown>
+
+export interface MqttClient {
+  connected: boolean
+  publish: (...args: any[]) => any
+  subscribe: (...args: any[]) => any
+  on: (...args: any[]) => any
+  once: (...args: any[]) => any
+  end: (...args: any[]) => any
+}
+
+function notImplemented(): never {
+  throw new Error('mqtt stub: real client called in a test — vi.mock(\'mqtt\') was not applied')
+}
+
+const stubClient: MqttClient = {
+  connected: false,
+  publish: notImplemented,
+  subscribe: notImplemented,
+  on: notImplemented,
+  once: notImplemented,
+  end: notImplemented,
+}
+
+export function connect(_url: string, _opts?: IClientOptions): MqttClient {
+  return stubClient
+}
+
+const mqttDefault = { connect }
+
+export default mqttDefault

--- a/src/streaming/tests/mqttBridge.test.ts
+++ b/src/streaming/tests/mqttBridge.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for the MQTT bridge — config resolution, identity helpers, payload
+ * parsing. The mqtt npm module is mocked so no real socket is opened at
+ * import time or during any test.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import os from 'node:os'
+
+// Hoisted state shared with the @/src/db mock factory — lets each test stub
+// the device_settings row that resolveConfig will read.
+const dbMock = vi.hoisted(() => {
+  const state: { row: any | undefined, throwOnSelect: boolean } = {
+    row: undefined,
+    throwOnSelect: false,
+  }
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      limit: vi.fn(async () => {
+        if (state.throwOnSelect) throw new Error('boom')
+        return state.row !== undefined ? [state.row] : []
+      }),
+      where: vi.fn(() => ({
+        orderBy: vi.fn(() => ({
+          limit: vi.fn(async () => []),
+        })),
+      })),
+    })),
+  }))
+  return { state, select }
+})
+
+// The bridge imports `mqtt` at module load. The package is provided by the
+// frontend agent's PR (sleepypod-core-28); on this branch it isn't installed
+// yet. Mocking the import keeps the bridge loadable and guarantees no real
+// connect() ever runs during tests.
+vi.mock('mqtt', () => ({
+  default: { connect: vi.fn() },
+  connect: vi.fn(),
+}))
+
+vi.mock('@/src/db', () => ({
+  db: { select: dbMock.select, update: vi.fn() },
+  biometricsDb: { select: dbMock.select },
+}))
+
+// Stub the heavy app-router import — mqttBridge only needs createCaller({}) to
+// resolve at module load. None of these tests exercise command dispatch.
+vi.mock('@/src/server/routers/app', () => ({
+  appRouter: { createCaller: () => ({ device: {} }) },
+}))
+
+vi.mock('@/src/streaming/piezoStream', () => ({
+  onServerFrame: vi.fn(() => () => { /* unsubscribe */ }),
+}))
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getDacMonitorIfRunning: vi.fn(() => null),
+}))
+
+const { __test__ } = await import('../mqttBridge')
+const { resolveConfig, slugify, deviceId, parsePayload } = __test__
+
+const MQTT_ENV_KEYS = [
+  'MQTT_ENABLED',
+  'MQTT_URL',
+  'MQTT_USERNAME',
+  'MQTT_PASSWORD',
+  'MQTT_TOPIC_PREFIX',
+  'MQTT_HA_DISCOVERY',
+  'MQTT_TLS',
+  'MQTT_TLS_INSECURE',
+  'MQTT_DEVICE_ID',
+] as const
+
+function clearMqttEnv() {
+  for (const k of MQTT_ENV_KEYS) Reflect.deleteProperty(process.env, k)
+}
+
+beforeEach(() => {
+  clearMqttEnv()
+  dbMock.state.row = undefined
+  dbMock.state.throwOnSelect = false
+})
+
+afterEach(() => {
+  clearMqttEnv()
+})
+
+describe('mqttBridge — resolveConfig source attribution', () => {
+  it('returns "default" sources for every field when neither DB nor env is set', async () => {
+    const { config, sources } = await resolveConfig()
+
+    expect(sources).toEqual({
+      enabled: 'default',
+      url: 'default',
+      username: 'default',
+      password: 'default',
+      topicPrefix: 'default',
+      haDiscovery: 'default',
+      tlsEnabled: 'default',
+      tlsInsecure: 'default',
+    })
+    expect(config).toEqual({
+      enabled: false,
+      url: null,
+      username: null,
+      password: null,
+      topicPrefix: 'sleepypod',
+      haDiscovery: true,
+      tlsEnabled: false,
+      tlsInsecure: false,
+    })
+  })
+
+  it('returns "env" sources when only env vars are set', async () => {
+    process.env.MQTT_ENABLED = 'true'
+    process.env.MQTT_URL = 'mqtt://broker.local:1883'
+    process.env.MQTT_USERNAME = 'envuser'
+    process.env.MQTT_PASSWORD = 'envpass'
+    process.env.MQTT_TOPIC_PREFIX = 'env-prefix'
+    process.env.MQTT_HA_DISCOVERY = '0'
+    process.env.MQTT_TLS = '1'
+    process.env.MQTT_TLS_INSECURE = 'true'
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources).toEqual({
+      enabled: 'env',
+      url: 'env',
+      username: 'env',
+      password: 'env',
+      topicPrefix: 'env',
+      haDiscovery: 'env',
+      tlsEnabled: 'env',
+      tlsInsecure: 'env',
+    })
+    expect(config).toEqual({
+      enabled: true,
+      url: 'mqtt://broker.local:1883',
+      username: 'envuser',
+      password: 'envpass',
+      topicPrefix: 'env-prefix',
+      haDiscovery: false,
+      tlsEnabled: true,
+      tlsInsecure: true,
+    })
+  })
+
+  it('returns "db" sources when the device_settings row populates every field', async () => {
+    dbMock.state.row = {
+      mqttEnabled: true,
+      mqttUrl: 'mqtt://db-broker:1883',
+      mqttUsername: 'dbuser',
+      mqttPassword: 'dbpass',
+      mqttTopicPrefix: 'db-prefix',
+      mqttHaDiscovery: false,
+      mqttTlsEnabled: true,
+      mqttTlsInsecure: true,
+    }
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources).toEqual({
+      enabled: 'db',
+      url: 'db',
+      username: 'db',
+      password: 'db',
+      topicPrefix: 'db',
+      haDiscovery: 'db',
+      tlsEnabled: 'db',
+      tlsInsecure: 'db',
+    })
+    expect(config).toEqual({
+      enabled: true,
+      url: 'mqtt://db-broker:1883',
+      username: 'dbuser',
+      password: 'dbpass',
+      topicPrefix: 'db-prefix',
+      haDiscovery: false,
+      tlsEnabled: true,
+      tlsInsecure: true,
+    })
+  })
+})
+
+describe('mqttBridge — resolveConfig per-field precedence', () => {
+  it('DB value beats env value when both are set (url field)', async () => {
+    process.env.MQTT_URL = 'mqtt://env-broker:1883'
+    dbMock.state.row = { mqttUrl: 'mqtt://db-broker:1883' }
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources.url).toBe('db')
+    expect(config.url).toBe('mqtt://db-broker:1883')
+  })
+
+  it('env value wins when DB row leaves the field NULL (url field)', async () => {
+    process.env.MQTT_URL = 'mqtt://env-broker:1883'
+    dbMock.state.row = { mqttUrl: null }
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources.url).toBe('env')
+    expect(config.url).toBe('mqtt://env-broker:1883')
+  })
+
+  it('boolean fields: DB false beats env true (mqttEnabled)', async () => {
+    process.env.MQTT_ENABLED = 'true'
+    dbMock.state.row = { mqttEnabled: false }
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources.enabled).toBe('db')
+    expect(config.enabled).toBe(false)
+  })
+
+  it('topicPrefix: defaults to "sleepypod" when neither DB nor env are set', async () => {
+    const { config, sources } = await resolveConfig()
+    expect(sources.topicPrefix).toBe('default')
+    expect(config.topicPrefix).toBe('sleepypod')
+  })
+
+  it('haDiscovery: defaults to true when neither DB nor env are set', async () => {
+    const { config, sources } = await resolveConfig()
+    expect(sources.haDiscovery).toBe('default')
+    expect(config.haDiscovery).toBe(true)
+  })
+
+  it('tlsInsecure: defaults to false when neither DB nor env are set', async () => {
+    const { config, sources } = await resolveConfig()
+    expect(sources.tlsInsecure).toBe('default')
+    expect(config.tlsInsecure).toBe(false)
+  })
+
+  it('mixes precedence across fields in a single call', async () => {
+    // url -> DB, password -> env, username -> default
+    process.env.MQTT_PASSWORD = 'envpass'
+    dbMock.state.row = {
+      mqttUrl: 'mqtt://db:1883',
+      mqttUsername: null,
+      mqttPassword: null,
+    }
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources.url).toBe('db')
+    expect(config.url).toBe('mqtt://db:1883')
+    expect(sources.password).toBe('env')
+    expect(config.password).toBe('envpass')
+    expect(sources.username).toBe('default')
+    expect(config.username).toBeNull()
+  })
+
+  it('falls back to env / default when reading device_settings throws', async () => {
+    dbMock.state.throwOnSelect = true
+    process.env.MQTT_URL = 'mqtt://env-only:1883'
+
+    const { config, sources } = await resolveConfig()
+
+    expect(sources.url).toBe('env')
+    expect(config.url).toBe('mqtt://env-only:1883')
+    expect(sources.enabled).toBe('default')
+    expect(config.enabled).toBe(false)
+  })
+})
+
+describe('mqttBridge — resolveConfig password handling', () => {
+  // The router derives passwordIsSet from the resolved password value:
+  //   passwordIsSet = config.password !== null && config.password.length > 0
+  // These tests pin that mapping at the bridge level so the contract holds
+  // even if the router-side derivation is rewritten.
+  function passwordIsSet(p: string | null): boolean {
+    return p !== null && p.length > 0
+  }
+
+  it('null resolved password → passwordIsSet=false', async () => {
+    dbMock.state.row = { mqttPassword: null }
+    const { config } = await resolveConfig()
+    expect(config.password).toBeNull()
+    expect(passwordIsSet(config.password)).toBe(false)
+  })
+
+  it('empty-string resolved password → passwordIsSet=false', async () => {
+    dbMock.state.row = { mqttPassword: '' }
+    const { config } = await resolveConfig()
+    expect(config.password).toBe('')
+    expect(passwordIsSet(config.password)).toBe(false)
+  })
+
+  it('non-empty resolved password → passwordIsSet=true', async () => {
+    dbMock.state.row = { mqttPassword: 'x' }
+    const { config } = await resolveConfig()
+    expect(config.password).toBe('x')
+    expect(passwordIsSet(config.password)).toBe(true)
+  })
+})
+
+describe('mqttBridge — slugify', () => {
+  it('lowercases input', () => {
+    expect(slugify('SleepyPod')).toBe('sleepypod')
+  })
+
+  it('strips characters outside [a-z0-9-_]', () => {
+    expect(slugify('hello world!')).toBe('hello-world')
+    expect(slugify('foo.bar+baz')).toBe('foo-bar-baz')
+  })
+
+  it('trims leading and trailing dashes after substitution', () => {
+    expect(slugify('---abc---')).toBe('abc')
+    expect(slugify('!!!hello!!!')).toBe('hello')
+  })
+
+  it('falls back to "sleepypod" when the result would be empty', () => {
+    expect(slugify('')).toBe('sleepypod')
+    expect(slugify('!!!')).toBe('sleepypod')
+    expect(slugify('---')).toBe('sleepypod')
+  })
+
+  it('preserves digits, hyphens, and underscores', () => {
+    expect(slugify('pod_3-test_42')).toBe('pod_3-test_42')
+  })
+})
+
+describe('mqttBridge — deviceId', () => {
+  it('uses MQTT_DEVICE_ID env when set', () => {
+    process.env.MQTT_DEVICE_ID = 'pod-bedroom'
+    expect(deviceId()).toBe('pod-bedroom')
+  })
+
+  it('slugifies the env override', () => {
+    process.env.MQTT_DEVICE_ID = 'Pod Bedroom!'
+    expect(deviceId()).toBe('pod-bedroom')
+  })
+
+  it('ignores whitespace-only env override and falls back to hostname', () => {
+    process.env.MQTT_DEVICE_ID = '   '
+    const hostnameSpy = vi.spyOn(os, 'hostname').mockReturnValue('Living Room Pod')
+    expect(deviceId()).toBe('living-room-pod')
+    hostnameSpy.mockRestore()
+  })
+
+  it('slugifies the hostname when no env override is set', () => {
+    const hostnameSpy = vi.spyOn(os, 'hostname').mockReturnValue('SLEEPY.local')
+    expect(deviceId()).toBe('sleepy-local')
+    hostnameSpy.mockRestore()
+  })
+
+  it('falls back to "sleepypod" when the hostname is empty', () => {
+    const hostnameSpy = vi.spyOn(os, 'hostname').mockReturnValue('')
+    expect(deviceId()).toBe('sleepypod')
+    hostnameSpy.mockRestore()
+  })
+})
+
+describe('mqttBridge — parsePayload', () => {
+  it('parses a valid JSON object', () => {
+    const buf = Buffer.from(JSON.stringify({ side: 'left', powered: true }))
+    expect(parsePayload(buf)).toEqual({ side: 'left', powered: true })
+  })
+
+  it('returns {} for an empty buffer', () => {
+    expect(parsePayload(Buffer.alloc(0))).toEqual({})
+  })
+
+  it('returns {} for whitespace-only payloads', () => {
+    expect(parsePayload(Buffer.from('   \n  '))).toEqual({})
+  })
+
+  it('returns {} for malformed JSON', () => {
+    expect(parsePayload(Buffer.from('{not json'))).toEqual({})
+    expect(parsePayload(Buffer.from('{"a":'))).toEqual({})
+  })
+
+  it('returns {} for JSON primitive values (string / number / boolean / null)', () => {
+    expect(parsePayload(Buffer.from('"hello"'))).toEqual({})
+    expect(parsePayload(Buffer.from('42'))).toEqual({})
+    expect(parsePayload(Buffer.from('true'))).toEqual({})
+    expect(parsePayload(Buffer.from('null'))).toEqual({})
+  })
+})

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { lingui } from '@lingui/vite-plugin'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
@@ -9,6 +10,15 @@ export default defineConfig({
       plugins: ['@lingui/babel-plugin-lingui-macro'],
     },
   }), lingui()],
+  resolve: {
+    alias: {
+      // The `mqtt` npm package is added by sleepypod-core-28 (frontend PR).
+      // Until that lands, alias it to a local test stub so the bridge module
+      // is resolvable under vitest. Tests then layer vi.mock('mqtt') on top
+      // to control behaviour.
+      mqtt: fileURLToPath(new URL('./src/streaming/tests/__stubs__/mqtt.ts', import.meta.url)),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Backend half of the MQTT epic (sleepypod-core-26 / sleepypod-core-27).

- `src/streaming/mqttBridge.ts` — single shared client with LWT, exp-backoff reconnect, retained state mirror, HA discovery on connect, and `cmd/<verb>` dispatch into existing tRPC procedures (no logic duplication).
- `src/server/routers/mqtt.ts` — `getSettings` (with per-field source attribution), `updateSettings` (password write-only, never returned), `testConnection`, `getStatus`. Registered in `appRouter`.
- `src/db/schema.ts` + `migrations/0007_round_hardball.sql` — seven nullable `mqtt*` columns on `device_settings`. Plaintext credentials per ADR.
- `instrumentation.ts` — `startMqttBridge()` after the piezo stream server, `shutdownMqttBridge()` in graceful-shutdown sequence; both non-fatal on failure.
- `docs/adr/0019-mqtt-bridge.md` — transport choice, LAN-only default, plaintext-credential decision with revisit-when-protectedProcedure-lands callout.

Config resolution per field: `device_settings` row > `MQTT_*` env > default. Disabled by default; the bridge stays dormant until a URL is configured.

> **Depends on sleepypod-core-28** (frontend agent) for the `mqtt` npm dep on `package.json` / `pnpm-lock.yaml`. The single `// @ts-ignore` on the import line resolves once that PR merges. Local `pnpm tsc`, `pnpm lint`, and `pnpm test` all pass against this branch.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean (existing stryker.config warning unchanged)
- [x] `pnpm test` — 406 passed, 1 skipped, 0 failures
- [ ] Once `sleepypod-core-28` merges: remove `// @ts-ignore` on the import, re-run gates
- [ ] Manual: point `MQTT_URL` at a local mosquitto, verify HA discovery topics appear and a `homeassistant/climate/<id>/left/config` entity round-trips a temperature command back through `cmd/set-temperature`

Refs: sleepypod-core-26 (epic), sleepypod-core-27 (this), sleepypod-core-28 (UI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MQTT bridge integration for connecting your device to Home Assistant and other MQTT-compatible systems.
  * Added MQTT configuration options including broker URL, authentication credentials, and TLS support.
  * Added Home Assistant MQTT discovery for seamless device integration.
  * Added ability to send commands to your device via MQTT.
  * Added MQTT connection testing and status monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->