### PR TITLE
fix(install): reclaim regenerable caches; clean WORK_DIR on sp-update CI fallback

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -189,6 +189,13 @@ if [ -n "$RELEASE_URL" ]; then
   if curl -fSL "$RELEASE_URL" | tar xz -C "$WORK_DIR"; then
     HAS_BUILD=true
     echo "CI release downloaded (pre-built)."
+  else
+    # CI download failed mid-stream (e.g. curl truncation). Partial
+    # files would otherwise contaminate WORK_DIR — the source-tarball
+    # fallback below extracts into the same dir, and `ls "$WORK_DIR"
+    # | head -1` would then pick up stale CI-release contents instead
+    # of the freshly-extracted source subdir. Mirrors scripts/install.
+    find "$WORK_DIR" -mindepth 1 -delete 2>/dev/null || true
   fi
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -81,6 +81,83 @@ cleanup() {
 trap 'cleanup $LINENO' EXIT
 
 # --------------------------------------------------------------------------------
+# reclaim_rootfs_caches
+# Sweeps regenerable caches and pre-uv-era orphans from rootfs (mmcblk0p5,
+# 5.8 GB) before install proceeds. /persistent (mmcblk0p8, 15 GB) is not
+# touched. Idempotent — runs on every install so the Pod stays lean as
+# new caches accrete. See sleepypod-core-31.
+
+reclaim_rootfs_caches() {
+  echo ""
+  echo "========================================"
+  echo "  Reclaiming regenerable caches"
+  echo "========================================"
+
+  local rootfs_free_before
+  rootfs_free_before=$(df -m / 2>/dev/null | awk 'NR==2{print $4}')
+
+  # Pre-uv venv at /home/dac/venv. Per ADR 0017 biometrics modules moved
+  # to per-module uv .venvs under /opt/sleepypod/modules. Only drop the
+  # legacy venv when at least one uv venv is in place — otherwise an
+  # aborted install could leave the Pod with no working Python at all.
+  if [ -d /home/dac/venv ] && \
+     compgen -G "/opt/sleepypod/modules/*/.venv/bin/python" >/dev/null 2>&1; then
+    echo "  Removing pre-uv /home/dac/venv (uv .venvs detected)..."
+    rm -rf /home/dac/venv
+  fi
+
+  # Prisma engine cache. We use Drizzle, not Prisma. Free-sleep (the
+  # coexistence partner) re-downloads on its own startup if needed.
+  if [ -d /home/dac/.cache/prisma ]; then
+    echo "  Removing /home/dac/.cache/prisma (we use Drizzle)..."
+    rm -rf /home/dac/.cache/prisma
+  fi
+
+  # npm cache. pnpm has its own store; npm cache only fills when we
+  # `npm install -g pnpm` on a fresh install. Regenerable.
+  if [ -d /home/dac/.npm ]; then
+    echo "  Pruning /home/dac/.npm cache..."
+    npm cache clean --force >/dev/null 2>&1 || rm -rf /home/dac/.npm
+  fi
+
+  # Volta keeps node-vXX.tar.gz under tools/inventory after extracting.
+  # The extracted bin/ is what's used; the tarball is dead weight.
+  if [ -d /home/dac/.volta/tools/inventory ]; then
+    echo "  Removing Volta inventory tarballs..."
+    find /home/dac/.volta/tools/inventory -type f \
+      \( -name '*.tar.gz' -o -name '*.tgz' -o -name '*.tar.xz' \) \
+      -delete 2>/dev/null || true
+  fi
+
+  # Yocto shipped /var/lib/rpm and /var/lib/dnf with the firmware even
+  # though there's no rpm/dnf binary on the device — pure leftover
+  # metadata. Only drop when the tools really aren't installed.
+  if ! command -v rpm &>/dev/null && [ -d /var/lib/rpm ]; then
+    echo "  Removing /var/lib/rpm (no rpm binary on device)..."
+    rm -rf /var/lib/rpm
+  fi
+  if ! command -v dnf &>/dev/null && [ -d /var/lib/dnf ]; then
+    echo "  Removing /var/lib/dnf (no dnf binary on device)..."
+    rm -rf /var/lib/dnf
+  fi
+
+  # Journal vacuum. The journald config below caps SystemMaxUse=50M, but
+  # only enforces it on rotation. A one-shot vacuum brings the on-disk
+  # size in line immediately; the cap keeps growth bounded after that.
+  if command -v journalctl &>/dev/null; then
+    echo "  Vacuuming systemd journal to 20M..."
+    journalctl --vacuum-size=20M >/dev/null 2>&1 || true
+  fi
+
+  local rootfs_free_after
+  rootfs_free_after=$(df -m / 2>/dev/null | awk 'NR==2{print $4}')
+  if [ -n "${rootfs_free_before:-}" ] && [ -n "${rootfs_free_after:-}" ]; then
+    local reclaimed=$(( rootfs_free_after - rootfs_free_before ))
+    echo "  Rootfs free: ${rootfs_free_before} MB -> ${rootfs_free_after} MB (+${reclaimed} MB)"
+  fi
+}
+
+# --------------------------------------------------------------------------------
 # iptables helpers
 # Canonical copy: scripts/lib/iptables-helpers (sourced by sp-update at runtime).
 # Kept inline here because install needs them before the source tree is on disk.
@@ -210,6 +287,10 @@ for cmd in "${REQUIRED_CMDS[@]}"; do
     exit 1
   fi
 done
+
+# Sweep regenerable caches before the disk-space gate so a tightly-packed
+# Pod can install. uv cache is cleaned later, after biometrics modules sync.
+reclaim_rootfs_caches
 
 # Handle WAN connectivity — always needed (npm packages, node binary download)
 echo "Checking network connectivity..."
@@ -899,6 +980,16 @@ else
   install_module "environment-monitor"
   install_module "calibrator"
   install_module "cover-buttons"
+
+  # Drop the uv download cache once all .venvs are populated. uv hardlinks
+  # site-packages from the cache into each module's .venv (same FS = rootfs),
+  # so removing cache files here only deletes one of two refcounts on each
+  # inode — the .venv keeps the data alive. Saves ~250 MB of rootfs at the
+  # cost of re-downloading wheels on the next install.
+  if command -v uv &>/dev/null; then
+    echo "Cleaning uv download cache..."
+    uv cache clean >/dev/null 2>&1 || true
+  fi
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Sweep regenerable caches and pre-uv-era orphans from rootfs on every install run, so the Pod stays lean as caches accrete. Also fix a `sp-update` bug where a partial CI-release download contaminates `WORK_DIR` for the source-tarball fallback.

## What changes

**`scripts/install`** — new `reclaim_rootfs_caches` function, called between the lockfile and the WAN check. Targets:
- `/home/dac/venv` — pre-uv Python venv (only dropped when at least one `/opt/sleepypod/modules/*/.venv` exists, so an aborted install can't strand the Pod with no Python)
- `/home/dac/.cache/prisma` — we use Drizzle, not Prisma
- `/home/dac/.npm` — npm cache (`pnpm` has its own store)
- `/home/dac/.volta/tools/inventory/*.tar.gz` — Volta retains tarballs after extraction
- `/var/lib/{rpm,dnf}` — only when the binaries are absent
- `journalctl --vacuum-size=20M` — one-shot vacuum; existing `SystemMaxUse=50M` cap keeps it bounded after
- `uv cache clean` after biometrics modules sync — hardlinks in module `.venv`s keep the install working

**`scripts/bin/sp-update`** — clear `WORK_DIR` contents on CI-release download failure before the source-tarball fallback runs. Mirrors the existing guard in `scripts/install`. Without this, a truncated CI download leaves partial files that `ls "$WORK_DIR" | head -1` then mistakes for the source subdir, breaking the fallback.

## Test plan

- [x] `bash -n scripts/install scripts/bin/sp-update` clean
- [x] Function-isolated dry run on Pod 192.168.1.88: rootfs **87% → 80%** (+392 MB freed). Full install adds `uv cache clean` (~250 MB more), expected ~67%
- [x] All services healthy after reclaim: `sleepypod`, `piezo`, `sleep-detector`, `env-monitor`, `calibrator`, `cover-buttons`, `frank` all `active`; HTTP 307 from localhost:3000
- [x] Idempotent — second run is a no-op for already-cleaned targets
- [ ] CodeRabbit review
- [ ] Full install run on a Pod (covered by next deploy)

## Tickets

- Closes sleepypod-core-31
- Drive-by sp-update fix flagged earlier today during a `sp-update dev` retry