### PR TITLE
test(scheduler): cover checkLiveness, broadcast payload shape, onTemp fallback

### DIFF
--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -71,6 +71,7 @@ vi.mock('@/src/services/autoOffWatcher', () => ({
 }))
 
 import { JobManager } from '../jobManager'
+import { JobType } from '../types'
 
 /**
  * Count reload cycles by spying on Scheduler.cancelRecurringJobs, which is
@@ -235,5 +236,139 @@ describe('JobManager public surface (stub DB)', () => {
     await manager.shutdown()
     await manager.shutdown()
     // afterEach will call once more
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Heartbeat liveness — pins the staleness arithmetic, RUN_ONCE skip, null
+// nextInvocation skip, and the reload-cooldown branch so a node-schedule
+// freeze (no fires, no exception) still triggers a recovery reload.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager.checkLiveness', () => {
+  const STALE_MS = 90_000
+  let manager: JobManager
+
+  beforeEach(() => {
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: STALE_MS,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+    vi.restoreAllMocks()
+  })
+
+  // ScheduledJob shape stripped to what checkLiveness reads (id + type).
+  const fakeJob = (id: string, type: JobType): any => ({ id, type, schedule: '', job: {} })
+
+  function stubScheduler(jobs: Array<{ id: string, type: JobType }>, nextAt: (id: string) => Date | null) {
+    const scheduler = manager.getScheduler()
+    vi.spyOn(scheduler, 'getJobs').mockReturnValue(jobs.map(j => fakeJob(j.id, j.type)))
+    vi.spyOn(scheduler, 'getNextInvocation').mockImplementation((id: string) => nextAt(id))
+  }
+
+  it('returns empty list and does not reload when all jobs fire in the future', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() + 60_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark future jobs stale — arithmetic is `now - staleMs`, not `now + staleMs`', async () => {
+    // Kills `now - staleMs` → `now + staleMs` mutator: under the mutation a job
+    // ~30s in the future would satisfy `nextMs < now + 90_000` and reload-spam.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() + 30_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark a job at exactly the staleness boundary — comparison is strict `<`', async () => {
+    // Kills `<` → `<=`: at nextMs === now - staleMs, strict `<` is false.
+    const fixedNow = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(fixedNow)
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(fixedNow - STALE_MS),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('marks a recurring job overdue past the stale window and forces a reload', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual(['temp-1'])
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips RUN_ONCE jobs even when their next invocation is overdue', async () => {
+    // Kills mutating the RUN_ONCE guard to a no-op or its conditional to true/false:
+    // a one-shot whose Date has passed must NOT be force-reloaded — node-schedule
+    // already retires it after firing.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'runonce-1-0', type: JobType.RUN_ONCE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores jobs whose getNextInvocation returns null', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => null,
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('suppresses follow-up reloads while the cooldown window is open', async () => {
+    // Kills `cooldownLeft > 0` → `false` and removing the cooldown branch:
+    // a persistent freeze should NOT spin reload on every tick.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    await manager.checkLiveness() // first detection — reloads
+    await manager.checkLiveness() // still inside 5-min cooldown
+    await manager.checkLiveness()
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the stale id list even when suppressed by cooldown', async () => {
+    // The function returns `stale` from the cooldown branch (line 296), not [].
+    // Mutating that return to `[]` would break health endpoints that read the list.
+    vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    await manager.checkLiveness() // first call sets cooldown
+    expect(await manager.checkLiveness()).toEqual(['temp-1'])
   })
 })

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -23,12 +23,14 @@ vi.mock('@/src/hardware/dacTransport', () => ({
   sendCommand: vi.fn(async () => {}),
 }))
 
+const broadcastMutationStatus = vi.fn<(side: 'left' | 'right', patch: Record<string, unknown>) => void>()
 vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
-  broadcastMutationStatus: vi.fn(),
+  broadcastMutationStatus: (side: 'left' | 'right', patch: Record<string, unknown>) => broadcastMutationStatus(side, patch),
 }))
 
+const cancelAutoOffTimer = vi.fn<(side: 'left' | 'right') => void>()
 vi.mock('@/src/services/autoOffWatcher', () => ({
-  cancelAutoOffTimer: vi.fn(),
+  cancelAutoOffTimer: (side: 'left' | 'right') => cancelAutoOffTimer(side),
 }))
 
 // Mock child_process.exec so executeReboot tests never spawn systemctl.
@@ -67,6 +69,7 @@ vi.mock('@/src/db', async () => {
 
 import * as dbModule from '@/src/db'
 import { JobManager } from '../jobManager'
+import { fahrenheitToLevel } from '@/src/hardware/types'
 const { sqlite } = dbModule as typeof dbModule & { sqlite: BetterSqlite3.Database }
 
 function resetSchema(): void {
@@ -360,6 +363,11 @@ describe('JobManager — job ordering and gating', () => {
     setPower.mockClear()
     setAlarm.mockClear()
     connect.mockClear()
+    broadcastMutationStatus.mockClear()
+    cancelAutoOffTimer.mockClear()
+    setTemperature.mockImplementation(async () => {})
+    setPower.mockImplementation(async () => {})
+    setAlarm.mockImplementation(async () => {})
     manager = new JobManager('America/Los_Angeles', {
       heartbeatIntervalMs: 60_000,
       heartbeatStaleMs: 90_000,
@@ -1713,5 +1721,196 @@ describe('JobManager handler closures', () => {
 
     // loadSchedules must not throw — initial brightness apply is wrapped in try/catch
     await expect(manager.loadSchedules()).resolves.toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// broadcastMutationStatus payload shape + downstream side-effects.
+//
+// Mutation testing flagged the broadcastMutationStatus(...) object literals
+// (lines 349, 384, 420, 436 of jobManager.ts) and the `onTemperature ?? 75`
+// fallback (line 383) as surviving — existing tests covered the hardware
+// client calls but did not assert on the streaming payload itself.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager — streaming + downstream side-effects', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    setAlarm.mockClear()
+    connect.mockClear()
+    broadcastMutationStatus.mockClear()
+    cancelAutoOffTimer.mockClear()
+    setTemperature.mockImplementation(async () => {})
+    setPower.mockImplementation(async () => {})
+    setAlarm.mockImplementation(async () => {})
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('runTemperatureJob broadcasts targetTemperature + targetLevel after setTemperature', async () => {
+    seedSidePowered('left', true)
+
+    await manager.runTemperatureJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      time: '08:00',
+      temperature: 78,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', {
+      targetTemperature: 78,
+      targetLevel: fahrenheitToLevel(78),
+    })
+  })
+
+  it('runTemperatureJob does NOT broadcast when the side is unpowered', async () => {
+    seedSidePowered('left', false)
+
+    await manager.runTemperatureJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      time: '08:00',
+      temperature: 78,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
+  })
+
+  it('runPowerOnJob broadcasts targetTemperature matching onTemperature when set', async () => {
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 84,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+      targetTemperature: 84,
+      targetLevel: fahrenheitToLevel(84),
+    })
+    expect(cancelAutoOffTimer).toHaveBeenCalledWith('right')
+  })
+
+  it('runPowerOnJob falls back to 75°F in the BROADCAST when onTemperature is null', async () => {
+    // Kills `??` → `&&` mutator at jobManager.ts:383. Under `&&`, a null
+    // onTemperature would propagate to the broadcast as null/undefined; under
+    // `??`, the fallback 75 must surface in targetTemperature + targetLevel.
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: null as unknown as number,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', {
+      targetTemperature: 75,
+      targetLevel: fahrenheitToLevel(75),
+    })
+  })
+
+  it('runPowerOffJob broadcasts targetLevel:0 (and no temperature key)', async () => {
+    seedSidePowered('left', true)
+
+    await manager.runPowerOffJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+  })
+
+  it('runAlarmJob broadcasts alarm temperature + isAlarmVibrating:true', async () => {
+    seedSidePowered('right', true)
+
+    await manager.runAlarmJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'thursday' as const,
+      time: '06:30',
+      alarmTemperature: 88,
+      vibrationIntensity: 90,
+      vibrationPattern: 'rise' as const,
+      duration: 30,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+      targetTemperature: 88,
+      targetLevel: fahrenheitToLevel(88),
+      isAlarmVibrating: true,
+    })
+    // setAlarm forwarded the exact vibration parameters from the schedule
+    expect(setAlarm).toHaveBeenCalledWith('right', {
+      vibrationIntensity: 90,
+      vibrationPattern: 'rise',
+      duration: 30,
+    })
+  })
+
+  it('runPowerOnJob does NOT cancelAutoOffTimer when a run-once session is active', async () => {
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      status: 'active',
+    })
+
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(cancelAutoOffTimer).not.toHaveBeenCalled()
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Address surviving mutants flagged in the weekly Stryker baseline (#543) for `src/scheduler/jobManager.ts`. Tests-only, no production changes.

- `JobManager.checkLiveness` — new describe block (8 tests) pinning the strict-`<` boundary, the `now - staleMs` arithmetic direction, the `RUN_ONCE` skip, the null-`nextInvocation` skip, and the cooldown branch's return shape (must still return the stale id list, not `[]`).
- `broadcastMutationStatus` payload shape on temp / power-on / power-off / alarm happy paths — kills the `ObjectLiteral` mutants at jobManager.ts:349/384/420/436 that previous tests didn't reach.
- `runPowerOnJob` — the `onTemperature ?? 75` fallback is now asserted on the **broadcast** (which is where the operator runs). The existing null test only checked `setPower(..., null)`, which receives the raw `sched.onTemperature` field and so never exercised the `??`.

Also exposes the `broadcastMutationStatus` and `cancelAutoOffTimer` module mocks as named `vi.fn`s so assertions can read their call args.

## Test plan

- [x] `pnpm test src/scheduler/tests/jobManager.test.ts src/scheduler/tests/jobOrdering.test.ts --run` — 102/102 passing
- [x] `pnpm lint` — clean for changed files (only pre-existing warning in `stryker.config.mjs`)
- [ ] After merge, re-run `pnpm test:mutation` on the `services-scheduler` shard and confirm the targeted mutants flip from `Survived` to `Killed`