### PR TITLE
fix(hardware): classify real Pod 5 sensor labels as Pod 5, not Pod 3

### DIFF
--- a/src/hardware/responseParser.ts
+++ b/src/hardware/responseParser.ts
@@ -84,21 +84,27 @@ function parseKeyValueResponse(response: string): Record<string, string> {
 
 /**
  * Extract pod version from sensor label.
- * Example: "8SLEEP-SN-12345-H00" -> Pod 3
+ *
+ * Sensor labels come in two observed shapes:
+ *   "8SLEEP-SN-12345-I00"      — revision code in the last segment (test sim)
+ *   "20600-0003-J55-B0708DE3"  — revision code in segment 3, serial in segment 4 (real Pod 5)
+ *
+ * Scan segments from the end and key off the first one shaped like a hardware
+ * revision code ([A-Z][0-9]{2}). Popping the final segment unconditionally
+ * misclassifies real Pod 5 hardware as Pod 3 because the trailing serial
+ * (`B0708DE3`) is alphabetically before `H00`.
  */
 function extractPodVersion(sensorLabel: string): PodVersion {
-  const hwRev = sensorLabel.split('-').pop() || ''
-
-  if (hwRev >= 'J00') {
-    return PodVersion.POD_5
+  const segments = sensorLabel.split('-')
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const seg = segments[i]
+    if (/^[A-Z]\d{2}$/.test(seg)) {
+      const letter = seg[0]
+      if (letter >= 'J') return PodVersion.POD_5
+      if (letter === 'I') return PodVersion.POD_4
+      if (letter === 'H') return PodVersion.POD_3
+    }
   }
-  else if (hwRev >= 'I00') {
-    return PodVersion.POD_4
-  }
-  else if (hwRev >= 'H00') {
-    return PodVersion.POD_3
-  }
-
   return PodVersion.POD_3
 }
 

--- a/src/hardware/tests/responseParser.test.ts
+++ b/src/hardware/tests/responseParser.test.ts
@@ -125,7 +125,9 @@ priming = false
 
     const status = parseDeviceStatus(withQuotes)
     expect(status.sensorLabel).toBe('20600-0003-J55-B0708DE3')
-    expect(status.podVersion).toBe(PodVersion.POD_3)
+    // Real Pod 5 labels put the rev code (`J55`) in segment 3 and a serial
+    // (`B0708DE3`) in segment 4 — must classify as Pod 5, not Pod 3.
+    expect(status.podVersion).toBe(PodVersion.POD_5)
   })
 
   test('handles invalid gesture JSON', () => {


### PR DESCRIPTION
## Summary

Pod 5 devices have been reporting themselves as **Pod 3** on the system status page.

`extractPodVersion` in `src/hardware/responseParser.ts` did `sensorLabel.split('-').pop()` and compared the trailing segment against `H00` / `I00` / `J00`. Real Pod 5 hardware emits

```
sensorLabel = "20600-0003-J55-B0708DE3"
```

The trailing segment is the serial (`B0708DE3`), which is alphabetically before `H00`, so every branch fell through to the `POD_3` default. Only the fake test fixture (`8SLEEP-SN-12345-J00`) puts the revision code in the last segment, hiding the bug.

The test at `responseParser.test.ts:128` had actually **encoded the bug** — asserting `POD_3` for the real-hardware label string. Flipped that assertion to `POD_5`.

## Fix

Scan all segments for one matching `[A-Z][0-9]{2}` and key off its leading letter (`H` → Pod 3, `I` → Pod 4, `J`+ → Pod 5). Works for both the simulated `*-J00` fixtures and real `*-J55-<serial>` labels.

## Test plan

- [x] `pnpm vitest run src/hardware` — 235 passed, 1 skipped
- [ ] Verify on a real Pod 5: status page → "Pod 5" instead of "Pod 3"
- [ ] Verify on a real Pod 4 still shows "Pod 4" (no regression)
- [ ] Verify on a real Pod 3 still shows "Pod 3" (no regression)