### PR TITLE
feat(biometrics): export tarball + nightly rsync push (sp-20, sp-21)

### DIFF
--- a/app/api/export/archive/route.test.ts
+++ b/app/api/export/archive/route.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the export archive route's pure helper. The streaming response
+ * itself is exercised via the production smoke (a manual curl in the PR
+ * description) — here we verify the file-selection logic that decides which
+ * RAW waveforms and gzipped archives end up in the tarball.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, writeFile, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { gatherRawFiles } from './route'
+
+let root: string
+let tmpfsDir: string
+let archiveDir: string
+let legacyDir: string
+
+async function touchAt(file: string, unixSec: number) {
+  await writeFile(file, '')
+  await utimes(file, unixSec, unixSec)
+}
+
+beforeAll(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'sp-export-test-'))
+  tmpfsDir = path.join(root, 'biometrics')
+  archiveDir = path.join(root, 'biometrics-archive')
+  legacyDir = path.join(root, 'legacy')
+  await mkdir(tmpfsDir)
+  await mkdir(archiveDir)
+  await mkdir(legacyDir)
+
+  // tmpfs: live RAW frames at t=1000 and t=2000
+  await touchAt(path.join(tmpfsDir, '00010001.RAW'), 1000)
+  await touchAt(path.join(tmpfsDir, '00010002.RAW'), 2000)
+  // archive: gzipped cold archives at t=500 and t=1500
+  await touchAt(path.join(archiveDir, '00009998.RAW.gz'), 500)
+  await touchAt(path.join(archiveDir, '00009999.RAW.gz'), 1500)
+  // legacy /persistent: same basename as a tmpfs file (dedup target) plus a stray
+  await touchAt(path.join(legacyDir, '00010001.RAW'), 1000)
+  await touchAt(path.join(legacyDir, '00007777.RAW'), 800)
+  // junk that must not match
+  await touchAt(path.join(tmpfsDir, 'NOTRAW.txt'), 1500)
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('gatherRawFiles', () => {
+  it('returns files from all sources whose mtime falls in [startTs, endTs]', async () => {
+    const result = await gatherRawFiles([tmpfsDir, archiveDir, legacyDir], 0, 5000)
+    const names = result.map(f => f.basename).sort()
+    expect(names).toEqual([
+      '00007777.RAW',
+      '00009998.RAW.gz',
+      '00009999.RAW.gz',
+      '00010001.RAW',
+      '00010002.RAW',
+    ])
+  })
+
+  it('includes both .RAW and .RAW.gz', async () => {
+    const result = await gatherRawFiles([tmpfsDir, archiveDir], 0, 5000)
+    const names = result.map(f => f.basename)
+    expect(names).toContain('00010001.RAW')
+    expect(names).toContain('00009999.RAW.gz')
+  })
+
+  it('filters by mtime window', async () => {
+    const result = await gatherRawFiles([tmpfsDir, archiveDir], 1200, 1800)
+    expect(result.map(f => f.basename)).toEqual(['00009999.RAW.gz'])
+  })
+
+  it('dedupes same basename across sources, preferring earlier dirs', async () => {
+    const result = await gatherRawFiles([tmpfsDir, legacyDir], 0, 5000)
+    const winners = result.filter(f => f.basename === '00010001.RAW')
+    expect(winners).toHaveLength(1)
+    expect(winners[0].abs.startsWith(tmpfsDir)).toBe(true)
+  })
+
+  it('rejects names that are not seqno.RAW or seqno.RAW.gz', async () => {
+    const result = await gatherRawFiles([tmpfsDir], 0, 5000)
+    expect(result.find(f => f.basename === 'NOTRAW.txt')).toBeUndefined()
+  })
+
+  it('tolerates missing source dirs', async () => {
+    const result = await gatherRawFiles(
+      ['/nonexistent/path/does/not/exist', tmpfsDir],
+      0,
+      5000,
+    )
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('returns an empty list when no files match the window', async () => {
+    const result = await gatherRawFiles([tmpfsDir, archiveDir], 9000, 9999)
+    expect(result).toEqual([])
+  })
+})

--- a/app/api/export/archive/route.ts
+++ b/app/api/export/archive/route.ts
@@ -5,13 +5,65 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Readable } from 'node:stream'
 
-const EXPORT_TOKEN = process.env.EXPORT_TOKEN
 const BIOMETRICS_DB_PATH = process.env.BIOMETRICS_DATABASE_URL?.replace('file:', '') ?? ''
-const RAW_DIR = process.env.RAW_DATA_DIR ?? '/persistent'
 
-const SAFE_FILENAME = /^[\w.-]+\.RAW$/i
+// Raw waveform sources, in priority order. After the tmpfs migration (#499)
+// firmware writes to RAW_TMPFS_DIR; the archiver gzips into RAW_ARCHIVE_DIR.
+// RAW_DATA_DIR remains so pre-#499 pods (with *.RAW directly on /persistent)
+// still export.
+const RAW_TMPFS_DIR = process.env.RAW_TMPFS_DIR ?? '/persistent/biometrics'
+const RAW_ARCHIVE_DIR = process.env.RAW_ARCHIVE_DIR ?? '/persistent/biometrics-archive'
+const RAW_LEGACY_DIR = process.env.RAW_DATA_DIR ?? '/persistent'
+
+// Accepts <seqno>.RAW (live) or <seqno>.RAW.gz (cold archive).
+const SAFE_RAW_NAME = /^[\w.-]+\.RAW(\.gz)?$/i
 
 let inflight = false
+
+interface SourceFile {
+  abs: string
+  basename: string
+}
+
+/**
+ * Walk one source dir for *.RAW or *.RAW.gz whose mtime falls in
+ * [startTs, endTs]. Missing dir → []. Same basename across dirs is
+ * deduped (tmpfs wins over archive wins over legacy) to avoid two
+ * copies of the same waveform window in the tarball.
+ */
+export async function gatherRawFiles(
+  sources: readonly string[],
+  startTs: number,
+  endTs: number,
+): Promise<SourceFile[]> {
+  const seen = new Set<string>()
+  const out: SourceFile[] = []
+  for (const dir of sources) {
+    let entries: string[]
+    try {
+      entries = await readdir(dir)
+    }
+    catch {
+      continue
+    }
+    for (const name of entries) {
+      if (!SAFE_RAW_NAME.test(name)) continue
+      if (seen.has(name)) continue
+      const full = path.join(dir, name)
+      try {
+        const s = await stat(full)
+        const mtime = Math.floor(s.mtime.getTime() / 1000)
+        if (mtime < startTs || mtime > endTs) continue
+        seen.add(name)
+        out.push({ abs: full, basename: name })
+      }
+      catch {
+        // skip unreadable entry
+      }
+    }
+  }
+  return out
+}
 
 async function dumpSqlite(dbPath: string, outPath: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -32,14 +84,6 @@ async function dumpSqlite(dbPath: string, outPath: string): Promise<void> {
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
-
-  if (!EXPORT_TOKEN) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-  const token = url.searchParams.get('token')
-  if (!token || token !== EXPORT_TOKEN) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
 
   if (inflight) {
     return Response.json(
@@ -67,21 +111,16 @@ export async function GET(request: Request) {
     if (include.includes('raw')) {
       const rawStaged = path.join(stagingDir, 'raw')
       await mkdir(rawStaged)
-      let entries: string[] = []
-      try {
-        entries = await readdir(RAW_DIR)
-      }
-      catch { /* RAW_DIR missing — ok, archive will have empty raw/ */ }
-      for (const name of entries) {
-        if (!SAFE_FILENAME.test(name)) continue
-        const full = path.join(RAW_DIR, name)
+      const files = await gatherRawFiles(
+        [RAW_TMPFS_DIR, RAW_ARCHIVE_DIR, RAW_LEGACY_DIR],
+        startTs,
+        endTs,
+      )
+      for (const f of files) {
         try {
-          const s = await stat(full)
-          const mtime = Math.floor(s.mtime.getTime() / 1000)
-          if (mtime < startTs || mtime > endTs) continue
-          await symlink(full, path.join(rawStaged, name))
+          await symlink(f.abs, path.join(rawStaged, f.basename))
         }
-        catch { /* skip unreadable entry */ }
+        catch { /* skip duplicates / unreadable */ }
       }
     }
 

--- a/modules/archive-push/archive-push.example.conf
+++ b/modules/archive-push/archive-push.example.conf
@@ -1,6 +1,6 @@
 # Example config for sleepypod-archive-push.
-# Copy to /etc/sleepypod/archive-push.conf and edit. Sourced as bash —
-# values must be plain strings without quotes (or properly quoted).
+# Copy to /etc/sleepypod/archive-push.conf and edit. Plain KEY=VALUE —
+# values are read literally, NOT bash-sourced. Do not quote values.
 
 # Master switch. Default false; flip to true once HOST/REMOTE_USER/REMOTE_PATH
 # are set and the identity key has been added to the remote authorized_keys.

--- a/modules/archive-push/archive-push.example.conf
+++ b/modules/archive-push/archive-push.example.conf
@@ -1,0 +1,19 @@
+# Example config for sleepypod-archive-push.
+# Copy to /etc/sleepypod/archive-push.conf and edit. Sourced as bash —
+# values must be plain strings without quotes (or properly quoted).
+
+# Master switch. Default false; flip to true once HOST/REMOTE_USER/REMOTE_PATH
+# are set and the identity key has been added to the remote authorized_keys.
+ENABLED=false
+
+# Remote target.
+HOST=nas.local
+REMOTE_USER=sleepypod
+REMOTE_PATH=/volume1/sleepypod-archive
+PORT=22
+
+# SSH identity. Generated on the pod via Settings → Backup → "Generate Key".
+IDENTITY=/etc/sleepypod/archive-push.id_ed25519
+
+# Comma-separated. Currently supported: raw, db.
+INCLUDE=raw,db

--- a/modules/archive-push/sleepypod-archive-push
+++ b/modules/archive-push/sleepypod-archive-push
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Push gzipped biometrics archive (and optional db dump) to a user-configured
-# remote via rsync over ssh. Reads /etc/sleepypod/archive-push.conf (sourced
-# as bash). Disabled by default — config flips ENABLED=true.
+# remote via rsync over ssh. Reads /etc/sleepypod/archive-push.conf as plain
+# KEY=VALUE (NOT bash-sourced — the conf is written by an LAN-reachable tRPC
+# handler and sourcing would be a command-injection sink). Disabled by default
+# — config flips ENABLED=true.
 #
 # Designed for nightly timer runs. No-ops cleanly when disabled or
 # misconfigured so a stale config doesn't crash the timer.
@@ -16,8 +18,21 @@ if [ ! -f "$CONFIG" ]; then
   exit 0
 fi
 
-# shellcheck disable=SC1090
-source "$CONFIG"
+# Read KEY=VALUE without `source` so attacker-controlled values never hit
+# a shell parser. `declare -g` assigns the literal string; nothing inside
+# value gets word-split, expanded, or evaluated.
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    ''|'#'*) continue ;;
+  esac
+  key="${line%%=*}"
+  value="${line#*=}"
+  case "$key" in
+    ENABLED|HOST|REMOTE_USER|REMOTE_PATH|PORT|IDENTITY|INCLUDE)
+      declare -g "$key"="$value"
+      ;;
+  esac
+done < "$CONFIG"
 
 if [ "${ENABLED:-false}" != "true" ]; then
   echo "archive-push: ENABLED=false — skipping"
@@ -36,7 +51,7 @@ if [ ! -f "$IDENTITY" ]; then
   exit 1
 fi
 
-SSH_CMD="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p $PORT -i $IDENTITY"
+SSH_CMD="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/etc/sleepypod/known_hosts -o ConnectTimeout=15 -p $PORT -i $IDENTITY"
 
 pushed_raw=0
 pushed_db=0

--- a/modules/archive-push/sleepypod-archive-push
+++ b/modules/archive-push/sleepypod-archive-push
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Push gzipped biometrics archive (and optional db dump) to a user-configured
+# remote via rsync over ssh. Reads /etc/sleepypod/archive-push.conf (sourced
+# as bash). Disabled by default — config flips ENABLED=true.
+#
+# Designed for nightly timer runs. No-ops cleanly when disabled or
+# misconfigured so a stale config doesn't crash the timer.
+set -euo pipefail
+
+CONFIG="${ARCHIVE_PUSH_CONFIG:-/etc/sleepypod/archive-push.conf}"
+ARCHIVE_DIR="${ARCHIVE_DIR:-/persistent/biometrics-archive}"
+DB_PATH="${BIOMETRICS_DB_PATH:-/persistent/sleepypod-data/biometrics.db}"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "archive-push: no config at $CONFIG — skipping"
+  exit 0
+fi
+
+# shellcheck disable=SC1090
+source "$CONFIG"
+
+if [ "${ENABLED:-false}" != "true" ]; then
+  echo "archive-push: ENABLED=false — skipping"
+  exit 0
+fi
+
+: "${HOST:?HOST required in $CONFIG}"
+: "${REMOTE_USER:?REMOTE_USER required in $CONFIG}"
+: "${REMOTE_PATH:?REMOTE_PATH required in $CONFIG}"
+IDENTITY="${IDENTITY:-/etc/sleepypod/archive-push.id_ed25519}"
+PORT="${PORT:-22}"
+INCLUDE="${INCLUDE:-raw,db}"
+
+if [ ! -f "$IDENTITY" ]; then
+  echo "archive-push: identity $IDENTITY missing — generate via Settings → Backup" >&2
+  exit 1
+fi
+
+SSH_CMD="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -p $PORT -i $IDENTITY"
+
+pushed_raw=0
+pushed_db=0
+
+if [[ ",$INCLUDE," == *",raw,"* ]] && [ -d "$ARCHIVE_DIR" ]; then
+  echo "archive-push: rsync $ARCHIVE_DIR -> $REMOTE_USER@$HOST:$REMOTE_PATH/raw/"
+  rsync -az --partial --timeout=300 -e "$SSH_CMD" \
+    "$ARCHIVE_DIR/" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/raw/"
+  pushed_raw=1
+fi
+
+if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
+  stamp=$(date -u +%Y%m%dT%H%M%SZ)
+  tmp=$(mktemp -t sp-bio-XXXXXX.sql.gz)
+  trap 'rm -f "$tmp"' EXIT
+  sqlite3 "$DB_PATH" .dump | gzip > "$tmp"
+  echo "archive-push: rsync biometrics.sql.gz -> $REMOTE_USER@$HOST:$REMOTE_PATH/db/biometrics-$stamp.sql.gz"
+  rsync -az --partial --timeout=300 -e "$SSH_CMD" \
+    "$tmp" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/db/biometrics-$stamp.sql.gz"
+  pushed_db=1
+fi
+
+echo "archive-push: done raw=$pushed_raw db=$pushed_db"

--- a/modules/archive-push/sleepypod-archive-push.service
+++ b/modules/archive-push/sleepypod-archive-push.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Sleepypod biometrics archive push to remote (rsync over ssh)
+Documentation=https://github.com/sleepypod/core/tree/main/modules/archive-push
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sleepypod
+Group=sleepypod
+ExecStart=/usr/local/bin/sleepypod-archive-push
+Nice=10
+IOSchedulingClass=idle
+ProtectSystem=strict
+ReadWritePaths=/etc/sleepypod
+PrivateTmp=true
+NoNewPrivileges=true

--- a/modules/archive-push/sleepypod-archive-push.timer
+++ b/modules/archive-push/sleepypod-archive-push.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily sleepypod archive push (03:30 local)
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+RandomizedDelaySec=15min
+Unit=sleepypod-archive-push.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install
+++ b/scripts/install
@@ -1161,7 +1161,7 @@ if [ -d "$PUSH_SRC" ]; then
   install -m 0644 "$PUSH_SRC/sleepypod-archive-push.service" /etc/systemd/system/
   install -m 0644 "$PUSH_SRC/sleepypod-archive-push.timer"   /etc/systemd/system/
 
-  # Config dir owned root:sleepypod 0750 so the service user reads + the app
+  # Config dir owned root:sleepypod 0770 so the service user reads + the app
   # user (in group sleepypod) writes via the tRPC handlers.
   mkdir -p /etc/sleepypod
   if id sleepypod &>/dev/null; then

--- a/scripts/install
+++ b/scripts/install
@@ -744,21 +744,19 @@ if [ -f "$INSTALL_DIR/.env" ]; then
     sed -i "s|^BIOMETRICS_DATABASE_URL=.*|BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db|" "$INSTALL_DIR/.env" || \
     echo "BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db" >> "$INSTALL_DIR/.env"
 
-  # Generate EXPORT_TOKEN once if missing — preserved across upgrades.
-  if ! grep -q "^EXPORT_TOKEN=" "$INSTALL_DIR/.env"; then
-    echo "EXPORT_TOKEN=$(head -c 24 /dev/urandom | base64 | tr -d '+/=' )" >> "$INSTALL_DIR/.env"
+  # EXPORT_TOKEN was retired with the LAN-only export endpoint — strip if present.
+  if grep -q "^EXPORT_TOKEN=" "$INSTALL_DIR/.env"; then
+    sed -i '/^EXPORT_TOKEN=/d' "$INSTALL_DIR/.env"
   fi
 else
   echo "Creating environment file..."
   touch "$INSTALL_DIR/.env"
   chmod 640 "$INSTALL_DIR/.env"
-  EXPORT_TOKEN_VAL="$(head -c 24 /dev/urandom | base64 | tr -d '+/=' )"
   cat > "$INSTALL_DIR/.env" << EOF
 DATABASE_URL=file:$DATA_DIR/sleepypod.db
 BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db
 DAC_SOCK_PATH=$DAC_SOCK_PATH
 NODE_ENV=production
-EXPORT_TOKEN=$EXPORT_TOKEN_VAL
 EOF
 fi
 
@@ -1146,6 +1144,42 @@ if [ -d "$ARCHIVER_SRC" ]; then
     fi
   done
   [ "$archived" -gt 0 ] && echo "Archived $archived stranded pre-tmpfs RAW files"
+fi
+
+# ============================================================================
+# Archive push — nightly rsync of cold archive to user-configured remote.
+# ============================================================================
+# Disabled by default; user opts in via Settings → Backup. Config + ssh key
+# live under /etc/sleepypod (writeable by the sleepypod group so the
+# next-server tRPC handlers can stage them). The unit runs as the sleepypod
+# user, not root — same trust boundary as the rest of the app.
+PUSH_SRC="$INSTALL_DIR/modules/archive-push"
+if [ -d "$PUSH_SRC" ]; then
+  echo "Installing archive-push (rsync to remote)..."
+
+  install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
+  install -m 0644 "$PUSH_SRC/sleepypod-archive-push.service" /etc/systemd/system/
+  install -m 0644 "$PUSH_SRC/sleepypod-archive-push.timer"   /etc/systemd/system/
+
+  # Config dir owned root:sleepypod 0750 so the service user reads + the app
+  # user (in group sleepypod) writes via the tRPC handlers.
+  mkdir -p /etc/sleepypod
+  if id sleepypod &>/dev/null; then
+    chown root:sleepypod /etc/sleepypod
+    chmod 0770 /etc/sleepypod
+  fi
+
+  # Seed example conf only if no real conf exists.
+  if [ ! -f /etc/sleepypod/archive-push.conf ] && [ ! -f /etc/sleepypod/archive-push.example.conf ]; then
+    install -m 0640 "$PUSH_SRC/archive-push.example.conf" /etc/sleepypod/archive-push.example.conf
+    if id sleepypod &>/dev/null; then
+      chown root:sleepypod /etc/sleepypod/archive-push.example.conf
+    fi
+  fi
+
+  systemctl daemon-reload
+  # Timer always enabled; the script no-ops when ENABLED=false in the conf.
+  systemctl enable --now sleepypod-archive-push.timer
 fi
 
 # Re-fix DB permissions after all services restarted with new UMask.

--- a/src/components/Settings/ArchivePushSettingsForm.tsx
+++ b/src/components/Settings/ArchivePushSettingsForm.tsx
@@ -146,7 +146,10 @@ function Editor({ initial }: { initial: InitialConfig }) {
             <input
               type="number"
               value={form.port}
-              onChange={e => setForm(f => ({ ...f, port: Number(e.target.value) || 22 }))}
+              onChange={(e) => {
+                const parsed = Number(e.target.value)
+                setForm(f => ({ ...f, port: Number.isFinite(parsed) ? parsed : 22 }))
+              }}
               className="w-32 rounded-lg bg-zinc-800 px-3 py-2 text-sm text-white outline-none focus:ring-1 focus:ring-sky-500"
             />
           </Field>

--- a/src/components/Settings/ArchivePushSettingsForm.tsx
+++ b/src/components/Settings/ArchivePushSettingsForm.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState } from 'react'
+import { CheckCircle2, Copy, Globe, KeyRound, Loader2, Plug, Save, User, XCircle } from 'lucide-react'
+import { trpc } from '@/src/utils/trpc'
+import { Toggle } from './Toggle'
+
+interface FormState {
+  enabled: boolean
+  host: string
+  remoteUser: string
+  remotePath: string
+  port: number
+  identity: string
+  include: Array<'raw' | 'db'>
+}
+
+interface InitialConfig {
+  config: FormState
+  publicKey: string | null
+}
+
+/**
+ * Settings form for the archive-push feature (sp-21). Lets the user
+ * configure a remote rsync target, generate an ssh keypair on the pod,
+ * copy the pubkey into their remote's authorized_keys, and run a
+ * non-destructive connection test before flipping ENABLED on.
+ *
+ * The inner editor uses a `key` prop bound to the loaded config so a
+ * server-driven change (e.g. after generateKey) cleanly remounts and
+ * picks up the new initial state without a setState-in-effect.
+ */
+export function ArchivePushSettingsForm() {
+  const configQuery = trpc.archivePush.getConfig.useQuery({})
+
+  if (configQuery.isLoading) {
+    return <div className="h-40 animate-pulse rounded-2xl bg-zinc-900" />
+  }
+
+  const data = configQuery.data ?? {
+    config: {
+      enabled: false,
+      host: '',
+      remoteUser: '',
+      remotePath: '',
+      port: 22,
+      identity: '/etc/sleepypod/archive-push.id_ed25519',
+      include: ['raw', 'db'] as Array<'raw' | 'db'>,
+    },
+    publicKey: null,
+  }
+
+  // Stable key drawn from the server snapshot — when the user generates a
+  // key (or another tab edits the conf) the snapshot changes, the key
+  // changes, and the editor remounts cleanly with the latest defaults.
+  const formKey = JSON.stringify({ c: data.config, k: data.publicKey })
+
+  return <Editor key={formKey} initial={data} />
+}
+
+function Editor({ initial }: { initial: InitialConfig }) {
+  const utils = trpc.useUtils()
+  const setConfig = trpc.archivePush.setConfig.useMutation({
+    onSuccess: () => utils.archivePush.getConfig.invalidate(),
+  })
+  const generateKey = trpc.archivePush.generateKey.useMutation({
+    onSuccess: () => utils.archivePush.getConfig.invalidate(),
+  })
+  const testConnection = trpc.archivePush.testConnection.useMutation()
+
+  const [form, setForm] = useState<FormState>(() => ({
+    ...initial.config,
+    include: [...initial.config.include],
+  }))
+  const [copied, setCopied] = useState(false)
+
+  const publicKey = initial.publicKey
+
+  const handleSave = () => setConfig.mutate(form)
+
+  const handleCopy = async () => {
+    if (!publicKey) return
+    try {
+      await navigator.clipboard.writeText(publicKey)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    }
+    catch {
+      /* clipboard blocked — user can select manually */
+    }
+  }
+
+  const toggleInclude = (key: 'raw' | 'db') => {
+    setForm(f => ({
+      ...f,
+      include: f.include.includes(key)
+        ? f.include.filter(k => k !== key)
+        : [...f.include, key],
+    }))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl bg-zinc-900 p-4">
+        <h3 className="mb-1 text-sm font-semibold text-white">Nightly archive push</h3>
+        <p className="mb-4 text-xs text-zinc-500">
+          Rsync the cold archive (and a biometrics.db dump) to a host you control. Runs once per
+          night via systemd timer. Disabled by default.
+        </p>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-zinc-200">Enable nightly push</span>
+          <Toggle
+            label="Enable nightly push"
+            enabled={form.enabled}
+            onToggle={() => setForm(f => ({ ...f, enabled: !f.enabled }))}
+          />
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <Field icon={Globe} label="Host">
+            <input
+              value={form.host}
+              onChange={e => setForm(f => ({ ...f, host: e.target.value }))}
+              placeholder="nas.local"
+              className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-white outline-none focus:ring-1 focus:ring-sky-500"
+            />
+          </Field>
+          <Field icon={User} label="Remote user">
+            <input
+              value={form.remoteUser}
+              onChange={e => setForm(f => ({ ...f, remoteUser: e.target.value }))}
+              placeholder="sleepypod"
+              className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-white outline-none focus:ring-1 focus:ring-sky-500"
+            />
+          </Field>
+          <Field icon={Globe} label="Remote path">
+            <input
+              value={form.remotePath}
+              onChange={e => setForm(f => ({ ...f, remotePath: e.target.value }))}
+              placeholder="/volume1/sleepypod-archive"
+              className="w-full rounded-lg bg-zinc-800 px-3 py-2 text-sm text-white outline-none focus:ring-1 focus:ring-sky-500"
+            />
+          </Field>
+          <Field icon={Globe} label="Port">
+            <input
+              type="number"
+              value={form.port}
+              onChange={e => setForm(f => ({ ...f, port: Number(e.target.value) || 22 }))}
+              className="w-32 rounded-lg bg-zinc-800 px-3 py-2 text-sm text-white outline-none focus:ring-1 focus:ring-sky-500"
+            />
+          </Field>
+
+          <div>
+            <span className="mb-2 block text-xs font-medium text-zinc-400">Include</span>
+            <div className="flex gap-2">
+              {(['raw', 'db'] as const).map(key => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => toggleInclude(key)}
+                  className={`flex-1 rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
+                    form.include.includes(key)
+                      ? 'bg-sky-600 text-white'
+                      : 'bg-zinc-800 text-zinc-400'
+                  }`}
+                >
+                  {key === 'raw' ? 'RAW waveforms' : 'biometrics.db'}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <button
+          onClick={handleSave}
+          disabled={setConfig.isPending}
+          className="mt-4 flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl bg-sky-600 p-3 text-sm font-medium text-white active:bg-sky-700 disabled:opacity-50"
+        >
+          {setConfig.isPending ? <Loader2 size={16} className="animate-spin" /> : <Save size={16} />}
+          {setConfig.isSuccess && !setConfig.isPending ? 'Saved' : 'Save'}
+        </button>
+      </div>
+
+      <div className="rounded-2xl bg-zinc-900 p-4">
+        <div className="mb-2 flex items-center gap-2">
+          <KeyRound size={14} className="text-amber-400" />
+          <h3 className="text-sm font-semibold text-white">SSH identity</h3>
+        </div>
+        <p className="mb-3 text-xs text-zinc-500">
+          Generate an ed25519 keypair on the pod, then add the public key to
+          {' '}
+          <code className="text-zinc-300">~/.ssh/authorized_keys</code>
+          {' '}
+          on your remote.
+        </p>
+
+        {publicKey
+          ? (
+              <div className="space-y-2">
+                <pre className="overflow-x-auto rounded-lg bg-zinc-800 p-3 font-mono text-[10px] text-zinc-300">
+                  {publicKey}
+                </pre>
+                <button
+                  onClick={handleCopy}
+                  className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl bg-zinc-800 p-3 text-sm font-medium text-zinc-200 active:bg-zinc-700"
+                >
+                  <Copy size={14} />
+                  {copied ? 'Copied' : 'Copy public key'}
+                </button>
+              </div>
+            )
+          : (
+              <button
+                onClick={() => generateKey.mutate({})}
+                disabled={generateKey.isPending}
+                className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl bg-zinc-800 p-3 text-sm font-medium text-zinc-200 active:bg-zinc-700 disabled:opacity-50"
+              >
+                {generateKey.isPending
+                  ? <Loader2 size={14} className="animate-spin" />
+                  : <KeyRound size={14} />}
+                Generate ed25519 keypair
+              </button>
+            )}
+        {generateKey.error && (
+          <p className="mt-2 text-xs text-red-400">{generateKey.error.message}</p>
+        )}
+      </div>
+
+      <div className="rounded-2xl bg-zinc-900 p-4">
+        <div className="mb-2 flex items-center gap-2">
+          <Plug size={14} className="text-emerald-400" />
+          <h3 className="text-sm font-semibold text-white">Test connection</h3>
+        </div>
+        <p className="mb-3 text-xs text-zinc-500">
+          Probe the remote with a non-destructive
+          {' '}
+          <code className="text-zinc-300">ssh ... true</code>
+          . Save first if you&apos;ve edited the form.
+        </p>
+        <button
+          onClick={() => testConnection.mutate({})}
+          disabled={testConnection.isPending}
+          className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl bg-zinc-800 p-3 text-sm font-medium text-zinc-200 active:bg-zinc-700 disabled:opacity-50"
+        >
+          {testConnection.isPending ? <Loader2 size={14} className="animate-spin" /> : <Plug size={14} />}
+          Run test
+        </button>
+        {testConnection.data && (
+          <div className={`mt-3 flex items-start gap-2 rounded-lg p-3 text-xs ${
+            testConnection.data.ok
+              ? 'bg-emerald-950/40 text-emerald-300'
+              : 'bg-red-950/40 text-red-300'
+          }`}
+          >
+            {testConnection.data.ok ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
+            <span className="font-mono break-all">{testConnection.data.message}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({ icon: Icon, label, children }: {
+  icon: React.ComponentType<{ size?: number, className?: string }>
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 flex items-center gap-1.5 text-xs font-medium text-zinc-400">
+        <Icon size={12} />
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Settings, User, RotateCcw, Wifi, Hand, Radio, Cog } from 'lucide-react'
+import { Settings, User, RotateCcw, Wifi, Hand, Radio, Cog, HardDriveUpload } from 'lucide-react'
 import clsx from 'clsx'
 import { trpc } from '@/src/utils/trpc'
 import { useSideNames } from '@/src/hooks/useSideNames'
@@ -13,8 +13,9 @@ import { TapGestureConfig } from './TapGestureConfig'
 import { HapticsTestCard } from './HapticsTestCard'
 import { MqttSettingsForm } from './MqttSettingsForm'
 import { HomeKitConfig } from './HomeKitConfig'
+import { ArchivePushSettingsForm } from './ArchivePushSettingsForm'
 
-const TAB_IDS = ['device', 'sides', 'gestures', 'mqtt'] as const
+const TAB_IDS = ['device', 'sides', 'gestures', 'mqtt', 'backup'] as const
 type TabId = typeof TAB_IDS[number]
 
 function isTabId(v: string | null): v is TabId {
@@ -77,12 +78,13 @@ export function SettingsScreen() {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="gap-4">
-        <TabsList className="grid h-10 w-full grid-cols-4 gap-1 rounded-xl bg-zinc-900 p-1">
+        <TabsList className="grid h-10 w-full grid-cols-5 gap-1 rounded-xl bg-zinc-900 p-1">
           {([
             { id: 'device', label: 'Device', Icon: Cog },
             { id: 'sides', label: 'Sides', Icon: User },
             { id: 'gestures', label: 'Gestures', Icon: Hand },
             { id: 'mqtt', label: 'MQTT', Icon: Radio },
+            { id: 'backup', label: 'Backup', Icon: HardDriveUpload },
           ] as const).map(({ id, label, Icon }) => (
             <TabsTrigger
               key={id}
@@ -109,6 +111,10 @@ export function SettingsScreen() {
 
         <TabsContent value="mqtt">
           <MqttSettingsForm />
+        </TabsContent>
+
+        <TabsContent value="backup">
+          <ArchivePushSettingsForm />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/biometrics/RawDataButton.tsx
+++ b/src/components/biometrics/RawDataButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useMemo } from 'react'
-import { Download, X, FileText, HardDrive, Trash2, Database } from 'lucide-react'
+import { Download, X, FileText, HardDrive, Trash2, Database, Package } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { useSide } from '@/src/hooks/useSide'
 import { useWeekNavigator } from '@/src/hooks/useWeekNavigator'
@@ -171,6 +171,14 @@ export function RawDataButton() {
     link.click()
   }, [])
 
+  const exportArchive = useCallback(() => {
+    const startTs = Math.floor(weekStart.getTime() / 1000)
+    const endTs = Math.floor(weekEnd.getTime() / 1000)
+    const link = document.createElement('a')
+    link.href = `/api/export/archive?startTs=${startTs}&endTs=${endTs}&include=raw,db`
+    link.click()
+  }, [weekStart, weekEnd])
+
   return (
     <>
       <button
@@ -315,6 +323,18 @@ export function RawDataButton() {
             {/* Info text — matches iOS */}
             <p className="mt-3 text-center text-[10px] text-zinc-500">
               CSV files can be opened in Excel, Numbers, or imported into Python/R for analysis.
+            </p>
+
+            {/* Full archive — RAW waveforms + biometrics.db dump for the visible week */}
+            <button
+              onClick={exportArchive}
+              className="mt-3 flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl bg-zinc-800/60 p-3 text-sm font-medium text-zinc-200 active:bg-zinc-700"
+            >
+              <Package size={16} className="text-amber-400" />
+              Export Archive (.tar.gz)
+            </button>
+            <p className="mt-2 text-center text-[10px] text-zinc-500">
+              RAW waveforms + biometrics.db SQL dump for this week. Untar then `sqlite3 biometrics.db &lt; biometrics.sql`.
             </p>
 
             {/* Raw sensor files section — wired to raw.files tRPC router */}

--- a/src/server/routers/app.ts
+++ b/src/server/routers/app.ts
@@ -13,6 +13,7 @@ import { waterLevelRouter } from './waterLevel'
 import { runOnceRouter } from './runOnce'
 import { mqttRouter } from './mqtt'
 import { homekitRouter } from './homekit'
+import { archivePushRouter } from './archivePush'
 
 export const appRouter = router({
   healthcheck: publicProcedure
@@ -37,6 +38,7 @@ export const appRouter = router({
   runOnce: runOnceRouter,
   mqtt: mqttRouter,
   homekit: homekitRouter,
+  archivePush: archivePushRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/archivePush.ts
+++ b/src/server/routers/archivePush.ts
@@ -1,0 +1,255 @@
+/**
+ * tRPC router for the archive-push feature (sp-21). Reads and writes
+ * /etc/sleepypod/archive-push.conf, generates an ed25519 keypair the user
+ * adds to their remote's authorized_keys, and runs a connection test via
+ * `ssh -o BatchMode=yes`. The push itself is driven by a systemd timer —
+ * this router only manipulates configuration.
+ *
+ * Why a flat KEY=VALUE conf instead of yaml: the timer's bash script
+ * sources it directly, no parser needed on either side.
+ */
+import { z } from 'zod'
+import { TRPCError } from '@trpc/server'
+import { execFile } from 'node:child_process'
+import { access, mkdir, readFile, writeFile, chmod } from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { publicProcedure, router } from '@/src/server/trpc'
+
+const execFileAsync = promisify(execFile)
+
+// Lazily read at each call so tests can override via env (vitest sets them
+// in beforeAll after the module has already imported).
+function paths() {
+  const dir = process.env.ARCHIVE_PUSH_CONFIG_DIR ?? '/etc/sleepypod'
+  const config = process.env.ARCHIVE_PUSH_CONFIG ?? path.join(dir, 'archive-push.conf')
+  const identity = process.env.ARCHIVE_PUSH_IDENTITY ?? path.join(dir, 'archive-push.id_ed25519')
+  return { dir, config, identity, pubkey: `${identity}.pub` }
+}
+
+// Whitelisted keys — anything else in the file is preserved silently when
+// rewriting (so a future field added by a newer pod doesn't get dropped on
+// rollback), but not exposed to the API.
+const KNOWN_KEYS = ['ENABLED', 'HOST', 'REMOTE_USER', 'REMOTE_PATH', 'PORT', 'IDENTITY', 'INCLUDE'] as const
+
+const ConfigSchema = z.object({
+  enabled: z.boolean(),
+  host: z.string(),
+  remoteUser: z.string(),
+  remotePath: z.string(),
+  port: z.number().int().min(1).max(65535),
+  identity: z.string(),
+  include: z.array(z.enum(['raw', 'db'])).min(0),
+})
+
+type ConfigShape = z.infer<typeof ConfigSchema>
+
+function defaultConfig(): ConfigShape {
+  return {
+    enabled: false,
+    host: '',
+    remoteUser: '',
+    remotePath: '',
+    port: 22,
+    identity: paths().identity,
+    include: ['raw', 'db'],
+  }
+}
+
+/** Parse a KEY=VALUE conf file. Trims whitespace; ignores blanks and `#` comments. */
+export function parseConf(text: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq < 0) continue
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+    // Strip surrounding single or double quotes if balanced.
+    const dq = '"'
+    const sq = '\''
+    if (
+      (value.startsWith(dq) && value.endsWith(dq))
+      || (value.startsWith(sq) && value.endsWith(sq))
+    ) {
+      value = value.slice(1, -1)
+    }
+    out[key] = value
+  }
+  return out
+}
+
+/** Render a config back to KEY=VALUE text. Leading comment + stable key order. */
+export function renderConf(cfg: ConfigShape): string {
+  const lines = [
+    '# /etc/sleepypod/archive-push.conf — managed by Settings → Backup.',
+    '# Sourced as bash by sleepypod-archive-push. Edit via the UI when possible.',
+    `ENABLED=${cfg.enabled ? 'true' : 'false'}`,
+    `HOST=${cfg.host}`,
+    `REMOTE_USER=${cfg.remoteUser}`,
+    `REMOTE_PATH=${cfg.remotePath}`,
+    `PORT=${cfg.port}`,
+    `IDENTITY=${cfg.identity}`,
+    `INCLUDE=${cfg.include.join(',')}`,
+    '',
+  ]
+  return lines.join('\n')
+}
+
+function confToShape(parsed: Record<string, string>): ConfigShape {
+  const include = (parsed.INCLUDE ?? 'raw,db')
+    .split(',')
+    .map(s => s.trim())
+    .filter((s): s is 'raw' | 'db' => s === 'raw' || s === 'db')
+  const port = Number(parsed.PORT ?? '22')
+  return {
+    enabled: parsed.ENABLED === 'true',
+    host: parsed.HOST ?? '',
+    remoteUser: parsed.REMOTE_USER ?? '',
+    remotePath: parsed.REMOTE_PATH ?? '',
+    port: Number.isFinite(port) && port > 0 ? port : 22,
+    identity: parsed.IDENTITY ?? paths().identity,
+    include: include.length > 0 ? include : ['raw', 'db'],
+  }
+}
+
+async function readConfig(): Promise<ConfigShape> {
+  try {
+    const text = await readFile(paths().config, 'utf8')
+    return confToShape(parseConf(text))
+  }
+  catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return defaultConfig()
+    throw err
+  }
+}
+
+async function writeConfig(cfg: ConfigShape): Promise<void> {
+  const p = paths()
+  await mkdir(p.dir, { recursive: true })
+  await writeFile(p.config, renderConf(cfg), { mode: 0o640 })
+}
+
+async function readPublicKey(): Promise<string | null> {
+  try {
+    return (await readFile(paths().pubkey, 'utf8')).trim()
+  }
+  catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+}
+
+export const archivePushRouter = router({
+  /** Current config + whether an SSH identity has been generated. */
+  getConfig: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/archive-push/config', protect: false, tags: ['ArchivePush'] } })
+    .input(z.object({}))
+    .output(z.object({
+      config: ConfigSchema,
+      publicKey: z.string().nullable(),
+    }))
+    .query(async () => {
+      const [config, publicKey] = await Promise.all([readConfig(), readPublicKey()])
+      return { config, publicKey }
+    }),
+
+  /** Persist config to /etc/sleepypod/archive-push.conf. */
+  setConfig: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/archive-push/config', protect: false, tags: ['ArchivePush'] } })
+    .input(ConfigSchema)
+    .output(z.object({ ok: z.literal(true) }))
+    .mutation(async ({ input }) => {
+      await writeConfig(input)
+      return { ok: true }
+    }),
+
+  /**
+   * Generate an ed25519 keypair at IDENTITY_PATH if it does not exist.
+   * Idempotent — returns the public key either way. The user copies the
+   * pubkey into their remote's authorized_keys to enable push.
+   */
+  generateKey: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/archive-push/key', protect: false, tags: ['ArchivePush'] } })
+    .input(z.object({}))
+    .output(z.object({ publicKey: z.string(), generated: z.boolean() }))
+    .mutation(async () => {
+      const p = paths()
+      await mkdir(p.dir, { recursive: true })
+
+      let generated = false
+      try {
+        await access(p.identity)
+      }
+      catch {
+        try {
+          await execFileAsync('ssh-keygen', [
+            '-t', 'ed25519',
+            '-N', '',
+            '-f', p.identity,
+            '-C', 'sleepypod-archive-push',
+          ], { timeout: 15000 })
+          generated = true
+          await chmod(p.identity, 0o600).catch(() => {})
+        }
+        catch (err) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `ssh-keygen failed: ${err instanceof Error ? err.message : String(err)}`,
+          })
+        }
+      }
+
+      const pub = await readPublicKey()
+      if (!pub) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Public key missing after generation',
+        })
+      }
+      return { publicKey: pub, generated }
+    }),
+
+  /**
+   * Probe the remote with `ssh -o BatchMode=yes <host> true`. Validates the
+   * key is authorized + host accepts the connection. No side effects beyond
+   * a possible known_hosts append on first contact.
+   */
+  testConnection: publicProcedure
+    .meta({ openapi: { method: 'POST', path: '/archive-push/test', protect: false, tags: ['ArchivePush'] } })
+    .input(z.object({}))
+    .output(z.object({ ok: z.boolean(), message: z.string() }))
+    .mutation(async () => {
+      const cfg = await readConfig()
+      if (!cfg.host || !cfg.remoteUser) {
+        return { ok: false, message: 'host and remoteUser must be set before testing' }
+      }
+      try {
+        await access(cfg.identity)
+      }
+      catch {
+        return { ok: false, message: `identity ${cfg.identity} missing — generate a key first` }
+      }
+      try {
+        await execFileAsync('ssh', [
+          '-o', 'BatchMode=yes',
+          '-o', 'StrictHostKeyChecking=accept-new',
+          '-o', 'ConnectTimeout=10',
+          '-i', cfg.identity,
+          '-p', String(cfg.port),
+          `${cfg.remoteUser}@${cfg.host}`,
+          'true',
+        ], { timeout: 15000 })
+        return { ok: true, message: 'connection ok' }
+      }
+      catch (err) {
+        const stderr = (err as { stderr?: string }).stderr ?? (err instanceof Error ? err.message : String(err))
+        return { ok: false, message: stderr.toString().trim().slice(0, 500) }
+      }
+    }),
+})
+
+// Re-export for tests that want to assert against the resolved paths.
+export const __test__ = { paths, KNOWN_KEYS }

--- a/src/server/routers/archivePush.ts
+++ b/src/server/routers/archivePush.ts
@@ -28,18 +28,21 @@ function paths() {
   return { dir, config, identity, pubkey: `${identity}.pub` }
 }
 
-// Whitelisted keys — anything else in the file is preserved silently when
-// rewriting (so a future field added by a newer pod doesn't get dropped on
-// rollback), but not exposed to the API.
+// Whitelisted keys — every other key in the file is dropped on rewrite.
+// (Past comments claimed passthrough; we don't actually do that.)
 const KNOWN_KEYS = ['ENABLED', 'HOST', 'REMOTE_USER', 'REMOTE_PATH', 'PORT', 'IDENTITY', 'INCLUDE'] as const
+
+// String fields land in a bash-sourced conf — reject anything that could
+// terminate the line or sneak past shell-quoting (CR, LF, NUL).
+const SAFE_STRING = z.string().regex(/^[^\r\n\0]*$/, 'no newlines or NUL')
 
 const ConfigSchema = z.object({
   enabled: z.boolean(),
-  host: z.string(),
-  remoteUser: z.string(),
-  remotePath: z.string(),
+  host: SAFE_STRING,
+  remoteUser: SAFE_STRING,
+  remotePath: SAFE_STRING,
   port: z.number().int().min(1).max(65535),
-  identity: z.string(),
+  identity: SAFE_STRING,
   include: z.array(z.enum(['raw', 'db'])).min(0),
 })
 
@@ -57,7 +60,12 @@ function defaultConfig(): ConfigShape {
   }
 }
 
-/** Parse a KEY=VALUE conf file. Trims whitespace; ignores blanks and `#` comments. */
+/**
+ * Parse a KEY=VALUE conf file. Trims surrounding whitespace on both key
+ * and value (manual edits often leave spaces around `=`); preserves
+ * internal whitespace. The companion bash reader does the same, so the
+ * file is *not* `source`d.
+ */
 export function parseConf(text: string): Record<string, string> {
   const out: Record<string, string> = {}
   for (const raw of text.split(/\r?\n/)) {
@@ -66,26 +74,24 @@ export function parseConf(text: string): Record<string, string> {
     const eq = line.indexOf('=')
     if (eq < 0) continue
     const key = line.slice(0, eq).trim()
-    let value = line.slice(eq + 1).trim()
-    // Strip surrounding single or double quotes if balanced.
-    const dq = '"'
-    const sq = '\''
-    if (
-      (value.startsWith(dq) && value.endsWith(dq))
-      || (value.startsWith(sq) && value.endsWith(sq))
-    ) {
-      value = value.slice(1, -1)
-    }
-    out[key] = value
+    if (!key) continue
+    out[key] = line.slice(eq + 1).trim()
   }
   return out
 }
 
-/** Render a config back to KEY=VALUE text. Leading comment + stable key order. */
+/**
+ * Render a config to KEY=VALUE text. Values are written verbatim — the
+ * bash reader assigns them via `declare`, never `source`, so quoting is
+ * unnecessary AND attacker-controlled values cannot reach a shell parser.
+ * The schema rejects CR/LF/NUL on string fields; nothing else can split a
+ * line or sneak past the reader.
+ */
 export function renderConf(cfg: ConfigShape): string {
   const lines = [
     '# /etc/sleepypod/archive-push.conf — managed by Settings → Backup.',
-    '# Sourced as bash by sleepypod-archive-push. Edit via the UI when possible.',
+    '# Read by sleepypod-archive-push as plain KEY=VALUE. Do NOT `source` it —',
+    '# values are not shell-quoted on purpose.',
     `ENABLED=${cfg.enabled ? 'true' : 'false'}`,
     `HOST=${cfg.host}`,
     `REMOTE_USER=${cfg.remoteUser}`,
@@ -185,9 +191,15 @@ export const archivePushRouter = router({
       }
       catch {
         try {
+          // Quiet flag suppresses the comment line. Concurrent generateKey
+          // calls will both pass access() and both invoke ssh-keygen — the
+          // second hits the "Overwrite?" prompt and we'll surface the 15s
+          // timeout. Acceptable: the failure mode is "user retries", and
+          // the UI button is debounced by isPending anyway.
           await execFileAsync('ssh-keygen', [
             '-t', 'ed25519',
             '-N', '',
+            '-q',
             '-f', p.identity,
             '-C', 'sleepypod-archive-push',
           ], { timeout: 15000 })
@@ -236,6 +248,9 @@ export const archivePushRouter = router({
         await execFileAsync('ssh', [
           '-o', 'BatchMode=yes',
           '-o', 'StrictHostKeyChecking=accept-new',
+          // sleepypod's home is /nonexistent — point known_hosts at the
+          // service's writable config dir so accept-new can persist.
+          '-o', `UserKnownHostsFile=${path.join(paths().dir, 'known_hosts')}`,
           '-o', 'ConnectTimeout=10',
           '-i', cfg.identity,
           '-p', String(cfg.port),

--- a/src/server/routers/tests/archivePush.test.ts
+++ b/src/server/routers/tests/archivePush.test.ts
@@ -46,10 +46,10 @@ describe('parseConf', () => {
     expect(result).toEqual({ ENABLED: 'true', HOST: 'nas.local', PORT: '2222' })
   })
 
-  it('strips matched surrounding quotes', () => {
+  it('preserves values verbatim — does not strip quotes (we do not source)', () => {
     const result = parseConf('REMOTE_PATH="/volume1/sleepypod"\nINCLUDE=\'raw,db\'')
-    expect(result.REMOTE_PATH).toBe('/volume1/sleepypod')
-    expect(result.INCLUDE).toBe('raw,db')
+    expect(result.REMOTE_PATH).toBe('"/volume1/sleepypod"')
+    expect(result.INCLUDE).toBe('\'raw,db\'')
   })
 
   it('skips lines without =', () => {
@@ -78,6 +78,27 @@ describe('renderConf', () => {
     expect(parsed.PORT).toBe('2222')
     expect(parsed.IDENTITY).toBe('/etc/sleepypod/key')
     expect(parsed.INCLUDE).toBe('raw,db')
+  })
+
+  // Regression: the original renderer interpolated values raw and the bash
+  // script `source`d the result, so a malicious LAN client could land RCE
+  // via `host: "x$(curl … | bash)"`. We now read KEY=VALUE without sourcing,
+  // and the schema rejects CR/LF/NUL — so every other byte must round-trip.
+  it('round-trips values containing shell metacharacters', () => {
+    const cfg = {
+      enabled: false,
+      host: 'host with space and $(cmd)',
+      remoteUser: 'user`tick`',
+      remotePath: '/path with \'quote\' and "dquote"',
+      port: 22,
+      identity: '/etc/sleepypod/key',
+      include: ['raw'] as const,
+    }
+    const parsed = parseConf(renderConf({ ...cfg, include: [...cfg.include] }))
+    expect(parsed.HOST).toBe(cfg.host)
+    expect(parsed.REMOTE_USER).toBe(cfg.remoteUser)
+    expect(parsed.REMOTE_PATH).toBe(cfg.remotePath)
+    expect(parsed.IDENTITY).toBe(cfg.identity)
   })
 })
 

--- a/src/server/routers/tests/archivePush.test.ts
+++ b/src/server/routers/tests/archivePush.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the archive-push router. Covers conf parsing/rendering,
+ * getConfig/setConfig roundtrip on a temp dir, and behaviour when the conf
+ * is absent. Excludes ssh-keygen / ssh — those shell out to binaries we'd
+ * have to mock and provide little signal in a unit run.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+let configDir: string
+
+beforeAll(async () => {
+  configDir = await mkdtemp(path.join(tmpdir(), 'sp-push-test-'))
+  process.env.ARCHIVE_PUSH_CONFIG_DIR = configDir
+  process.env.ARCHIVE_PUSH_CONFIG = path.join(configDir, 'archive-push.conf')
+  process.env.ARCHIVE_PUSH_IDENTITY = path.join(configDir, 'archive-push.id_ed25519')
+})
+
+afterAll(async () => {
+  await rm(configDir, { recursive: true, force: true })
+  delete process.env.ARCHIVE_PUSH_CONFIG_DIR
+  delete process.env.ARCHIVE_PUSH_CONFIG
+  delete process.env.ARCHIVE_PUSH_IDENTITY
+})
+
+beforeEach(async () => {
+  await rm(path.join(configDir, 'archive-push.conf'), { force: true })
+  await rm(path.join(configDir, 'archive-push.id_ed25519.pub'), { force: true })
+})
+
+const { archivePushRouter, parseConf, renderConf } = await import('@/src/server/routers/archivePush')
+const caller = archivePushRouter.createCaller({})
+
+describe('parseConf', () => {
+  it('parses KEY=VALUE pairs and ignores blanks + comments', () => {
+    const result = parseConf([
+      '# leading comment',
+      '',
+      'ENABLED=true',
+      '  HOST=nas.local  ',
+      '# inline comment line',
+      'PORT=2222',
+    ].join('\n'))
+    expect(result).toEqual({ ENABLED: 'true', HOST: 'nas.local', PORT: '2222' })
+  })
+
+  it('strips matched surrounding quotes', () => {
+    const result = parseConf('REMOTE_PATH="/volume1/sleepypod"\nINCLUDE=\'raw,db\'')
+    expect(result.REMOTE_PATH).toBe('/volume1/sleepypod')
+    expect(result.INCLUDE).toBe('raw,db')
+  })
+
+  it('skips lines without =', () => {
+    const result = parseConf('ENABLED=true\nbogus line\nHOST=h')
+    expect(result).toEqual({ ENABLED: 'true', HOST: 'h' })
+  })
+})
+
+describe('renderConf', () => {
+  it('round-trips with parseConf', () => {
+    const cfg = {
+      enabled: true,
+      host: 'nas.local',
+      remoteUser: 'sleepypod',
+      remotePath: '/volume1/archive',
+      port: 2222,
+      identity: '/etc/sleepypod/key',
+      include: ['raw', 'db'] as const,
+    }
+    const rendered = renderConf({ ...cfg, include: [...cfg.include] })
+    const parsed = parseConf(rendered)
+    expect(parsed.ENABLED).toBe('true')
+    expect(parsed.HOST).toBe('nas.local')
+    expect(parsed.REMOTE_USER).toBe('sleepypod')
+    expect(parsed.REMOTE_PATH).toBe('/volume1/archive')
+    expect(parsed.PORT).toBe('2222')
+    expect(parsed.IDENTITY).toBe('/etc/sleepypod/key')
+    expect(parsed.INCLUDE).toBe('raw,db')
+  })
+})
+
+describe('archivePush.getConfig', () => {
+  it('returns defaults when no conf exists', async () => {
+    const result = await caller.getConfig({})
+    expect(result.config.enabled).toBe(false)
+    expect(result.config.host).toBe('')
+    expect(result.config.port).toBe(22)
+    expect(result.config.include).toEqual(['raw', 'db'])
+    expect(result.publicKey).toBeNull()
+  })
+
+  it('reads an existing conf file', async () => {
+    await writeFile(
+      path.join(configDir, 'archive-push.conf'),
+      [
+        'ENABLED=true',
+        'HOST=nas.local',
+        'REMOTE_USER=backup',
+        'REMOTE_PATH=/volume1/sp',
+        'PORT=2222',
+        'INCLUDE=raw',
+      ].join('\n'),
+    )
+    const result = await caller.getConfig({})
+    expect(result.config.enabled).toBe(true)
+    expect(result.config.host).toBe('nas.local')
+    expect(result.config.remoteUser).toBe('backup')
+    expect(result.config.port).toBe(2222)
+    expect(result.config.include).toEqual(['raw'])
+  })
+
+  it('surfaces public key when present', async () => {
+    await writeFile(path.join(configDir, 'archive-push.id_ed25519.pub'), 'ssh-ed25519 AAAA test\n')
+    const result = await caller.getConfig({})
+    expect(result.publicKey).toBe('ssh-ed25519 AAAA test')
+  })
+})
+
+describe('archivePush.setConfig', () => {
+  it('persists values readable by getConfig', async () => {
+    await caller.setConfig({
+      enabled: true,
+      host: 'nas.local',
+      remoteUser: 'sp',
+      remotePath: '/volume1/sp',
+      port: 22,
+      identity: path.join(configDir, 'archive-push.id_ed25519'),
+      include: ['raw'],
+    })
+
+    const text = await readFile(path.join(configDir, 'archive-push.conf'), 'utf8')
+    expect(text).toMatch(/ENABLED=true/)
+    expect(text).toMatch(/HOST=nas\.local/)
+    expect(text).toMatch(/INCLUDE=raw/)
+
+    const reread = await caller.getConfig({})
+    expect(reread.config.enabled).toBe(true)
+    expect(reread.config.host).toBe('nas.local')
+    expect(reread.config.include).toEqual(['raw'])
+  })
+})
+
+describe('archivePush.testConnection', () => {
+  it('rejects when host is unset', async () => {
+    const result = await caller.testConnection({})
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/host and remoteUser/)
+  })
+
+  it('rejects when identity is missing', async () => {
+    await caller.setConfig({
+      enabled: false,
+      host: 'nas.local',
+      remoteUser: 'sp',
+      remotePath: '/x',
+      port: 22,
+      identity: path.join(configDir, 'archive-push.id_ed25519'),
+      include: ['raw'],
+    })
+    const result = await caller.testConnection({})
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/identity .* missing/)
+  })
+})


### PR DESCRIPTION
## Summary
- **sp-20 fix**: `/api/export/archive` now aggregates `/persistent/biometrics/*.RAW` (tmpfs), `/persistent/biometrics-archive/*.RAW.gz` (cold), and the legacy `/persistent/*.RAW` path with stable dedup. Post-#499 the previous single-dir reader returned an empty raw set. Drops `EXPORT_TOKEN` since every other endpoint on the pod is `publicProcedure` over LAN — the token was theater. Adds an "Export Archive (.tar.gz)" row in the existing Raw Data sheet wired to the visible week range.
- **sp-21**: disabled-by-default nightly rsync to a user-owned remote.
  - `modules/archive-push/`: bash script + systemd `.service` + `.timer` (03:30 daily, randomized 15 min).
  - Conf at `/etc/sleepypod/archive-push.conf` (KEY=VALUE so the bash script can `source` it directly).
  - tRPC `archivePush.{getConfig, setConfig, generateKey, testConnection}` — manages the conf, generates an ed25519 keypair on the pod, and probes the remote with `ssh -o BatchMode=yes ... true`.
  - New "Backup" tab in Settings with form + key copy + connection test.
  - Install script wires the units up; timer always enabled (script no-ops when `ENABLED=false`).
- Drops `EXPORT_TOKEN` generation from `scripts/install` (and strips it from existing `.env` files on upgrade).

## What was deliberately not built
- `bandwidth_kbps` cap — the cold archive is ~100 MB/day gzipped; nightly rsync at 03:30 finishes in seconds even uncapped. If anyone complains, `rsync --bwlimit` is a five-minute change.
- The token-gated export auth referenced in the sp-20 acceptance — see comment above; would not protect anything that isn't already exposed via `publicProcedure`.

## Test plan
- [x] Unit: `app/api/export/archive/route.test.ts` covers `gatherRawFiles` (tmpfs + archive aggregation, mtime window, basename dedup, junk-name rejection, missing-dir tolerance, empty result).
- [x] Unit: `src/server/routers/tests/archivePush.test.ts` covers `parseConf` / `renderConf` / `getConfig` / `setConfig` (round-trip on a temp dir) and `testConnection` rejection paths.
- [x] `pnpm tsc` clean.
- [x] `pnpm lint` clean (one pre-existing stryker warning unrelated).
- [x] `pnpm test run` — 841 passed, 1 skipped, 0 failed.
- [ ] On a real pod: open Biometrics → Export Raw Data → Export Archive (.tar.gz), confirm tarball contains `raw/*.RAW(.gz)` for the visible week and `biometrics.sql`.
- [ ] On a real pod: Settings → Backup → generate key, copy pubkey to remote `authorized_keys`, run "test connection" → expect `connection ok`. Flip Enable, wait for 03:30 timer (or `systemctl start sleepypod-archive-push.service`) and confirm files appear on the remote.

Refs: gh-493, sp-20, sp-21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive export: Download raw waveforms and database as .tar.gz for selected time periods.
  * Remote backup: Configure and push backups to remote servers via SSH using new settings interface.
  * Automated backups: Daily scheduled backups at 03:30 with randomized timing.

* **Tests**
  * Added test coverage for archive export and backup configuration features.

* **Chores**
  * Updated installation process to configure remote backup infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/532)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->