### PR TITLE
fix(sp-update): keep new sp-* tools on rollback

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -79,13 +79,16 @@ cleanup() {
         ! -name '.env' \
         -exec rm -rf {} +
       cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
-      # Restore CLI tools from rolled-back code
-      if [ -d "$INSTALL_DIR/scripts/bin" ]; then
-        for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-          cp "$tool" /usr/local/bin/
-          chmod +x "/usr/local/bin/$(basename "$tool")"
-        done
-      fi
+      # Intentionally NOT restoring sp-* tools to /usr/local/bin/.
+      # They were already swapped in atomically (see install(1) below)
+      # before the failure; restoring the pre-update copies can re-pin a
+      # pod on a broken sp-update and create an infinite loop. Concretely:
+      # pre-#494 sp-update used `cp` for self-replace, which truncated the
+      # running file's inode mid-run and made bash parse garbage from the
+      # new bytes (the "/usr/local/bin/sp-update: line N: ...: command not
+      # found" symptom). #494 fixed that with install(1), but if rollback
+      # then restored the pre-#494 copy, the next run would corrupt itself
+      # the same way. App code rolls back; sp-* tools roll forward.
       echo "Previous code restored."
     fi
     if [ -n "${DB_BACKUP:-}" ] && [ -f "$DB_BACKUP" ]; then


### PR DESCRIPTION
## Summary

The `cleanup()` rollback path in `sp-update` always restored `sp-*` tools from `\$BACKUP_DIR`. Combined with pre-#494 sp-updates that self-replaced via `cp` (truncating the running script's inode mid-run, making bash parse garbage out of the new bytes), this created an infinite update loop:

1. Run pre-#494 sp-update.
2. It atomically swaps in the new (post-#494) sp-update via `cp` mid-run.
3. `cp` truncates the inode bash is reading → bash hits a stray token, errors with `/usr/local/bin/sp-update: line N: <random>: command not found` (the [thread that triggered this](https://github.com/sleepypod/core/pull/514#discussion_r... ) saw it as `git-info`).
4. `cleanup()` restores the broken pre-#494 sp-update from `\$BACKUP_DIR`. Loop.

After this fix, step 4 keeps the new (atomic-install) sp-update in place. The next run uses `install(1)` and recovers cleanly.

App code still rolls back fully — only the standalone `sp-*` CLI wrappers roll forward. Safe because `sp-*` are thin (systemctl wrappers + self-contained sp-update), so a newer sp-update against rolled-back app code can still recover.

## Test plan

- [x] `bash -n scripts/bin/sp-update` clean
- [x] Pre-push gates pass (tsc / lint / drizzle)
- [ ] Manual: trigger a deliberate failure mid-update (e.g. \`exit 1\` after the \`install -m 0755\` block) and verify \`/usr/local/bin/sp-update\` contains the **new** content after rollback, not the pre-update copy
- [ ] Manual: re-run \`sp-update dev-latest\` and confirm it completes cleanly using the kept-forward binary

Refs: PR #494 (atomic self-replace via install(1))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified update rollback behavior to restore only application code while preserving CLI tool binaries, preventing rollback-related issues during failed updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/526)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->