### PR TITLE
docs(readme): drop misleading 'firmware replacement' wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/discord/1450213183653679205?logo=discord&logoColor=white&label=discord)](https://discord.gg/UMmv5R6MXa)
 
-Self-hosted firmware replacement for Pod 3, 4, and 5. Runs on the Pod's embedded Linux — no cloud round-trips, no remote dependency. Local web UI, scheduler, on-device biometrics, and native integrations for Home Assistant (MQTT) and Apple Home (HomeKit).
+Self-hosted control app for Pod 3, 4, and 5. Runs on the Pod's stock embedded Linux — replaces the cloud-bound controller with a local web UI, scheduler, on-device biometrics, and native integrations for Home Assistant (MQTT) and Apple Home (HomeKit).
 
 <p align="center">
   <img src="docs/images/temperature-control.png" width="280" alt="Temperature control" />


### PR DESCRIPTION
Sleepypod is a userspace Node.js app — kernel and dac daemon are untouched. 'Control app that replaces the cloud-bound controller' is accurate; 'firmware replacement' overclaims.