### PR TITLE
ci(mutation): fire Discord webhook on workflow_dispatch too

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -322,12 +322,14 @@ jobs:
             core.setOutput('killed', String(totals.killed))
             core.setOutput('total', String(totals.total))
 
-      # Push notification so the weekly run isn't invisible. Gated to
-      # `schedule` only — manual reruns and PR-labeled runs would spam
-      # the channel. Uses Discord's `<url>` syntax to suppress preview
-      # embeds so the message stays one line.
-      - name: Notify Discord (scheduled runs only)
-        if: github.event_name == 'schedule' && steps.update-issue.outputs.score != ''
+      # Push notification so the weekly run isn't invisible. Fires on
+      # schedule and workflow_dispatch (manual reruns are rare and the
+      # ping is useful for verifying the webhook). PR-labeled runs are
+      # excluded so per-PR mutation tests don't spam the channel. Uses
+      # Discord's `<url>` syntax to suppress preview embeds so the
+      # message stays one line.
+      - name: Notify Discord
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.update-issue.outputs.score != ''
         env:
           WEBHOOK: ${{ secrets.DISCORD_MUTATION_WEBHOOK }}
           SCORE: ${{ steps.update-issue.outputs.score }}


### PR DESCRIPTION
Schedule-only gate meant the webhook couldn't be verified without waiting a week. Manual reruns are rare; the ping is worth more than the silence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow notifications to trigger for both scheduled and manual workflow runs, improving visibility into pipeline status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->