### PR TITLE
ci(mutation): mutate whole repo across 10 area shards

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,13 +38,31 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          # The --mutate CLI flag overrides the config's exclude patterns,
-          # so we have to repeat them here per shard. Keep these three
-          # exclusions in sync with stryker.config.mjs's mutate: block.
+          # Each shard's --mutate string is the include globs + the
+          # exclude globs (the CLI flag overrides the config's mutate
+          # block entirely, so excludes must be repeated per shard).
+          # Areas roughly grouped by code-cohesion + file count so wall
+          # time stays balanced across the matrix.
+          - name: lib-utils
+            mutate: "src/lib/**/*.{ts,tsx},src/utils/**/*.{ts,tsx},src/modules/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
           - name: services-scheduler
-            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
-          - name: hardware-lib
-            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+            mutate: "src/services/**/*.{ts,tsx},src/scheduler/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: hardware
+            mutate: "src/hardware/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: server-db
+            mutate: "src/server/**/*.{ts,tsx},src/db/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: streaming-homekit
+            mutate: "src/streaming/**/*.{ts,tsx},src/homekit/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: react-runtime
+            mutate: "src/hooks/**/*.{ts,tsx},src/providers/**/*.{ts,tsx},src/ui/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: app-routes
+            mutate: "app/**/*.{ts,tsx},!app/**/*.test.{ts,tsx},!app/**/*.d.ts"
+          - name: components-features
+            mutate: "src/components/Sensors/**/*.{ts,tsx},src/components/Schedule/**/*.{ts,tsx},src/components/biometrics/**/*.{ts,tsx},src/components/Settings/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: components-views
+            mutate: "src/components/status/**/*.{ts,tsx},src/components/SleepStages/**/*.{ts,tsx},src/components/Environment/**/*.{ts,tsx},src/components/TempScreen/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: components-misc
+            mutate: "src/components/**/*.{ts,tsx},!src/components/Sensors/**,!src/components/Schedule/**,!src/components/biometrics/**,!src/components/Settings/**,!src/components/status/**,!src/components/SleepStages/**,!src/components/Environment/**,!src/components/TempScreen/**,!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,19 +16,17 @@ export default {
     configFile: 'vitest.config.mts',
   },
 
-  // Start narrow: mutate only the modules that have real unit test coverage.
-  // Next.js app code (app/, components/, hooks/, utils/) is under-tested
-  // and would add hours of wall-clock time to each mutation run without
-  // telling us anything useful. Expand once we're confident the report is
-  // actionable.
+  // Mutate everything under src/ and app/. NoCoverage / Survived counts
+  // surface exactly the areas that need more tests — filtering them out
+  // hides the signal. CI splits this into area shards (see mutation.yml)
+  // so wall-clock stays manageable; local runs use this full list.
   mutate: [
-    'src/services/**/*.ts',
-    'src/scheduler/**/*.ts',
-    'src/hardware/**/*.ts',
-    'src/lib/**/*.ts',
+    'src/**/*.{ts,tsx}',
+    'app/**/*.{ts,tsx}',
     '!src/**/tests/**',
-    '!src/**/*.test.ts',
+    '!src/**/*.test.{ts,tsx}',
     '!src/**/*.d.ts',
+    '!app/**/*.d.ts',
   ],
 
   // Skip "static mutants" — mutations inside module-level / constant


### PR DESCRIPTION
## Summary

Follow-up to #541. Now that the pinned-issue + Discord + history pipeline is wired up, broaden what we're actually mutating.

**Scope:** Previously narrow (`services`, `scheduler`, `hardware`, `lib` only — comment said app/ + components/ were "under-tested, would add hours"). Mutation testing exists *precisely* to surface under-tested code — filtering it out was hiding the signal. Now mutates everything under `src/` and `app/`. We're open-source with unlimited Actions minutes and the run is Saturday off-hours; the wider scope is essentially free.

**Sharding:** Goes from 2 → 10 area-cohesive shards so individual-shard wall-time stays reasonable and the matrix fits comfortably under GitHub's 20-concurrent-job limit for OSS:

| Shard | Areas | ~Files |
|---|---|---|
| `lib-utils` | lib, utils, modules | 16 |
| `services-scheduler` | services, scheduler | 8 |
| `hardware` | hardware | 16 |
| `server-db` | server, db | 25 |
| `streaming-homekit` | streaming, homekit | 14 |
| `react-runtime` | hooks, providers, ui | 20 |
| `app-routes` | app/ | 17 |
| `components-features` | Sensors, Schedule, biometrics, Settings | 44 |
| `components-views` | status, SleepStages, Environment, TempScreen | 28 |
| `components-misc` | remaining components | 15 |

`stryker.config.mjs`'s `mutate` block also broadened so local runs match. The `summarize` and `record-baseline` jobs aggregate over all `mutation-report-*` artifacts and need no change.

## Test plan

- [ ] Manual workflow_dispatch after merge — all 10 shards run, none time out (90-min cap is unchanged), summarize aggregates all 10 into the pinned issue.
- [ ] Confirm `concurrency: mutation-${{ github.ref }}` + `cancel-in-progress: true` still behaves correctly with the larger matrix.
- [ ] Next scheduled Saturday run produces a single pinned-issue update with merged numbers + Discord ping reflecting the new total mutant count.