### PR TITLE
fix(build): strip turbopack-hashed external ids from chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/generate-git-info.mjs && lingui compile",
-    "build": "next build && node scripts/strip-turbopack-external-hashes.mjs && cp -r .next/static .next/standalone/.next/static && [ -d public ] && cp -r public .next/standalone/public || true",
+    "build": "next build && node scripts/strip-turbopack-external-hashes.mjs && cp -r .next/static .next/standalone/.next/static && ([ -d public ] && cp -r public .next/standalone/public || true)",
     "dev": "next dev",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prebuild": "node scripts/generate-git-info.mjs && lingui compile",
-    "build": "next build && cp -r .next/static .next/standalone/.next/static && [ -d public ] && cp -r public .next/standalone/public || true",
+    "build": "next build && node scripts/strip-turbopack-external-hashes.mjs && cp -r .next/static .next/standalone/.next/static && [ -d public ] && cp -r public .next/standalone/public || true",
     "dev": "next dev",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -250,20 +250,6 @@ fi
 # Install production dependencies
 pnpm install --frozen-lockfile --prod
 
-# Turbopack mangles native module requires with pnpm virtual store hashes
-# that differ between CI (x86_64) and pod (arm64). Create symlinks so the
-# hashed names in .next resolve to the real modules.
-for chunk in "$INSTALL_DIR"/.next/server/chunks/*.js; do
-  [ -f "$chunk" ] || continue
-  for hashed in $(grep -o 'better-sqlite3-[a-f0-9]\{16\}' "$chunk" 2>/dev/null | sort -u); do
-    if [ ! -e "$INSTALL_DIR/node_modules/$hashed" ]; then
-      ln -sf better-sqlite3 "$INSTALL_DIR/node_modules/$hashed"
-      echo "Linked $hashed → better-sqlite3"
-    fi
-  done
-  break  # only need to scan one chunk
-done
-
 # Build only if no pre-built .next exists
 if [ ! -d "$INSTALL_DIR/.next" ]; then
   echo "No pre-built .next found, building..."

--- a/scripts/install
+++ b/scripts/install
@@ -654,16 +654,6 @@ else
   SP_BRANCH="$EFFECTIVE_BRANCH" pnpm build
 fi
 
-# Turbopack hashes serverExternalPackages module names — create symlinks so the
-# hashed references resolve to the real modules at runtime.
-for PKG in better-sqlite3 mqtt; do
-  HASHED_NAME=$(grep -roh "${PKG}-[a-f0-9]\{16\}" "$INSTALL_DIR/.next/server/" 2>/dev/null | head -1)
-  if [ -n "$HASHED_NAME" ] && [ ! -e "$INSTALL_DIR/node_modules/$HASHED_NAME" ]; then
-    echo "Creating symlink for Turbopack module: $HASHED_NAME -> $PKG"
-    ln -sf "$PKG" "$INSTALL_DIR/node_modules/$HASHED_NAME"
-  fi
-done
-
 # Create or preserve environment file
 if [ -f "$INSTALL_DIR/.env" ]; then
   echo "Existing .env found, backing up..."

--- a/scripts/strip-turbopack-external-hashes.mjs
+++ b/scripts/strip-turbopack-external-hashes.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Turbopack standalone builds bake content-hashed external module ids into
+// chunks (e.g. require("better-sqlite3-0cddb9bd3059e7dc")). At runtime, the
+// pod's node_modules has the bare package name, so the require throws
+// "Cannot find module". Strip the -<16hex> suffix from references to any
+// package that resolves under node_modules.
+//
+// Runs after `next build` against `.next/server/chunks/` and any
+// `.next/standalone/.next/server/chunks/` output. Exits non-zero if a
+// hashed reference to a known package survives the rewrite.
+
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const NODE_MODULES = join(ROOT, 'node_modules')
+const TARGETS = [
+  '.next/server/chunks',
+  '.next/standalone/.next/server/chunks',
+]
+const HASH = '[a-f0-9]{16}'
+
+function listPackages() {
+  const set = new Set()
+  if (!existsSync(NODE_MODULES)) return set
+  for (const entry of readdirSync(NODE_MODULES, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+    if (entry.name.startsWith('@')) {
+      const scope = join(NODE_MODULES, entry.name)
+      for (const sub of readdirSync(scope, { withFileTypes: true })) {
+        if (sub.name.startsWith('.')) continue
+        set.add(`${entry.name}/${sub.name}`)
+      }
+    }
+    else {
+      set.add(entry.name)
+    }
+  }
+  return set
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function* walkJs(dir) {
+  if (!existsSync(dir)) return
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    if (entry.isDirectory()) yield* walkJs(p)
+    else if (entry.isFile() && entry.name.endsWith('.js')) yield p
+  }
+}
+
+const packages = listPackages()
+if (packages.size === 0) {
+  console.error('[strip-hashes] node_modules empty; aborting')
+  process.exit(1)
+}
+
+// Sort longest-first so "better-sqlite3" matches before "better".
+const sorted = [...packages].sort((a, b) => b.length - a.length)
+const replacers = sorted.map(pkg => ({
+  pkg,
+  re: new RegExp(`${escapeRegex(pkg)}-${HASH}\\b`, 'g'),
+}))
+
+let filesChanged = 0
+let refsRewritten = 0
+
+for (const target of TARGETS) {
+  for (const file of walkJs(target)) {
+    const original = readFileSync(file, 'utf8')
+    let next = original
+    for (const { pkg, re } of replacers) {
+      next = next.replace(re, () => {
+        refsRewritten++
+        return pkg
+      })
+    }
+    if (next !== original) {
+      writeFileSync(file, next)
+      filesChanged++
+    }
+  }
+}
+
+console.log(
+  `[strip-hashes] rewrote ${refsRewritten} reference(s) across ${filesChanged} file(s)`,
+)
+
+// Verify: any surviving `<known-pkg>-<16hex>` is a regression.
+const survivors = []
+const verifyRe = new RegExp(
+  `(?<![\\w./@-])([@\\w][\\w./@-]*?)-(${HASH})\\b`,
+  'g',
+)
+for (const target of TARGETS) {
+  for (const file of walkJs(target)) {
+    const content = readFileSync(file, 'utf8')
+    for (const m of content.matchAll(verifyRe)) {
+      if (packages.has(m[1])) {
+        survivors.push({ file, match: m[0] })
+        if (survivors.length >= 20) break
+      }
+    }
+    if (survivors.length >= 20) break
+  }
+  if (survivors.length >= 20) break
+}
+
+if (survivors.length > 0) {
+  console.error(
+    `[strip-hashes] ERROR: ${survivors.length} hashed reference(s) survived rewrite:`,
+  )
+  for (const s of survivors) console.error(`  ${s.file}: ${s.match}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Closes sleepypod-core-41.

Turbopack standalone builds bake content-hashed external module ids into chunk \`require\` calls (e.g. \`require(\"better-sqlite3-0cddb9bd3059e7dc\")\`). At runtime the pod has the bare package in \`node_modules\` and the require throws \`Cannot find module\`, crash-looping \`sleepypod.service\` (192.168.1.88, 9h after #512).

- New postbuild step \`scripts/strip-turbopack-external-hashes.mjs\`: walks \`.next/server/chunks\` and the \`.next/standalone\` mirror, rewrites \`<pkg>-<16hex>\` to bare names for any package present under \`node_modules\`. Verifies its own output — exits non-zero if any hashed reference survives, which is the CI gate for the build artifact.
- Drops the install/sp-update symlink stop-gaps.

## Test plan

- [x] Local repro: \`grep -roE '[a-zA-Z@][a-zA-Z0-9_/@.-]*-[a-f0-9]{16}' .next/server/chunks/\` finds \`better-sqlite3-0cdd…\`, \`typescript-86c2…\`.
- [x] After \`node scripts/strip-turbopack-external-hashes.mjs\`: 16 references rewritten across 8 files; grep returns zero hits; re-run is a no-op.
- [x] \`pnpm lint\` clean.
- [ ] CI green on Linux build (full \`next build\` + standalone copy).
- [ ] Fresh deploy to 192.168.1.88 boots without manual symlinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HomeKit integration with QR code-based pairing setup
  * Added HomeKit controls for temperature adjustment, occupancy detection, snooze, and prime functions
  * Added HomeKit settings panel to enable/disable the bridge and manage paired controllers

* **Chores**
  * Improved build process and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->