### PR TITLE
ci(codecov): webpack bundle-stats job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -1,0 +1,54 @@
+name: Bundle Stats
+
+# Production builds use Turbopack (next.config.mjs), which skips the
+# webpack() hook — so @codecov/nextjs-webpack-plugin never runs in the
+# deploy build. This job runs a webpack-only build solely to upload
+# bundle stats to Codecov. The artifact is discarded.
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+jobs:
+  bundle-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prebuild (git-info + lingui)
+        run: pnpm run prebuild
+
+      - name: Build (webpack, for Codecov bundle stats)
+        run: pnpm exec next build --webpack

--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -52,3 +52,5 @@ jobs:
 
       - name: Build (webpack, for Codecov bundle stats)
         run: pnpm exec next build --webpack
+        env:
+          CODECOV_BUNDLE_STATS: '1'

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,9 +42,9 @@ const nextConfig = {
     })
     config.plugins.push(
       codecovNextJSWebpackPlugin({
-        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+        enableBundleAnalysis: process.env.GITHUB_ACTIONS === 'true',
         bundleName: 'sleepypod-core',
-        uploadToken: process.env.CODECOV_TOKEN,
+        oidc: { useGitHubOIDC: true },
         gitService: 'github',
         webpack: options.webpack,
       }),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,8 +6,17 @@ import { codecovNextJSWebpackPlugin } from '@codecov/nextjs-webpack-plugin'
 // monorepos) doesn't pick the wrong root and skip standalone output.
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Set by .github/workflows/bundle-stats.yml. That job runs `next build --webpack`
+// to feed the Codecov bundle plugin (Turbopack skips webpack(), so the deploy
+// build can't upload). Some packages ship ESM that only resolves cleanly under
+// Turbopack — transpile them under this build so webpack can finish compiling.
+const isBundleStatsBuild = process.env.CODECOV_BUNDLE_STATS === '1'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  ...(isBundleStatsBuild && {
+    transpilePackages: ['@trpc/react-query'],
+  }),
   // Keep production browser source maps off — serving .map files on LAN
   // exposes TypeScript source, API route internals, and file paths.
   // Use server-side-only source maps + a private error monitor for prod debugging.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -49,6 +49,19 @@ const nextConfig = {
       test: /\.po$/,
       use: ['@lingui/loader'],
     })
+    if (isBundleStatsBuild) {
+      // @trpc/react-query v11 is bundled by tsdown with __commonJS/__toESM
+      // interop wrappers — webpack's static ESM analysis can't see the named
+      // exports through them and errors out. Runtime is fine; we only need
+      // the build to produce stats. Downgrade exportsPresence to a warning.
+      config.module.parser = {
+        ...config.module.parser,
+        javascript: {
+          ...config.module.parser?.javascript,
+          exportsPresence: 'warn',
+        },
+      }
+    }
     config.plugins.push(
       codecovNextJSWebpackPlugin({
         enableBundleAnalysis: process.env.GITHUB_ACTIONS === 'true',


### PR DESCRIPTION
## Summary
- Next.js 16 defaults to Turbopack, which skips the `webpack()` hook in `next.config.mjs`, so `@codecov/nextjs-webpack-plugin` never runs during the deploy build (verified on commit fdce534 — no Codecov upload in `Build & Package` logs).
- Adds `bundle-stats.yml`: runs `next build --webpack` as a parallel CI job purely so the Codecov plugin can register and upload bundle stats via OIDC. The deploy build in `build.yml` stays on Turbopack.

## Caveat
Reports webpack bundle sizes, not the Turbopack bundles we actually ship. Reasonable proxy for regression detection; not exact for absolute size. Revisit when Codecov ships a Turbopack plugin.

## Test plan
- [ ] Workflow runs on this PR and uploads bundle analysis for `sleepypod-core` to Codecov.
- [ ] `Build & Package` (Turbopack) remains untouched.