### PR TITLE
ci(codecov): add pytest workflow + flag-scoped reports

### DIFF
--- a/.github/workflows/python-modules.yml
+++ b/.github/workflows/python-modules.yml
@@ -1,0 +1,119 @@
+name: Python Modules
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'modules/**/*.py'
+      - 'modules/**/pyproject.toml'
+      - 'modules/**/uv.lock'
+      - '.github/workflows/python-modules.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'modules/**/*.py'
+      - 'modules/**/pyproject.toml'
+      - 'modules/**/uv.lock'
+      - '.github/workflows/python-modules.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.module.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          # `common` has no pyproject.toml; tests live under modules/common/
+          # and import `from common.X`, so they must run with cwd=modules/.
+          - name: common
+            workdir: modules
+            target: common
+            cov_source: common
+          - name: cover-buttons
+            workdir: modules/cover-buttons
+            target: .
+            cov_source: .
+          - name: environment-monitor
+            workdir: modules/environment-monitor
+            target: .
+            cov_source: .
+          - name: piezo-processor
+            workdir: modules/piezo-processor
+            target: .
+            cov_source: .
+          - name: sleep-detector
+            workdir: modules/sleep-detector
+            target: .
+            cov_source: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          # Pod runtime is pinned to 3.10 by every module's pyproject
+          # (`requires-python = ">=3.9,<3.11"`). Match it in CI.
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install module + test deps
+        working-directory: ${{ matrix.module.workdir }}
+        run: |
+          uv venv .venv
+          # shellcheck source=/dev/null
+          . .venv/bin/activate
+          # The `common` module has no pyproject — it's a shared package
+          # imported by the others. Skip the editable install in that case
+          # and let test-time sys.modules stubs cover any pod-only imports.
+          if [ -f pyproject.toml ]; then
+            uv pip install -e .
+          fi
+          uv pip install pytest pytest-cov
+
+      - name: Run pytest with coverage
+        working-directory: ${{ matrix.module.workdir }}
+        run: |
+          # shellcheck source=/dev/null
+          . .venv/bin/activate
+          pytest ${{ matrix.module.target }} \
+            --cov=${{ matrix.module.cov_source }} \
+            --cov-report=xml:coverage.xml \
+            --junit-xml=junit.xml \
+            -o junit_family=legacy
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          slug: sleepypod/core
+          flags: python,${{ matrix.module.name }}
+          files: ${{ matrix.module.workdir }}/coverage.xml
+          # Coverage XML uses paths relative to the pytest run dir; tell
+          # Codecov where that was so report paths resolve to repo paths.
+          working-directory: ${{ matrix.module.workdir }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          use_oidc: true
+          slug: sleepypod/core
+          flags: python,${{ matrix.module.name }}
+          files: ${{ matrix.module.workdir }}/junit.xml

--- a/.github/workflows/python-modules.yml
+++ b/.github/workflows/python-modules.yml
@@ -35,26 +35,38 @@ jobs:
         module:
           # `common` has no pyproject.toml; tests live under modules/common/
           # and import `from common.X`, so they must run with cwd=modules/.
+          #
+          # We don't `pip install -e .` per module: each module is a flat
+          # layout with `main.py` + `test_main.py` at the top, which trips
+          # setuptools auto-discovery ("Multiple top-level modules"). Tests
+          # don't need the module installed anyway — they `from main import`
+          # via cwd. We just install the runtime deps main.py loads at
+          # import time (the rest are stubbed in sys.modules by the tests).
           - name: common
             workdir: modules
             target: common
             cov_source: common
+            deps: ""
           - name: cover-buttons
             workdir: modules/cover-buttons
             target: .
             cov_source: .
+            deps: ""
           - name: environment-monitor
             workdir: modules/environment-monitor
             target: .
             cov_source: .
+            deps: ""
           - name: piezo-processor
             workdir: modules/piezo-processor
             target: .
             cov_source: .
+            deps: "numpy scipy"
           - name: sleep-detector
             workdir: modules/sleep-detector
             target: .
             cov_source: .
+            deps: ""
 
     steps:
       - name: Checkout
@@ -72,19 +84,13 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install module + test deps
+      - name: Install test deps
         working-directory: ${{ matrix.module.workdir }}
         run: |
           uv venv .venv
           # shellcheck source=/dev/null
           . .venv/bin/activate
-          # The `common` module has no pyproject — it's a shared package
-          # imported by the others. Skip the editable install in that case
-          # and let test-time sys.modules stubs cover any pod-only imports.
-          if [ -f pyproject.toml ]; then
-            uv pip install -e .
-          fi
-          uv pip install pytest pytest-cov
+          uv pip install pytest pytest-cov ${{ matrix.module.deps }}
 
       - name: Run pytest with coverage
         working-directory: ${{ matrix.module.workdir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           use_oidc: true
           slug: sleepypod/core
+          flags: javascript
 
       - name: Upload test results to Codecov
         if: matrix.task.name == 'Unit Tests' && !cancelled()
@@ -76,3 +77,4 @@ jobs:
           use_oidc: true
           slug: sleepypod/core
           files: test-results/junit.xml
+          flags: javascript

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,73 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+      javascript:
+        flags:
+          - javascript
+        target: auto
+        threshold: 1%
+      python:
+        flags:
+          - python
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Carry forward each flag's last good coverage when its workflow didn't run
+# on this commit (e.g. python-modules.yml is path-filtered to modules/**, so
+# a TS-only PR must not show python coverage as 0%).
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: javascript
+      paths:
+        - src/
+        - app/
+        - lib/
+    - name: python
+      paths:
+        - modules/
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: javascript
+      name: TypeScript / React
+      paths:
+        - src/**
+        - app/**
+        - lib/**
+    - component_id: python
+      name: Pod Python modules
+      paths:
+        - modules/**
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/test_*.py"
+  - "**/tests/**"
+  - ".next/**"
+  - "node_modules/**"
+  - "scripts/**"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/python-modules.yml` running pytest with coverage for `modules/common`, `cover-buttons`, `environment-monitor`, `piezo-processor`, `sleep-detector` (145 tests previously uncovered by CI).
- Add `codecov.yml` defining `javascript` + `python` flags with carryforward (so a path-filtered Python run doesn't zero-out the JS flag), matching components for the dashboard, and ignore patterns for test files.
- Tag the existing Vitest upload in `test.yml` with `flags: javascript` so the two test runners are reported separately.

## Test plan
- [ ] Confirm the Python Modules workflow runs on this PR (touches `.github/workflows/python-modules.yml`)
- [ ] Verify each matrix shard (5 modules) completes and uploads `coverage.xml` + `junit.xml`
- [ ] Confirm Codecov PR comment shows both `javascript` and `python` flags
- [ ] Verify components view at https://app.codecov.io/gh/sleepypod/core shows TypeScript / React and Pod Python modules separately

Local smoke results (Python 3.14, pytest-cov):
- common: 24 passed
- cover-buttons: 11 passed
- environment-monitor: 14 passed
- piezo-processor: 76 passed
- sleep-detector: 20 passed