### PR TITLE
feat(install): relocate node_modules to /persistent off rootfs

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -239,6 +239,14 @@ echo "Source updated."
 
 cd "$INSTALL_DIR"
 
+# Move node_modules off rootfs onto /persistent before pnpm runs.
+# Migrates existing rootfs node_modules on the first sp-update after
+# the relocation feature lands; subsequent runs are no-ops.
+if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/relocation-helpers"
+  ensure_persistent_node_modules "$INSTALL_DIR"
+fi
+
 # Install production dependencies
 pnpm install --frozen-lockfile --prod
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -86,6 +86,7 @@ COPYFILE_DISABLE=1 tar cf - --no-mac-metadata \
   --exclude='test-results' \
   --exclude='.serena' \
   --exclude='.claude' \
+  --exclude='docs' \
   -C "$PROJECT_DIR" . \
   | $SSH_CMD "tar xf - -C '$REMOTE_DIR' 2>/dev/null"
 

--- a/scripts/install
+++ b/scripts/install
@@ -615,6 +615,14 @@ if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
   print_pod_capabilities
 fi
 
+# Move node_modules off rootfs onto /persistent before pnpm runs so the
+# install writes directly to the persistent partition. On upgrades from
+# a pre-relocation install this migrates the existing tree once.
+if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/relocation-helpers"
+  ensure_persistent_node_modules "$INSTALL_DIR"
+fi
+
 # Install production dependencies (prebuild-install downloads prebuilt better-sqlite3)
 echo "Installing dependencies..."
 CI=true pnpm install --frozen-lockfile --prod

--- a/scripts/lib/relocation-helpers
+++ b/scripts/lib/relocation-helpers
@@ -1,0 +1,56 @@
+# shellcheck shell=bash
+# Relocation helpers — keep heavy app trees off the constrained rootfs.
+#
+# rootfs   /dev/mmcblk0p5  5.8 GB  (often 80%+ full — OS, /usr, .next, /opt)
+# persist  /dev/mmcblk0p8  15  GB  (~12% used — DBs, biometrics, app data)
+#
+# /home/dac/sleepypod-core/node_modules (~700 MB) lives on rootfs by
+# default. This helper moves it to /persistent and replaces the original
+# path with a symlink. pnpm install writes through the symlink; Node's
+# native module resolver follows it transparently.
+#
+# Sourced by:
+#   - scripts/install     (inline copy not needed — code is on disk before use)
+#   - scripts/bin/sp-update
+#
+# Idempotent: subsequent runs detect the existing symlink and no-op.
+
+PERSISTENT_APP_ROOT="/persistent/sleepypod-core"
+
+ensure_persistent_node_modules() {
+  local install_dir="${1:-${INSTALL_DIR:-/home/dac/sleepypod-core}}"
+  local persistent_nm="$PERSISTENT_APP_ROOT/node_modules"
+  local install_nm="$install_dir/node_modules"
+
+  mkdir -p "$PERSISTENT_APP_ROOT"
+
+  # Symlink already pointing at the persistent target — no-op.
+  if [ -L "$install_nm" ]; then
+    local current_target
+    current_target=$(readlink -f "$install_nm" 2>/dev/null || true)
+    if [ "$current_target" = "$persistent_nm" ]; then
+      return 0
+    fi
+    echo "Replacing stale node_modules symlink (was: $current_target)..."
+    rm -f "$install_nm"
+  fi
+
+  # Real directory on rootfs — migrate. Cross-filesystem mv is cp+rm
+  # and preserves the pnpm hardlink graph; ~2-5 min for 700 MB on eMMC.
+  if [ -d "$install_nm" ]; then
+    if [ -d "$persistent_nm" ]; then
+      # Both exist: trust just-installed rootfs copy, drop stale persistent
+      # to avoid mixing pnpm stores from different installs.
+      echo "Removing stale $persistent_nm before migration..."
+      rm -rf "$persistent_nm"
+    fi
+    echo "Migrating node_modules to $persistent_nm (one-time, may take a few minutes)..."
+    mv "$install_nm" "$persistent_nm"
+  else
+    # Fresh install — create empty dir so the symlink target exists.
+    mkdir -p "$persistent_nm"
+  fi
+
+  ln -sfn "$persistent_nm" "$install_nm"
+  echo "node_modules -> $persistent_nm (symlink)"
+}


### PR DESCRIPTION
## Summary

Move the ~700 MB `node_modules` tree off the constrained rootfs partition (mmcblk0p5, 5.8 GB) onto `/persistent` (mmcblk0p8, 15 GB at 12% used). Also strip `docs/` from the production tarball.

## What changes

**`scripts/lib/relocation-helpers`** — new shared helper. Exports `ensure_persistent_node_modules`. Migrates a real rootfs `node_modules` cross-filesystem (`mv` preserves the pnpm hardlink graph), then symlinks `/home/dac/sleepypod-core/node_modules` → `/persistent/sleepypod-core/node_modules`. Idempotent — subsequent runs detect the symlink and no-op.

**`scripts/install`** — sources the helper after the source tree lands, calls it before `pnpm install --frozen-lockfile --prod`. Install writes directly to `/persistent`.

**`scripts/bin/sp-update`** — same call before its `pnpm install`. First `sp-update` after this lands does a one-time migration during the existing service-stop window (sp-update does `systemctl stop sleepypod.service` at line 159, before the helper call).

**`scripts/deploy`** — `--exclude='docs'` added to the deploy tarball. ~67 MB of dev-only content shouldn't ship to production Pods.

## Why this is safe

- pnpm and Node both follow symlinks transparently. `require('better-sqlite3')` works through the symlink.
- The Turbopack hashed-module symlinks (`node_modules/better-sqlite3-{hash}` → `better-sqlite3`) are relative, resolve correctly inside the relocated dir.
- Cross-fs `mv` on coreutils replicates the pnpm hardlink graph during the cp+rm — verified live.
- Service downtime: sp-update already stops sleepypod.service before pnpm install. Install upgrades happen during a maintenance window, and `Restart=always` covers the migration window if the service is up.

## Test plan

- [x] `bash -n` clean on `scripts/install`, `scripts/bin/sp-update`, `scripts/deploy`, `scripts/lib/relocation-helpers`
- [x] Helper sources cleanly and exports the function
- [x] Live migration on 192.168.1.88: 738 MB cross-fs move in 60s, symlink verified, service restart clean (HTTP 307)
- [x] `/persistent` size delta matches: 1.6 GB → 2.3 GB used (+700 MB)
- [x] `/home/dac/sleepypod-core/node_modules` is now a symlink to `/persistent/sleepypod-core/node_modules`
- [x] Idempotent — subsequent helper run no-ops
- [ ] CodeRabbit review
- [ ] Full deploy run after merge

## Tickets

- Closes sleepypod-core-32
- Builds on #510 (sleepypod-core-31, merged)
- Unblocks sleepypod-core-33 (HomeKit integration)