### PR TITLE
ci(codecov): switch bundle analysis to OIDC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,9 +42,9 @@ const nextConfig = {
     })
     config.plugins.push(
       codecovNextJSWebpackPlugin({
-        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+        enableBundleAnalysis: process.env.GITHUB_ACTIONS === 'true',
         bundleName: 'sleepypod-core',
-        uploadToken: process.env.CODECOV_TOKEN,
+        oidc: { useGitHubOIDC: true },
         gitService: 'github',
         webpack: options.webpack,
       }),


### PR DESCRIPTION
## Summary
- Switch the `@codecov/nextjs-webpack-plugin` to GitHub OIDC, matching the auth style adopted for coverage/test-results uploads in #535.
- Gate `enableBundleAnalysis` on `GITHUB_ACTIONS` so local `pnpm build` runs skip the upload step instead of needing a `CODECOV_TOKEN`.
- Grant `id-token: write` on the build workflow so OIDC can mint a token.

## Test plan
- [ ] CI build job succeeds and uploads bundle analysis to Codecov for `sleepypod-core`.
- [ ] Local `pnpm build` does not attempt a Codecov upload (no token, no OIDC context).