### PR TITLE
test(lib,hardware): cover formatTemp, determineTrend, dacMonitor knobs

### DIFF
--- a/src/hardware/tests/dacMonitor.test.ts
+++ b/src/hardware/tests/dacMonitor.test.ts
@@ -238,6 +238,63 @@ describe('DacMonitor', () => {
     )
   })
 
+  test('setPollInterval is a no-op when given the current interval', async () => {
+    const monitor = createMonitor(POLL_MS)
+    await monitor.start()
+    const updates: unknown[] = []
+    monitor.on('status:updated', s => updates.push(s))
+    await sleep(POLL_MS * 3 + 20)
+    const before = updates.length
+
+    monitor.setPollInterval(POLL_MS) // same value → early return
+    updates.length = 0
+    await sleep(POLL_MS * 3 + 20)
+
+    // Cadence unchanged: roughly the same number of polls in the same window
+    expect(updates.length).toBeGreaterThanOrEqual(before - 1)
+    expect(updates.length).toBeLessThanOrEqual(before + 1)
+  })
+
+  test('setPollInterval restarts the interval timer at the new cadence', async () => {
+    const monitor = createMonitor(200) // start slow
+    await monitor.start()
+    const updates: unknown[] = []
+    monitor.on('status:updated', s => updates.push(s))
+
+    monitor.setPollInterval(POLL_MS) // speed up to 50ms
+    await sleep(POLL_MS * 5 + 50)
+
+    // At 50ms cadence over ~300ms we should see at least 3 polls; at 200ms we'd see 1
+    expect(updates.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('setActive / setIdle reconfigure pollIntervalMs without crashing', async () => {
+    const monitor = createMonitor()
+    await monitor.start()
+    await waitFor(() => monitor.getLastStatus() !== null, 500)
+
+    monitor.setActive()
+    monitor.setIdle()
+    monitor.setActive()
+
+    expect(monitor.getStatus()).toBe('running')
+  })
+
+  test('start marks status degraded when daemon is unreachable', async () => {
+    const monitor = new DacMonitor({
+      socketPath: '/tmp/sleepypod-test-nonexistent.sock',
+      pollIntervalMs: POLL_MS,
+    })
+    monitors.push(monitor)
+    const errors: unknown[] = []
+    monitor.on('error', e => errors.push(e))
+
+    await monitor.start()
+
+    expect(monitor.getStatus()).toBe('degraded')
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+  })
+
   test('gesture:detected event includes timestamp', async () => {
     const monitor = createMonitor()
     const gestures: Array<{ timestamp: unknown }> = []

--- a/src/lib/tests/tempUtils.test.ts
+++ b/src/lib/tests/tempUtils.test.ts
@@ -3,10 +3,12 @@ import {
   centiDegreesToC,
   centiDegreesToF,
   centiPercentToPercent,
-  toF,
-  toC,
+  determineTrend,
   ensureF,
+  formatTemp,
   mapToEightSleepScale,
+  toC,
+  toF,
 } from '../tempUtils'
 
 describe('centiDegreesToC', () => {
@@ -82,6 +84,47 @@ describe('ensureF', () => {
 
   test('defaults to Fahrenheit', () => {
     expect(ensureF(72)).toBe(72)
+  })
+})
+
+describe('formatTemp', () => {
+  test('rounds to nearest integer and defaults to Fahrenheit', () => {
+    expect(formatTemp(72.4)).toBe('72°F')
+    expect(formatTemp(72.6)).toBe('73°F')
+  })
+
+  test('rounds .5 upward (Math.round semantics)', () => {
+    expect(formatTemp(72.5)).toBe('73°F')
+  })
+
+  test('honours Celsius unit', () => {
+    expect(formatTemp(22.3, 'C')).toBe('22°C')
+  })
+
+  test('handles negative values', () => {
+    expect(formatTemp(-5.4, 'C')).toBe('-5°C')
+  })
+})
+
+describe('determineTrend', () => {
+  test('"up" when target is more than 0.5° above current', () => {
+    expect(determineTrend(70, 71)).toBe('up')
+  })
+
+  test('"down" when target is more than 0.5° below current', () => {
+    expect(determineTrend(72, 70)).toBe('down')
+  })
+
+  test('"stable" when |diff| <= 0.5°', () => {
+    expect(determineTrend(70, 70)).toBe('stable')
+    expect(determineTrend(70, 70.5)).toBe('stable')
+    expect(determineTrend(70.5, 70)).toBe('stable')
+  })
+
+  test('thresholds are exclusive (exactly 0.5 is stable, not up/down)', () => {
+    expect(determineTrend(70, 70.5)).toBe('stable')
+    expect(determineTrend(70, 70.51)).toBe('up')
+    expect(determineTrend(70.51, 70)).toBe('down')
   })
 })
 


### PR DESCRIPTION
## Summary
- `src/lib/tempUtils.ts` had two functions with zero tests: `formatTemp` and `determineTrend`. Added them.
- `src/hardware/dacMonitor.ts` had no tests for `setPollInterval` / `setActive` / `setIdle` or the degraded-on-start path. Added them.

## Coverage delta
| Area | Before | After |
| --- | ---: | ---: |
| `dacMonitor.ts` statements | 78.89% | **94.49%** |
| `dacMonitor.ts` lines | 85.10% | **100%** |
| Overall statements | 83.82% | 84.45% |
| Overall lines | 85.00% | 85.56% |

## Test plan
- [x] `pnpm test run src/lib/tests/tempUtils.test.ts` — 26 tests pass
- [x] `pnpm test run src/hardware/tests/dacMonitor.test.ts` — 18 tests pass
- [x] Full suite: `pnpm test run --coverage` clean
- [ ] Codecov flag check — `javascript` flag should pick up the lift on this PR