### PR TITLE
test(scheduler): cover jobManager + run-once

### DIFF
--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -158,3 +158,82 @@ describe('JobManager.reloadSchedules coalescing', () => {
     expect(count()).toBe(2)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Misc public-surface tests that don't need a real DB. The stub mock above
+// returns empty rows from every select, so DB-driven branches can't be hit
+// here — but the in-memory scheduler-side surface (getScheduler, run-once
+// scheduling, cancellation, heartbeat lifecycle) can.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager public surface (stub DB)', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('getScheduler exposes the underlying Scheduler', () => {
+    const sched = manager.getScheduler()
+    expect(sched).toBeDefined()
+    expect(typeof sched.scheduleJob).toBe('function')
+    expect(sched.getTimezone()).toBe('UTC')
+  })
+
+  it('scheduleRunOnceSession adds setpoint + cleanup jobs', () => {
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    const setPointTime = fmt(new Date(now.getTime() + 5 * 60_000))
+    const wakeTime = fmt(new Date(now.getTime() + 60 * 60_000))
+
+    manager.scheduleRunOnceSession(123, 'left', [{ time: setPointTime, temperature: 80 }], wakeTime, 'UTC')
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('runonce-123-0')
+    expect(ids).toContain('runonce-cleanup-123')
+  })
+
+  it('cancelRunOnceSession removes only run-once jobs scoped to the side', () => {
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    const setPointTime = fmt(new Date(now.getTime() + 5 * 60_000))
+    const wakeTime = fmt(new Date(now.getTime() + 60 * 60_000))
+
+    manager.scheduleRunOnceSession(1, 'left', [{ time: setPointTime, temperature: 80 }], wakeTime, 'UTC')
+    manager.scheduleRunOnceSession(2, 'right', [{ time: setPointTime, temperature: 80 }], wakeTime, 'UTC')
+
+    expect(manager.getScheduler().getJobs()).toHaveLength(4)
+
+    manager.cancelRunOnceSession('right')
+
+    const remaining = manager.getScheduler().getJobs()
+    expect(remaining.every(j => j.metadata?.side !== 'right')).toBe(true)
+    expect(remaining.filter(j => j.metadata?.side === 'left')).toHaveLength(2)
+  })
+
+  it('startHeartbeat / stopHeartbeat are idempotent', () => {
+    manager.startHeartbeat()
+    manager.startHeartbeat() // second call no-ops
+    manager.stopHeartbeat()
+    manager.stopHeartbeat() // double-stop is safe
+  })
+
+  it('checkLiveness returns empty when no jobs are registered', async () => {
+    const stale = await manager.checkLiveness()
+    expect(stale).toEqual([])
+  })
+
+  it('shutdown can be called repeatedly without error', async () => {
+    await manager.shutdown()
+    await manager.shutdown()
+    // afterEach will call once more
+  })
+})

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type BetterSqlite3 from 'better-sqlite3'
 
@@ -7,14 +7,20 @@ type AnyAsync = (...args: any[]) => Promise<void>
 const setTemperature = vi.fn<AnyAsync>()
 const setPower = vi.fn<AnyAsync>()
 const setAlarm = vi.fn<AnyAsync>()
+const startPriming = vi.fn<AnyAsync>()
 const connect = vi.fn<() => Promise<void>>()
 setTemperature.mockResolvedValue(undefined)
 setPower.mockResolvedValue(undefined)
 setAlarm.mockResolvedValue(undefined)
+startPriming.mockResolvedValue(undefined)
 connect.mockResolvedValue(undefined)
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
-  getSharedHardwareClient: () => ({ connect, setTemperature, setPower, setAlarm }),
+  getSharedHardwareClient: () => ({ connect, setTemperature, setPower, setAlarm, startPriming }),
+}))
+
+vi.mock('@/src/hardware/dacTransport', () => ({
+  sendCommand: vi.fn(async () => {}),
 }))
 
 vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
@@ -23,6 +29,23 @@ vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
 
 vi.mock('@/src/services/autoOffWatcher', () => ({
   cancelAutoOffTimer: vi.fn(),
+}))
+
+// Mock child_process.exec so executeReboot tests never spawn systemctl.
+const execMock = vi.fn<(cmd: string, cb: (err: Error | null) => void) => void>()
+execMock.mockImplementation((_cmd, cb) => cb(null))
+vi.mock('child_process', () => ({
+  exec: (cmd: string, cb: (err: Error | null) => void) => execMock(cmd, cb),
+}))
+
+// Mock node:fs/promises so calibration-trigger tests don't touch disk.
+const writeFileMock = vi.fn<AnyAsync>()
+const renameMock = vi.fn<AnyAsync>()
+writeFileMock.mockResolvedValue(undefined)
+renameMock.mockResolvedValue(undefined)
+vi.mock('node:fs/promises', () => ({
+  writeFile: (...args: any[]) => writeFileMock(...args),
+  rename: (...args: any[]) => renameMock(...args),
 }))
 
 // In-memory primary DB seeded with the schema the JobManager reads
@@ -50,6 +73,11 @@ function resetSchema(): void {
   ;(sqlite as any).exec(`
     DROP TABLE IF EXISTS device_state;
     DROP TABLE IF EXISTS run_once_sessions;
+    DROP TABLE IF EXISTS temperature_schedules;
+    DROP TABLE IF EXISTS power_schedules;
+    DROP TABLE IF EXISTS alarm_schedules;
+    DROP TABLE IF EXISTS device_settings;
+    DROP TABLE IF EXISTS side_settings;
 
     CREATE TABLE device_state (
       side TEXT PRIMARY KEY,
@@ -71,7 +99,203 @@ function resetSchema(): void {
       status TEXT NOT NULL DEFAULT 'active',
       created_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
+    CREATE TABLE temperature_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      time TEXT NOT NULL,
+      temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE power_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      on_time TEXT NOT NULL,
+      off_time TEXT NOT NULL,
+      on_temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE alarm_schedules (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      side TEXT NOT NULL,
+      day_of_week TEXT NOT NULL,
+      time TEXT NOT NULL,
+      vibration_intensity INTEGER NOT NULL,
+      vibration_pattern TEXT NOT NULL DEFAULT 'rise',
+      duration INTEGER NOT NULL,
+      alarm_temperature REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE device_settings (
+      id INTEGER PRIMARY KEY,
+      timezone TEXT NOT NULL DEFAULT 'America/Los_Angeles',
+      temperature_unit TEXT NOT NULL DEFAULT 'F',
+      reboot_daily INTEGER NOT NULL DEFAULT 0,
+      reboot_time TEXT DEFAULT '03:00',
+      prime_pod_daily INTEGER NOT NULL DEFAULT 0,
+      prime_pod_time TEXT DEFAULT '14:00',
+      led_night_mode_enabled INTEGER NOT NULL DEFAULT 0,
+      led_day_brightness INTEGER NOT NULL DEFAULT 100,
+      led_night_brightness INTEGER NOT NULL DEFAULT 0,
+      led_night_start_time TEXT DEFAULT '22:00',
+      led_night_end_time TEXT DEFAULT '07:00',
+      global_max_on_hours INTEGER,
+      mqtt_enabled INTEGER,
+      mqtt_url TEXT,
+      mqtt_username TEXT,
+      mqtt_password TEXT,
+      mqtt_topic_prefix TEXT,
+      mqtt_ha_discovery INTEGER,
+      mqtt_tls_enabled INTEGER,
+      mqtt_tls_insecure INTEGER,
+      homekit_enabled INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE side_settings (
+      side TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      away_mode INTEGER NOT NULL DEFAULT 0,
+      always_on INTEGER NOT NULL DEFAULT 0,
+      auto_off_enabled INTEGER NOT NULL DEFAULT 0,
+      auto_off_minutes INTEGER NOT NULL DEFAULT 30,
+      away_start TEXT,
+      away_return TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
   `)
+}
+
+function insertTempSchedule(opts: {
+  side: 'left' | 'right'
+  dayOfWeek: string
+  time: string
+  temperature: number
+  enabled?: boolean
+}): number {
+  const info = (sqlite as any)
+    .prepare(
+      `INSERT INTO temperature_schedules (side, day_of_week, time, temperature, enabled)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .run(opts.side, opts.dayOfWeek, opts.time, opts.temperature, opts.enabled === false ? 0 : 1)
+  return Number(info.lastInsertRowid)
+}
+
+function insertPowerSchedule(opts: {
+  side: 'left' | 'right'
+  dayOfWeek: string
+  onTime: string
+  offTime: string
+  onTemperature: number
+  enabled?: boolean
+}): number {
+  const info = (sqlite as any)
+    .prepare(
+      `INSERT INTO power_schedules (side, day_of_week, on_time, off_time, on_temperature, enabled)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      opts.side,
+      opts.dayOfWeek,
+      opts.onTime,
+      opts.offTime,
+      opts.onTemperature,
+      opts.enabled === false ? 0 : 1,
+    )
+  return Number(info.lastInsertRowid)
+}
+
+function insertAlarmSchedule(opts: {
+  side: 'left' | 'right'
+  dayOfWeek: string
+  time: string
+  alarmTemperature: number
+  enabled?: boolean
+}): number {
+  const info = (sqlite as any)
+    .prepare(
+      `INSERT INTO alarm_schedules
+        (side, day_of_week, time, vibration_intensity, vibration_pattern, duration, alarm_temperature, enabled)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(opts.side, opts.dayOfWeek, opts.time, 80, 'rise', 30, opts.alarmTemperature, opts.enabled === false ? 0 : 1)
+  return Number(info.lastInsertRowid)
+}
+
+function insertDeviceSettings(overrides: Record<string, unknown> = {}): void {
+  const defaults: Record<string, unknown> = {
+    id: 1,
+    timezone: 'America/Los_Angeles',
+    temperature_unit: 'F',
+    reboot_daily: 0,
+    reboot_time: '03:00',
+    prime_pod_daily: 0,
+    prime_pod_time: '14:00',
+    led_night_mode_enabled: 0,
+    led_day_brightness: 100,
+    led_night_brightness: 0,
+    led_night_start_time: '22:00',
+    led_night_end_time: '07:00',
+    homekit_enabled: 0,
+  }
+  const row = { ...defaults, ...overrides }
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO device_settings
+        (id, timezone, temperature_unit, reboot_daily, reboot_time, prime_pod_daily, prime_pod_time,
+         led_night_mode_enabled, led_day_brightness, led_night_brightness,
+         led_night_start_time, led_night_end_time, homekit_enabled)
+       VALUES (@id, @timezone, @temperature_unit, @reboot_daily, @reboot_time, @prime_pod_daily, @prime_pod_time,
+               @led_night_mode_enabled, @led_day_brightness, @led_night_brightness,
+               @led_night_start_time, @led_night_end_time, @homekit_enabled)`
+    )
+    .run(row)
+}
+
+function insertSideSettings(opts: {
+  side: 'left' | 'right'
+  awayStart?: string | null
+  awayReturn?: string | null
+}): void {
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO side_settings (side, name, away_start, away_return)
+       VALUES (?, ?, ?, ?)`
+    )
+    .run(opts.side, opts.side, opts.awayStart ?? null, opts.awayReturn ?? null)
+}
+
+function insertRunOnceSession(opts: {
+  side: 'left' | 'right'
+  setPoints: string
+  wakeTime: string
+  startedAt: Date
+  expiresAt: Date
+  status?: 'active' | 'completed' | 'cancelled'
+}): number {
+  const info = (sqlite as any)
+    .prepare(
+      `INSERT INTO run_once_sessions (side, set_points, wake_time, started_at, expires_at, status)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      opts.side,
+      opts.setPoints,
+      opts.wakeTime,
+      Math.floor(opts.startedAt.getTime() / 1000),
+      Math.floor(opts.expiresAt.getTime() / 1000),
+      opts.status ?? 'active',
+    )
+  return Number(info.lastInsertRowid)
 }
 
 function seedSidePowered(side: 'left' | 'right', isPowered: boolean): void {
@@ -406,5 +630,1088 @@ describe('JobManager — liveness heartbeat', () => {
     manager.startHeartbeat()
     manager.stopHeartbeat()
     // No throw, no leaked timer — afterEach shutdown will catch any leak.
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// loadSchedules — exercises every branch in the DB→cron registration path
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager.loadSchedules', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    setAlarm.mockClear()
+    startPriming.mockClear()
+    connect.mockClear()
+    manager = new JobManager('America/Los_Angeles', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('registers a temperature job for each enabled temperature schedule', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 75 })
+    insertTempSchedule({ side: 'right', dayOfWeek: 'tuesday', time: '08:30', temperature: 78 })
+    insertTempSchedule({ side: 'left', dayOfWeek: 'wednesday', time: '09:00', temperature: 80, enabled: false })
+
+    await manager.loadSchedules()
+
+    const jobs = manager.getScheduler().getJobs()
+    const tempJobs = jobs.filter(j => j.type === 'temperature')
+    expect(tempJobs).toHaveLength(2)
+  })
+
+  it('registers power-on AND power-off jobs for each enabled power schedule', async () => {
+    insertPowerSchedule({
+      side: 'left',
+      dayOfWeek: 'friday',
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+    })
+    insertPowerSchedule({
+      side: 'right',
+      dayOfWeek: 'saturday',
+      onTime: '23:00',
+      offTime: '06:00',
+      onTemperature: 78,
+      enabled: false,
+    })
+
+    await manager.loadSchedules()
+
+    const jobs = manager.getScheduler().getJobs()
+    expect(jobs.filter(j => j.type === 'power_on')).toHaveLength(1)
+    expect(jobs.filter(j => j.type === 'power_off')).toHaveLength(1)
+  })
+
+  it('registers alarm jobs only for enabled alarm schedules', async () => {
+    insertAlarmSchedule({ side: 'left', dayOfWeek: 'monday', time: '06:30', alarmTemperature: 90 })
+    insertAlarmSchedule({ side: 'right', dayOfWeek: 'monday', time: '07:00', alarmTemperature: 88, enabled: false })
+
+    await manager.loadSchedules()
+
+    const jobs = manager.getScheduler().getJobs()
+    expect(jobs.filter(j => j.type === 'alarm')).toHaveLength(1)
+  })
+
+  it('schedules priming + pre-prime reboot + pre-prime calibration when primePodDaily is on', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '14:00' })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('daily-prime')
+    expect(ids).toContain('prime-prereboot')
+    expect(ids).toContain('pre-prime-calibration')
+  })
+
+  it('schedules daily reboot when rebootDaily is on', async () => {
+    insertDeviceSettings({ reboot_daily: 1, reboot_time: '03:00' })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('daily-reboot')
+  })
+
+  it('schedules LED night start + end and applies initial brightness when enabled', async () => {
+    insertDeviceSettings({
+      led_night_mode_enabled: 1,
+      led_night_start_time: '22:00',
+      led_night_end_time: '07:00',
+      led_day_brightness: 100,
+      led_night_brightness: 10,
+    })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('led-night-start')
+    expect(ids).toContain('led-night-end')
+  })
+
+  it('schedules nothing system-wide when device_settings has no flags set', async () => {
+    insertDeviceSettings({}) // all defaults: nothing daily-on
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).not.toContain('daily-prime')
+    expect(ids).not.toContain('daily-reboot')
+    expect(ids).not.toContain('led-night-start')
+  })
+
+  it('handles empty device_settings table gracefully', async () => {
+    // No row inserted at all — settings query returns nothing
+    await manager.loadSchedules()
+    expect(manager.getScheduler().getJobs()).toEqual([])
+  })
+
+  it('schedules away-mode start/return one-time jobs for sides with future windows', async () => {
+    const futureStart = new Date(Date.now() + 60 * 60_000).toISOString()
+    const futureReturn = new Date(Date.now() + 4 * 60 * 60_000).toISOString()
+    insertSideSettings({ side: 'left', awayStart: futureStart, awayReturn: futureReturn })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('away-start-left')
+    expect(ids).toContain('away-return-left')
+  })
+
+  it('skips away-mode jobs whose dates are in the past', async () => {
+    const pastStart = new Date(Date.now() - 60 * 60_000).toISOString()
+    const pastReturn = new Date(Date.now() - 30 * 60_000).toISOString()
+    insertSideSettings({ side: 'right', awayStart: pastStart, awayReturn: pastReturn })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).not.toContain('away-start-right')
+    expect(ids).not.toContain('away-return-right')
+  })
+
+  it('skips side_settings rows with no away window', async () => {
+    insertSideSettings({ side: 'left' })
+    insertSideSettings({ side: 'right' })
+
+    await manager.loadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids.filter(id => id.startsWith('away-'))).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Run-once scheduling, restoration, and cancellation
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager run-once sessions', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    connect.mockClear()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('hasActiveRunOnceSession returns true when an active non-expired session exists', async () => {
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      status: 'active',
+    })
+
+    expect(await manager.hasActiveRunOnceSession('left')).toBe(true)
+    expect(await manager.hasActiveRunOnceSession('right')).toBe(false)
+  })
+
+  it('hasActiveRunOnceSession returns false for expired sessions', async () => {
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(Date.now() - 2 * 60 * 60_000),
+      expiresAt: new Date(Date.now() - 60_000),
+      status: 'active',
+    })
+
+    expect(await manager.hasActiveRunOnceSession('left')).toBe(false)
+  })
+
+  it('runTemperatureJob skips when a run-once session is active for the side', async () => {
+    seedSidePowered('left', true)
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+    })
+
+    await manager.runTemperatureJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      time: '10:00',
+      temperature: 75,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(setTemperature).not.toHaveBeenCalled()
+  })
+
+  it('runPowerOnJob fires setPower(true) and broadcasts onTemperature when set', async () => {
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '06:00',
+      onTemperature: 82,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(setPower).toHaveBeenCalledWith('left', true, 82)
+  })
+
+  it('runPowerOnJob falls back to 75°F broadcast when onTemperature is null', async () => {
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '06:00',
+      onTemperature: null as unknown as number, // exercise the ?? 75 branch
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(setPower).toHaveBeenCalledWith('right', true, null)
+  })
+
+  it('runPowerOnJob skips when a run-once session is active', async () => {
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+    })
+
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '06:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('runPowerOffJob skips when a run-once session is active', async () => {
+    seedSidePowered('right', true)
+    insertRunOnceSession({
+      side: 'right',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+    })
+
+    await manager.runPowerOffJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '06:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(setPower).not.toHaveBeenCalled()
+    // device_state was NOT mutated since we bailed before withSideLock
+    expect(readSide('right')?.is_powered).toBe(1)
+  })
+
+  it('scheduleRunOnceSession schedules future setpoints and a cleanup job', () => {
+    const now = new Date()
+    const futureA = new Date(now.getTime() + 5 * 60_000)
+    const futureB = new Date(now.getTime() + 10 * 60_000)
+
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+
+    const wake = new Date(now.getTime() + 30 * 60_000)
+    manager.scheduleRunOnceSession(
+      42,
+      'left',
+      [
+        { time: fmt(futureA), temperature: 80 },
+        { time: fmt(futureB), temperature: 75 },
+      ],
+      fmt(wake),
+      'UTC',
+    )
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('runonce-42-0')
+    expect(ids).toContain('runonce-42-1')
+    expect(ids).toContain('runonce-cleanup-42')
+  })
+
+  it('scheduleRunOnceSession skips setpoints that resolve into the past', () => {
+    // Spy on timeToDate via direct injection: pass a mock side that lands in the past.
+    // We can't easily mock timeToDate from this scope, so instead exercise the
+    // skip path by passing an empty setPoints array and verifying only the
+    // cleanup is registered.
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+
+    manager.scheduleRunOnceSession(
+      99,
+      'left',
+      [],
+      fmt(new Date(now.getTime() + 60 * 60_000)),
+      'UTC',
+    )
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids.filter(id => id.startsWith('runonce-99-'))).toHaveLength(0)
+    expect(ids).toContain('runonce-cleanup-99')
+  })
+
+  it('cancelRunOnceSession removes only run-once jobs for the matching side', () => {
+    const now = new Date()
+    const fut = (mins: number) =>
+      new Date(now.getTime() + mins * 60_000)
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+
+    manager.scheduleRunOnceSession(1, 'left', [{ time: fmt(fut(5)), temperature: 80 }], fmt(fut(60)), 'UTC')
+    manager.scheduleRunOnceSession(2, 'right', [{ time: fmt(fut(5)), temperature: 80 }], fmt(fut(60)), 'UTC')
+
+    expect(manager.getScheduler().getJobs().filter(j => j.type === 'run_once')).toHaveLength(4)
+
+    manager.cancelRunOnceSession('left')
+
+    const remaining = manager.getScheduler().getJobs()
+    expect(remaining.every(j => j.metadata?.side !== 'left')).toBe(true)
+    expect(remaining.filter(j => j.metadata?.side === 'right')).toHaveLength(2)
+  })
+
+  it('loadSchedules expires past-due active sessions and powers off the side', async () => {
+    insertDeviceSettings({})
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(Date.now() - 4 * 60 * 60_000),
+      expiresAt: new Date(Date.now() - 60_000),
+      status: 'active',
+    })
+
+    await manager.loadSchedules()
+
+    const row = (sqlite as any).prepare(`SELECT status FROM run_once_sessions LIMIT 1`).get() as { status: string }
+    expect(row.status).toBe('completed')
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('loadSchedules restores active future sessions with future setpoints', async () => {
+    insertDeviceSettings({ timezone: 'UTC' })
+    const now = new Date()
+    const fut = (mins: number) =>
+      new Date(now.getTime() + mins * 60_000)
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+
+    insertRunOnceSession({
+      side: 'right',
+      setPoints: JSON.stringify([{ time: fmt(fut(15)), temperature: 80 }]),
+      wakeTime: fmt(fut(120)),
+      startedAt: now,
+      expiresAt: fut(180),
+      status: 'active',
+    })
+
+    await manager.loadSchedules()
+
+    const runOnceJobs = manager.getScheduler().getJobs().filter(j => j.type === 'run_once')
+    // 1 setpoint + 1 cleanup
+    expect(runOnceJobs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('loadSchedules marks malformed-setPoints sessions as completed and continues', async () => {
+    insertDeviceSettings({})
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: 'not-valid-json',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      status: 'active',
+    })
+
+    await manager.loadSchedules()
+
+    const row = (sqlite as any).prepare(`SELECT status FROM run_once_sessions LIMIT 1`).get() as { status: string }
+    expect(row.status).toBe('completed')
+  })
+
+  it('run-once cleanup bails out when status is not active by cleanup time', async () => {
+    // Capture the cleanup handler closure via a scheduleOneTimeJob spy, then
+    // mutate DB to cancelled and invoke the captured handler directly. This
+    // avoids real-time waits for cron firing.
+    const sched = manager.getScheduler()
+    const captured = new Map<string, () => Promise<void>>()
+    const orig = sched.scheduleOneTimeJob.bind(sched)
+    sched.scheduleOneTimeJob = (id, type, fireDate, handler, metadata) => {
+      captured.set(id, handler)
+      return orig(id, type, fireDate, handler, metadata)
+    }
+
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    seedSidePowered('left', true)
+
+    const sessionId = insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: fmt(new Date(now.getTime() + 60 * 60_000)),
+      startedAt: now,
+      expiresAt: new Date(now.getTime() + 2 * 60 * 60_000),
+      status: 'active',
+    })
+
+    manager.scheduleRunOnceSession(
+      sessionId,
+      'left',
+      [],
+      fmt(new Date(now.getTime() + 60 * 60_000)),
+      'UTC',
+    )
+
+    // Cancel the session before invoking the cleanup handler
+    ;(sqlite as any).prepare(`UPDATE run_once_sessions SET status='cancelled' WHERE id=?`).run(sessionId)
+
+    const cleanupHandler = captured.get(`runonce-cleanup-${sessionId}`)
+    expect(cleanupHandler).toBeDefined()
+    await cleanupHandler!()
+
+    // setPower must NOT have been called (handler bailed when it saw status != active)
+    expect(setPower).not.toHaveBeenCalled()
+    // Side still powered — cleanup did not run
+    expect(readSide('left')?.is_powered).toBe(1)
+  })
+
+  it('run-once cleanup bails out when status row is missing entirely', async () => {
+    const sched = manager.getScheduler()
+    const captured = new Map<string, () => Promise<void>>()
+    const orig = sched.scheduleOneTimeJob.bind(sched)
+    sched.scheduleOneTimeJob = (id, type, fireDate, handler, metadata) => {
+      captured.set(id, handler)
+      return orig(id, type, fireDate, handler, metadata)
+    }
+
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    seedSidePowered('left', true)
+
+    const sessionId = insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: fmt(new Date(now.getTime() + 60 * 60_000)),
+      startedAt: now,
+      expiresAt: new Date(now.getTime() + 2 * 60 * 60_000),
+      status: 'active',
+    })
+
+    manager.scheduleRunOnceSession(
+      sessionId,
+      'left',
+      [],
+      fmt(new Date(now.getTime() + 60 * 60_000)),
+      'UTC',
+    )
+
+    // Delete the row entirely
+    ;(sqlite as any).prepare(`DELETE FROM run_once_sessions WHERE id=?`).run(sessionId)
+
+    const cleanupHandler = captured.get(`runonce-cleanup-${sessionId}`)!
+    await cleanupHandler()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reload / shutdown / lifecycle paths
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager lifecycle', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    connect.mockClear()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('updateTimezone replaces config and reloads schedules', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 75 })
+    await manager.loadSchedules()
+    const before = manager.getScheduler().getTimezone()
+    expect(before).toBe('UTC')
+
+    await manager.updateTimezone('America/New_York')
+    expect(manager.getScheduler().getTimezone()).toBe('America/New_York')
+    // Schedule re-registered after tz change
+    expect(manager.getScheduler().getJobs().filter(j => j.type === 'temperature')).toHaveLength(1)
+  })
+
+  it('reloadSchedules preserves one-time jobs while replacing recurring jobs', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 75 })
+    await manager.loadSchedules()
+
+    // Add a one-time job manually that reload should preserve
+    const futureFire = new Date(Date.now() + 60 * 60_000)
+    manager.getScheduler().scheduleOneTimeJob(
+      'manual-onetime',
+      'run_once' as any,
+      futureFire,
+      async () => {},
+      { side: 'left' },
+    )
+
+    await manager.reloadSchedules()
+
+    const ids = manager.getScheduler().getJobs().map(j => j.id)
+    expect(ids).toContain('manual-onetime')
+  })
+
+  it('getScheduler returns the underlying Scheduler instance', () => {
+    const sched = manager.getScheduler()
+    expect(sched).toBeDefined()
+    expect(typeof sched.scheduleJob).toBe('function')
+  })
+
+  it('shutdown is idempotent — safe to call after already shutting down', async () => {
+    await manager.shutdown()
+    await manager.shutdown() // second call must not throw
+    // afterEach will call again
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cron-builder edge cases (private parseTime / buildWeeklyCron via public API)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager cron building', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('builds correct weekly cron for sunday', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'sunday', time: '06:30', temperature: 72 })
+    await manager.loadSchedules()
+    const job = manager.getScheduler().getJobs().find(j => j.type === 'temperature')
+    expect(job?.schedule).toBe('30 6 * * 0')
+  })
+
+  it('builds correct weekly cron for saturday', async () => {
+    insertTempSchedule({ side: 'right', dayOfWeek: 'saturday', time: '23:45', temperature: 80 })
+    await manager.loadSchedules()
+    const job = manager.getScheduler().getJobs().find(j => j.type === 'temperature')
+    expect(job?.schedule).toBe('45 23 * * 6')
+  })
+
+  it('throws on invalid time strings during loadSchedules', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'monday', time: 'not-a-time', temperature: 75 })
+    await expect(manager.loadSchedules()).rejects.toThrow(/Invalid time format/)
+  })
+
+  it('schedulePrimePreReboot wraps midnight when prime is at 00:30', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '00:30' })
+    await manager.loadSchedules()
+    const reboot = manager.getScheduler().getJob('prime-prereboot')
+    // 00:30 - 60min = 23:30 prior day → cron "30 23 * * *"
+    expect(reboot?.schedule).toBe('30 23 * * *')
+  })
+
+  it('schedulePrePrimeCalibration computes 30 minutes earlier with midnight wrap', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '00:15' })
+    await manager.loadSchedules()
+    const cal = manager.getScheduler().getJob('pre-prime-calibration')
+    // 00:15 - 30min = 23:45 prior day → cron "45 23 * * *"
+    expect(cal?.schedule).toBe('45 23 * * *')
+  })
+
+  it('LED night mode handles same-day window (e.g. 01:00–06:00)', async () => {
+    insertDeviceSettings({
+      led_night_mode_enabled: 1,
+      led_night_start_time: '01:00',
+      led_night_end_time: '06:00',
+      led_day_brightness: 100,
+      led_night_brightness: 5,
+    })
+    await manager.loadSchedules()
+    const start = manager.getScheduler().getJob('led-night-start')
+    const end = manager.getScheduler().getJob('led-night-end')
+    expect(start?.schedule).toBe('0 1 * * *')
+    expect(end?.schedule).toBe('0 6 * * *')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Capture and invoke registered handler closures by spying on scheduleJob
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager handler closures', () => {
+  let manager: JobManager
+  let captured: Map<string, () => Promise<void>>
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    setAlarm.mockClear()
+    startPriming.mockClear()
+    connect.mockClear()
+    captured = new Map()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+
+    // Wrap scheduleJob and scheduleOneTimeJob to capture handler closures.
+    const sched = manager.getScheduler()
+    const origCron = sched.scheduleJob.bind(sched)
+    sched.scheduleJob = (id, type, cron, handler, metadata) => {
+      captured.set(id, handler)
+      return origCron(id, type, cron, handler, metadata)
+    }
+    const origOne = sched.scheduleOneTimeJob.bind(sched)
+    sched.scheduleOneTimeJob = (id, type, fireDate, handler, metadata) => {
+      captured.set(id, handler)
+      return origOne(id, type, fireDate, handler, metadata)
+    }
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('daily-prime handler invokes startPriming on the shared client', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '14:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('daily-prime')
+    expect(handler).toBeDefined()
+    await handler!()
+    expect(startPriming).toHaveBeenCalledOnce()
+  })
+
+  it('daily-reboot handler runs executeReboot (systemctl reboot)', async () => {
+    insertDeviceSettings({ reboot_daily: 1, reboot_time: '03:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('daily-reboot')
+    expect(handler).toBeDefined()
+
+    execMock.mockImplementationOnce((_cmd, cb) => cb(null))
+
+    await handler!()
+
+    expect(execMock).toHaveBeenCalledWith('systemctl reboot', expect.any(Function))
+  })
+
+  it('daily-reboot handler surfaces exec failure as a rejected promise', async () => {
+    insertDeviceSettings({ reboot_daily: 1, reboot_time: '03:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('daily-reboot')!
+
+    execMock.mockImplementationOnce((_cmd, cb) => cb(new Error('boom')))
+
+    await expect(handler()).rejects.toThrow('boom')
+  })
+
+  it('prime-prereboot handler invokes executeReboot', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '14:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('prime-prereboot')!
+
+    execMock.mockImplementationOnce((_cmd, cb) => cb(null))
+
+    await handler()
+    expect(execMock).toHaveBeenCalledWith('systemctl reboot', expect.any(Function))
+  })
+
+  it('pre-prime-calibration handler writes a trigger file', async () => {
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '14:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('pre-prime-calibration')!
+
+    writeFileMock.mockClear()
+    renameMock.mockClear()
+
+    await handler()
+
+    expect(writeFileMock).toHaveBeenCalledOnce()
+    expect(renameMock).toHaveBeenCalledOnce()
+    const [tmpPath, payload] = writeFileMock.mock.calls[0]
+    expect(String(tmpPath)).toMatch(/\.calibrate-trigger\.\d+\.tmp$/)
+    const parsed = JSON.parse(payload as string)
+    expect(parsed.side).toBe('all')
+    expect(parsed.sensor_type).toBe('all')
+  })
+
+  it('pre-prime-calibration uses CALIBRATION_TRIGGER_PATH env var when set', async () => {
+    process.env.CALIBRATION_TRIGGER_PATH = '/tmp/sleepypod-test-cal/trigger'
+    insertDeviceSettings({ prime_pod_daily: 1, prime_pod_time: '14:00' })
+    await manager.loadSchedules()
+    const handler = captured.get('pre-prime-calibration')!
+
+    writeFileMock.mockClear()
+
+    await handler()
+    const [tmpPath] = writeFileMock.mock.calls[0]
+    expect(String(tmpPath)).toMatch(/^\/tmp\/sleepypod-test-cal\//)
+
+    delete process.env.CALIBRATION_TRIGGER_PATH
+  })
+
+  it('led-night-start and led-night-end handlers send LED brightness commands', async () => {
+    insertDeviceSettings({
+      led_night_mode_enabled: 1,
+      led_night_start_time: '22:00',
+      led_night_end_time: '07:00',
+      led_day_brightness: 100,
+      led_night_brightness: 5,
+    })
+    await manager.loadSchedules()
+
+    const startHandler = captured.get('led-night-start')!
+    const endHandler = captured.get('led-night-end')!
+    await startHandler()
+    await endHandler()
+
+    // The shared client's connect was called for each LED command + the
+    // initial brightness application during loadSchedules.
+    expect(connect).toHaveBeenCalled()
+  })
+
+  it('temperature cron handler closure delegates to runTemperatureJob with isPowered gate', async () => {
+    insertTempSchedule({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 75 })
+    seedSidePowered('left', true)
+    await manager.loadSchedules()
+
+    const handler = captured.get('temp-1')!
+    await handler()
+
+    expect(setTemperature).toHaveBeenCalledWith('left', 75)
+  })
+
+  it('power-on cron handler closure delegates to runPowerOnJob', async () => {
+    insertPowerSchedule({
+      side: 'right',
+      dayOfWeek: 'monday',
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+    })
+    await manager.loadSchedules()
+
+    const handler = captured.get('power-on-1')!
+    await handler()
+
+    expect(setPower).toHaveBeenCalledWith('right', true, 80)
+  })
+
+  it('power-off cron handler closure delegates to runPowerOffJob and clears DB', async () => {
+    insertPowerSchedule({
+      side: 'left',
+      dayOfWeek: 'monday',
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+    })
+    seedSidePowered('left', true)
+    await manager.loadSchedules()
+
+    const handler = captured.get('power-off-1')!
+    await handler()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+    expect(readSide('left')?.is_powered).toBe(0)
+  })
+
+  it('alarm cron handler closure delegates to runAlarmJob with isPowered gate', async () => {
+    insertAlarmSchedule({ side: 'right', dayOfWeek: 'monday', time: '06:00', alarmTemperature: 90 })
+    seedSidePowered('right', true)
+    await manager.loadSchedules()
+
+    const handler = captured.get('alarm-1')!
+    await handler()
+
+    expect(setAlarm).toHaveBeenCalled()
+    expect(setTemperature).toHaveBeenCalledWith('right', 90)
+  })
+
+  it('away-mode start handler powers off the side and flips awayMode flag', async () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString()
+    insertSideSettings({ side: 'left', awayStart: future })
+    await manager.loadSchedules()
+
+    const handler = captured.get('away-start-left')!
+    await handler()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('away-mode return handler restores power for the side', async () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString()
+    insertSideSettings({ side: 'right', awayReturn: future })
+    await manager.loadSchedules()
+
+    const handler = captured.get('away-return-right')!
+    await handler()
+
+    expect(setPower).toHaveBeenCalledWith('right', true)
+  })
+
+  it('away-mode start handler tolerates hardware failures', async () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString()
+    insertSideSettings({ side: 'left', awayStart: future })
+    await manager.loadSchedules()
+
+    setPower.mockRejectedValueOnce(new Error('hw down'))
+    const handler = captured.get('away-start-left')!
+    // Must not reject: handler swallows hw errors with console.warn
+    await expect(handler()).resolves.toBeUndefined()
+  })
+
+  it('away-mode return handler tolerates hardware failures', async () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString()
+    insertSideSettings({ side: 'right', awayReturn: future })
+    await manager.loadSchedules()
+
+    setPower.mockRejectedValueOnce(new Error('hw down'))
+    const handler = captured.get('away-return-right')!
+    await expect(handler()).resolves.toBeUndefined()
+  })
+
+  it('run-once setpoint handler issues setTemperature on the locked side', async () => {
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    const setpointTime = fmt(new Date(now.getTime() + 30 * 60_000))
+    const wakeTime = fmt(new Date(now.getTime() + 8 * 60 * 60_000))
+
+    manager.scheduleRunOnceSession(7, 'left', [{ time: setpointTime, temperature: 78 }], wakeTime, 'UTC')
+
+    const handler = captured.get('runonce-7-0')!
+    await handler()
+
+    expect(setTemperature).toHaveBeenCalledWith('left', 78)
+  })
+
+  it('run-once cleanup handler powers the side off when status is still active', async () => {
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    const wakeTime = fmt(new Date(now.getTime() + 8 * 60 * 60_000))
+    seedSidePowered('left', true)
+
+    const sessionId = insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime,
+      startedAt: now,
+      expiresAt: new Date(now.getTime() + 24 * 60 * 60_000),
+      status: 'active',
+    })
+
+    manager.scheduleRunOnceSession(sessionId, 'left', [], wakeTime, 'UTC')
+
+    const handler = captured.get(`runonce-cleanup-${sessionId}`)!
+    await handler()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+    const row = (sqlite as any).prepare(`SELECT status FROM run_once_sessions WHERE id=?`).get(sessionId) as { status: string }
+    expect(row.status).toBe('completed')
+  })
+
+  it('run-once cleanup handler tolerates hardware failures during power-off', async () => {
+    const now = new Date()
+    const fmt = (d: Date) =>
+      `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+    const wakeTime = fmt(new Date(now.getTime() + 8 * 60 * 60_000))
+    seedSidePowered('right', true)
+
+    const sessionId = insertRunOnceSession({
+      side: 'right',
+      setPoints: '[]',
+      wakeTime,
+      startedAt: now,
+      expiresAt: new Date(now.getTime() + 24 * 60 * 60_000),
+      status: 'active',
+    })
+
+    manager.scheduleRunOnceSession(sessionId, 'right', [], wakeTime, 'UTC')
+    const handler = captured.get(`runonce-cleanup-${sessionId}`)!
+
+    setPower.mockRejectedValueOnce(new Error('hw failure'))
+    await expect(handler()).resolves.toBeUndefined()
+  })
+
+  it('run-once expired session loadSchedules path tolerates hardware failure', async () => {
+    insertDeviceSettings({})
+    insertRunOnceSession({
+      side: 'right',
+      setPoints: '[]',
+      wakeTime: '07:00',
+      startedAt: new Date(Date.now() - 4 * 60 * 60_000),
+      expiresAt: new Date(Date.now() - 60_000),
+      status: 'active',
+    })
+    setPower.mockRejectedValueOnce(new Error('hw failure'))
+
+    // Should not throw — the catch block in loadRunOnceSessions swallows
+    await expect(manager.loadSchedules()).resolves.toBeUndefined()
+  })
+
+  it('scheduler events trigger jobScheduled / jobExecuted (success) / jobError listeners', async () => {
+    const sched = manager.getScheduler()
+    const fakeJob = {
+      id: 'test-event',
+      type: 'temperature',
+      schedule: '0 0 * * *',
+      job: { cancel: () => undefined } as any,
+    }
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    sched.emit('jobScheduled', fakeJob as any)
+    sched.emit('jobExecuted', 'test-event', { success: true, timestamp: new Date() })
+    sched.emit('jobExecuted', 'test-event', { success: false, error: 'oops', timestamp: new Date() })
+    sched.emit('jobError', 'test-event', new Error('failed'))
+
+    expect(logSpy).toHaveBeenCalled()
+    expect(errSpy).toHaveBeenCalled()
+    logSpy.mockRestore()
+    errSpy.mockRestore()
+  })
+
+  it('startHeartbeat fires the interval body when timer elapses', async () => {
+    // Use a real fast interval here so the setInterval body executes once.
+    // Replace manager with one that has a short interval.
+    await manager.shutdown()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 10,
+      heartbeatStaleMs: 90_000,
+    })
+    const checkSpy = vi.spyOn(manager, 'checkLiveness').mockResolvedValue([])
+    manager.startHeartbeat()
+    await new Promise(r => setTimeout(r, 50))
+    manager.stopHeartbeat()
+    expect(checkSpy).toHaveBeenCalled()
+  })
+
+  it('heartbeat-triggered reload tolerates reloadSchedules failure', async () => {
+    // Use a fresh manager with a small stale threshold so the fake past time triggers.
+    await manager.shutdown()
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 50,
+    })
+    const sched = manager.getScheduler()
+    sched.scheduleJob('test-past', 'temperature' as any, '0 0 * * *', async () => {})
+
+    const fakePast = new Date(Date.now() - 5_000)
+    vi.spyOn(sched, 'getNextInvocation').mockImplementation(id =>
+      id === 'test-past' ? (fakePast as any) : null,
+    )
+
+    vi.spyOn(manager, 'reloadSchedules').mockRejectedValue(new Error('reload boom'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const stale = await manager.checkLiveness()
+    expect(stale).toContain('test-past')
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+
+  it('runPowerOffJob tolerates DB failure inside markSideOff', async () => {
+    seedSidePowered('left', true)
+    // Drop the table so the update inside markSideOff throws — runPowerOffJob
+    // must still issue setPower(false) and not surface the DB error.
+    ;(sqlite as any).exec(`DROP TABLE device_state`)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      manager.runPowerOffJob({
+        id: 1,
+        side: 'left',
+        dayOfWeek: 'monday' as const,
+        onTime: '22:00',
+        offTime: '07:00',
+        onTemperature: 80,
+        enabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('markSideOff failed for left'),
+      expect.any(String),
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('LED night mode tolerates initial-brightness send failure', async () => {
+    insertDeviceSettings({
+      led_night_mode_enabled: 1,
+      led_night_start_time: '22:00',
+      led_night_end_time: '07:00',
+      led_day_brightness: 100,
+      led_night_brightness: 5,
+    })
+
+    // Make connect throw once during initial-brightness apply
+    connect.mockRejectedValueOnce(new Error('hw down'))
+
+    // loadSchedules must not throw — initial brightness apply is wrapped in try/catch
+    await expect(manager.loadSchedules()).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- \`src/scheduler/jobManager.ts\`: **36% → 99.7% lines** (branches 27% → 93%)
- 66 tests added across \`jobManager.test.ts\` and \`jobOrdering.test.ts\` (21 → 87 in scheduler/tests)

Covers loadSchedules + handlers + run-once paths, including DB error fallback and timing edges.

## Source bugs surfaced (not fixed)
- \`scheduleRunOnceSession:819\` — \`if (fireDate <= now) continue\` is dead: \`timeToDate\` always rolls past wall-clock times forward.
- \`parseTime\` accepts \`"99:99"\` — only NaN-guards, no range check on hour/minute.

## Test plan
- [x] vitest 260/260 passes
- [x] tsc + lint + drizzle pre-push hooks clean
- [ ] Codecov shows lift on jobManager.ts