### PR TITLE
docs(readme): refresh badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sleepypod
+# sleepypod — local-first Pod mattress controller
 
 [![CI](https://github.com/sleepypod/core/actions/workflows/test.yml/badge.svg?branch=dev)](https://github.com/sleepypod/core/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
@@ -6,7 +6,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/discord/1450213183653679205?logo=discord&logoColor=white&label=discord)](https://discord.gg/UMmv5R6MXa)
 
-A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web UI, scheduler, and integrations for Home Assistant (MQTT) and Apple Home (HomeKit).
+Self-hosted firmware replacement for Pod 3, 4, and 5. Runs on the Pod's embedded Linux — no cloud round-trips, no remote dependency. Local web UI, scheduler, on-device biometrics, and native integrations for Home Assistant (MQTT) and Apple Home (HomeKit).
 
 <p align="center">
   <img src="docs/images/temperature-control.png" width="280" alt="Temperature control" />
@@ -47,24 +47,15 @@ The script:
 After install, these are available system-wide:
 
 ```bash
-sp-status    # systemctl status sleepypod.service
-sp-restart   # restart the service
-sp-logs      # journalctl -u sleepypod.service -f
-sp-update    # pull latest, rebuild, migrate, restart (with automatic rollback)
+sp-status         # systemctl status sleepypod.service
+sp-restart        # restart the service
+sp-logs           # journalctl -u sleepypod.service -f
+sp-update         # pull latest, rebuild, migrate, restart (with automatic rollback)
+sp-maintenance    # one-shot manual prime / reboot / status
+sp-uninstall      # stop services, remove systemd units, optionally wipe data
+sp-sleepypod      # if free-sleep is also installed: stop it and start sleepypod
+sp-freesleep      # mirror of the above in the other direction
 ```
-
-### Switching between sleepypod and free-sleep
-
-Already running [free-sleep](https://github.com/throwaway31265/free-sleep)? sleepypod installs alongside it — both use port 3000 but only one runs at a time. Switch freely without losing any settings or data:
-
-```bash
-sp-sleepypod    # Stop free-sleep, start sleepypod + biometrics modules
-sp-freesleep    # Stop sleepypod, start free-sleep
-```
-
-This makes it easy to evaluate sleepypod: install it, try it out, and switch back any time if you prefer free-sleep. Your temperature schedules, alarm configs, and sleep data are all preserved across switches.
-
-Need help? Join the [Discord](https://discord.gg/UMmv5R6MXa) or [open an issue](https://github.com/sleepypod/core/issues).
 
 ---
 
@@ -374,6 +365,8 @@ flowchart LR
 | Package manager | pnpm |
 | Test runner | Vitest |
 | Linter | ESLint flat config + @stylistic |
+| HomeKit bridge | hap-nodejs (embedded in next-server) |
+| MQTT client | mqtt.js (outbound to user's broker) |
 
 ---
 
@@ -413,14 +406,24 @@ graph LR
 | `alarm_schedules` | Vibration alarms with intensity, pattern, and duration |
 | `tap_gestures` | Configurable double/triple-tap actions |
 | `system_health` | Health status per component (core app + modules) |
+| `run_once_sessions` | Ephemeral one-shot temperature / power runs |
 
 ### `biometrics.db` — time-series health data
 
 | Table | Purpose |
 |-------|---------|
 | `vitals` | Heart rate, HRV, breathing rate — one row per ~60s interval |
+| `vitals_quality` | Per-interval signal quality flags for the `vitals` row |
 | `sleep_records` | Session boundaries, duration, exit count, presence intervals |
 | `movement` | Per-interval movement scores |
+| `bed_temp` | Per-side bed-surface temperature samples |
+| `freezer_temp` | Reservoir / freezer-side temperature samples |
+| `ambient_light` | Room ambient-light samples |
+| `flow_readings` | Pump flow-rate samples |
+| `water_level_readings` | Continuous water-level samples |
+| `water_level_alerts` | Threshold crossings (low / refill events) |
+| `calibration_profiles` | Saved sensor calibration coefficients (per ADR 0014) |
+| `calibration_runs` | Audit log of calibration runs |
 
 Biometrics uses WAL mode and a 5-second busy timeout so multiple sidecar processes can write concurrently without contention.
 
@@ -488,6 +491,9 @@ sleepypod-core/
 │   │   ├── client.ts               # dac.sock Unix socket client
 │   │   ├── deviceStateSync.ts      # status:updated → DB + stub sleep records
 │   │   └── types.ts                # DeviceStatus, SideStatus, etc.
+│   ├── homekit/                    # hap-nodejs bridge, accessories, identity
+│   ├── streaming/                  # piezoStream WS, bonjour announce, MQTT bridge
+│   ├── services/                   # autoOffWatcher, temperatureKeepalive, etc.
 │   ├── modules/
 │   │   └── types.ts                # ModuleManifest interface
 │   ├── scheduler/
@@ -515,7 +521,7 @@ sleepypod-core/
 |----------|---------------|-------------|
 | `DATABASE_URL` | `file:./sleepypod.dev.db` | Path to sleepypod.db |
 | `BIOMETRICS_DATABASE_URL` | `file:./biometrics.dev.db` | Path to biometrics.db |
-| `DAC_SOCK_PATH` | `/run/dac.sock` | Unix socket path for hardware control |
+| `DAC_SOCK_PATH` | `/persistent/deviceinfo/dac.sock` | Unix socket path for hardware control |
 | `NODE_ENV` | `development` | Set to `production` in the systemd service |
 
 ---
@@ -565,8 +571,12 @@ Key decisions are documented in [`docs/adr/`](docs/adr/):
 | [0006](docs/adr/0006-developer-tooling.md) | ESLint, Vitest, Conventional Commits, pnpm |
 | [0010](docs/adr/0010-drizzle-orm-sqlite.md) | Drizzle ORM + SQLite for embedded constraints |
 | [0012](docs/adr/0012-biometrics-module-system.md) | Plugin/sidecar architecture for biometrics |
+| [0014](docs/adr/0014-sensor-calibration.md) | Per-sensor calibration profiles |
 | [0015](docs/adr/0015-event-bus-mutation-broadcast.md) | Event bus: broadcast device state after mutations |
+| [0017](docs/adr/0017-uv-python-package-management.md) | uv for Python module package management |
+| [0018](docs/adr/0018-tmpfs-raw-frames.md) | Tmpfs for `/persistent/*.RAW` to spare eMMC writes |
 | [0019](docs/adr/0019-mqtt-bridge.md) | MQTT bridge for Home Assistant integration |
+| [0020](docs/adr/0020-homekit-identity-derivation.md) | Deterministic HomeKit identity from hardware-rooted seed |
 
 ### Key tradeoffs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # sleepypod
 
+[![CI](https://github.com/sleepypod/core/actions/workflows/test.yml/badge.svg?branch=dev)](https://github.com/sleepypod/core/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
+[![Release](https://img.shields.io/github/v/release/sleepypod/core?sort=semver)](https://github.com/sleepypod/core/releases/latest)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/discord/1450213183653679205?logo=discord&logoColor=white&label=discord)](https://discord.gg/UMmv5R6MXa)
 
 A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web interface and scheduler.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/discord/1450213183653679205?logo=discord&logoColor=white&label=discord)](https://discord.gg/UMmv5R6MXa)
 
-A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web interface and scheduler.
+A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web UI, scheduler, and integrations for Home Assistant (MQTT) and Apple Home (HomeKit).
 
 <p align="center">
   <img src="docs/images/temperature-control.png" width="280" alt="Temperature control" />
@@ -20,7 +20,7 @@ A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs dir
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/UMmv5R6MXa">Discord</a> · <a href="https://github.com/sleepypod/core/issues">Issues</a> · <a href="#installation">Install guide</a>
+  <a href="https://github.com/sleepypod/core/issues">Issues</a> · <a href="#installation">Install guide</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # sleepypod
 
-[![core coverage](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
-[![ios coverage](https://codecov.io/gh/sleepypod/ios/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/ios)
+[![codecov](https://codecov.io/gh/sleepypod/core/branch/dev/graph/badge.svg)](https://codecov.io/gh/sleepypod/core)
 
 A self-hosted control system for Pod mattress covers (Pod 3, 4, and 5). Runs directly on the Pod's embedded Linux hardware, replacing the cloud dependency with a local-first web interface and scheduler.
 


### PR DESCRIPTION
## Summary

- Drop the iOS coverage badge (belongs in \`sleepypod/ios\`'s README, not core's).
- Add CI status, latest release, AGPL license, and Discord badges.

## Why

Old row had only the two coverage badges (and the iOS one pointed at a different repo). For an OSS readme, the highest-signal badges are: is dev green, what's covered, what's the latest version, what's the license, where do I get help.

## Notes

- The Discord badge needs the server widget enabled (Server Settings → Widget) to render the live member count. Until that's flipped on, shields.io will show \"invalid\" — easy to swap to a static \`badge/Discord-join\` if widget isn't desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added status badges (CI, Release, License) to README
  * Enhanced project description highlighting Home Assistant (MQTT) and Apple Home (HomeKit) integration support
  * Updated header navigation links

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/536)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->