### PR TITLE
Revert "ci(mutation): mutate whole repo across 10 area shards (#542)"

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,31 +38,13 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          # Each shard's --mutate string is the include globs + the
-          # exclude globs (the CLI flag overrides the config's mutate
-          # block entirely, so excludes must be repeated per shard).
-          # Areas roughly grouped by code-cohesion + file count so wall
-          # time stays balanced across the matrix.
-          - name: lib-utils
-            mutate: "src/lib/**/*.{ts,tsx},src/utils/**/*.{ts,tsx},src/modules/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          # The --mutate CLI flag overrides the config's exclude patterns,
+          # so we have to repeat them here per shard. Keep these three
+          # exclusions in sync with stryker.config.mjs's mutate: block.
           - name: services-scheduler
-            mutate: "src/services/**/*.{ts,tsx},src/scheduler/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: hardware
-            mutate: "src/hardware/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: server-db
-            mutate: "src/server/**/*.{ts,tsx},src/db/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: streaming-homekit
-            mutate: "src/streaming/**/*.{ts,tsx},src/homekit/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: react-runtime
-            mutate: "src/hooks/**/*.{ts,tsx},src/providers/**/*.{ts,tsx},src/ui/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: app-routes
-            mutate: "app/**/*.{ts,tsx},!app/**/*.test.{ts,tsx},!app/**/*.d.ts"
-          - name: components-features
-            mutate: "src/components/Sensors/**/*.{ts,tsx},src/components/Schedule/**/*.{ts,tsx},src/components/biometrics/**/*.{ts,tsx},src/components/Settings/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: components-views
-            mutate: "src/components/status/**/*.{ts,tsx},src/components/SleepStages/**/*.{ts,tsx},src/components/Environment/**/*.{ts,tsx},src/components/TempScreen/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: components-misc
-            mutate: "src/components/**/*.{ts,tsx},!src/components/Sensors/**,!src/components/Schedule/**,!src/components/biometrics/**,!src/components/Settings/**,!src/components/status/**,!src/components/SleepStages/**,!src/components/Environment/**,!src/components/TempScreen/**,!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+          - name: hardware-lib
+            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,17 +16,19 @@ export default {
     configFile: 'vitest.config.mts',
   },
 
-  // Mutate everything under src/ and app/. NoCoverage / Survived counts
-  // surface exactly the areas that need more tests — filtering them out
-  // hides the signal. CI splits this into area shards (see mutation.yml)
-  // so wall-clock stays manageable; local runs use this full list.
+  // Start narrow: mutate only the modules that have real unit test coverage.
+  // Next.js app code (app/, components/, hooks/, utils/) is under-tested
+  // and would add hours of wall-clock time to each mutation run without
+  // telling us anything useful. Expand once we're confident the report is
+  // actionable.
   mutate: [
-    'src/**/*.{ts,tsx}',
-    'app/**/*.{ts,tsx}',
+    'src/services/**/*.ts',
+    'src/scheduler/**/*.ts',
+    'src/hardware/**/*.ts',
+    'src/lib/**/*.ts',
     '!src/**/tests/**',
-    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.test.ts',
     '!src/**/*.d.ts',
-    '!app/**/*.d.ts',
   ],
 
   // Skip "static mutants" — mutations inside module-level / constant


### PR DESCRIPTION
## Summary

Reverts #542. All 10 shards failed at dry-run with:

```
WARN VitestTestRunner Vitest failed to find test files related to mutated files.
INFO DryRunExecutor No tests were found
ERROR Stryker No tests were executed. Stryker will exit prematurely.
```

See [run 25638408426](https://github.com/sleepypod/core/actions/runs/25638408426). Even shards covering areas with known test coverage (e.g. `lib-utils`) failed — so the issue isn't just "new areas have no tests." Likely either brace expansion in the `--mutate` negation patterns is not being applied (so test files get mutated), or vitest's `--related` resolution interacts badly with `tsconfigPaths` + the lingui babel macro for `.tsx` files.

Restoring the working 2-shard config from #541 to put scheduled runs back to green. Will re-investigate properly (likely needs `disableBail`/related-test config in the stryker vitest-runner) before re-attempting whole-repo coverage.

## Test plan

- [ ] Manual `workflow_dispatch` after merge — confirm both `services-scheduler` and `hardware-lib` shards complete successfully and pinned issue updates.