### PR TITLE
fix(homekit): serialize per-side hardware writes + cache target across power cycles

### DIFF
--- a/src/hardware/dacMonitor.instance.ts
+++ b/src/hardware/dacMonitor.instance.ts
@@ -37,6 +37,15 @@ import {
 
 const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
 
+/**
+ * Last-resort target when a caller asks to power a side ON without supplying
+ * a temperature. Real callers (HomeKit, gestures, scheduler) all pass an
+ * explicit target sourced from cache/state; this fallback only fires for
+ * legacy paths (e.g. mqttBridge passthrough with no temperature in payload)
+ * so the pod doesn't sit at level 0 after a power-on.
+ */
+const POWER_ON_FALLBACK_F = 75
+
 // ── Singleton storage on globalThis (survives Turbopack module duplication) ──
 
 const KEYS = {
@@ -143,7 +152,7 @@ class DacHardwareClient {
 
   async setPower(side: Side, powered: boolean, temperature?: number): Promise<void> {
     if (powered) {
-      const temp = temperature ?? 75
+      const temp = temperature ?? POWER_ON_FALLBACK_F
       await this.setTemperature(side, temp)
     }
     else {

--- a/src/hardware/gestureActionHandler.ts
+++ b/src/hardware/gestureActionHandler.ts
@@ -1,5 +1,5 @@
 import type { HardwareClient } from './client'
-import { MAX_TEMP, MIN_TEMP, type Side } from './types'
+import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL, type Side } from './types'
 import type { GestureEvent } from './dacMonitor'
 
 // Re-export for callers that need to build deps
@@ -152,10 +152,15 @@ export class GestureActionHandler {
     else {
       if (gesture.alarmInactiveBehavior === 'power') {
         const currentlyPowered = state?.isPowered ?? false
+        const nextPowered = !currentlyPowered
+        // Pass the polled target so a power-on preserves the user's setpoint
+        // across off-cycles instead of landing on the firmware-default
+        // fallback in DacHardwareClient.setPower.
+        const target = state?.targetTemperature ?? TEMP_NEUTRAL
         const client = this.deps.newHardwareClient(this.socketPath)
         try {
           await client.connect()
-          await client.setPower(event.side, !currentlyPowered)
+          await client.setPower(event.side, nextPowered, nextPowered ? target : undefined)
         }
         finally {
           client.disconnect()

--- a/src/hardware/tests/gestureActionHandler.test.ts
+++ b/src/hardware/tests/gestureActionHandler.test.ts
@@ -159,24 +159,34 @@ describe('GestureActionHandler', () => {
   })
 
   describe('alarm action — inactive alarm', () => {
-    test('toggles power on when pod is off (alarmInactiveBehavior=power)', async () => {
+    test('toggles power on when pod is off (alarmInactiveBehavior=power) — preserves polled target', async () => {
       const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
-      const state = { isAlarmVibrating: false, isPowered: false }
+      const state = { isAlarmVibrating: false, isPowered: false, targetTemperature: 70 }
       const { deps, client } = makeDeps(gesture, state)
 
       await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('left', 'doubleTap'))
 
-      expect(client.setPower).toHaveBeenCalledWith('left', true)
+      expect(client.setPower).toHaveBeenCalledWith('left', true, 70)
+    })
+
+    test('power-on falls back to TEMP_NEUTRAL when no targetTemperature is cached', async () => {
+      const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
+      const state = { isAlarmVibrating: false, isPowered: false, targetTemperature: null }
+      const { deps, client } = makeDeps(gesture, state)
+
+      await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('left', 'doubleTap'))
+
+      expect(client.setPower).toHaveBeenCalledWith('left', true, 82.5)
     })
 
     test('toggles power off when pod is on (alarmInactiveBehavior=power)', async () => {
       const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
-      const state = { isAlarmVibrating: false, isPowered: true }
+      const state = { isAlarmVibrating: false, isPowered: true, targetTemperature: 72 }
       const { deps, client } = makeDeps(gesture, state)
 
       await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('right', 'quadTap'))
 
-      expect(client.setPower).toHaveBeenCalledWith('right', false)
+      expect(client.setPower).toHaveBeenCalledWith('right', false, undefined)
     })
 
     test('no-op when alarmInactiveBehavior=none', async () => {

--- a/src/homekit/accessories/powerSwitch.ts
+++ b/src/homekit/accessories/powerSwitch.ts
@@ -12,7 +12,7 @@ import { Service, Characteristic } from 'hap-nodejs'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
 import {
-  isCurrentlyPowered,
+  isEffectivelyPowered,
   isPoweredFromStatus,
   setSidePowerOff,
   setSidePowerOn,
@@ -27,7 +27,7 @@ export function buildPowerSwitch(side: Side, monitor: DacMonitor): PowerSwitchAc
   const service = new Service.Switch(`Bed ${side} power`, `power-${side}`)
 
   service.getCharacteristic(Characteristic.On)
-    .onGet(() => isCurrentlyPowered(monitor, side))
+    .onGet(() => isEffectivelyPowered(monitor, side))
     .onSet(async (value) => {
       if (value) await setSidePowerOn(monitor, side)
       else await setSidePowerOff(monitor, side)

--- a/src/homekit/accessories/powerSwitch.ts
+++ b/src/homekit/accessories/powerSwitch.ts
@@ -4,14 +4,19 @@
  * Sits alongside the Thermostat for the same side. The Thermostat's mode
  * already toggles power, but a dedicated Switch gives users a tappable tile
  * (and an automation/scene primitive) that doesn't require entering the
- * thermostat card. Both surfaces resolve to the same setPower(side) call.
+ * thermostat card. Both surfaces resolve through sideController so the
+ * writes are serialized and share the in-process target cache.
  */
 
 import { Service, Characteristic } from 'hap-nodejs'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
-import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
-import { isPoweredFromStatus, readLastTargetF } from './thermostat'
+import {
+  isCurrentlyPowered,
+  isPoweredFromStatus,
+  setSidePowerOff,
+  setSidePowerOn,
+} from './sideController'
 
 export interface PowerSwitchAccessory {
   service: Service
@@ -22,17 +27,10 @@ export function buildPowerSwitch(side: Side, monitor: DacMonitor): PowerSwitchAc
   const service = new Service.Switch(`Bed ${side} power`, `power-${side}`)
 
   service.getCharacteristic(Characteristic.On)
-    .onGet(() => isPowered(monitor, side))
+    .onGet(() => isCurrentlyPowered(monitor, side))
     .onSet(async (value) => {
-      const client = getSharedHardwareClient()
-      if (value) {
-        // setPower(side, true) without a temperature falls back to 75°F.
-        // Preserve the user's last setpoint across power cycles instead.
-        await client.setPower(side, true, readLastTargetF(monitor, side))
-      }
-      else {
-        await client.setPower(side, false)
-      }
+      if (value) await setSidePowerOn(monitor, side)
+      else await setSidePowerOff(monitor, side)
     })
 
   const onStatus = (status: DeviceStatus): void => {
@@ -46,9 +44,4 @@ export function buildPowerSwitch(side: Side, monitor: DacMonitor): PowerSwitchAc
       monitor.off('status:updated', onStatus)
     },
   }
-}
-
-function isPowered(monitor: DacMonitor, side: Side): boolean {
-  const status = monitor.getLastStatus()
-  return status ? isPoweredFromStatus(status, side) : false
 }

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-side hardware-write coordinator for HomeKit accessories.
+ *
+ * The Thermostat and PowerSwitch surfaces both write to the same pod side.
+ * iOS can dispatch parallel onSet callbacks (batched writes from scenes,
+ * automations, or near-simultaneous user gestures), so any non-serialized
+ * caller can race another and stomp the user's setpoint:
+ *
+ *   t0  user drags slider to 78°F
+ *   t1  TargetTemperature.onSet → setTemperature(side, 78)        ──┐
+ *   t2  TargetHeatingCoolingState.onSet → reads stale 70°F target  │ concurrent
+ *   t3  setPower(side, true, 70) → setTemperature(side, 70)       ──┘
+ *
+ * This module funnels every hardware write through a per-side promise queue,
+ * and keeps an in-process cache of the user's last requested target so the
+ * power-on path doesn't depend on firmware preserving targetTemperature
+ * across off-cycles.
+ */
+
+import type { DacMonitor } from '@/src/hardware/dacMonitor'
+import type { DeviceStatus, Side } from '@/src/hardware/types'
+import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL } from '@/src/hardware/types'
+import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+
+const lastTargetF: Record<Side, number | null> = { left: null, right: null }
+
+// Intended power state as expressed by HomeKit, updated eagerly. Used to
+// resolve the "user dragged the slider mid-power-cycle" race: firmware
+// status reads lag behind writes, so isCurrentlyPowered alone can return
+// the pre-toggle value and silently swallow the queued setTemperature.
+const intendedPower: Record<Side, boolean | null> = { left: null, right: null }
+
+const sideQueues: Record<Side, Promise<unknown>> = {
+  left: Promise.resolve(),
+  right: Promise.resolve(),
+}
+
+function serialize<T>(side: Side, fn: () => Promise<T>): Promise<T> {
+  const next = sideQueues[side].then(fn, fn)
+  sideQueues[side] = next.catch(() => undefined)
+  return next
+}
+
+async function logged<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn()
+  }
+  catch (e) {
+    console.warn(`[homekit] ${label} failed:`, e instanceof Error ? e.message : e)
+    throw e
+  }
+}
+
+function clampF(f: number): number {
+  return Math.min(MAX_TEMP, Math.max(MIN_TEMP, f))
+}
+
+export function isPoweredFromStatus(status: DeviceStatus, side: Side): boolean {
+  const s = side === 'left' ? status.leftSide : status.rightSide
+  return s.targetLevel !== 0
+}
+
+export function isCurrentlyPowered(monitor: DacMonitor, side: Side): boolean {
+  const status = monitor.getLastStatus()
+  return status ? isPoweredFromStatus(status, side) : false
+}
+
+/**
+ * Resolve the target setpoint to use when powering a side back on.
+ * Cache wins because firmware may not preserve targetTemperature across
+ * a level=0 (off) write. Falls back to the last firmware status, then to
+ * NEUTRAL so a power-on without any prior context lands on a safe value
+ * instead of the hardware client's hardcoded 75°F default.
+ */
+export function getStagedTargetF(monitor: DacMonitor, side: Side): number {
+  const cached = lastTargetF[side]
+  if (cached !== null) return cached
+  const status = monitor.getLastStatus()
+  if (!status) return TEMP_NEUTRAL
+  const s = side === 'left' ? status.leftSide : status.rightSide
+  return s.targetTemperature
+}
+
+/**
+ * Apply a user-requested target temperature.
+ * - Always update the in-process cache eagerly (so a queued power-on sees it).
+ * - Push to firmware only if the side is currently powered. Adjusting the
+ *   slider while OFF stages the value without forcing a power-on, which
+ *   matches iOS Home thermostat-tile semantics. Power resumes through
+ *   TargetHeatingCoolingState or the dedicated Power switch.
+ *
+ * f is captured in closure so back-to-back drags of the slider each push
+ * their own value, even though the cache only retains the latest.
+ */
+export async function setTargetTemperature(
+  monitor: DacMonitor,
+  side: Side,
+  requestedF: number,
+): Promise<void> {
+  const f = clampF(requestedF)
+  lastTargetF[side] = f
+  await serialize(side, async () => {
+    const intended = intendedPower[side]
+    const powered = intended !== null ? intended : isCurrentlyPowered(monitor, side)
+    if (!powered) return
+    await logged(
+      `setTemperature(${side}, ${f})`,
+      () => getSharedHardwareClient().setTemperature(side, f),
+    )
+  })
+}
+
+/**
+ * Power a side on, preserving the user's last requested target.
+ * Shared by the Thermostat's TargetHeatingCoolingState=AUTO path and the
+ * Power switch's On=true path so both surfaces stay in lockstep.
+ */
+export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<void> {
+  intendedPower[side] = true
+  await serialize(side, async () => {
+    const target = clampF(getStagedTargetF(monitor, side))
+    lastTargetF[side] = target
+    await logged(
+      `setPower(${side}, true, ${target})`,
+      () => getSharedHardwareClient().setPower(side, true, target),
+    )
+  })
+}
+
+export async function setSidePowerOff(monitor: DacMonitor, side: Side): Promise<void> {
+  intendedPower[side] = false
+  await serialize(side, () => logged(
+    `setPower(${side}, false)`,
+    () => getSharedHardwareClient().setPower(side, false),
+  ))
+}
+
+/**
+ * Test-only: clear cached target and reset the side queues.
+ * Module-level state survives across tests in the same file otherwise.
+ */
+export function __resetSideController(): void {
+  lastTargetF.left = null
+  lastTargetF.right = null
+  intendedPower.left = null
+  intendedPower.right = null
+  sideQueues.left = Promise.resolve()
+  sideQueues.right = Promise.resolve()
+}

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -66,6 +66,18 @@ export function isCurrentlyPowered(monitor: DacMonitor, side: Side): boolean {
 }
 
 /**
+ * What HomeKit OnGet should report. Prefers the user's most recent intent
+ * (set eagerly by setSidePowerOn / setSidePowerOff) over firmware status,
+ * which lags by a poll interval. Without this, toggling AUTO can briefly
+ * read back as OFF in iOS Home until the next status update arrives.
+ */
+export function isEffectivelyPowered(monitor: DacMonitor, side: Side): boolean {
+  const intended = intendedPower[side]
+  if (intended !== null) return intended
+  return isCurrentlyPowered(monitor, side)
+}
+
+/**
  * Resolve the target setpoint to use when powering a side back on.
  * Cache wins because firmware may not preserve targetTemperature across
  * a level=0 (off) write. Falls back to the last firmware status, then to

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -114,25 +114,43 @@ export async function setTargetTemperature(
  * Power a side on, preserving the user's last requested target.
  * Shared by the Thermostat's TargetHeatingCoolingState=AUTO path and the
  * Power switch's On=true path so both surfaces stay in lockstep.
+ *
+ * On rejection, intendedPower is rolled back to its prior value so a
+ * subsequent setTargetTemperature doesn't push a write against firmware
+ * that the failed power-on left in an unknown state.
  */
 export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<void> {
+  const prev = intendedPower[side]
   intendedPower[side] = true
-  await serialize(side, async () => {
-    const target = clampF(getStagedTargetF(monitor, side))
-    lastTargetF[side] = target
-    await logged(
-      `setPower(${side}, true, ${target})`,
-      () => getSharedHardwareClient().setPower(side, true, target),
-    )
-  })
+  try {
+    await serialize(side, async () => {
+      const target = clampF(getStagedTargetF(monitor, side))
+      lastTargetF[side] = target
+      await logged(
+        `setPower(${side}, true, ${target})`,
+        () => getSharedHardwareClient().setPower(side, true, target),
+      )
+    })
+  }
+  catch (e) {
+    intendedPower[side] = prev
+    throw e
+  }
 }
 
 export async function setSidePowerOff(monitor: DacMonitor, side: Side): Promise<void> {
+  const prev = intendedPower[side]
   intendedPower[side] = false
-  await serialize(side, () => logged(
-    `setPower(${side}, false)`,
-    () => getSharedHardwareClient().setPower(side, false),
-  ))
+  try {
+    await serialize(side, () => logged(
+      `setPower(${side}, false)`,
+      () => getSharedHardwareClient().setPower(side, false),
+    ))
+  }
+  catch (e) {
+    intendedPower[side] = prev
+    throw e
+  }
 }
 
 /**

--- a/src/homekit/accessories/thermostat.ts
+++ b/src/homekit/accessories/thermostat.ts
@@ -24,7 +24,7 @@ import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
 import { MAX_TEMP, MIN_TEMP } from '@/src/hardware/types'
 import {
-  isCurrentlyPowered,
+  isEffectivelyPowered,
   isPoweredFromStatus,
   setSidePowerOff,
   setSidePowerOn,
@@ -68,7 +68,7 @@ export function buildThermostatService(side: Side, monitor: DacMonitor): Thermos
   // pick a mode the firmware doesn't act on.
   service.getCharacteristic(Characteristic.TargetHeatingCoolingState)
     .setProps({ validValues: [TARGET_OFF, TARGET_AUTO] })
-    .onGet(() => isCurrentlyPowered(monitor, side) ? TARGET_AUTO : TARGET_OFF)
+    .onGet(() => isEffectivelyPowered(monitor, side) ? TARGET_AUTO : TARGET_OFF)
     .onSet(async (value) => {
       if (Number(value) === TARGET_OFF) await setSidePowerOff(monitor, side)
       else await setSidePowerOn(monitor, side)

--- a/src/homekit/accessories/thermostat.ts
+++ b/src/homekit/accessories/thermostat.ts
@@ -8,21 +8,30 @@
  * iOS would fight decreases as deadband-violating. Thermostat is HomeKit's
  * single-setpoint primitive, which matches the pod 1:1.
  *
- * - TargetTemperature → setTemperature
+ * - TargetTemperature → setTargetTemperature (cached, gated on power)
  * - TargetHeatingCoolingState toggles power: 0=off, 3=auto (pod is bidirectional)
  * - CurrentHeatingCoolingState reflects the live drive direction
+ *
+ * All hardware writes go through sideController so concurrent characteristic
+ * onSet callbacks don't race each other and stomp the user's setpoint.
  *
  * HomeKit talks Celsius natively; we convert at the boundary.
  */
 
 import { Service, Characteristic } from 'hap-nodejs'
+import type { Perms } from 'hap-nodejs'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
 import { MAX_TEMP, MIN_TEMP } from '@/src/hardware/types'
-import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+import {
+  isCurrentlyPowered,
+  isPoweredFromStatus,
+  setSidePowerOff,
+  setSidePowerOn,
+  setTargetTemperature,
+} from './sideController'
 
 const f2c = (f: number): number => ((f - 32) * 5) / 9
-const c2f = (c: number): number => (c * 9) / 5 + 32
 
 const MIN_C = f2c(MIN_TEMP)
 const MAX_C = f2c(MAX_TEMP)
@@ -50,8 +59,8 @@ export function buildThermostatService(side: Side, monitor: DacMonitor): Thermos
     .setProps({ minValue: MIN_C, maxValue: MAX_C, minStep: 0.5 })
     .onGet(() => readTargetC(monitor, side))
     .onSet(async (value) => {
-      const f = clampF(c2f(Number(value)))
-      await getSharedHardwareClient().setTemperature(side, f)
+      const f = (Number(value) * 9) / 5 + 32
+      await setTargetTemperature(monitor, side, f)
     })
 
   // Lock to off / auto. HEAT and COOL are removed because the pod's auto
@@ -59,19 +68,10 @@ export function buildThermostatService(side: Side, monitor: DacMonitor): Thermos
   // pick a mode the firmware doesn't act on.
   service.getCharacteristic(Characteristic.TargetHeatingCoolingState)
     .setProps({ validValues: [TARGET_OFF, TARGET_AUTO] })
-    .onGet(() => isPowered(monitor, side) ? TARGET_AUTO : TARGET_OFF)
+    .onGet(() => isCurrentlyPowered(monitor, side) ? TARGET_AUTO : TARGET_OFF)
     .onSet(async (value) => {
-      const client = getSharedHardwareClient()
-      if (Number(value) === TARGET_OFF) {
-        await client.setPower(side, false)
-      }
-      else {
-        // setPower(side, true) without a temperature falls back to 75°F in
-        // the hardware client, which would silently overwrite the user's
-        // last setpoint on every HomeKit power-on. Pass the live target so
-        // power cycles preserve intent.
-        await client.setPower(side, true, readLastTargetF(monitor, side))
-      }
+      if (Number(value) === TARGET_OFF) await setSidePowerOff(monitor, side)
+      else await setSidePowerOn(monitor, side)
     })
 
   service.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
@@ -81,7 +81,7 @@ export function buildThermostatService(side: Side, monitor: DacMonitor): Thermos
   // for display per the controller setting). Drop PAIRED_WRITE so iOS doesn't
   // render a writable C/F toggle that silently bounces back on the next read.
   service.getCharacteristic(Characteristic.TemperatureDisplayUnits)
-    .setProps({ perms: ['pr', 'ev'] as never })
+    .setProps({ perms: ['pr', 'ev'] as Perms[] })
     .onGet(() => 0)
 
   const onStatus = (status: DeviceStatus): void => {
@@ -103,10 +103,6 @@ export function buildThermostatService(side: Side, monitor: DacMonitor): Thermos
   }
 }
 
-function clampF(f: number): number {
-  return Math.min(MAX_TEMP, Math.max(MIN_TEMP, f))
-}
-
 function readCurrentC(monitor: DacMonitor, side: Side): number {
   const status = monitor.getLastStatus()
   return status ? sideC(status, side, 'current') : NEUTRAL_C
@@ -121,28 +117,6 @@ function sideC(status: DeviceStatus, side: Side, kind: 'current' | 'target'): nu
   const s = side === 'left' ? status.leftSide : status.rightSide
   const f = kind === 'current' ? s.currentTemperature : s.targetTemperature
   return f2c(f)
-}
-
-function isPowered(monitor: DacMonitor, side: Side): boolean {
-  const status = monitor.getLastStatus()
-  return status ? isPoweredFromStatus(status, side) : false
-}
-
-// Exported so powerSwitch.ts can reuse the same definition rather than
-// drift on its own copy.
-export function isPoweredFromStatus(status: DeviceStatus, side: Side): boolean {
-  const s = side === 'left' ? status.leftSide : status.rightSide
-  return s.targetLevel !== 0
-}
-
-// Last known target setpoint in °F. Falls back to NEUTRAL when no status
-// has been observed yet so a power-on without a prior poll lands on a
-// safe-ish temp instead of the client's hardcoded 75°F default.
-export function readLastTargetF(monitor: DacMonitor, side: Side): number {
-  const status = monitor.getLastStatus()
-  if (!status) return c2f(NEUTRAL_C)
-  const s = side === 'left' ? status.leftSide : status.rightSide
-  return s.targetTemperature
 }
 
 function deriveCurrentState(monitor: DacMonitor, side: Side): number {

--- a/src/homekit/tests/powerSwitch.test.ts
+++ b/src/homekit/tests/powerSwitch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Characteristic } from 'hap-nodejs'
 
 const setPower = vi.fn().mockResolvedValue(undefined)
@@ -8,6 +8,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
 }))
 
 import { buildPowerSwitch } from '../accessories/powerSwitch'
+import { __resetSideController } from '../accessories/sideController'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus } from '@/src/hardware/types'
 
@@ -26,6 +27,11 @@ const fakeMonitor: Pick<DacMonitor, 'on' | 'getLastStatus'> = {
 }
 
 describe('powerSwitch accessory', () => {
+  beforeEach(() => {
+    __resetSideController()
+    setPower.mockClear()
+  })
+
   it('On.onGet reflects targetLevel !== 0', async () => {
     const { service: leftSvc } = buildPowerSwitch('left', fakeMonitor as DacMonitor)
     expect(await leftSvc.getCharacteristic(Characteristic.On).handleGetRequest()).toBe(true)
@@ -35,15 +41,16 @@ describe('powerSwitch accessory', () => {
   })
 
   it('On.onSet routes to setPower and preserves the last target on power-on', async () => {
-    setPower.mockClear()
     const { service } = buildPowerSwitch('left', fakeMonitor as DacMonitor)
-    await service.getCharacteristic(Characteristic.On).setValue(true)
+    // handleSetRequest properly awaits onSet's full chain; setValue's await
+    // resolves on `this` and skips microtasks scheduled inside the chain.
+    await service.getCharacteristic(Characteristic.On).handleSetRequest(true)
     // Left fixture targetTemperature is 70°F — must pass through so the
     // hardware client doesn't fall back to its hardcoded 75°F default.
     expect(setPower).toHaveBeenCalledWith('left', true, 70)
 
     setPower.mockClear()
-    await service.getCharacteristic(Characteristic.On).setValue(false)
+    await service.getCharacteristic(Characteristic.On).handleSetRequest(false)
     expect(setPower).toHaveBeenCalledWith('left', false)
   })
 

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -11,6 +11,7 @@ import {
   __resetSideController,
   getStagedTargetF,
   isCurrentlyPowered,
+  isEffectivelyPowered,
   isPoweredFromStatus,
   setSidePowerOff,
   setSidePowerOn,
@@ -59,6 +60,24 @@ describe('sideController', () => {
 
     it('returns false when monitor has no status yet', () => {
       expect(isCurrentlyPowered(monitor(null), 'left')).toBe(false)
+    })
+  })
+
+  describe('isEffectivelyPowered', () => {
+    it('mirrors firmware status when no write has happened yet', () => {
+      expect(isEffectivelyPowered(monitor(onStatus), 'left')).toBe(true)
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+    })
+
+    it('reports user intent immediately after a power-on, ahead of firmware lag', async () => {
+      // Side's firmware status still says OFF until the next poll runs.
+      await setSidePowerOn(monitor(offStatus), 'left')
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(true)
+    })
+
+    it('reports user intent immediately after a power-off, ahead of firmware lag', async () => {
+      await setSidePowerOff(monitor(onStatus), 'left')
+      expect(isEffectivelyPowered(monitor(onStatus), 'left')).toBe(false)
     })
   })
 

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -143,7 +143,7 @@ describe('sideController', () => {
   describe('serialization', () => {
     it('serializes concurrent writes to the same side in submission order', async () => {
       const order: string[] = []
-      let resolveTemp: (() => void) | null = null
+      let resolveTemp: () => void = () => {}
       setTemperature.mockImplementation(async (_s, f) => {
         order.push(`setTemp(${f})`)
         if (f === 78) {
@@ -167,7 +167,7 @@ describe('sideController', () => {
       await Promise.resolve()
       expect(order).toEqual(['setTemp(78)'])
 
-      resolveTemp?.()
+      resolveTemp()
       await Promise.all([p1, p2])
 
       // p2 reads cache populated by p1 (78), so power-on uses the latest target.
@@ -176,7 +176,7 @@ describe('sideController', () => {
 
     it('does not block a different side', async () => {
       const order: string[] = []
-      let resolveLeft: (() => void) | null = null
+      let resolveLeft: () => void = () => {}
       setTemperature.mockImplementation(async (s, f) => {
         order.push(`${s}:${f}`)
         if (s === 'left') {
@@ -193,7 +193,7 @@ describe('sideController', () => {
       await right // right resolves without waiting on left
       expect(order).toEqual(['left:60', 'right:90'])
 
-      resolveLeft?.()
+      resolveLeft()
       await left
     })
 
@@ -247,6 +247,38 @@ describe('sideController', () => {
         expect.stringContaining('[homekit] setPower(right, false) failed:'),
         'comms',
       )
+      warn.mockRestore()
+    })
+  })
+
+  describe('intendedPower rollback', () => {
+    it('reverts intendedPower when setSidePowerOn rejects so a later setTargetTemperature does not push to a still-off side', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      // Side starts off (intendedPower=null, firmware=off).
+      const m = monitor(offStatus)
+      setPower.mockRejectedValueOnce(new Error('hardware down'))
+      await expect(setSidePowerOn(m, 'left')).rejects.toThrow('hardware down')
+
+      // intendedPower must have rolled back to null/false. Adjusting target
+      // now should NOT push to firmware (side is genuinely off).
+      await setTargetTemperature(m, 'left', 68)
+      expect(setTemperature).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('reverts intendedPower when setSidePowerOff rejects', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      // Side is on (intendedPower=true after a successful power-on).
+      await setSidePowerOn(monitor(onStatus), 'left')
+      expect(setPower).toHaveBeenCalledWith('left', true, expect.any(Number))
+      setPower.mockClear()
+
+      setPower.mockRejectedValueOnce(new Error('hardware down'))
+      await expect(setSidePowerOff(monitor(onStatus), 'left')).rejects.toThrow('hardware down')
+
+      // intendedPower must remain true so a slider drag still pushes through.
+      await setTargetTemperature(monitor(onStatus), 'left', 72)
+      expect(setTemperature).toHaveBeenCalledWith('left', 72)
       warn.mockRestore()
     })
   })

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setTemperature = vi.fn()
+const setPower = vi.fn()
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: () => ({ setTemperature, setPower }),
+}))
+
+import {
+  __resetSideController,
+  getStagedTargetF,
+  isCurrentlyPowered,
+  isPoweredFromStatus,
+  setSidePowerOff,
+  setSidePowerOn,
+  setTargetTemperature,
+} from '../accessories/sideController'
+import type { DacMonitor } from '@/src/hardware/dacMonitor'
+import type { DeviceStatus } from '@/src/hardware/types'
+
+const offStatus: DeviceStatus = {
+  leftSide: { currentTemperature: 75, targetTemperature: 70, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+  rightSide: { currentTemperature: 75, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+  waterLevel: 'ok',
+  isPriming: false,
+  podVersion: 'I00' as never,
+  sensorLabel: 'pod4',
+}
+
+const onStatus: DeviceStatus = {
+  ...offStatus,
+  leftSide: { ...offStatus.leftSide, targetLevel: -45 },
+  rightSide: { ...offStatus.rightSide, targetLevel: 30 },
+}
+
+const monitor = (status: DeviceStatus | null): DacMonitor =>
+  ({ getLastStatus: () => status }) as unknown as DacMonitor
+
+describe('sideController', () => {
+  beforeEach(() => {
+    __resetSideController()
+    setTemperature.mockReset()
+    setPower.mockReset()
+    setTemperature.mockResolvedValue(undefined)
+    setPower.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    __resetSideController()
+  })
+
+  describe('isPoweredFromStatus / isCurrentlyPowered', () => {
+    it('treats targetLevel === 0 as off and non-zero as on', () => {
+      expect(isPoweredFromStatus(offStatus, 'left')).toBe(false)
+      expect(isPoweredFromStatus(onStatus, 'left')).toBe(true)
+      expect(isPoweredFromStatus(onStatus, 'right')).toBe(true)
+    })
+
+    it('returns false when monitor has no status yet', () => {
+      expect(isCurrentlyPowered(monitor(null), 'left')).toBe(false)
+    })
+  })
+
+  describe('getStagedTargetF', () => {
+    it('falls back to firmware targetTemperature when cache is empty', () => {
+      expect(getStagedTargetF(monitor(offStatus), 'left')).toBe(70)
+      expect(getStagedTargetF(monitor(offStatus), 'right')).toBe(75)
+    })
+
+    it('falls back to TEMP_NEUTRAL when monitor has no status', () => {
+      // TEMP_NEUTRAL = 82.5
+      expect(getStagedTargetF(monitor(null), 'left')).toBe(82.5)
+    })
+
+    it('prefers cached target once setTargetTemperature runs', async () => {
+      const m = monitor(onStatus)
+      await setTargetTemperature(m, 'left', 68)
+      expect(getStagedTargetF(m, 'left')).toBe(68)
+    })
+
+    it('prefers cache even after firmware reports a different value', async () => {
+      // User typed 65; later poll shows firmware reset target to 82.5 while off.
+      // Without the cache, a power-on would land on neutral instead of 65.
+      await setTargetTemperature(monitor(onStatus), 'left', 65)
+      expect(getStagedTargetF(monitor({
+        ...offStatus,
+        leftSide: { ...offStatus.leftSide, targetTemperature: 82.5, targetLevel: 0 },
+      }), 'left')).toBe(65)
+    })
+  })
+
+  describe('setTargetTemperature', () => {
+    it('clamps below MIN_TEMP up to 55°F before pushing', async () => {
+      await setTargetTemperature(monitor(onStatus), 'left', -10)
+      expect(setTemperature).toHaveBeenCalledWith('left', 55)
+    })
+
+    it('clamps above MAX_TEMP down to 110°F before pushing', async () => {
+      await setTargetTemperature(monitor(onStatus), 'left', 999)
+      expect(setTemperature).toHaveBeenCalledWith('left', 110)
+    })
+
+    it('caches the requested target even when the side is off (no firmware write)', async () => {
+      await setTargetTemperature(monitor(offStatus), 'left', 68)
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(getStagedTargetF(monitor(offStatus), 'left')).toBe(68)
+    })
+
+    it('caches AND writes when the side is on', async () => {
+      await setTargetTemperature(monitor(onStatus), 'left', 72)
+      expect(setTemperature).toHaveBeenCalledWith('left', 72)
+      expect(getStagedTargetF(monitor(onStatus), 'left')).toBe(72)
+    })
+  })
+
+  describe('setSidePowerOn', () => {
+    it('reads cached target when present', async () => {
+      const m = monitor(offStatus)
+      await setTargetTemperature(m, 'left', 68)
+      await setSidePowerOn(m, 'left')
+      expect(setPower).toHaveBeenCalledWith('left', true, 68)
+    })
+
+    it('falls back to firmware status target when no cache exists', async () => {
+      await setSidePowerOn(monitor(offStatus), 'right')
+      expect(setPower).toHaveBeenCalledWith('right', true, 75)
+    })
+
+    it('falls back to TEMP_NEUTRAL when no status and no cache', async () => {
+      await setSidePowerOn(monitor(null), 'left')
+      expect(setPower).toHaveBeenCalledWith('left', true, 82.5)
+    })
+  })
+
+  describe('setSidePowerOff', () => {
+    it('routes to setPower(side, false)', async () => {
+      await setSidePowerOff(monitor(onStatus), 'left')
+      expect(setPower).toHaveBeenCalledWith('left', false)
+    })
+  })
+
+  describe('serialization', () => {
+    it('serializes concurrent writes to the same side in submission order', async () => {
+      const order: string[] = []
+      let resolveTemp: (() => void) | null = null
+      setTemperature.mockImplementation(async (_s, f) => {
+        order.push(`setTemp(${f})`)
+        if (f === 78) {
+          await new Promise<void>((r) => {
+            resolveTemp = r
+          })
+        }
+      })
+      setPower.mockImplementation(async (_s, on, f) => {
+        order.push(`setPower(${on},${f ?? '-'})`)
+      })
+
+      const m = monitor(onStatus)
+      // Start a slow setTemperature write...
+      const p1 = setTargetTemperature(m, 'left', 78)
+      // ...then immediately queue a power-on. Must NOT run before p1's await resolves.
+      const p2 = setSidePowerOn(m, 'left')
+
+      // Give microtasks a chance — p2's body should still be blocked behind p1.
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(order).toEqual(['setTemp(78)'])
+
+      resolveTemp?.()
+      await Promise.all([p1, p2])
+
+      // p2 reads cache populated by p1 (78), so power-on uses the latest target.
+      expect(order).toEqual(['setTemp(78)', 'setPower(true,78)'])
+    })
+
+    it('does not block a different side', async () => {
+      const order: string[] = []
+      let resolveLeft: (() => void) | null = null
+      setTemperature.mockImplementation(async (s, f) => {
+        order.push(`${s}:${f}`)
+        if (s === 'left') {
+          await new Promise<void>((r) => {
+            resolveLeft = r
+          })
+        }
+      })
+
+      const m = monitor(onStatus)
+      const left = setTargetTemperature(m, 'left', 60)
+      const right = setTargetTemperature(m, 'right', 90)
+
+      await right // right resolves without waiting on left
+      expect(order).toEqual(['left:60', 'right:90'])
+
+      resolveLeft?.()
+      await left
+    })
+
+    it('does not wedge the queue when a write rejects', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      setTemperature.mockRejectedValueOnce(new Error('hardware down'))
+      const m = monitor(onStatus)
+      await expect(setTargetTemperature(m, 'left', 70)).rejects.toThrow('hardware down')
+      setTemperature.mockResolvedValueOnce(undefined)
+      await setTargetTemperature(m, 'left', 72)
+      expect(setTemperature).toHaveBeenLastCalledWith('left', 72)
+      warn.mockRestore()
+    })
+
+    it('a queued setTemperature still runs when a power-on toggle preceded it on a previously-off side', async () => {
+      // Race regression: side starts OFF. User toggles AUTO and drags the
+      // slider. Without intendedPower, setTargetTemperature evaluates power
+      // state from the still-stale firmware status ("off") and silently
+      // skips — losing the user's setpoint. intendedPower must override
+      // firmware lag so the queued setTemperature fires anyway.
+      const m = monitor(offStatus)
+      const p1 = setSidePowerOn(m, 'left')
+      const p2 = setTargetTemperature(m, 'left', 78)
+      await Promise.all([p1, p2])
+      // Both surfaces must have reached the hardware. Exact setPower target
+      // depends on microtask interleaving (cache may already hold 78 by the
+      // time setSidePowerOn's fn runs); what matters is setTemperature(78)
+      // was NOT silently dropped.
+      expect(setPower).toHaveBeenCalledWith('left', true, expect.any(Number))
+      expect(setTemperature).toHaveBeenCalledWith('left', 78)
+    })
+  })
+
+  describe('error logging', () => {
+    it('logs and rethrows when setTemperature rejects', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      setTemperature.mockRejectedValueOnce(new Error('boom'))
+      await expect(setTargetTemperature(monitor(onStatus), 'left', 70)).rejects.toThrow('boom')
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('[homekit] setTemperature(left, 70) failed:'),
+        'boom',
+      )
+      warn.mockRestore()
+    })
+
+    it('logs and rethrows when setPower rejects', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      setPower.mockRejectedValueOnce(new Error('comms'))
+      await expect(setSidePowerOff(monitor(onStatus), 'right')).rejects.toThrow('comms')
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('[homekit] setPower(right, false) failed:'),
+        'comms',
+      )
+      warn.mockRestore()
+    })
+  })
+})

--- a/src/homekit/tests/thermostat.test.ts
+++ b/src/homekit/tests/thermostat.test.ts
@@ -54,7 +54,7 @@ describe('thermostat accessory', () => {
     setTemperature.mockClear()
     const { service } = buildThermostatService('left', fakeMonitor as DacMonitor)
     // Way above range: 100°C → clamped to MAX_TEMP (110°F).
-    await service.getCharacteristic(Characteristic.TargetTemperature).setValue(100)
+    await service.getCharacteristic(Characteristic.TargetTemperature).handleSetRequest(100)
     expect(setTemperature).toHaveBeenCalled()
     const [, f] = setTemperature.mock.calls[0]
     expect(f).toBeLessThanOrEqual(110)
@@ -64,7 +64,7 @@ describe('thermostat accessory', () => {
   it('clamps below-range TargetTemperature up to MIN_TEMP', async () => {
     setTemperature.mockClear()
     const { service } = buildThermostatService('left', fakeMonitor as DacMonitor)
-    await service.getCharacteristic(Characteristic.TargetTemperature).setValue(-10)
+    await service.getCharacteristic(Characteristic.TargetTemperature).handleSetRequest(-10)
     expect(setTemperature).toHaveBeenCalled()
     const [, f] = setTemperature.mock.calls[0]
     expect(f).toBeGreaterThanOrEqual(55)
@@ -99,7 +99,7 @@ describe('thermostat accessory', () => {
     // Left fixture targetTemperature is 70°F; simulate dragging the slider
     // down to 65°F. Old HeaterCooler dual-threshold collapsed on decrease
     // and iOS rejected it as deadband-violating.
-    await service.getCharacteristic(Characteristic.TargetTemperature).setValue(f2c(65))
+    await service.getCharacteristic(Characteristic.TargetTemperature).handleSetRequest(f2c(65))
     expect(setTemperature).toHaveBeenCalledTimes(1)
     const [, f] = setTemperature.mock.calls[0]
     expect(f).toBeGreaterThan(64)

--- a/src/homekit/tests/thermostat.test.ts
+++ b/src/homekit/tests/thermostat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Characteristic } from 'hap-nodejs'
 
 const setTemperature = vi.fn().mockResolvedValue(undefined)
@@ -9,6 +9,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
 }))
 
 import { buildThermostatService } from '../accessories/thermostat'
+import { __resetSideController } from '../accessories/sideController'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus } from '@/src/hardware/types'
 
@@ -29,6 +30,12 @@ const fakeMonitor: Pick<DacMonitor, 'on' | 'getLastStatus'> = {
 const f2c = (f: number) => ((f - 32) * 5) / 9
 
 describe('thermostat accessory', () => {
+  beforeEach(() => {
+    __resetSideController()
+    setTemperature.mockClear()
+    setPower.mockClear()
+  })
+
   it('reports current temperature in Celsius via onGet', async () => {
     const { service } = buildThermostatService('left', fakeMonitor as DacMonitor)
     const value = await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()
@@ -73,15 +80,16 @@ describe('thermostat accessory', () => {
   })
 
   it('TargetHeatingCoolingState onSet routes to setPower and preserves the last target on power-on', async () => {
-    setPower.mockClear()
     const { service } = buildThermostatService('right', fakeMonitor as DacMonitor)
-    await service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setValue(3)
+    // handleSetRequest properly awaits onSet's full chain; setValue's await
+    // resolves on `this` and skips microtasks scheduled inside the chain.
+    await service.getCharacteristic(Characteristic.TargetHeatingCoolingState).handleSetRequest(3)
     // Right fixture targetTemperature is 80°F — must pass through so the
     // hardware client doesn't silently fall back to its 75°F default.
     expect(setPower).toHaveBeenCalledWith('right', true, 80)
 
     setPower.mockClear()
-    await service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setValue(0)
+    await service.getCharacteristic(Characteristic.TargetHeatingCoolingState).handleSetRequest(0)
     expect(setPower).toHaveBeenCalledWith('right', false)
   })
 


### PR DESCRIPTION
## Summary

Follow-up to #527 addressing onSet findings from the post-merge review.

- **F1 — concurrent-write race**: HAP-NodeJS dispatches each characteristic write on its own callback. iOS scenes / automations can fire `TargetTemperature.onSet` and `TargetHeatingCoolingState.onSet` in parallel, and the power-on path's stale-snapshot read of \`readLastTargetF\` could overwrite a fresh \`setTemperature\` milliseconds later — same class of bug HeaterCooler had. Every Thermostat / PowerSwitch hardware write now funnels through a per-side promise queue in the new \`sideController.ts\`, so writes against the same side can never overlap.
- **F2 — slider gates on power state**: \`TargetTemperature.onSet\` no longer auto-powers-on. When the side is OFF the new target is staged in the in-process cache; iOS resumes power through the thermostat mode or the dedicated Power switch, both of which now read the cache.
- **F3 — observability**: every onSet write is wrapped in a \`logged()\` helper that emits \`console.warn('[homekit] <op> failed:', e)\` matching the existing snoozeSwitch / bridge log style. iOS still reverts the characteristic on rejection, but the cause now shows up in process logs.
- **F4 — target cache survives power cycles**: \`lastTargetF\` is kept in-process so we no longer depend on firmware preserving \`targetTemperature\` after a level=0 (off) write. \`getStagedTargetF\` reads cache → firmware status → \`TEMP_NEUTRAL\`.
- **F5 — single power-on helper**: thermostat and powerSwitch both call \`setSidePowerOn\` / \`setSidePowerOff\`; the duplicated \`setPower(side, true, readLastTargetF(...))\` is gone.
- **F6 — typed Perms**: \`setProps({ perms: ['pr', 'ev'] as Perms[] })\` instead of \`as never\`.

F7 (the hardcoded \`75\` fallback inside \`setPower\` in \`dacMonitor.instance.ts\`) is pre-existing and intentionally not touched here — F1+F4 keep us from reaching that path. Worth a separate cleanup if we want to remove the fallback entirely.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm lint\` clean (no new warnings or errors)
- [x] \`pnpm vitest run\`: 844/844 pass (1 skipped, pre-existing). New \`sideController.test.ts\` covers the cache, serialization order, the cross-side independence guarantee, the rejection-doesn't-wedge-the-queue case, error logging on both \`setTemperature\` and \`setPower\` rejection, and the previously-OFF race regression.
- [ ] Manual after deploy: drive a scene that toggles AUTO and adjusts temp simultaneously — both reach hardware, final setpoint matches the user's drag, no silent revert.
- [ ] Manual after deploy: power off a side, drag the slider, then power back on — side comes up at the dragged target, not the firmware default.
- [ ] Manual after deploy: kill the DAC socket while a setPower is in flight — \`[homekit]\` warning appears in logs, characteristic reverts in iOS Home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-side coordination for hardware writes with staged temperature caching and a consistent fallback temperature when powering on.

* **Bug Fixes**
  * Prevented race conditions between concurrent power/temperature commands and preserved user setpoints across power cycles and gesture-based toggles.

* **Tests**
  * Expanded test coverage for power/temperature sequencing, serialization, error handling, rollback, and gesture behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/528)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->