### PR TITLE
test(hardware): cover deviceStateSync + iptablesCheck

### DIFF
--- a/src/hardware/tests/deviceStateSync.test.ts
+++ b/src/hardware/tests/deviceStateSync.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type BetterSqlite3 from 'better-sqlite3'
 import type { DeviceStatus } from '../types'
+import { PodVersion } from '../types'
 
 vi.mock('@/src/db', async () => {
   const BetterSqlite3 = (await import('better-sqlite3')).default
@@ -23,7 +24,7 @@ vi.mock('@/src/db', async () => {
 })
 
 import * as dbModule from '@/src/db'
-import { DeviceStateSync, markSideMutated, _resetMutationStamps } from '../deviceStateSync'
+import { DeviceStateSync, markSideMutated, _resetMutationStamps, getAlarmState } from '../deviceStateSync'
 
 const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
   sqlite: BetterSqlite3.Database
@@ -260,5 +261,410 @@ describe('DeviceStateSync — mutation freshness window', () => {
     const row = readSide('right')
     expect(row?.is_powered).toBe(0)
     expect(row?.target_temperature).toBeNull()
+  })
+})
+
+function readWaterLevels() {
+  return (biometricsSqlite as any)
+    .prepare(`SELECT id, timestamp, level FROM water_level_readings ORDER BY id ASC`)
+    .all() as Array<{ id: number, timestamp: number, level: string }>
+}
+
+function readFlowReadings() {
+  return (biometricsSqlite as any)
+    .prepare(`SELECT id, timestamp, left_flowrate_cd, right_flowrate_cd, left_pump_rpm, right_pump_rpm FROM flow_readings ORDER BY id ASC`)
+    .all() as Array<{
+    id: number
+    timestamp: number
+    left_flowrate_cd: number | null
+    right_flowrate_cd: number | null
+    left_pump_rpm: number
+    right_pump_rpm: number
+  }>
+}
+
+function setAlarmVibrating(side: 'left' | 'right', isAlarmVibrating: boolean): void {
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO device_state (side, is_alarm_vibrating, last_updated)
+       VALUES (?, ?, unixepoch())
+       ON CONFLICT(side) DO UPDATE SET is_alarm_vibrating = excluded.is_alarm_vibrating, last_updated = unixepoch()`
+    )
+    .run(side, isAlarmVibrating ? 1 : 0)
+}
+
+describe('DeviceStateSync — power transition stamps poweredOnAt', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+  })
+
+  it('OFF→ON stamps poweredOnAt when no mutation gate is active', async () => {
+    seedSide('right', false, null)
+
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 5,
+      targetLevel: 5,
+      heatingDuration: 100,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(1)
+    expect(row?.powered_on_at).not.toBeNull()
+  })
+
+  it('ON→OFF clears poweredOnAt', async () => {
+    seedSide('right', true, 80)
+
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 0,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(0)
+    expect(row?.powered_on_at).toBeNull()
+  })
+
+  it('initial sync with no prior row treats wasPowered as false', async () => {
+    // No seed; row absent
+    await sync.sync(status({
+      side: 'right',
+      currentLevel: 5,
+      targetLevel: 5,
+      heatingDuration: 100,
+    }))
+
+    const row = readSide('right')
+    expect(row?.is_powered).toBe(1)
+    expect(row?.powered_on_at).not.toBeNull()
+  })
+
+  it('catches db errors thrown from upsertSide and logs', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Drop device_state table so the transaction throws
+    ;(sqlite as any).exec(`DROP TABLE device_state`)
+
+    await expect(
+      sync.sync(status({
+        side: 'right',
+        currentLevel: 5,
+        targetLevel: 5,
+        heatingDuration: 100,
+      }))
+    ).resolves.toBeUndefined()
+
+    expect(errSpy).toHaveBeenCalled()
+    const msg = errSpy.mock.calls[0]?.[0]
+    expect(String(msg)).toContain('failed to write device_state')
+    errSpy.mockRestore()
+  })
+})
+
+describe('DeviceStateSync — getAlarmState', () => {
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+  })
+
+  it('returns isAlarmVibrating per side from DB', () => {
+    setAlarmVibrating('left', true)
+    setAlarmVibrating('right', false)
+
+    expect(getAlarmState()).toEqual({ left: true, right: false })
+  })
+
+  it('defaults to false for sides not yet present in DB', () => {
+    // No rows present at all
+    expect(getAlarmState()).toEqual({ left: false, right: false })
+  })
+
+  it('falls back to {left:false,right:false} on DB error', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(sqlite as any).exec(`DROP TABLE device_state`)
+
+    expect(getAlarmState()).toEqual({ left: false, right: false })
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+})
+
+describe('DeviceStateSync — recordWaterLevel', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('writes ok on first sync, then rate-limits within 60s', async () => {
+    await sync.sync(status({ side: 'right' }))
+    expect(readWaterLevels().length).toBe(1)
+    expect(readWaterLevels()[0]?.level).toBe('ok')
+
+    // Within 60s window — no new write.
+    vi.setSystemTime(new Date('2026-05-09T12:00:30Z'))
+    await sync.sync(status({ side: 'right' }))
+    expect(readWaterLevels().length).toBe(1)
+
+    // After 60s — writes again.
+    vi.setSystemTime(new Date('2026-05-09T12:01:01Z'))
+    await sync.sync(status({ side: 'right' }))
+    expect(readWaterLevels().length).toBe(2)
+  })
+
+  it('writes "low" when waterLevel is "low"', async () => {
+    const s = status({ side: 'right' })
+    s.waterLevel = 'low'
+    await sync.sync(s)
+    const rows = readWaterLevels()
+    expect(rows[0]?.level).toBe('low')
+  })
+
+  it('logs and continues when biometricsDb write fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(biometricsSqlite as any).exec(`DROP TABLE water_level_readings`)
+
+    await expect(sync.sync(status({ side: 'right' }))).resolves.toBeUndefined()
+    expect(errSpy).toHaveBeenCalled()
+    const msg = String(errSpy.mock.calls[0]?.[0] ?? '')
+    expect(msg).toContain('failed to write water level')
+    errSpy.mockRestore()
+  })
+})
+
+describe('DeviceStateSync — recordFlowData', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function frzHealthFrame(opts: {
+    leftRpm?: number
+    rightRpm?: number
+    leftFlow?: number | null
+    rightFlow?: number | null
+  } = {}): Record<string, unknown> {
+    const left: any = { pump: { rpm: opts.leftRpm ?? 100 }, temps: {} }
+    const right: any = { pump: { rpm: opts.rightRpm ?? 100 }, temps: {} }
+    if (opts.leftFlow !== null && opts.leftFlow !== undefined) left.temps.flowrate = opts.leftFlow
+    if (opts.rightFlow !== null && opts.rightFlow !== undefined) right.temps.flowrate = opts.rightFlow
+    return { left, right }
+  }
+
+  it('ignores frames missing pump/temps fields (e.g. piezo, capSense)', () => {
+    sync.recordFlowData({ piezo: { samples: [] } })
+    sync.recordFlowData({ left: { foo: 1 }, right: { bar: 2 } })
+    sync.recordFlowData({ left: null, right: null })
+    expect(readFlowReadings().length).toBe(0)
+  })
+
+  it('writes a row on the first frame and rate-limits writes within 60s', () => {
+    sync.recordFlowData(frzHealthFrame({ leftFlow: 1.23, rightFlow: 1.21 }))
+    expect(readFlowReadings().length).toBe(1)
+    const row = readFlowReadings()[0]
+    expect(row?.left_flowrate_cd).toBe(123)
+    expect(row?.right_flowrate_cd).toBe(121)
+
+    // Same minute → no second write
+    vi.setSystemTime(new Date('2026-05-09T12:00:30Z'))
+    sync.recordFlowData(frzHealthFrame({ leftFlow: 1.5, rightFlow: 1.5 }))
+    expect(readFlowReadings().length).toBe(1)
+
+    // After 60s → writes again
+    vi.setSystemTime(new Date('2026-05-09T12:01:01Z'))
+    sync.recordFlowData(frzHealthFrame({ leftFlow: 1.5, rightFlow: 1.5 }))
+    expect(readFlowReadings().length).toBe(2)
+  })
+
+  it('persists null flowrate when frame omits temps.flowrate', () => {
+    sync.recordFlowData(frzHealthFrame({ leftFlow: null, rightFlow: null }))
+    const row = readFlowReadings()[0]
+    expect(row?.left_flowrate_cd).toBeNull()
+    expect(row?.right_flowrate_cd).toBeNull()
+  })
+
+  it('logs and swallows when biometricsDb flow write fails', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(biometricsSqlite as any).exec(`DROP TABLE flow_readings`)
+
+    sync.recordFlowData(frzHealthFrame({ leftFlow: 1.0, rightFlow: 1.0 }))
+    expect(errSpy).toHaveBeenCalled()
+    const msg = String(errSpy.mock.calls[0]?.[0] ?? '')
+    expect(msg).toContain('failed to write flow readings')
+    errSpy.mockRestore()
+  })
+})
+
+describe('DeviceStateSync — flow anomaly detection', () => {
+  let sync: DeviceStateSync
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-09T12:00:00Z'))
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  function frame(opts: {
+    leftRpm?: number
+    rightRpm?: number
+    leftFlow?: number | null
+    rightFlow?: number | null
+  } = {}): Record<string, unknown> {
+    const left: any = { pump: { rpm: opts.leftRpm ?? 0 }, temps: {} }
+    const right: any = { pump: { rpm: opts.rightRpm ?? 0 }, temps: {} }
+    if (opts.leftFlow !== null && opts.leftFlow !== undefined) left.temps.flowrate = opts.leftFlow
+    if (opts.rightFlow !== null && opts.rightFlow !== undefined) right.temps.flowrate = opts.rightFlow
+    return { left, right }
+  }
+
+  function anomalyTypes(): string[] {
+    return (warnSpy.mock.calls as unknown[][])
+      .map((c: unknown[]) => String(c[0] ?? ''))
+      .map((s: string) => {
+        const m = s.match(/\[FlowAnomaly\] (\w+)/)
+        return m ? m[1] : ''
+      })
+      .filter(Boolean)
+  }
+
+  it('warns when pump runs but flowrate is missing (left + right)', () => {
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: null, rightRpm: 200, rightFlow: null }))
+    const types = anomalyTypes()
+    expect(types).toContain('left_flowrate_missing')
+    expect(types).toContain('right_flowrate_missing')
+  })
+
+  it('warns when pump runs but flowrate is near zero', () => {
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: 0.01, rightRpm: 100, rightFlow: 0.02 }))
+    const types = anomalyTypes()
+    expect(types).toContain('left_pump_no_flow')
+    expect(types).toContain('right_pump_no_flow')
+  })
+
+  it('does NOT warn no-flow when pump is below RPM minimum', () => {
+    sync.recordFlowData(frame({ leftRpm: 10, leftFlow: 0.0, rightRpm: 10, rightFlow: 0.0 }))
+    expect(anomalyTypes()).not.toContain('left_pump_no_flow')
+    expect(anomalyTypes()).not.toContain('right_pump_no_flow')
+  })
+
+  it('warns when left/right flow asymmetry exceeds threshold (and both above near-zero)', () => {
+    // 5.0 vs 1.0 → 500cd vs 100cd, diff 400 > 300 threshold
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: 5.0, rightRpm: 100, rightFlow: 1.0 }))
+    expect(anomalyTypes()).toContain('flow_asymmetry')
+  })
+
+  it('does NOT warn asymmetry when one side is near-zero', () => {
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: 5.0, rightRpm: 100, rightFlow: 0.0 }))
+    // The asymmetry guard requires BOTH sides above near-zero; near-zero left is filtered
+    expect(anomalyTypes()).not.toContain('flow_asymmetry')
+  })
+
+  it('warns on sudden flowrate spikes between consecutive frames', () => {
+    // First frame primes prevFlow; cooldown blocks duplicate types so use distinct anomalies.
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: 1.0, rightRpm: 100, rightFlow: 1.0 }))
+    // Second frame: jump by > 5.0 (500cd) — passes FLOWRATE_SUDDEN_CHANGE_CD = 500
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: 7.0, rightRpm: 100, rightFlow: 7.0 }))
+    const types = anomalyTypes()
+    expect(types).toContain('left_flow_spike')
+    expect(types).toContain('right_flow_spike')
+  })
+
+  it('rate-limits repeated anomaly warnings of the same type', () => {
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: null, rightRpm: 0, rightFlow: 0.5 }))
+    const before = anomalyTypes().filter(t => t === 'left_flowrate_missing').length
+    expect(before).toBe(1)
+    // Second emission within cooldown window
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: null, rightRpm: 0, rightFlow: 0.5 }))
+    const after = anomalyTypes().filter(t => t === 'left_flowrate_missing').length
+    expect(after).toBe(1)
+  })
+
+  it('emits the warning again after the cooldown window expires', () => {
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: null, rightRpm: 0, rightFlow: 0.5 }))
+    expect(anomalyTypes().filter(t => t === 'left_flowrate_missing').length).toBe(1)
+    // Advance past the 5-min cooldown
+    vi.setSystemTime(new Date('2026-05-09T12:06:00Z'))
+    sync.recordFlowData(frame({ leftRpm: 100, leftFlow: null, rightRpm: 0, rightFlow: 0.5 }))
+    expect(anomalyTypes().filter(t => t === 'left_flowrate_missing').length).toBe(2)
+  })
+})
+
+describe('DeviceStateSync — sync targetTemperature behaviour without mutation', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    sync = new DeviceStateSync()
+  })
+
+  it('clears targetTemperature when durationExpired and no mutation is active', async () => {
+    seedSide('right', true, 83)
+
+    await sync.sync(status({
+      side: 'right',
+      targetTemperature: 83,
+      currentLevel: 5,
+      targetLevel: 0,
+      heatingDuration: 0,
+    }))
+
+    const row = readSide('right')
+    expect(row?.target_temperature).toBeNull()
+    expect(row?.is_powered).toBe(0)
+  })
+
+  it('writes targetTemperature from firmware when actively heating', async () => {
+    await sync.sync(status({
+      side: 'right',
+      targetTemperature: 78,
+      currentLevel: 5,
+      targetLevel: 5,
+      heatingDuration: 100,
+    }))
+
+    const row = readSide('right')
+    expect(row?.target_temperature).toBe(78)
+    expect(row?.is_powered).toBe(1)
+  })
+
+  it('podVersion field on status payload is irrelevant to upsert', async () => {
+    const s = status({ side: 'right', currentLevel: 5, targetLevel: 5, heatingDuration: 100 })
+    // Sanity that mocked enum is wired up through types
+    s.podVersion = PodVersion.POD_4
+    await sync.sync(s)
+    expect(readSide('right')?.is_powered).toBe(1)
   })
 })

--- a/src/hardware/tests/iptablesCheck.test.ts
+++ b/src/hardware/tests/iptablesCheck.test.ts
@@ -1,34 +1,71 @@
-import { describe, it, expect } from 'vitest'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 /**
  * Tests for iptables rule validation.
- * Since execSync can't run iptables in CI/dev, we test the rule
- * definitions and the check logic indirectly.
+ * The module shells out via execSync; we mock node:child_process and
+ * drive both branches (rules present, rules missing, repair, persist).
  */
 
-describe('iptablesCheck module', () => {
+vi.mock('node:child_process', () => {
+  const execSync = vi.fn()
+  return { execSync, default: { execSync } }
+})
+
+import { execSync as mockedExecSync } from 'node:child_process'
+
+const execSyncMock = mockedExecSync as unknown as ReturnType<typeof vi.fn>
+
+interface ExecHandlerArgs {
+  cmd: string
+  options?: { encoding?: string, timeout?: number }
+}
+
+type ExecHandler = (args: ExecHandlerArgs) => string | Buffer | undefined
+
+function setExecHandler(handler: ExecHandler): void {
+  execSyncMock.mockImplementation((cmd: string, options?: any) => {
+    const result = handler({ cmd, options })
+    return result == null ? '' : result
+  })
+}
+
+function unavailableError(message: string, status?: number): Error {
+  const err = new Error(message) as Error & { status?: number }
+  if (status !== undefined) err.status = status
+  return err
+}
+
+describe('iptablesCheck — module surface', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+    // Default: every call throws ENOENT-style — module assumes rules present.
+    execSyncMock.mockImplementation(() => {
+      throw unavailableError('iptables: command not found', 127)
+    })
+  })
+
   it('exports checkIptables and checkAndRepairIptables', async () => {
     const mod = await import('../iptablesCheck')
     expect(typeof mod.checkIptables).toBe('function')
     expect(typeof mod.checkAndRepairIptables).toBe('function')
   })
 
-  it('checkIptables returns ok=true in dev (no iptables available)', async () => {
+  it('checkIptables returns ok=true when iptables is unavailable', async () => {
     const { checkIptables } = await import('../iptablesCheck')
     const result = checkIptables()
-    // In dev/CI, iptables isn't available so all rules are assumed present
     expect(result.ok).toBe(true)
-    expect(result.rules.length).toBeGreaterThan(0)
+    expect(result.rules.length).toBe(5)
   })
 
   it('validates all critical rules are defined', async () => {
     const { checkIptables } = await import('../iptablesCheck')
     const result = checkIptables()
 
-    // Verify expected rules exist in the check list
     const ruleNames = result.rules.map(r => r.name)
     expect(ruleNames).toContain('mDNS outbound (UDP 5353)')
     expect(ruleNames).toContain('mDNS inbound (UDP 5353)')
+    expect(ruleNames).toContain('mDNS outbound source (UDP 5353)')
     expect(ruleNames).toContain('LAN access (192.168.0.0/16)')
     expect(ruleNames).toContain('NTP outbound (UDP 123)')
   })
@@ -45,5 +82,301 @@ describe('iptablesCheck module', () => {
     const chains = new Set(result.rules.map(r => r.chain))
     expect(chains.has('INPUT')).toBe(true)
     expect(chains.has('OUTPUT')).toBe(true)
+  })
+})
+
+describe('iptablesCheck — resolveIptablesPath', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+  })
+
+  it('uses an explicit override path without invoking which', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) {
+        throw new Error('which should not have been called')
+      }
+      // Listing always finds the rule
+      return 'udp dpt:5353 udp spt:5353 192.168.0.0/16 udp dpt:123'
+    })
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables('/custom/path/iptables')
+    expect(result.ok).toBe(true)
+    // No `which` call should have happened in this run
+    const calls = execSyncMock.mock.calls.map(c => String(c[0]))
+    expect(calls.some(c => c.includes('which iptables'))).toBe(false)
+    expect(calls.some(c => c.startsWith('/custom/path/iptables -L'))).toBe(true)
+  })
+
+  it('falls back to known POD_CAPS paths when which fails and a candidate is executable', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) throw unavailableError('which: not found', 127)
+      if (cmd.startsWith('test -x ')) {
+        // First candidate matches (/sbin/iptables)
+        if (cmd.includes('/sbin/iptables')) return ''
+        throw unavailableError('not found', 1)
+      }
+      // Listing returns rule presence
+      return 'udp dpt:5353 udp spt:5353 192.168.0.0/16 udp dpt:123'
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(true)
+
+    const calls = execSyncMock.mock.calls.map(c => String(c[0]))
+    expect(calls.some(c => c === 'which iptables 2>/dev/null')).toBe(true)
+    expect(calls.some(c => c.startsWith('test -x /sbin/iptables'))).toBe(true)
+    expect(calls.some(c => c.startsWith('/sbin/iptables -L'))).toBe(true)
+  })
+
+  it('falls back to bare "iptables" when which fails and no candidate is executable', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) throw unavailableError('which: not found', 127)
+      if (cmd.startsWith('test -x ')) throw unavailableError('not found', 1)
+      // Listing — return empty so rules are seen as missing (not assumed-ok via unavailable)
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+
+    const calls = execSyncMock.mock.calls.map(c => String(c[0]))
+    expect(calls.some(c => c.startsWith('iptables -L INPUT'))).toBe(true)
+    expect(calls.some(c => c.startsWith('iptables -L OUTPUT'))).toBe(true)
+    // All rules missing → ok=false
+    expect(result.ok).toBe(false)
+    expect(result.rules.every(r => r.present === false)).toBe(true)
+  })
+})
+
+describe('iptablesCheck — checkIptables rule classification', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+  })
+
+  it('marks each rule present when listing output contains its check token', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.includes('-L INPUT')) return 'udp dpt:5353 192.168.0.0/16'
+      if (cmd.includes('-L OUTPUT')) return 'udp dpt:5353 udp spt:5353 udp dpt:123'
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(true)
+    expect(result.rules.find(r => r.name === 'LAN access (192.168.0.0/16)')?.present).toBe(true)
+    expect(result.rules.find(r => r.name === 'NTP outbound (UDP 123)')?.present).toBe(true)
+    expect(result.rules.find(r => r.name === 'mDNS outbound source (UDP 5353)')?.present).toBe(true)
+  })
+
+  it('marks rule absent when listing output omits the token (and is reachable)', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.includes('-L INPUT')) return '' // no INPUT rules
+      if (cmd.includes('-L OUTPUT')) return 'udp dpt:5353 udp spt:5353 udp dpt:123'
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(false)
+    const lan = result.rules.find(r => r.name === 'LAN access (192.168.0.0/16)')
+    const inboundMdns = result.rules.find(r => r.name === 'mDNS inbound (UDP 5353)')
+    expect(lan?.present).toBe(false)
+    expect(inboundMdns?.present).toBe(false)
+  })
+
+  it('treats Permission denied / Operation not permitted from listing as "assume ok"', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.startsWith('/sbin/iptables -L')) {
+        throw unavailableError('iptables v1.8.7: Permission denied (you must be root)')
+      }
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(true)
+    expect(result.rules.every(r => r.present)).toBe(true)
+  })
+
+  it('treats unknown listing failures as rule-missing and warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.startsWith('/sbin/iptables -L')) {
+        // status=2 is "other error" in iptables: not in the assumed-ok list
+        throw unavailableError('iptables: kernel module xt_udp not loaded', 2)
+      }
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(false)
+    expect(result.rules.every(r => r.present === false)).toBe(true)
+    expect(warnSpy).toHaveBeenCalled()
+    const msgs = warnSpy.mock.calls.map(c => String(c[0]))
+    expect(msgs.some(m => m.includes('Failed to check'))).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('treats exit code 3 / 4 from listing as "assume ok"', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.startsWith('/sbin/iptables -L')) {
+        throw unavailableError('chain not found', 3)
+      }
+      return ''
+    })
+
+    const { checkIptables } = await import('../iptablesCheck')
+    const result = checkIptables()
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('iptablesCheck — checkAndRepairIptables', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns repaired=[] when all rules are already present', async () => {
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.includes('-L INPUT')) return 'udp dpt:5353 192.168.0.0/16'
+      if (cmd.includes('-L OUTPUT')) return 'udp dpt:5353 udp spt:5353 udp dpt:123'
+      return ''
+    })
+
+    const { checkAndRepairIptables } = await import('../iptablesCheck')
+    const result = checkAndRepairIptables()
+    expect(result.ok).toBe(true)
+    expect(result.repaired).toEqual([])
+  })
+
+  it('repairs missing rules and persists via iptables-save', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const repaired: string[] = []
+    let savedRules = false
+
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      // Missing: LAN access; rest present
+      if (cmd.startsWith('/sbin/iptables -L INPUT')) return 'udp dpt:5353' // omits 192.168.0.0/16
+      if (cmd.startsWith('/sbin/iptables -L OUTPUT')) return 'udp dpt:5353 udp spt:5353 udp dpt:123'
+      // Repair invocation
+      if (cmd.includes('-A INPUT -s 192.168.0.0/16')) {
+        repaired.push(cmd)
+        return ''
+      }
+      // Persist
+      if (cmd.startsWith('/sbin/iptables-save')) {
+        savedRules = true
+        return ''
+      }
+      return ''
+    })
+
+    const { checkAndRepairIptables } = await import('../iptablesCheck')
+    const result = checkAndRepairIptables()
+    expect(result.repaired).toEqual(['LAN access (192.168.0.0/16)'])
+    expect(repaired.length).toBe(1)
+    expect(savedRules).toBe(true)
+    expect(logSpy).toHaveBeenCalled()
+    const messages = logSpy.mock.calls.map(c => String(c[0]))
+    expect(messages.some(m => m.includes('Repaired missing rule'))).toBe(true)
+    expect(messages.some(m => m.includes('Saved 1 repaired rules'))).toBe(true)
+    logSpy.mockRestore()
+  })
+
+  it('logs an error and continues when a repair invocation fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.startsWith('/sbin/iptables -L INPUT')) return ''
+      if (cmd.startsWith('/sbin/iptables -L OUTPUT')) return ''
+      // Every repair fails
+      if (cmd.includes('-I OUTPUT') || cmd.includes('-I INPUT') || cmd.includes('-A INPUT')) {
+        throw unavailableError('iptables: not permitted', 4)
+      }
+      // No persist call expected since repaired list is empty
+      return ''
+    })
+
+    const { checkAndRepairIptables } = await import('../iptablesCheck')
+    const result = checkAndRepairIptables()
+    expect(result.repaired).toEqual([])
+    expect(errSpy).toHaveBeenCalled()
+    const errMsgs = errSpy.mock.calls.map(c => String(c[0]))
+    expect(errMsgs.some(m => m.includes('Failed to repair rule'))).toBe(true)
+
+    // No "Saved N repaired rules" log when nothing was repaired
+    const logMsgs = logSpy.mock.calls.map(c => String(c[0]))
+    expect(logMsgs.some(m => m.includes('Saved'))).toBe(false)
+
+    logSpy.mockRestore()
+    errSpy.mockRestore()
+  })
+
+  it('warns when persisting via iptables-save fails after a successful repair', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) return '/sbin/iptables\n'
+      if (cmd.startsWith('/sbin/iptables -L INPUT')) return 'udp dpt:5353' // missing LAN
+      if (cmd.startsWith('/sbin/iptables -L OUTPUT')) return 'udp dpt:5353 udp spt:5353 udp dpt:123'
+      if (cmd.includes('-A INPUT -s 192.168.0.0/16')) return ''
+      if (cmd.startsWith('/sbin/iptables-save')) {
+        throw unavailableError('No such file or directory: /etc/iptables/rules.v4')
+      }
+      return ''
+    })
+
+    const { checkAndRepairIptables } = await import('../iptablesCheck')
+    const result = checkAndRepairIptables()
+    expect(result.repaired).toEqual(['LAN access (192.168.0.0/16)'])
+    const warnMsgs = warnSpy.mock.calls.map(c => String(c[0]))
+    expect(warnMsgs.some(m => m.includes('Failed to persist rules'))).toBe(true)
+
+    logSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
+  it('derives iptables-save path from the resolved iptables path', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    let saveCmd = ''
+
+    setExecHandler(({ cmd }) => {
+      if (cmd.includes('which iptables')) throw unavailableError('not found', 1)
+      if (cmd.startsWith('test -x ')) {
+        if (cmd.includes('/usr/sbin/iptables')) return ''
+        throw unavailableError('not found', 1)
+      }
+      if (cmd.startsWith('/usr/sbin/iptables -L INPUT')) return ''
+      if (cmd.startsWith('/usr/sbin/iptables -L OUTPUT')) return ''
+      // Repairs succeed
+      if (cmd.includes('-I ') || cmd.includes('-A ')) return ''
+      if (cmd.includes('iptables-save')) {
+        saveCmd = cmd
+        return ''
+      }
+      return ''
+    })
+
+    const { checkAndRepairIptables } = await import('../iptablesCheck')
+    const result = checkAndRepairIptables()
+    expect(result.repaired.length).toBeGreaterThan(0)
+    expect(saveCmd.startsWith('/usr/sbin/iptables-save > /etc/iptables/rules.v4')).toBe(true)
+    logSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- \`src/hardware/deviceStateSync.ts\`: **48% → 100% lines** (branches 31% → 96%)
- \`src/hardware/iptablesCheck.ts\`: **56% → 100% lines** (branches 46% → 92%)
- 25 + 13 tests added (237/237 project pass)

Covers power transitions, getAlarmState, recordWaterLevel rate-limit, recordFlowData frame filtering + rate-limit + null persistence, flow anomaly detection (asymmetry/RPM gate/spike/cooldown), iptables path resolution + rule classification + repair persistence.

## Source bugs surfaced (not fixed)
- \`deviceStateSync.ts:267\` — asymmetry threshold compares \`NaN > 300\` when flowrate is missing. Works incidentally; fragile if comparator flips.
- \`deviceStateSync.ts:155-165\` — \`onConflictDoUpdate\` silently nulls \`targetTemperature\` when there's no prior row.
- \`iptablesCheck.ts:179\` — \`iptables.replace(/iptables\$/, 'iptables-save')\` mangles \`iptables.real\`-style paths.

## Test plan
- [x] vitest 237/237 passes
- [x] tsc + lint + drizzle pre-push hooks clean
- [ ] Codecov shows lift on both files