### PR TITLE
ci(codecov): switch to OIDC auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
   ci:
     name: ${{ matrix.task.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -62,13 +66,13 @@ jobs:
         if: matrix.task.name == 'Unit Tests' && !cancelled()
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           slug: sleepypod/core
 
       - name: Upload test results to Codecov
         if: matrix.task.name == 'Unit Tests' && !cancelled()
         uses: codecov/test-results-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           slug: sleepypod/core
           files: test-results/junit.xml


### PR DESCRIPTION
## Summary

- Replace \`CODECOV_TOKEN\` with OIDC for both \`codecov-action@v5\` and \`test-results-action@v1\` uploads.
- Add \`id-token: write\` (plus explicit \`contents: read\` and \`packages: read\`) on the CI job so the OIDC token is mintable.

## Why

The badge has been showing \"unknown\" because uploads from CI fail with:

\`\`\`
error - Upload queued for processing failed: {\"message\":\"Repository not found\"}
\`\`\`

Codecov's API confirms \`sleepypod/core\` is \`active:true, activated:true\` but \`totals:null\` — the repo is set up correctly, but no upload has ever been ingested. That pattern indicates the \`CODECOV_TOKEN\` secret value doesn't match what Codecov expects for this repo. Since the GitHub App is already installed, OIDC is the simpler fix: it eliminates the shared-secret mismatch failure mode entirely.

## Test plan

- [ ] After merge, watch the CI run on \`dev\` — the \"Upload coverage reports to Codecov\" step should log a successful upload (no \"Repository not found\").
- [ ] Hit \`https://api.codecov.io/api/v2/github/sleepypod/repos/core/\` and confirm \`totals\` is no longer null.
- [ ] README badges flip from \"unknown\" to a coverage percentage.
- [ ] Once verified, the \`CODECOV_TOKEN\` secret can be deleted from repo settings.