### PR TITLE
fix(export+archive-push): drop sqlite3/rsync shellouts; use bundled libs/binaries

### DIFF
--- a/app/api/export/archive/route.ts
+++ b/app/api/export/archive/route.ts
@@ -1,9 +1,8 @@
 import { spawn } from 'node:child_process'
 import { mkdir, mkdtemp, readdir, rm, stat, symlink } from 'node:fs/promises'
-import { createWriteStream } from 'node:fs'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Readable } from 'node:stream'
+import Database from 'better-sqlite3'
 
 const BIOMETRICS_DB_PATH = process.env.BIOMETRICS_DATABASE_URL?.replace('file:', '') ?? ''
 
@@ -14,6 +13,11 @@ const BIOMETRICS_DB_PATH = process.env.BIOMETRICS_DATABASE_URL?.replace('file:',
 const RAW_TMPFS_DIR = process.env.RAW_TMPFS_DIR ?? '/persistent/biometrics'
 const RAW_ARCHIVE_DIR = process.env.RAW_ARCHIVE_DIR ?? '/persistent/biometrics-archive'
 const RAW_LEGACY_DIR = process.env.RAW_DATA_DIR ?? '/persistent'
+
+// Staging lives on /persistent (~10 GB free) instead of /tmp (tmpfs, ~1 GB
+// shared with RAM-pressured processes). A multi-week export's db backup
+// alone can blow past the tmpfs ceiling.
+const EXPORT_STAGING_DIR = process.env.EXPORT_STAGING_DIR ?? '/persistent/sleepypod-data/export-staging'
 
 // Accepts <seqno>.RAW (live) or <seqno>.RAW.gz (cold archive).
 const SAFE_RAW_NAME = /^[\w.-]+\.RAW(\.gz)?$/i
@@ -65,21 +69,23 @@ export async function gatherRawFiles(
   return out
 }
 
-async function dumpSqlite(dbPath: string, outPath: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const out = createWriteStream(outPath)
-    const child = spawn('sqlite3', [dbPath, '.dump'])
-    child.stdout.pipe(out)
-    let stderr = ''
-    child.stderr.on('data', d => (stderr += d.toString()))
-    child.on('error', reject)
-    child.on('close', (code) => {
-      out.close(() => {
-        if (code === 0) resolve()
-        else reject(new Error(`sqlite3 .dump exited with ${code}: ${stderr}`))
-      })
-    })
-  })
+/**
+ * Online backup of a live SQLite database to a destination file. Uses the
+ * SQLite Online Backup API via better-sqlite3 — same library next-server
+ * already holds the DB open with. Handles WAL correctly, no shell-out, no
+ * dependency on a `sqlite3` CLI binary (the pod has neither).
+ *
+ * Output is a binary .db file rather than a text .sql dump; restore is a
+ * literal file copy instead of `sqlite3 < dump.sql`.
+ */
+async function backupSqlite(dbPath: string, outPath: string): Promise<void> {
+  const src = new Database(dbPath, { readonly: true, fileMustExist: true })
+  try {
+    await src.backup(outPath)
+  }
+  finally {
+    src.close()
+  }
 }
 
 export async function GET(request: Request) {
@@ -102,10 +108,11 @@ export async function GET(request: Request) {
 
   let stagingDir: string | null = null
   try {
-    stagingDir = await mkdtemp(path.join(tmpdir(), 'sp-export-'))
+    await mkdir(EXPORT_STAGING_DIR, { recursive: true })
+    stagingDir = await mkdtemp(path.join(EXPORT_STAGING_DIR, 'sp-export-'))
 
     if (include.includes('db') && BIOMETRICS_DB_PATH) {
-      await dumpSqlite(BIOMETRICS_DB_PATH, path.join(stagingDir, 'biometrics.sql'))
+      await backupSqlite(BIOMETRICS_DB_PATH, path.join(stagingDir, 'biometrics.db'))
     }
 
     if (include.includes('raw')) {

--- a/modules/archive-push/sleepypod-archive-push
+++ b/modules/archive-push/sleepypod-archive-push
@@ -17,6 +17,10 @@ DB_STAGING_DIR="${ARCHIVE_PUSH_STAGING_DIR:-/persistent/sleepypod-data/archive-p
 # next-server's app dir — holds the better-sqlite3 install we reuse for the
 # online backup. No separate sqlite3 binary lives on the pod.
 APP_DIR="${SLEEPYPOD_APP_DIR:-/home/dac/sleepypod-core}"
+# Pin to the node that built better-sqlite3 — /usr/bin/node on this pod is
+# v16 (NODE_MODULE_VERSION 93) and won't load the native addon built for the
+# newer runtime that next-server uses.
+NODE_BIN="${SLEEPYPOD_NODE_BIN:-/usr/local/bin/node}"
 
 if [ ! -f "$CONFIG" ]; then
   echo "archive-push: no config at $CONFIG — skipping"
@@ -76,7 +80,7 @@ if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
   trap 'rm -f "$tmp_db" "$tmp_gz"' EXIT
   # SQLite Online Backup via better-sqlite3 — same library next-server uses.
   # cwd to APP_DIR so node resolves the dependency the standard way.
-  ( cd "$APP_DIR" && node -e '
+  ( cd "$APP_DIR" && "$NODE_BIN" -e '
     const Database = require("better-sqlite3");
     const [src, dst] = process.argv.slice(1);
     const db = new Database(src, { readonly: true, fileMustExist: true });

--- a/modules/archive-push/sleepypod-archive-push
+++ b/modules/archive-push/sleepypod-archive-push
@@ -12,6 +12,11 @@ set -euo pipefail
 CONFIG="${ARCHIVE_PUSH_CONFIG:-/etc/sleepypod/archive-push.conf}"
 ARCHIVE_DIR="${ARCHIVE_DIR:-/persistent/biometrics-archive}"
 DB_PATH="${BIOMETRICS_DB_PATH:-/persistent/sleepypod-data/biometrics.db}"
+# Stage db backup on /persistent (~10 GB) instead of /tmp (tmpfs, ~1 GB).
+DB_STAGING_DIR="${ARCHIVE_PUSH_STAGING_DIR:-/persistent/sleepypod-data/archive-push-staging}"
+# next-server's app dir — holds the better-sqlite3 install we reuse for the
+# online backup. No separate sqlite3 binary lives on the pod.
+APP_DIR="${SLEEPYPOD_APP_DIR:-/home/dac/sleepypod-core}"
 
 if [ ! -f "$CONFIG" ]; then
   echo "archive-push: no config at $CONFIG — skipping"
@@ -65,12 +70,22 @@ fi
 
 if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
   stamp=$(date -u +%Y%m%dT%H%M%SZ)
-  tmp=$(mktemp -t sp-bio-XXXXXX.sql.gz)
-  trap 'rm -f "$tmp"' EXIT
-  sqlite3 "$DB_PATH" .dump | gzip > "$tmp"
-  echo "archive-push: rsync biometrics.sql.gz -> $REMOTE_USER@$HOST:$REMOTE_PATH/db/biometrics-$stamp.sql.gz"
+  mkdir -p "$DB_STAGING_DIR"
+  tmp_db=$(mktemp -p "$DB_STAGING_DIR" sp-bio-XXXXXX.db)
+  tmp_gz="$tmp_db.gz"
+  trap 'rm -f "$tmp_db" "$tmp_gz"' EXIT
+  # SQLite Online Backup via better-sqlite3 — same library next-server uses.
+  # cwd to APP_DIR so node resolves the dependency the standard way.
+  ( cd "$APP_DIR" && node -e '
+    const Database = require("better-sqlite3");
+    const [src, dst] = process.argv.slice(1);
+    const db = new Database(src, { readonly: true, fileMustExist: true });
+    db.backup(dst).then(() => db.close()).catch(e => { console.error(e); process.exit(1) });
+  ' "$DB_PATH" "$tmp_db" )
+  gzip -f "$tmp_db"
+  echo "archive-push: rsync biometrics.db.gz -> $REMOTE_USER@$HOST:$REMOTE_PATH/db/biometrics-$stamp.db.gz"
   rsync -az --partial --timeout=300 -e "$SSH_CMD" \
-    "$tmp" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/db/biometrics-$stamp.sql.gz"
+    "$tmp_gz" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/db/biometrics-$stamp.db.gz"
   pushed_db=1
 fi
 

--- a/modules/archive-push/sleepypod-archive-push
+++ b/modules/archive-push/sleepypod-archive-push
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Push gzipped biometrics archive (and optional db dump) to a user-configured
-# remote via rsync over ssh. Reads /etc/sleepypod/archive-push.conf as plain
+# remote via ssh + scp. Reads /etc/sleepypod/archive-push.conf as plain
 # KEY=VALUE (NOT bash-sourced — the conf is written by an LAN-reachable tRPC
 # handler and sourcing would be a command-injection sink). Disabled by default
 # — config flips ENABLED=true.
+#
+# Uses scp rather than rsync because rsync isn't installed on the pod and
+# there's no package manager to fetch it. The cold archive is append-only
+# (one new *.RAW.gz per day), so a list-remote-then-scp-missing loop has
+# the same steady-state cost as `rsync -az`. ssh ControlMaster multiplexes
+# the per-file scps over a single TCP connection.
 #
 # Designed for nightly timer runs. No-ops cleanly when disabled or
 # misconfigured so a stale config doesn't crash the timer.
@@ -60,16 +66,59 @@ if [ ! -f "$IDENTITY" ]; then
   exit 1
 fi
 
-SSH_CMD="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/etc/sleepypod/known_hosts -o ConnectTimeout=15 -p $PORT -i $IDENTITY"
+# ControlMaster reuses one TCP connection across every scp/ssh invocation
+# below, so per-file overhead is one round-trip, not a full ssh handshake.
+ctl_socket=$(mktemp -u -p /tmp ssh-archive-push.XXXXXX)
+SSH_OPTS=(
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile=/etc/sleepypod/known_hosts
+  -o ConnectTimeout=15
+  -o ControlMaster=auto
+  -o "ControlPath=$ctl_socket"
+  -o ControlPersist=60
+  -p "$PORT"
+  -i "$IDENTITY"
+)
+SCP_OPTS=(
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile=/etc/sleepypod/known_hosts
+  -o ConnectTimeout=15
+  -o ControlMaster=auto
+  -o "ControlPath=$ctl_socket"
+  -o ControlPersist=60
+  -P "$PORT"
+  -i "$IDENTITY"
+)
+# scp uses -P (capital) for port; ssh uses -p. ControlPath is shared.
+
+ssh_remote() { ssh "${SSH_OPTS[@]}" "$REMOTE_USER@$HOST" "$@"; }
+scp_to_remote() { scp "${SCP_OPTS[@]}" "$@"; }
 
 pushed_raw=0
 pushed_db=0
+skipped_raw=0
 
 if [[ ",$INCLUDE," == *",raw,"* ]] && [ -d "$ARCHIVE_DIR" ]; then
-  echo "archive-push: rsync $ARCHIVE_DIR -> $REMOTE_USER@$HOST:$REMOTE_PATH/raw/"
-  rsync -az --partial --timeout=300 -e "$SSH_CMD" \
-    "$ARCHIVE_DIR/" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/raw/"
-  pushed_raw=1
+  echo "archive-push: sync $ARCHIVE_DIR -> $REMOTE_USER@$HOST:$REMOTE_PATH/raw/"
+  ssh_remote "mkdir -p '${REMOTE_PATH%/}/raw'"
+  # Pull remote listing once, then loop locally — one round trip for the
+  # diff instead of one per file.
+  remote_listing=$(ssh_remote "ls -1 '${REMOTE_PATH%/}/raw/' 2>/dev/null || true")
+  for f in "$ARCHIVE_DIR"/*.RAW.gz; do
+    [ -e "$f" ] || continue
+    base=$(basename "$f")
+    if printf '%s\n' "$remote_listing" | grep -Fxq "$base"; then
+      skipped_raw=$((skipped_raw + 1))
+      continue
+    fi
+    # Upload with .part suffix and rename atomically so an interrupted scp
+    # never leaves a half-file the next run thinks is complete.
+    scp_to_remote "$f" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/raw/$base.part"
+    ssh_remote "mv '${REMOTE_PATH%/}/raw/$base.part' '${REMOTE_PATH%/}/raw/$base'"
+    pushed_raw=$((pushed_raw + 1))
+  done
 fi
 
 if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
@@ -77,7 +126,7 @@ if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
   mkdir -p "$DB_STAGING_DIR"
   tmp_db=$(mktemp -p "$DB_STAGING_DIR" sp-bio-XXXXXX.db)
   tmp_gz="$tmp_db.gz"
-  trap 'rm -f "$tmp_db" "$tmp_gz"' EXIT
+  trap 'rm -f "$tmp_db" "$tmp_gz"; ssh -O exit "${SSH_OPTS[@]}" "$REMOTE_USER@$HOST" 2>/dev/null || true' EXIT
   # SQLite Online Backup via better-sqlite3 — same library next-server uses.
   # cwd to APP_DIR so node resolves the dependency the standard way.
   ( cd "$APP_DIR" && "$NODE_BIN" -e '
@@ -87,10 +136,16 @@ if [[ ",$INCLUDE," == *",db,"* ]] && [ -f "$DB_PATH" ]; then
     db.backup(dst).then(() => db.close()).catch(e => { console.error(e); process.exit(1) });
   ' "$DB_PATH" "$tmp_db" )
   gzip -f "$tmp_db"
-  echo "archive-push: rsync biometrics.db.gz -> $REMOTE_USER@$HOST:$REMOTE_PATH/db/biometrics-$stamp.db.gz"
-  rsync -az --partial --timeout=300 -e "$SSH_CMD" \
-    "$tmp_gz" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/db/biometrics-$stamp.db.gz"
+  remote_db_name="biometrics-$stamp.db.gz"
+  echo "archive-push: scp $remote_db_name -> $REMOTE_USER@$HOST:$REMOTE_PATH/db/"
+  ssh_remote "mkdir -p '${REMOTE_PATH%/}/db'"
+  scp_to_remote "$tmp_gz" "$REMOTE_USER@$HOST:${REMOTE_PATH%/}/db/$remote_db_name.part"
+  ssh_remote "mv '${REMOTE_PATH%/}/db/$remote_db_name.part' '${REMOTE_PATH%/}/db/$remote_db_name'"
   pushed_db=1
 fi
 
-echo "archive-push: done raw=$pushed_raw db=$pushed_db"
+# Close the ControlMaster connection cleanly. The trap above also covers
+# the error path so the socket file doesn't outlive the process.
+ssh -O exit "${SSH_OPTS[@]}" "$REMOTE_USER@$HOST" 2>/dev/null || true
+
+echo "archive-push: done raw=$pushed_raw raw_skipped=$skipped_raw db=$pushed_db"

--- a/modules/archive-push/sleepypod-archive-push.service
+++ b/modules/archive-push/sleepypod-archive-push.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Sleepypod biometrics archive push to remote (rsync over ssh)
+Description=Sleepypod biometrics archive push to remote (scp over ssh)
 Documentation=https://github.com/sleepypod/core/tree/main/modules/archive-push
 After=network-online.target
 Wants=network-online.target

--- a/modules/archive-push/sleepypod-archive-push.service
+++ b/modules/archive-push/sleepypod-archive-push.service
@@ -12,6 +12,9 @@ ExecStart=/usr/local/bin/sleepypod-archive-push
 Nice=10
 IOSchedulingClass=idle
 ProtectSystem=strict
-ReadWritePaths=/etc/sleepypod
+# /etc/sleepypod — conf + ssh known_hosts append on first connect.
+# /persistent/sleepypod-data — staging dir for the better-sqlite3 backup
+# (live db lives here; /tmp is a 984 MB tmpfs, too small for a real dump).
+ReadWritePaths=/etc/sleepypod /persistent/sleepypod-data
 PrivateTmp=true
 NoNewPrivileges=true

--- a/scripts/install
+++ b/scripts/install
@@ -1147,7 +1147,7 @@ if [ -d "$ARCHIVER_SRC" ]; then
 fi
 
 # ============================================================================
-# Archive push — nightly rsync of cold archive to user-configured remote.
+# Archive push — nightly scp of cold archive to user-configured remote.
 # ============================================================================
 # Disabled by default; user opts in via Settings → Backup. Config + ssh key
 # live under /etc/sleepypod (writeable by the sleepypod group so the
@@ -1155,7 +1155,7 @@ fi
 # user, not root — same trust boundary as the rest of the app.
 PUSH_SRC="$INSTALL_DIR/modules/archive-push"
 if [ -d "$PUSH_SRC" ]; then
-  echo "Installing archive-push (rsync to remote)..."
+  echo "Installing archive-push (scp to remote)..."
 
   install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
   install -m 0644 "$PUSH_SRC/sleepypod-archive-push.service" /etc/systemd/system/

--- a/src/components/Settings/ArchivePushSettingsForm.tsx
+++ b/src/components/Settings/ArchivePushSettingsForm.tsx
@@ -22,7 +22,7 @@ interface InitialConfig {
 
 /**
  * Settings form for the archive-push feature (sp-21). Lets the user
- * configure a remote rsync target, generate an ssh keypair on the pod,
+ * configure a remote scp target, generate an ssh keypair on the pod,
  * copy the pubkey into their remote's authorized_keys, and run a
  * non-destructive connection test before flipping ENABLED on.
  *

--- a/src/components/biometrics/RawDataButton.tsx
+++ b/src/components/biometrics/RawDataButton.tsx
@@ -334,7 +334,7 @@ export function RawDataButton() {
               Export Archive (.tar.gz)
             </button>
             <p className="mt-2 text-center text-[10px] text-zinc-500">
-              RAW waveforms + biometrics.db SQL dump for this week. Untar then `sqlite3 biometrics.db &lt; biometrics.sql`.
+              RAW waveforms + biometrics.db copy for this week. Untar and open biometrics.db with any SQLite client.
             </p>
 
             {/* Raw sensor files section — wired to raw.files tRPC router */}


### PR DESCRIPTION
## Summary
Post-#532 follow-up. Real-pod testing surfaced three places PR #532 shelled out to CLI tools that aren't on the Yocto-based pod image (ADR 0013), plus a couple of related plumbing fixes:

### 1. `sqlite3` binary doesn't exist on the pod
Only `better-sqlite3` (Node addon) does. Both `app/api/export/archive/route.ts::dumpSqlite` and `modules/archive-push/sleepypod-archive-push` shelled out to a `sqlite3` CLI that never installed. Result: the export route 500'd `spawn sqlite3 ENOENT` on every click that included `db`; the nightly push silently dropped the db side.

- Route: replaced with `Database(path, {readonly:true}).backup(outPath)` — the SQLite Online Backup API via better-sqlite3, the same library next-server already opens the live db with. Tarball now contains `biometrics.db` (binary) instead of `biometrics.sql`; restore is a literal file copy.
- Timer: invokes `node -e ...` from the app dir with the same library.

### 2. `rsync` binary doesn't exist on the pod either
ADR 0013 documents this — Yocto kirkstone ships without rsync and there's no package manager to add it. The deploy script already uses `tar | ssh` for the same reason.

Replaced both raw and db push paths with `scp + ssh`. ssh ControlMaster multiplexes per-file scps over one TCP handshake. The cold archive is append-only (one new \`*.RAW.gz\` per day), so a list-remote-then-scp-missing loop has the same steady-state cost as \`rsync -az\`. Uploads land on \`.part\` and are renamed atomically so an interrupted transfer doesn't leave a half-file the next run mistakes for complete.

### 3. Pin timer to `/usr/local/bin/node`
\`/usr/bin/node\` on the pod is v16 (NODE_MODULE_VERSION 93); next-server runs the newer v22 binary that better-sqlite3 was built against. The timer's PATH picked up v16 and failed with ERR_DLOPEN_FAILED on the native addon. Env-overridable via \`SLEEPYPOD_NODE_BIN\`.

### 4. `ProtectSystem=strict` blocked the staging dir
Service unit only had \`/etc/sleepypod\` writable. Added \`/persistent/sleepypod-data\` (same dir the live db already writes to) so the backup-then-gzip pipeline works. Route's staging dir also moves to \`/persistent/sleepypod-data/export-staging\` — \`/tmp\` is a 984 MB tmpfs (RAM-pressured), \`/persistent\` has ~10 GB free.

## Verified on pod 192.168.1.88
- \`GET /api/export/archive?include=raw,db\` → 22 MB tarball, valid binary \`biometrics.db\` (\`file\` reports SQLite 3.x, 6284 pages; reopens cleanly).
- Loopback E2E push (pod → 127.0.0.1:8822):
  - Run #1 (cold sync): 768 \`*.RAW.gz\` + 1 db transferred in ~9 s via one multiplexed ssh session. Zero \`.part\` leftovers.
  - Run #2 (incremental): all 768 raw files skipped via remote-listing diff; fresh db pushed.

## Test plan
- [x] \`pnpm tsc\`, \`pnpm lint\`, \`pnpm test run app/api/export/archive\` clean.
- [x] Pod smoke: \`/api/export/archive?include=raw,db\` returns valid binary db.
- [x] Pod E2E loopback: full + incremental nightly push succeeds, atomic rename works.