### PR TITLE
docs: add iOS codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sleepypod
 
-[![codecov](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
+[![core coverage](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
+[![ios coverage](https://codecov.io/gh/sleepypod/ios/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/ios)
 
 A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web interface and scheduler.
 


### PR DESCRIPTION
Adds the iOS coverage badge alongside the existing core badge so the umbrella README surfaces both repos' coverage at a glance.