### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
+
+      - name: Upload coverage reports to Codecov
+        if: matrix.task.name == 'Unit Tests' && !cancelled()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: sleepypod/core

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sleepypod
 
+[![codecov](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
+
 A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web interface and scheduler.
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Adds `codecov/codecov-action@v5` after the Unit Tests matrix step, gated on `matrix.task.name == 'Unit Tests' && !cancelled()`
- Adds `[![codecov]](https://codecov.io/gh/sleepypod/core)` badge to README

Vitest already runs with `--coverage` (v8 provider, default reporters include clover.xml + JSON). Codecov action auto-detects coverage files in `coverage/`.

## Test plan
- [ ] Open this PR → green CI
- [ ] Confirm `Upload coverage reports to Codecov` step runs in the Unit Tests job only
- [ ] Confirm Codecov picks up the upload (check the action's logs or codecov.io/gh/sleepypod/core)
- [ ] Add `CODECOV_TOKEN` secret to repo before merge — `gh secret set CODECOV_TOKEN -R sleepypod/core` (token from https://codecov.io/gh/sleepypod/core/settings)