### PR TITLE
fix(sp-update): reset WORK_DIR before source-tarball fallback

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -193,6 +193,10 @@ if [ -n "$RELEASE_URL" ]; then
 fi
 
 if [ "$HAS_BUILD" = false ]; then
+  # A failed CI-release download can leave partial extraction in WORK_DIR;
+  # drop and recreate so the source-tarball structure check is reliable.
+  rm -rf "$WORK_DIR"
+  WORK_DIR=$(mktemp -d)
   # Fall back to source tarball (no .next — would need build on pod)
   # "latest" is not a real branch — use main for the source tarball
   SOURCE_BRANCH="$BRANCH"


### PR DESCRIPTION
## Summary

`sp-update` first tries the CI-release tarball, then falls back to the source tarball. Both extract to the same `WORK_DIR`, so a partial CI download leaves stale files in `WORK_DIR` that break the structure check during fallback (`Error: Unexpected tarball structure`).

Hit while running `sp-update dev` on a pod — CI release tarball truncates deterministically (~10 MB / 12.3 MB) → fallback runs but trips the structure check on leftover dirs.

## Fix

Drop and recreate `WORK_DIR` before the source-tarball fallback.

## Test plan

- [x] Manually scp'd patched script to pod, re-ran `sp-update dev`, succeeded.
- [ ] CI green.