### PR TITLE
fix(install): install sp-* CLI tools before starting service

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -865,6 +865,24 @@ MaxFileSec=1week
 JOURNALD
 systemctl restart systemd-journald 2>/dev/null || true
 
+# Install CLI tools from scripts/bin/ BEFORE the service starts. The systemd
+# unit's ExecStartPre references /usr/local/bin/sp-maintenance — if these
+# binaries aren't in place by the time systemctl restart fires below, the
+# service fails with "status=203/EXEC: No such file or directory".
+# /usr/local/bin is root-owned by default; copies inherit current uid (root,
+# since this script requires sudo) but we chown/chmod explicitly so the
+# installed file is guaranteed root:root 0755.
+if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+  echo "Installing CLI tools..."
+  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+    [ -f "$tool" ] || continue
+    target="/usr/local/bin/$(basename "$tool")"
+    cp "$tool" "$target"
+    chown root:root "$target"
+    chmod 0755 "$target"
+  done
+fi
+
 # Reload systemd and enable service
 echo "Enabling service..."
 systemctl daemon-reload
@@ -1186,22 +1204,6 @@ fi
 # On upgrades, old services (without UMask=0002) may have recreated WAL/SHM
 # files with 0644 between the initial fixup and the service restarts above.
 fix_db_permissions
-
-# Install CLI tools from scripts/bin/. /usr/local/bin is root-owned by
-# default — copies inherit current uid (root, since this script requires
-# sudo) but we chown/chmod explicitly so the file at the target path is
-# guaranteed root:root 0755 even if the source file under $INSTALL_DIR
-# has unusual ownership.
-if [ -d "$INSTALL_DIR/scripts/bin" ]; then
-  echo "Installing CLI tools..."
-  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-    [ -f "$tool" ] || continue
-    target="/usr/local/bin/$(basename "$tool")"
-    cp "$tool" "$target"
-    chown root:root "$target"
-    chmod 0755 "$target"
-  done
-fi
 
 # Optional SSH configuration
 if [ "$SKIP_SSH" = true ]; then


### PR DESCRIPTION
## Summary

- Pod 3 fresh install died on first boot with `sleepypod.service: Failed at step EXEC spawning /usr/local/bin/sp-maintenance: No such file or directory`.
- Root cause: the systemd unit's `ExecStartPre=+/usr/local/bin/sp-maintenance` (scripts/install:825) was wired up and started via `systemctl restart sleepypod.service` (scripts/install:922), but the `sp-*` CLI tools weren't copied into `/usr/local/bin/` until ~270 lines later (scripts/install:1190).
- Move the `sp-*` install block to immediately before `systemctl daemon-reload` / `enable` so the binaries exist before the service ever boots.

## Test plan

- [ ] Fresh install on a Pod 3 — confirm `sleepypod.service` starts cleanly (`systemctl status sleepypod` is `active (running)` without the 203/EXEC error).
- [ ] Verify `/usr/local/bin/sp-maintenance`, `/usr/local/bin/sp-update` exist and are `0755 root:root` after install completes.
- [ ] Re-run `scripts/install` on an existing pod (Pod 4) and confirm the service restart still works (idempotency).