### PR TITLE
ci: trigger CI on push to dev so Codecov badge updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev]
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [dev]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'lcov'],
     },
     name: 'unit',
     exclude: ['.claude/worktrees/**', '.ygg/worktrees/**', 'node_modules/**', '.next/**'],


### PR DESCRIPTION
The Codecov badge in README has been showing \`unknown\` because uploads only fired on \`pull_request\`. After a PR merges, dev's tip is a brand-new SHA (merge or squash commit) with no Codecov data attached, so the branch badge has nothing to render.

Adds:
- \`push: branches: [dev]\` trigger so every merge to dev re-runs CI and uploads coverage for the new tip SHA
- explicit \`reporter: ['text', 'lcov']\` in vitest coverage config so codecov-action picks up a predictable file path instead of relying on json auto-discovery

After merge, the next push to dev will populate Codecov's dev branch and the badge will show a real percentage.

## Test plan

- [ ] Confirm the manually-dispatched run on dev (post-merge) uploads coverage to Codecov
- [ ] Confirm README badge shows a percentage instead of \`unknown\`