### PR TITLE
test(server): cover untested tRPC routers

### DIFF
--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for the biometrics router. Covers happy path of every procedure
+ * plus key branches: BAD_REQUEST date-range checks, NOT_FOUND for missing
+ * IDs, sleep-stage fallback paths.
+ *
+ * biometricsDb (thenable chain + transaction), db (top-level select for
+ * device timezone), raw helper, and sleep-stages classifier are mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  txRowsQueue: [] as unknown[][],
+  popRows(): unknown[] { return dbState.rowsQueue.shift() ?? [] },
+  popTx(): unknown[] { return dbState.txRowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.popRows()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.onConflictDoNothing = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.groupBy = vi.fn(() => chain)
+    return chain
+  }
+
+  const makeTxChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.all = vi.fn(() => dbState.popTx())
+    return chain
+  }
+
+  const select = vi.fn(() => makeChain())
+  const insert = vi.fn(() => makeChain())
+  const update = vi.fn(() => makeChain())
+  const del = vi.fn(() => makeChain())
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: vi.fn(() => makeTxChain()),
+    update: vi.fn(() => makeTxChain()),
+  }))
+
+  return { select, insert, update, delete: del, transaction }
+})
+
+// Top-level db mock for device settings (timezone fetch in getSleepStages default)
+const topDbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve([{ timezone: 'America/Los_Angeles' }]).then(resolve)
+    chain.from = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    return chain
+  }
+  return { select: vi.fn(() => makeChain()) }
+})
+
+const rawMock = vi.hoisted(() => ({
+  listRawFiles: vi.fn(async () => [] as { name: string, sizeBytes: number, modifiedAt: string }[]),
+}))
+
+const sleepStagesMock = vi.hoisted(() => ({
+  classifySleepStages: vi.fn(() => [] as { start: number, duration: number, stage: 'wake' | 'light' | 'deep' | 'rem', heartRate: number | null, hrv: number | null, breathingRate: number | null, movement: number | null }[]),
+  mergeIntoBlocks: vi.fn(() => [] as { start: number, end: number, stage: 'wake' | 'light' | 'deep' | 'rem' }[]),
+  calculateDistribution: vi.fn(() => ({ wake: 0, light: 0, deep: 0, rem: 0 })),
+  calculateQualityScore: vi.fn(() => 0),
+}))
+
+vi.mock('@/src/db', () => ({
+  db: topDbMock,
+  biometricsDb: dbMock,
+}))
+
+vi.mock('@/src/server/routers/raw', () => rawMock)
+vi.mock('@/src/lib/sleep-stages', () => sleepStagesMock)
+
+const { biometricsRouter } = await import('@/src/server/routers/biometrics')
+const caller = biometricsRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbState.txRowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.update.mockClear()
+  dbMock.delete.mockClear()
+  dbMock.transaction.mockClear()
+  topDbMock.select.mockClear()
+  rawMock.listRawFiles.mockReset().mockResolvedValue([])
+  sleepStagesMock.classifySleepStages.mockReset().mockReturnValue([])
+  sleepStagesMock.mergeIntoBlocks.mockReset().mockReturnValue([])
+  sleepStagesMock.calculateDistribution.mockReset().mockReturnValue({ wake: 0, light: 0, deep: 0, rem: 0 })
+  sleepStagesMock.calculateQualityScore.mockReset().mockReturnValue(0)
+})
+
+describe('biometrics.getSleepRecords', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, side: 'left', enteredBedAt: new Date(0), leftBedAt: new Date(1000),
+        sleepDurationSeconds: 1, timesExitedBed: 0,
+        presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0),
+      },
+    ])
+    const out = await caller.getSleepRecords({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getSleepRecords({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.getVitals', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, side: 'left', timestamp: new Date(0), heartRate: 60, hrv: 50, breathingRate: 14 },
+    ])
+    const out = await caller.getVitals({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getVitals({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.getMovement / getMovementBuckets / getMovementSummary', () => {
+  it('getMovement returns rows', async () => {
+    dbState.rowsQueue.push([{ id: 1, side: 'left', timestamp: new Date(0), totalMovement: 100 }])
+    const out = await caller.getMovement({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('getMovement rejects inverted date range', async () => {
+    await expect(caller.getMovement({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+
+  it('getMovementBuckets coerces SQL bucketStart to a Date', async () => {
+    dbState.rowsQueue.push([
+      { bucketStart: 1700000, totalMovement: 250, eventCount: 1, sampleCount: 5 },
+    ])
+    const out = await caller.getMovementBuckets({ side: 'left', bucketSeconds: 60, limit: 100 })
+    expect(out).toHaveLength(1)
+    expect(out[0].bucketStart).toBeInstanceOf(Date)
+    expect(out[0].totalMovement).toBe(250)
+  })
+
+  it('getMovementBuckets rejects inverted date range', async () => {
+    await expect(caller.getMovementBuckets({
+      side: 'left', bucketSeconds: 60, limit: 10,
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+
+  it('getMovementSummary aggregates row to numbers', async () => {
+    dbState.rowsQueue.push([{ positionChanges: '4', restlessMinutes: '20', sampleCount: '60' }])
+    const out = await caller.getMovementSummary({ side: 'left' })
+    expect(out).toEqual({ positionChanges: 4, restlessMinutes: 20, sampleCount: 60 })
+  })
+
+  it('getMovementSummary handles empty result', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getMovementSummary({ side: 'left' })
+    expect(out).toEqual({ positionChanges: 0, restlessMinutes: 0, sampleCount: 0 })
+  })
+})
+
+describe('biometrics.getLatestSleep', () => {
+  it('returns null when no record', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestSleep({ side: 'left' })
+    expect(out).toBeNull()
+  })
+
+  it('returns latest record when present', async () => {
+    dbState.rowsQueue.push([
+      { id: 5, side: 'left', enteredBedAt: new Date(0), leftBedAt: null,
+        sleepDurationSeconds: 0, timesExitedBed: 0,
+        presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0) },
+    ])
+    const out = await caller.getLatestSleep({ side: 'left' })
+    expect(out?.id).toBe(5)
+  })
+})
+
+describe('biometrics.getVitalsSummary', () => {
+  it('returns null when recordCount=0', async () => {
+    dbState.rowsQueue.push([{
+      avgHeartRate: null, minHeartRate: null, maxHeartRate: null,
+      avgHRV: null, avgBreathingRate: null, recordCount: 0,
+    }])
+    const out = await caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns aggregated stats when records present', async () => {
+    dbState.rowsQueue.push([{
+      avgHeartRate: '60', minHeartRate: 50, maxHeartRate: 80,
+      avgHRV: '40', avgBreathingRate: '14', recordCount: 10,
+    }])
+    const out = await caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out?.avgHeartRate).toBe(60)
+    expect(out?.recordCount).toBe(10)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.reportVitals / reportVitalsBatch', () => {
+  it('reportVitals returns written:1', async () => {
+    const out = await caller.reportVitals({
+      side: 'left',
+      timestamp: 1700000000,
+      heartRate: 60, hrv: 50, breathingRate: 14,
+    })
+    expect(out).toEqual({ written: 1 })
+  })
+
+  it('reportVitalsBatch returns the count of inserted rows', async () => {
+    // The chain await resolves to whatever popRows returns from .returning()
+    dbState.rowsQueue.push([{ id: 1 }, { id: 2 }])
+    const out = await caller.reportVitalsBatch({
+      vitals: [
+        { side: 'left', timestamp: 1700000000, heartRate: 60, hrv: 50, breathingRate: 14 },
+        { side: 'left', timestamp: 1700000300, heartRate: 61, hrv: 51, breathingRate: 14 },
+      ],
+    })
+    expect(out).toEqual({ written: 2 })
+  })
+})
+
+describe('biometrics.getFileCount', () => {
+  it('aggregates raw file count and total MB', async () => {
+    rawMock.listRawFiles.mockResolvedValue([
+      { name: 'a.RAW', sizeBytes: 1024 * 1024, modifiedAt: 'x' },
+      { name: 'b.RAW', sizeBytes: 2 * 1024 * 1024, modifiedAt: 'y' },
+    ])
+    const out = await caller.getFileCount({})
+    expect(out.rawFiles).toEqual({ left: 2, right: 2 })
+    expect(out.totalSizeMB).toBe(3)
+  })
+
+  it('returns zeros on listRawFiles error', async () => {
+    rawMock.listRawFiles.mockRejectedValue(new Error('ENOENT'))
+    const out = await caller.getFileCount({})
+    expect(out).toEqual({ rawFiles: { left: 0, right: 0 }, totalSizeMB: 0 }) })
+})
+
+describe('biometrics.updateSleepRecord', () => {
+  it('rejects when no fields supplied', async () => {
+    await expect(caller.updateSleepRecord({ id: 1 })).rejects.toThrow(/No fields to update/)
+  })
+
+  it('throws NOT_FOUND when record missing during recompute', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.updateSleepRecord({
+      id: 1,
+      enteredBedAt: new Date('2025-01-01T00:00:00Z'),
+    })).rejects.toThrow(/Sleep record 1 not found/)
+  })
+
+  it('rejects leftBedAt at or before enteredBedAt', async () => {
+    dbState.txRowsQueue.push([
+      { id: 1, side: 'left', enteredBedAt: new Date('2025-01-01T00:00:00Z'), leftBedAt: new Date('2025-01-01T08:00:00Z') },
+    ])
+    await expect(caller.updateSleepRecord({
+      id: 1,
+      enteredBedAt: new Date('2025-01-01T10:00:00Z'),
+    })).rejects.toThrow(/leftBedAt must be after enteredBedAt/)
+  })
+
+  it('updates timesExitedBed when only it is provided (skips duration recompute)', async () => {
+    const updated = {
+      id: 1, side: 'left',
+      enteredBedAt: new Date(0), leftBedAt: new Date(1000),
+      sleepDurationSeconds: 1, timesExitedBed: 7,
+      presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+    const out = await caller.updateSleepRecord({ id: 1, timesExitedBed: 7 })
+    expect(out.timesExitedBed).toBe(7)
+  })
+})
+
+describe('biometrics.deleteSleepRecord', () => {
+  it('returns success when a row was deleted', async () => {
+    dbState.rowsQueue.push([{ id: 1 }])
+    const out = await caller.deleteSleepRecord({ id: 1 })
+    expect(out).toEqual({ success: true })
+  })
+
+  it('throws NOT_FOUND when nothing was deleted', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.deleteSleepRecord({ id: 99 })).rejects.toThrow(/Sleep record 99 not found/)
+  })
+})
+
+describe('biometrics.getSleepStages', () => {
+  it('rejects when both sleepRecordId and date range are provided', async () => {
+    await expect(caller.getSleepStages({
+      side: 'left',
+      sleepRecordId: 1,
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Provide either sleepRecordId or startDate/)
+  })
+
+  it('throws NOT_FOUND when sleepRecordId missing', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.getSleepStages({ side: 'left', sleepRecordId: 99 })).rejects.toThrow(/Sleep record 99 not found/)
+  })
+
+  it('returns empty result when no recent records exist (default branch)', async () => {
+    // Recent records query returns []
+    dbState.rowsQueue.push([])
+    const out = await caller.getSleepStages({ side: 'left' })
+    expect(out.epochs).toEqual([])
+    expect(out.sleepRecordId).toBeNull()
+  })
+
+  it('classifies stages from a sleepRecordId-supplied window', async () => {
+    const record = {
+      id: 1, side: 'left',
+      enteredBedAt: new Date('2025-01-01T22:00:00Z'),
+      leftBedAt: new Date('2025-01-02T07:00:00Z'),
+    }
+    // Three queries: record lookup, vitals window, movement window
+    dbState.rowsQueue.push([record])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), heartRate: 60, hrv: 50, breathingRate: 14 }])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), totalMovement: 100 }])
+
+    sleepStagesMock.classifySleepStages.mockReturnValue([
+      { start: 0, duration: 300_000, stage: 'light', heartRate: 60, hrv: 50, breathingRate: 14, movement: 100 },
+    ])
+    sleepStagesMock.mergeIntoBlocks.mockReturnValue([{ start: 0, end: 300_000, stage: 'light' }])
+    sleepStagesMock.calculateDistribution.mockReturnValue({ wake: 0, light: 1, deep: 0, rem: 0 })
+    sleepStagesMock.calculateQualityScore.mockReturnValue(80)
+
+    const out = await caller.getSleepStages({ side: 'left', sleepRecordId: 1 })
+    expect(out.sleepRecordId).toBe(1)
+    expect(out.epochs).toHaveLength(1)
+    expect(out.qualityScore).toBe(80)
+    expect(out.totalSleepMs).toBe(300_000)
+  })
+
+  it('rejects an inverted custom date range', async () => {
+    await expect(caller.getSleepStages({
+      side: 'left',
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})

--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -284,7 +284,8 @@ describe('biometrics.getFileCount', () => {
   it('returns zeros on listRawFiles error', async () => {
     rawMock.listRawFiles.mockRejectedValue(new Error('ENOENT'))
     const out = await caller.getFileCount({})
-    expect(out).toEqual({ rawFiles: { left: 0, right: 0 }, totalSizeMB: 0 }) })
+    expect(out).toEqual({ rawFiles: { left: 0, right: 0 }, totalSizeMB: 0 })
+  })
 })
 
 describe('biometrics.updateSleepRecord', () => {

--- a/src/server/routers/tests/calibration.test.ts
+++ b/src/server/routers/tests/calibration.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the calibration router — getStatus pivots rows by sensor type,
+ * getHistory passes filters, triggerCalibration writes atomic .tmp+rename,
+ * triggerFullCalibration writes "all/all", getVitalsQuality respects date
+ * range. fs/promises and biometricsDb fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMock = vi.hoisted(() => ({
+  writeFile: vi.fn<(...args: unknown[]) => Promise<void>>(async () => undefined),
+  rename: vi.fn<(...args: unknown[]) => Promise<void>>(async () => undefined),
+}))
+
+// biometricsDb chain — supports both query (select→from→where→orderBy→limit)
+// and insert (.insert→.values→.onConflictDoUpdate)
+const dbMock = vi.hoisted(() => {
+  // Default rows returned per table — overridable per test
+  const profileRows: unknown[] = []
+  const runRows: unknown[] = []
+  const qualityRows: unknown[] = []
+  let activeTable: 'profiles' | 'runs' | 'quality' = 'profiles'
+
+  // chains terminate at: where (for getStatus), .limit (for history/quality)
+  const limitProfiles = vi.fn(async () => profileRows)
+  const limitRuns = vi.fn(async () => runRows)
+  const limitQuality = vi.fn(async () => qualityRows)
+
+  const orderRuns = vi.fn(() => ({ limit: limitRuns }))
+  const orderQuality = vi.fn(() => ({ limit: limitQuality }))
+
+  // For getStatus: where() resolves directly (await on chain after where)
+  const whereProfilesAwait = vi.fn(async () => profileRows)
+  // For getHistory/getVitalsQuality: where().orderBy().limit()
+  const whereRuns = vi.fn(() => ({ orderBy: orderRuns }))
+  const whereQuality = vi.fn(() => ({ orderBy: orderQuality }))
+
+  const from = vi.fn(() => {
+    if (activeTable === 'profiles') return { where: whereProfilesAwait, limit: limitProfiles }
+    if (activeTable === 'runs') return { where: whereRuns, orderBy: orderRuns, limit: limitRuns }
+    return { where: whereQuality, orderBy: orderQuality, limit: limitQuality }
+  })
+  const select = vi.fn(() => ({ from }))
+
+  // Insert chain
+  const onConflict = vi.fn(async () => undefined)
+  const values = vi.fn(() => ({ onConflictDoUpdate: onConflict }))
+  const insert = vi.fn(() => ({ values }))
+
+  return {
+    select, insert, values, onConflict,
+    profileRows, runRows, qualityRows,
+    setActive: (t: 'profiles' | 'runs' | 'quality') => { activeTable = t },
+  }
+})
+
+vi.mock('node:fs/promises', () => ({ ...fsMock, default: fsMock }))
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: {
+    select: dbMock.select,
+    insert: dbMock.insert,
+  },
+}))
+
+const { calibrationRouter } = await import('@/src/server/routers/calibration')
+const caller = calibrationRouter.createCaller({})
+
+beforeEach(() => {
+  fsMock.writeFile.mockReset().mockResolvedValue(undefined)
+  fsMock.rename.mockReset().mockResolvedValue(undefined)
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.values.mockClear()
+  dbMock.onConflict.mockClear()
+  dbMock.profileRows.length = 0
+  dbMock.runRows.length = 0
+  dbMock.qualityRows.length = 0
+  dbMock.setActive('profiles')
+})
+
+describe('calibration.getStatus', () => {
+  it('pivots profile rows by sensor type and returns nulls for missing ones', async () => {
+    dbMock.setActive('profiles')
+    dbMock.profileRows.push({
+      id: 1, side: 'left', sensorType: 'piezo', status: 'completed',
+      qualityScore: 0.97, samplesUsed: 1024,
+      createdAt: new Date(0), expiresAt: null, errorMessage: null,
+    })
+
+    const result = await caller.getStatus({ side: 'left' })
+    expect(result.piezo?.status).toBe('completed')
+    expect(result.capacitance).toBeNull()
+    expect(result.temperature).toBeNull()
+  })
+})
+
+describe('calibration.getHistory', () => {
+  it('passes through limit and orders desc by createdAt', async () => {
+    dbMock.setActive('runs')
+    dbMock.runRows.push({
+      id: 1, side: 'left', sensorType: 'piezo', status: 'completed',
+      parameters: {}, qualityScore: 0.9,
+      sourceWindowStart: 0, sourceWindowEnd: 100,
+      samplesUsed: 50, errorMessage: null, durationMs: 10,
+      triggeredBy: 'manual', createdAt: new Date(0),
+    })
+
+    const out = await caller.getHistory({ side: 'left', limit: 5 })
+    expect(out).toHaveLength(1)
+    expect(out[0].sensorType).toBe('piezo')
+  })
+
+  it('with no sensorType filter still resolves', async () => {
+    dbMock.setActive('runs')
+    const out = await caller.getHistory({ side: 'right', sensorType: 'capacitance', limit: 1 })
+    expect(out).toEqual([])
+  })
+})
+
+describe('calibration.triggerCalibration', () => {
+  it('writes the trigger payload atomically (write tmp → rename) and queues pending row', async () => {
+    const result = await caller.triggerCalibration({ side: 'left', sensorType: 'piezo' })
+
+    // Atomic write pattern: writeFile to .tmp first, then rename
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1)
+    expect(fsMock.rename).toHaveBeenCalledTimes(1)
+    const [tmpPath, payload] = fsMock.writeFile.mock.calls[0]
+    expect(typeof tmpPath).toBe('string')
+    expect(String(tmpPath)).toMatch(/\.tmp$/)
+    const parsed = JSON.parse(String(payload))
+    expect(parsed.side).toBe('left')
+    expect(parsed.sensor_type).toBe('piezo')
+    expect(typeof parsed.ts).toBe('number')
+
+    // The rename target must drop the .tmp suffix
+    const [renameSrc, renameDst] = fsMock.rename.mock.calls[0]
+    expect(renameSrc).toBe(tmpPath)
+    expect(String(renameDst)).not.toMatch(/\.tmp$/)
+
+    // Pending row inserted with onConflictDoUpdate
+    expect(dbMock.insert).toHaveBeenCalledTimes(1)
+    expect(dbMock.onConflict).toHaveBeenCalledTimes(1)
+
+    expect(result.triggered).toBe(true)
+    expect(result.message).toContain('left')
+    expect(result.message).toContain('piezo')
+  })
+
+  it('wraps fs failures as INTERNAL_SERVER_ERROR', async () => {
+    fsMock.writeFile.mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(
+      caller.triggerCalibration({ side: 'left', sensorType: 'piezo' }),
+    ).rejects.toThrow(/Failed to trigger calibration: disk full/)
+  })
+})
+
+describe('calibration.triggerFullCalibration', () => {
+  it('writes the all/all payload', async () => {
+    const result = await caller.triggerFullCalibration({})
+
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(fsMock.writeFile.mock.calls[0][1]))
+    expect(payload.side).toBe('all')
+    expect(payload.sensor_type).toBe('all')
+    expect(result.triggered).toBe(true)
+  })
+
+  it('wraps fs failures', async () => {
+    fsMock.rename.mockRejectedValueOnce(new Error('boom'))
+    await expect(caller.triggerFullCalibration({})).rejects.toThrow(/Failed to trigger calibration/)
+  })
+})
+
+describe('calibration.getVitalsQuality', () => {
+  it('returns rows for a side with no date range', async () => {
+    dbMock.setActive('quality')
+    dbMock.qualityRows.push({
+      id: 1, vitalsId: 100, side: 'left',
+      timestamp: new Date(0), qualityScore: 0.88, flags: {},
+      hrRaw: 70, createdAt: new Date(0),
+    })
+
+    const out = await caller.getVitalsQuality({ side: 'left', limit: 100 })
+    expect(out).toHaveLength(1)
+    expect(out[0].side).toBe('left')
+  })
+
+  it('with startDate + endDate still resolves', async () => {
+    dbMock.setActive('quality')
+    const out = await caller.getVitalsQuality({
+      side: 'right',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-02-01'),
+      limit: 50,
+    })
+    expect(out).toEqual([])
+  })
+})

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the device router. Exercises every procedure's happy path plus
+ * a key branch (debounce coalesce, snooze timestamp, raw command allowlist).
+ *
+ * Hardware client, DB, broadcast helper, snooze/prime modules and the raw
+ * dac transport are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const helpersMock = vi.hoisted(() => {
+  const client = {
+    getDeviceStatus: vi.fn(),
+    setPower: vi.fn(),
+    setTemperature: vi.fn(),
+    setAlarm: vi.fn(),
+    clearAlarm: vi.fn(),
+    startPriming: vi.fn(),
+  }
+  const withHardwareClient = vi.fn(async (cb: (c: typeof client) => Promise<unknown>) => cb(client))
+  return { withHardwareClient, client }
+})
+
+const primeMock = vi.hoisted(() => ({
+  getPrimeCompletedAt: vi.fn(),
+  dismissPrimeNotification: vi.fn(),
+}))
+
+const snoozeMock = vi.hoisted(() => ({
+  snoozeAlarm: vi.fn(),
+  cancelSnooze: vi.fn(),
+  getSnoozeStatus: vi.fn<(side?: string) => { active: boolean, snoozeUntil: number | null }>(() => ({ active: false, snoozeUntil: null })),
+}))
+
+const broadcastMock = vi.hoisted(() => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+const transportMock = vi.hoisted(() => ({
+  sendCommand: vi.fn(),
+}))
+
+const stateSyncMock = vi.hoisted(() => ({
+  markSideMutated: vi.fn(),
+}))
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] { return dbState.rowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.onConflictDoUpdate = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    return chain
+  }
+  return {
+    select: vi.fn(() => makeChain()),
+    update: vi.fn(() => makeChain()),
+    insert: vi.fn(() => makeChain()),
+  }
+})
+
+vi.mock('@/src/server/helpers', () => ({ withHardwareClient: helpersMock.withHardwareClient }))
+vi.mock('@/src/hardware/primeNotification', () => primeMock)
+vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
+vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
+vi.mock('@/src/hardware/dacTransport', () => transportMock)
+vi.mock('@/src/hardware/deviceStateSync', () => stateSyncMock)
+vi.mock('@/src/db', () => ({
+  db: dbMock,
+  biometricsDb: {},
+}))
+
+const { deviceRouter } = await import('@/src/server/routers/device')
+const caller = deviceRouter.createCaller({})
+
+beforeEach(() => {
+  helpersMock.withHardwareClient.mockClear()
+  Object.values(helpersMock.client).forEach(fn => fn.mockReset())
+  helpersMock.client.getDeviceStatus.mockResolvedValue({
+    leftSide: { currentTemperature: 80, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+    rightSide: { currentTemperature: 80, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+    waterLevel: 'ok',
+    isPriming: false,
+    podVersion: 'I00',
+    sensorLabel: 'pod-test',
+  })
+  helpersMock.client.setPower.mockResolvedValue(undefined)
+  helpersMock.client.setTemperature.mockResolvedValue(undefined)
+  helpersMock.client.setAlarm.mockResolvedValue(undefined)
+  helpersMock.client.clearAlarm.mockResolvedValue(undefined)
+  helpersMock.client.startPriming.mockResolvedValue(undefined)
+
+  primeMock.getPrimeCompletedAt.mockReset().mockReturnValue(null)
+  primeMock.dismissPrimeNotification.mockReset()
+  snoozeMock.snoozeAlarm.mockReset()
+  snoozeMock.cancelSnooze.mockReset()
+  snoozeMock.getSnoozeStatus.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
+  broadcastMock.broadcastMutationStatus.mockReset()
+  transportMock.sendCommand.mockReset()
+  stateSyncMock.markSideMutated.mockReset()
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.insert.mockClear()
+})
+
+describe('device.getStatus', () => {
+  it('returns status with snooze block and converts to F by default', async () => {
+    primeMock.getPrimeCompletedAt.mockReturnValue(1700000000000)
+    snoozeMock.getSnoozeStatus.mockReturnValueOnce({ active: true, snoozeUntil: 1700001000000 })
+    snoozeMock.getSnoozeStatus.mockReturnValueOnce({ active: false, snoozeUntil: null })
+
+    const result = await caller.getStatus({})
+    expect(result.leftSide.currentTemperature).toBe(80)
+    expect(result.snooze.left.active).toBe(true)
+    expect(result.primeCompletedNotification?.timestamp).toBe(1700000000000)
+  })
+
+  it('converts to Celsius when unit=C', async () => {
+    const result = await caller.getStatus({ unit: 'C' })
+    // 80°F → 26.7°C (rounded to one decimal by router)
+    expect(result.leftSide.currentTemperature).toBeCloseTo(26.7, 1)
+  })
+})
+
+describe('device.setTemperature', () => {
+  it('debounces and resolves after timer fires', async () => {
+    vi.useFakeTimers()
+    try {
+      // Provide a prior deviceState row for the prev lookup
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+
+      const promise = caller.setTemperature({ side: 'left', temperature: 70 })
+      await vi.advanceTimersByTimeAsync(250)
+      const result = await promise
+
+      expect(result).toEqual({ success: true })
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledTimes(1)
+      expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalled()
+      expect(stateSyncMock.markSideMutated).toHaveBeenCalledWith('left')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('coalesces a second call into one hardware command (last value wins)', async () => {
+    vi.useFakeTimers()
+    try {
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+      dbState.rowsQueue.push([{ isPowered: true, poweredOnAt: new Date() }])
+
+      // Start call 1 and let it register its pending entry (await microtasks
+      // so the async DB lookup before pendingTemps.set has a chance to settle).
+      const p1 = caller.setTemperature({ side: 'left', temperature: 70 })
+      await vi.advanceTimersByTimeAsync(0)
+      // Call 2 now sees the pending entry and cancels the first timer.
+      const p2 = caller.setTemperature({ side: 'left', temperature: 75 })
+      await vi.advanceTimersByTimeAsync(250)
+      const [r1, r2] = await Promise.all([p1, p2])
+      expect(r1).toEqual({ success: true })
+      expect(r2).toEqual({ success: true })
+      // Only the second call's value reaches hardware
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledTimes(1)
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledWith('left', 75, undefined)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('device.setPower', () => {
+  it('powers on with the provided temperature, broadcasts, syncs DB', async () => {
+    dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+
+    const result = await caller.setPower({ side: 'left', powered: true, temperature: 72 })
+    expect(result).toEqual({ success: true })
+    expect(helpersMock.client.setPower).toHaveBeenCalledWith('left', true, 72)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', expect.objectContaining({
+      targetTemperature: 72,
+    }))
+  })
+
+  it('powers off and broadcasts targetLevel: 0', async () => {
+    dbState.rowsQueue.push([{ isPowered: true, poweredOnAt: new Date() }])
+
+    await caller.setPower({ side: 'left', powered: false })
+    expect(helpersMock.client.setPower).toHaveBeenCalledWith('left', false, undefined)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+  })
+})
+
+describe('device.setAlarm / clearAlarm / snoozeAlarm', () => {
+  it('setAlarm passes config to hardware and broadcasts vibrating=true', async () => {
+    await caller.setAlarm({
+      side: 'left',
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 60,
+    })
+
+    expect(snoozeMock.cancelSnooze).toHaveBeenCalledWith('left')
+    expect(helpersMock.client.setAlarm).toHaveBeenCalledWith('left', {
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 60,
+    })
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { isAlarmVibrating: true })
+  })
+
+  it('clearAlarm hits hardware and broadcasts vibrating=false', async () => {
+    await caller.clearAlarm({ side: 'right' })
+    expect(helpersMock.client.clearAlarm).toHaveBeenCalledWith('right')
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('right', { isAlarmVibrating: false })
+  })
+
+  it('snoozeAlarm clears alarm + invokes snoozeManager and returns timestamp', async () => {
+    const snoozeUntil = new Date(1700000000000)
+    snoozeMock.snoozeAlarm.mockReturnValue(snoozeUntil)
+
+    const result = await caller.snoozeAlarm({ side: 'left', duration: 300 })
+    expect(helpersMock.client.clearAlarm).toHaveBeenCalledWith('left')
+    expect(snoozeMock.snoozeAlarm).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.snoozeUntil).toBe(Math.floor(snoozeUntil.getTime() / 1000))
+  })
+})
+
+describe('device.startPriming / dismissPrimeNotification', () => {
+  it('startPriming hits hardware', async () => {
+    const result = await caller.startPriming({})
+    expect(helpersMock.client.startPriming).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('dismissPrimeNotification calls the helper', async () => {
+    const result = await caller.dismissPrimeNotification({})
+    expect(primeMock.dismissPrimeNotification).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('device.execute (raw command)', () => {
+  it('passes the command name through and returns disclaimer', async () => {
+    transportMock.sendCommand.mockResolvedValue('{ "ok": true }')
+
+    const result = await caller.execute({ command: 'DEVICE_STATUS' })
+    expect(result.command).toBe('DEVICE_STATUS')
+    expect(result.args).toBeNull()
+    expect(result.response).toBe('{ "ok": true }')
+    expect(result.disclaimer).toContain('Raw command execution')
+  })
+
+  it('rejects unknown command via Zod enum', async () => {
+    await expect(caller.execute({ command: 'BOGUS' as never })).rejects.toThrow()
+  })
+
+  it('wraps transport errors as INTERNAL_SERVER_ERROR', async () => {
+    transportMock.sendCommand.mockRejectedValue(new Error('socket dead'))
+    await expect(caller.execute({ command: 'DEVICE_STATUS' })).rejects.toThrow(/Failed to execute raw command: socket dead/)
+  })
+})

--- a/src/server/routers/tests/environment.test.ts
+++ b/src/server/routers/tests/environment.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the environment router — bedTemp/freezerTemp date-range queries
+ * with F/C unit conversion, latest fetchers, and the bed+freezer summary
+ * pair (Promise.all chain). biometricsDb mocked via a thenable chain.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] {
+    return dbState.rowsQueue.shift() ?? []
+  },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    return chain
+  }
+  return { select: vi.fn(() => makeChain()) }
+})
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: dbMock,
+}))
+
+const { environmentRouter } = await import('@/src/server/routers/environment')
+const caller = environmentRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+})
+
+describe('environment.getBedTemp', () => {
+  it('returns rows with Fahrenheit conversion by default', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, mcuTemp: 2500, humidity: 5000,
+        leftOuterTemp: 2100, leftCenterTemp: 2200, leftInnerTemp: 2300,
+        rightOuterTemp: 2400, rightCenterTemp: 2500, rightInnerTemp: 2600,
+      },
+    ])
+
+    const out = await caller.getBedTemp({ limit: 10 })
+    expect(out).toHaveLength(1)
+    // 20°C = 68°F (centidegrees 2000 -> 20°C -> 68°F)
+    expect(out[0].ambientTemp).toBe(68)
+    expect(out[0].humidity).toBe(50)
+  })
+
+  it('returns Celsius when unit=C', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, mcuTemp: null, humidity: null,
+        leftOuterTemp: null, leftCenterTemp: null, leftInnerTemp: null,
+        rightOuterTemp: null, rightCenterTemp: null, rightInnerTemp: null,
+      },
+    ])
+
+    const out = await caller.getBedTemp({ limit: 10, unit: 'C' })
+    expect(out[0].ambientTemp).toBe(20)
+    expect(out[0].mcuTemp).toBeNull()
+  })
+
+  it('rejects inverted date range as BAD_REQUEST', async () => {
+    await expect(caller.getBedTemp({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate must be before or equal to endDate/)
+  })
+})
+
+describe('environment.getFreezerTemp', () => {
+  it('returns rows with C conversion', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, heatsinkTemp: 3000, leftWaterTemp: 1500, rightWaterTemp: 1600,
+      },
+    ])
+
+    const out = await caller.getFreezerTemp({ limit: 10, unit: 'C' })
+    expect(out[0].ambientTemp).toBe(20)
+    expect(out[0].heatsinkTemp).toBe(30)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getFreezerTemp({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getLatestBedTemp / getLatestFreezerTemp', () => {
+  it('returns null when no row', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestBedTemp({})
+    expect(out).toBeNull()
+  })
+
+  it('latest bed temp returns the row', async () => {
+    dbState.rowsQueue.push([{
+      id: 7, timestamp: new Date(0),
+      ambientTemp: 2000, mcuTemp: null, humidity: null,
+      leftOuterTemp: null, leftCenterTemp: null, leftInnerTemp: null,
+      rightOuterTemp: null, rightCenterTemp: null, rightInnerTemp: null,
+    }])
+    const out = await caller.getLatestBedTemp({})
+    expect(out?.id).toBe(7)
+  })
+
+  it('latest freezer temp returns null when missing', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestFreezerTemp({})
+    expect(out).toBeNull()
+  })
+
+  it('latest freezer temp returns the row', async () => {
+    dbState.rowsQueue.push([{
+      id: 1, timestamp: new Date(0),
+      ambientTemp: 2000, heatsinkTemp: null, leftWaterTemp: null, rightWaterTemp: null,
+    }])
+    const out = await caller.getLatestFreezerTemp({ unit: 'C' })
+    expect(out?.ambientTemp).toBe(20)
+  })
+})
+
+describe('environment.getSummary', () => {
+  it('returns nulls for sections with no records', async () => {
+    // Both summary queries fire in Promise.all → push two responses
+    dbState.rowsQueue.push([{ avgAmbient: null, minAmbient: null, maxAmbient: null, avgHumidity: null, avgLeftCenter: null, avgRightCenter: null, recordCount: 0 }])
+    dbState.rowsQueue.push([{ avgAmbient: null, avgHeatsink: null, avgLeftWater: null, avgRightWater: null, recordCount: 0 }])
+
+    const out = await caller.getSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out.bedTemp).toBeNull()
+    expect(out.freezerTemp).toBeNull()
+  })
+
+  it('returns aggregated values when records present', async () => {
+    dbState.rowsQueue.push([{
+      avgAmbient: '2000', minAmbient: 1500, maxAmbient: 2500,
+      avgHumidity: '5000', avgLeftCenter: '2100', avgRightCenter: '2200',
+      recordCount: 60,
+    }])
+    dbState.rowsQueue.push([{
+      avgAmbient: '1000', avgHeatsink: '3000', avgLeftWater: '500', avgRightWater: '600',
+      recordCount: 60,
+    }])
+
+    const out = await caller.getSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+      unit: 'C',
+    })
+    expect(out.bedTemp?.avgAmbientTemp).toBe(20) // 2000 cdeg = 20°C
+    expect(out.bedTemp?.avgHumidity).toBe(50)
+    expect(out.bedTemp?.recordCount).toBe(60)
+    expect(out.freezerTemp?.avgAmbientTemp).toBe(10)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getSummary({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getAmbientLight', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(0), lux: 100 }])
+    const out = await caller.getAmbientLight({ limit: 10 })
+    expect(out).toHaveLength(1)
+    expect(out[0].lux).toBe(100)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getAmbientLight({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getLatestAmbientLight', () => {
+  it('returns null when no row', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestAmbientLight({})
+    expect(out).toBeNull()
+  })
+
+  it('returns row when present', async () => {
+    dbState.rowsQueue.push([{ id: 5, timestamp: new Date(0), lux: 50 }])
+    const out = await caller.getLatestAmbientLight({})
+    expect(out?.id).toBe(5)
+  })
+})
+
+describe('environment.getAmbientLightSummary', () => {
+  it('returns null when recordCount=0', async () => {
+    dbState.rowsQueue.push([{ avgLux: null, minLux: null, maxLux: null, recordCount: 0 }])
+    const out = await caller.getAmbientLightSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns summary stats when present', async () => {
+    dbState.rowsQueue.push([{ avgLux: '120', minLux: 5, maxLux: 500, recordCount: 144 }])
+    const out = await caller.getAmbientLightSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out?.avgLux).toBe(120)
+    expect(out?.recordCount).toBe(144)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getAmbientLightSummary({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the health router — scheduler counts, system db+drift checks,
+ * dacMonitor passthrough, hardware socket probe.
+ *
+ * Scheduler, db (sqlite + drizzle chain), shared hardware client, dacMonitor
+ * accessor, and iptablesCheck are mocked. Drift auto-reload import path is
+ * mocked too.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const schedulerMock = vi.hoisted(() => {
+  const scheduler = {
+    isEnabled: vi.fn(() => true),
+    getJobs: vi.fn(() => [] as { id: string, type: string, metadata?: { side?: string } }[]),
+    getNextInvocation: vi.fn<(id: string) => Date | null>(() => null),
+  }
+  const jobManager = {
+    getScheduler: vi.fn(() => scheduler),
+    reloadSchedules: vi.fn(async () => undefined),
+  }
+  const getJobManager = vi.fn(async () => jobManager)
+  return { getJobManager, scheduler, jobManager }
+})
+
+// db-related — sqlite.pragma + db.select chain (uses .all())
+const dbMock = vi.hoisted(() => {
+  const sqlitePragma = vi.fn()
+  const allSchedules = { temp: [] as unknown[], pow: [] as unknown[], alm: [] as unknown[] }
+  let activeTable: 'temp' | 'pow' | 'alm' = 'temp'
+
+  const all = vi.fn(() => {
+    if (activeTable === 'temp') return allSchedules.temp
+    if (activeTable === 'pow') return allSchedules.pow
+    return allSchedules.alm
+  })
+  const where = vi.fn(() => ({ all }))
+  const from = vi.fn((table: unknown) => {
+    // Detect which schedule table is being queried
+    const name = String(table?.constructor?.name ?? '')
+    if (name.includes('Power')) activeTable = 'pow'
+    else if (name.includes('Alarm')) activeTable = 'alm'
+    else activeTable = 'temp'
+    return { where }
+  })
+  const select = vi.fn(() => ({ from }))
+
+  return {
+    db: { select },
+    sqlite: { pragma: sqlitePragma },
+    sqlitePragma,
+    allSchedules,
+    setActive: (t: 'temp' | 'pow' | 'alm') => { activeTable = t },
+  }
+})
+
+const sharedClientMock = vi.hoisted(() => {
+  const client = { connect: vi.fn(async () => undefined) }
+  return {
+    getSharedHardwareClient: vi.fn(() => client),
+    getDacMonitorIfRunning: vi.fn(),
+    client,
+  }
+})
+
+const iptablesMock = vi.hoisted(() => ({
+  checkIptables: vi.fn(() => ({ ok: true, rules: [] })),
+}))
+
+vi.mock('@/src/scheduler', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/scheduler/instance', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/db', () => ({
+  db: dbMock.db,
+  sqlite: dbMock.sqlite,
+  biometricsDb: {},
+}))
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: sharedClientMock.getSharedHardwareClient,
+  getDacMonitorIfRunning: sharedClientMock.getDacMonitorIfRunning,
+}))
+vi.mock('@/src/hardware/iptablesCheck', () => iptablesMock)
+
+const { healthRouter } = await import('@/src/server/routers/health')
+const caller = healthRouter.createCaller({})
+
+beforeEach(() => {
+  schedulerMock.scheduler.isEnabled.mockReset().mockReturnValue(true)
+  schedulerMock.scheduler.getJobs.mockReset().mockReturnValue([])
+  schedulerMock.scheduler.getNextInvocation.mockReset().mockReturnValue(null)
+  schedulerMock.jobManager.reloadSchedules.mockReset().mockResolvedValue(undefined)
+  dbMock.sqlitePragma.mockReset()
+  dbMock.allSchedules.temp.length = 0
+  dbMock.allSchedules.pow.length = 0
+  dbMock.allSchedules.alm.length = 0
+  sharedClientMock.client.connect.mockReset().mockResolvedValue(undefined)
+  sharedClientMock.getDacMonitorIfRunning.mockReset()
+  iptablesMock.checkIptables.mockReset().mockReturnValue({ ok: true, rules: [] })
+})
+
+describe('health.scheduler', () => {
+  it('returns counts and unhealthy=true when scheduler enabled but empty', async () => {
+    schedulerMock.scheduler.isEnabled.mockReturnValue(true)
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.scheduler({})
+    expect(result.enabled).toBe(true)
+    expect(result.jobCounts.total).toBe(0)
+    // The point: enabled with zero jobs → unhealthy
+    expect(result.healthy).toBe(false)
+  })
+
+  it('returns healthy=true when scheduler is disabled regardless of count', async () => {
+    schedulerMock.scheduler.isEnabled.mockReturnValue(false)
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.scheduler({})
+    expect(result.healthy).toBe(true)
+  })
+
+  it('counts jobs by type and emits sorted upcoming list', async () => {
+    schedulerMock.scheduler.getJobs.mockReturnValue([
+      { id: 't-1', type: 'temperature', metadata: { side: 'left' } },
+      { id: 'p-on-1', type: 'power_on', metadata: { side: 'left' } },
+      { id: 'p-off-1', type: 'power_off', metadata: { side: 'left' } },
+      { id: 'a-1', type: 'alarm', metadata: { side: 'right' } },
+      { id: 'pr-1', type: 'prime' },
+      { id: 'rb-1', type: 'reboot' },
+    ])
+    const now = Date.now()
+    schedulerMock.scheduler.getNextInvocation.mockImplementation((id: string) => {
+      const offsets: Record<string, number> = {
+        't-1': 1000,
+        'p-on-1': 500,
+        'p-off-1': 2000,
+        'a-1': 100,
+        'pr-1': 10000,
+        'rb-1': 50000,
+      }
+      return new Date(now + offsets[id])
+    })
+
+    const result = await caller.scheduler({})
+    expect(result.jobCounts).toEqual({
+      temperature: 1, powerOn: 1, powerOff: 1, alarm: 1,
+      prime: 1, reboot: 1, total: 6,
+    })
+    // Sorted ascending: a-1 (100ms), p-on-1, t-1, p-off-1, pr-1, rb-1
+    expect(result.upcomingJobs.map(j => j.id)).toEqual(['a-1', 'p-on-1', 't-1', 'p-off-1', 'pr-1', 'rb-1'])
+    expect(result.healthy).toBe(true)
+  })
+
+  it('wraps internal errors as INTERNAL_SERVER_ERROR', async () => {
+    schedulerMock.getJobManager.mockRejectedValueOnce(new Error('scheduler down'))
+
+    await expect(caller.scheduler({})).rejects.toThrow(/Failed to get scheduler health/)
+  })
+})
+
+describe('health.system', () => {
+  it('reports ok when db responds and scheduler matches DB schedules', async () => {
+    dbMock.sqlitePragma.mockReturnValue(undefined)
+    dbMock.allSchedules.temp.push({ id: 1 })
+    dbMock.allSchedules.pow.push({ id: 1 })
+    dbMock.allSchedules.alm.push({ id: 1 })
+    // Expected: 1 temp + (1 power * 2) + 1 alarm = 4 user jobs
+    schedulerMock.scheduler.getJobs.mockReturnValue([
+      { id: 'a', type: 'temperature' },
+      { id: 'b', type: 'power_on' },
+      { id: 'c', type: 'power_off' },
+      { id: 'd', type: 'alarm' },
+    ])
+
+    const result = await caller.system({})
+    expect(result.status).toBe('ok')
+    expect(result.database.status).toBe('ok')
+    expect(result.scheduler.enabled).toBe(true)
+    expect(result.scheduler.drift?.drifted).toBe(false)
+    expect(result.iptables.ok).toBe(true)
+  })
+
+  it('reports degraded when sqlite pragma throws', async () => {
+    dbMock.sqlitePragma.mockImplementation(() => { throw new Error('db locked') })
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.system({})
+    expect(result.database.status).toBe('degraded')
+    expect(result.database.error).toBe('db locked')
+    expect(result.status).toBe('degraded')
+  })
+})
+
+describe('health.dacMonitor', () => {
+  it('returns not_initialized when monitor is null', async () => {
+    sharedClientMock.getDacMonitorIfRunning.mockReturnValue(null)
+    const result = await caller.dacMonitor({})
+    expect(result).toEqual({ status: 'not_initialized', podVersion: null, gesturesSupported: false })
+  })
+
+  it('returns monitor status + gestures flag when running', async () => {
+    sharedClientMock.getDacMonitorIfRunning.mockReturnValue({
+      getStatus: () => 'running',
+      getLastStatus: () => ({ podVersion: 'I00', gestures: { doubleTap: { l: 1, r: 0 } } }),
+    })
+
+    const result = await caller.dacMonitor({})
+    expect(result.status).toBe('running')
+    expect(result.podVersion).toBe('I00')
+    expect(result.gesturesSupported).toBe(true)
+  })
+})
+
+describe('health.hardware', () => {
+  it('returns ok with measured latency when connect resolves', async () => {
+    const result = await caller.hardware({})
+    expect(result.status).toBe('ok')
+    expect(typeof result.latencyMs).toBe('number')
+    expect(result.error).toBeUndefined()
+  })
+
+  it('returns degraded with error message when connect fails', async () => {
+    sharedClientMock.client.connect.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const result = await caller.hardware({})
+    expect(result.status).toBe('degraded')
+    expect(result.error).toBe('ECONNREFUSED')
+  })
+})

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -179,7 +179,9 @@ describe('health.system', () => {
   })
 
   it('reports degraded when sqlite pragma throws', async () => {
-    dbMock.sqlitePragma.mockImplementation(() => { throw new Error('db locked') })
+    dbMock.sqlitePragma.mockImplementation(() => {
+      throw new Error('db locked')
+    })
     schedulerMock.scheduler.getJobs.mockReturnValue([])
 
     const result = await caller.system({})

--- a/src/server/routers/tests/homekit.test.ts
+++ b/src/server/routers/tests/homekit.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the HomeKit router — buildStatus shape, setEnabled lifecycle
+ * (DB persists after enable/disable, rollback on persist failure),
+ * unpair/regenerate passthrough, and seedProbe legacy detection.
+ *
+ * The homekit module + storage probes + qrcode + db are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const homekitMock = vi.hoisted(() => ({
+  enable: vi.fn(),
+  disable: vi.fn(),
+  regeneratePairing: vi.fn(),
+  status: vi.fn(),
+  unpair: vi.fn(),
+}))
+
+const storageMock = vi.hoisted(() => ({
+  probeSeedSources: vi.fn(),
+  readIdentityIfPresent: vi.fn(),
+}))
+
+const qrcodeMock = vi.hoisted(() => ({
+  toDataURL: vi.fn(async () => 'data:image/png;base64,FAKE'),
+}))
+
+// db.select chain returns a row with homekitEnabled. db.update chain swallows
+// the set/where pair.
+const dbMock = vi.hoisted(() => {
+  const selectRow: { homekitEnabled: boolean } = { homekitEnabled: false }
+  const limit = vi.fn(async () => [selectRow])
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+
+  const setSpy = vi.fn<(updates: Record<string, unknown>) => { where: ReturnType<typeof vi.fn> }>(
+    () => ({ where: vi.fn(async () => undefined) }),
+  )
+  const update = vi.fn(() => ({ set: setSpy }))
+
+  return { select, update, setSpy, selectRow, limit, where, from }
+})
+
+vi.mock('@/src/homekit', () => homekitMock)
+vi.mock('@/src/homekit/storage', () => storageMock)
+vi.mock('qrcode', () => ({ default: qrcodeMock }))
+
+vi.mock('@/src/db', () => ({
+  db: { select: dbMock.select, update: dbMock.update },
+  biometricsDb: {},
+}))
+
+const { homekitRouter } = await import('@/src/server/routers/homekit')
+const caller = homekitRouter.createCaller({})
+
+beforeEach(() => {
+  homekitMock.enable.mockReset().mockResolvedValue(undefined)
+  homekitMock.disable.mockReset().mockResolvedValue(undefined)
+  homekitMock.regeneratePairing.mockReset().mockResolvedValue(undefined)
+  homekitMock.unpair.mockReset().mockResolvedValue(undefined)
+  homekitMock.status.mockReset().mockReturnValue({
+    running: false,
+    pincode: null,
+    setupId: null,
+    setupURI: null,
+    pairedControllers: [],
+  })
+  storageMock.probeSeedSources.mockReset()
+  storageMock.readIdentityIfPresent.mockReset()
+  qrcodeMock.toDataURL.mockClear().mockResolvedValue('data:image/png;base64,FAKE')
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.setSpy.mockClear()
+  dbMock.selectRow.homekitEnabled = false
+})
+
+describe('homekit.getStatus', () => {
+  it('returns flat status with qrDataUrl=null when setupURI is null', async () => {
+    dbMock.selectRow.homekitEnabled = false
+    homekitMock.status.mockReturnValue({
+      running: false,
+      pincode: null,
+      setupId: null,
+      setupURI: null,
+      pairedControllers: [],
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(result).toEqual({
+      enabled: false,
+      running: false,
+      pincode: null,
+      setupId: null,
+      setupURI: null,
+      qrDataUrl: null,
+      pairedControllers: [],
+    })
+    expect(qrcodeMock.toDataURL).not.toHaveBeenCalled()
+  })
+
+  it('encodes setupURI as a QR data URL when present and reflects DB enabled flag', async () => {
+    dbMock.selectRow.homekitEnabled = true
+    homekitMock.status.mockReturnValue({
+      running: true,
+      pincode: '111-22-333',
+      setupId: 'XYZ1',
+      setupURI: 'X-HM://0024K0R3F',
+      pairedControllers: ['controllerA'],
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(result.enabled).toBe(true)
+    expect(result.running).toBe(true)
+    expect(result.pincode).toBe('111-22-333')
+    expect(result.qrDataUrl).toBe('data:image/png;base64,FAKE')
+    expect(qrcodeMock.toDataURL).toHaveBeenCalledWith(
+      'X-HM://0024K0R3F',
+      { errorCorrectionLevel: 'Q', margin: 1 },
+    )
+    expect(result.pairedControllers).toEqual(['controllerA'])
+  })
+})
+
+describe('homekit.setEnabled', () => {
+  it('enables HomeKit then persists the flag', async () => {
+    await caller.setEnabled({ enabled: true })
+
+    expect(homekitMock.enable).toHaveBeenCalledTimes(1)
+    expect(homekitMock.disable).not.toHaveBeenCalled()
+    // Update should set homekitEnabled=true
+    expect(dbMock.setSpy).toHaveBeenCalled()
+    const setUpdates = dbMock.setSpy.mock.calls.at(-1)?.[0]
+    expect(setUpdates).toMatchObject({ homekitEnabled: true })
+    expect(setUpdates?.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('disables HomeKit then persists the flag', async () => {
+    dbMock.selectRow.homekitEnabled = true
+
+    await caller.setEnabled({ enabled: false })
+
+    expect(homekitMock.disable).toHaveBeenCalledTimes(1)
+    expect(homekitMock.enable).not.toHaveBeenCalled()
+    const setUpdates = dbMock.setSpy.mock.calls.at(-1)?.[0]
+    expect(setUpdates).toMatchObject({ homekitEnabled: false })
+  })
+
+  it('reverts the lifecycle when the DB persist fails (was disabled → enable rollback to disable)', async () => {
+    // Prior state was disabled. Caller is enabling; persist throws; router
+    // should call disableHomeKit again to roll back the runtime state.
+    dbMock.selectRow.homekitEnabled = false
+    dbMock.setSpy.mockReturnValueOnce({
+      where: vi.fn(async () => { throw new Error('disk full') }),
+    })
+
+    await expect(caller.setEnabled({ enabled: true })).rejects.toThrow(/Failed to toggle HomeKit/)
+
+    expect(homekitMock.enable).toHaveBeenCalledTimes(1)
+    // Rollback: prior wasEnabled=false → disable() runs again
+    expect(homekitMock.disable).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps lifecycle errors as INTERNAL_SERVER_ERROR', async () => {
+    homekitMock.enable.mockRejectedValueOnce(new Error('mDNS failure'))
+
+    await expect(caller.setEnabled({ enabled: true })).rejects.toThrow(/Failed to toggle HomeKit: mDNS failure/)
+  })
+})
+
+describe('homekit.unpair / regenerate', () => {
+  it('unpair calls homekit.unpair() and returns status', async () => {
+    const result = await caller.unpair({})
+    expect(homekitMock.unpair).toHaveBeenCalledTimes(1)
+    expect(result.enabled).toBe(false)
+  })
+
+  it('regenerate calls homekit.regeneratePairing() and returns status', async () => {
+    const result = await caller.regenerate({})
+    expect(homekitMock.regeneratePairing).toHaveBeenCalledTimes(1)
+    expect(result.enabled).toBe(false)
+  })
+})
+
+describe('homekit.seedProbe', () => {
+  it('passes through resolved + sources and reports identity present and non-legacy', async () => {
+    storageMock.probeSeedSources.mockReturnValue({
+      resolved: 'machineId',
+      sources: [
+        { source: 'machineId', path: '/etc/machine-id', present: true, readable: true, looksDegenerate: false },
+        { source: 'serial', path: null, present: false, readable: false, looksDegenerate: false },
+      ],
+    })
+    storageMock.readIdentityIfPresent.mockReturnValue({
+      derivedFrom: 'machineId',
+      rotation: 1,
+      derivedAt: 1700000000,
+    })
+
+    const result = await caller.seedProbe({})
+
+    expect(result.resolved).toBe('machineId')
+    expect(result.sources).toHaveLength(2)
+    expect(result.identity).toEqual({
+      derivedFrom: 'machineId',
+      rotation: 1,
+      derivedAt: 1700000000,
+      legacy: false,
+    })
+  })
+
+  it('returns null identity fields when no identity file is present', async () => {
+    storageMock.probeSeedSources.mockReturnValue({
+      resolved: 'random',
+      sources: [],
+    })
+    storageMock.readIdentityIfPresent.mockReturnValue(null)
+
+    const result = await caller.seedProbe({})
+
+    expect(result.identity).toEqual({
+      derivedFrom: null,
+      rotation: null,
+      derivedAt: null,
+      legacy: false,
+    })
+  })
+
+  it('marks identity legacy when derivedFrom is missing on the file', async () => {
+    storageMock.probeSeedSources.mockReturnValue({ resolved: 'machineId', sources: [] })
+    // Legacy identity files predate ADR 0020 — derivedFrom undefined.
+    storageMock.readIdentityIfPresent.mockReturnValue({})
+
+    const result = await caller.seedProbe({})
+
+    expect(result.identity.legacy).toBe(true)
+    expect(result.identity.derivedFrom).toBe(null)
+    expect(result.identity.rotation).toBe(null)
+  })
+})

--- a/src/server/routers/tests/raw.test.ts
+++ b/src/server/routers/tests/raw.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the raw router — files filters/sorts safely-named .RAW entries,
+ * deleteFile rejects bad filenames, symlinks, and the active/newest file,
+ * diskUsage falls back gracefully when df is unavailable.
+ *
+ * fs/promises and child_process.execFile are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMock = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  lstat: vi.fn(),
+  realpath: vi.fn(),
+  unlink: vi.fn(),
+}))
+
+const execMock = vi.hoisted(() => ({
+  execFile: vi.fn((_file: string, _args: string[], _opts: unknown, cb: (err: unknown, out: { stdout: string }) => void) => {
+    // default: succeed with empty df output
+    cb(null, { stdout: '' })
+  }),
+}))
+
+vi.mock('node:fs/promises', () => ({ ...fsMock, default: fsMock }))
+vi.mock('node:child_process', () => ({ execFile: execMock.execFile, default: { execFile: execMock.execFile } }))
+
+const { rawRouter, listRawFiles } = await import('@/src/server/routers/raw')
+const caller = rawRouter.createCaller({})
+
+beforeEach(() => {
+  fsMock.readdir.mockReset()
+  fsMock.stat.mockReset()
+  fsMock.lstat.mockReset()
+  fsMock.realpath.mockReset()
+  fsMock.unlink.mockReset()
+  execMock.execFile.mockReset()
+  execMock.execFile.mockImplementation((_f, _a, _o, cb) => cb(null, { stdout: '' }))
+})
+
+describe('listRawFiles helper', () => {
+  it('filters non-RAW files and sorts newest first', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW', 'README.txt', 'evil/../escape.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      if (name === 'a.RAW') return { size: 100, mtime: new Date('2025-01-01') } as never
+      return { size: 200, mtime: new Date('2025-02-01') } as never
+    })
+
+    const out = await listRawFiles()
+    // README.txt drops; the path-traversing entry doesn't match SAFE_FILENAME
+    expect(out.map(f => f.name)).toEqual(['b.RAW', 'a.RAW'])
+    expect(out[0].sizeBytes).toBe(200)
+  })
+
+  it('returns [] on ENOENT', async () => {
+    const err = Object.assign(new Error('no dir'), { code: 'ENOENT' })
+    fsMock.readdir.mockRejectedValue(err)
+
+    const out = await listRawFiles()
+    expect(out).toEqual([])
+  })
+
+  it('rethrows non-ENOENT errors', async () => {
+    fsMock.readdir.mockRejectedValue(new Error('permission denied'))
+    await expect(listRawFiles()).rejects.toThrow(/permission denied/)
+  })
+})
+
+describe('raw.files', () => {
+  it('passes through listRawFiles output', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW'] as never)
+    fsMock.stat.mockResolvedValue({ size: 50, mtime: new Date('2025-01-01') } as never)
+
+    const out = await caller.files({})
+    expect(out).toHaveLength(1)
+    expect(out[0].name).toBe('a.RAW')
+  })
+
+  it('wraps unexpected errors', async () => {
+    fsMock.readdir.mockRejectedValue(new Error('disk dead'))
+    await expect(caller.files({})).rejects.toThrow(/Failed to list RAW files/)
+  })
+})
+
+describe('raw.deleteFile', () => {
+  it('rejects path-traversal-style names BEFORE touching fs', async () => {
+    await expect(caller.deleteFile({ filename: '../escape.RAW' })).rejects.toThrow(/Invalid filename/)
+    expect(fsMock.lstat).not.toHaveBeenCalled()
+  })
+
+  it('rejects names without a .RAW suffix', async () => {
+    await expect(caller.deleteFile({ filename: 'random.txt' })).rejects.toThrow(/Invalid filename/)
+  })
+
+  it('rejects symlinks', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => true } as never)
+    await expect(caller.deleteFile({ filename: 'a.RAW' })).rejects.toThrow(/Path traversal detected/)
+  })
+
+  it('rejects when canonical path escapes RAW_DIR', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      // canonical of file lands outside canonical of dir
+      if (String(p).endsWith('a.RAW')) return '/elsewhere/a.RAW'
+      return '/persistent'
+    })
+    await expect(caller.deleteFile({ filename: 'a.RAW' })).rejects.toThrow(/Path traversal detected/)
+  })
+
+  it('refuses to delete the active (newest) file', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith('a.RAW')) return '/persistent/a.RAW'
+      return '/persistent'
+    })
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      // a.RAW is the newest (highest mtime ISO)
+      return { size: 1, mtime: name === 'a.RAW' ? new Date('2025-02-01') : new Date('2025-01-01') } as never
+    })
+
+    const result = await caller.deleteFile({ filename: 'a.RAW' })
+    expect(result).toEqual({ deleted: false, message: 'Cannot delete the active (newest) RAW file' })
+    expect(fsMock.unlink).not.toHaveBeenCalled()
+  })
+
+  it('returns "File not found" on ENOENT during the lstat probe', async () => {
+    const err = Object.assign(new Error('no'), { code: 'ENOENT' })
+    fsMock.lstat.mockRejectedValue(err)
+
+    const result = await caller.deleteFile({ filename: 'a.RAW' })
+    expect(result).toEqual({ deleted: false, message: 'File not found' })
+  })
+
+  it('deletes a non-active file', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith('b.RAW')) return '/persistent/b.RAW'
+      return '/persistent'
+    })
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      return { size: 1, mtime: name === 'a.RAW' ? new Date('2025-02-01') : new Date('2025-01-01') } as never
+    })
+    fsMock.unlink.mockResolvedValue(undefined as never)
+
+    const result = await caller.deleteFile({ filename: 'b.RAW' })
+    expect(result).toEqual({ deleted: true, message: 'Deleted b.RAW' })
+    expect(fsMock.unlink).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('raw.diskUsage', () => {
+  it('parses df output when available and aggregates raw bytes', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW'] as never)
+    fsMock.stat.mockResolvedValue({ size: 1234, mtime: new Date(0) } as never)
+    execMock.execFile.mockImplementation((_f, _a, _o, cb) => {
+      cb(null, { stdout: 'Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/sda1 1000 200 800 20% /persistent\n' })
+    })
+
+    const result = await caller.diskUsage({})
+    expect(result.totalBytes).toBe(1000)
+    expect(result.usedBytes).toBe(200)
+    expect(result.availableBytes).toBe(800)
+    expect(result.rawFileCount).toBe(1)
+    expect(result.rawBytes).toBe(1234)
+  })
+
+  it('falls back to zero df totals when df is unavailable', async () => {
+    fsMock.readdir.mockResolvedValue([] as never)
+    execMock.execFile.mockImplementation((_f, _a, _o, cb) => cb(new Error('df: command not found'), { stdout: '' }))
+
+    const result = await caller.diskUsage({})
+    expect(result.totalBytes).toBe(0)
+    expect(result.rawFileCount).toBe(0)
+  })
+})

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for the runOnce router — start (validates duration cap, primes hardware
+ * BEFORE inserting session, schedules remaining set points), getActive (parses
+ * setPoints JSON or returns empty on malformed), cancel.
+ *
+ * Db (better-sqlite3 chain), scheduler, hardware client, broadcaster, and
+ * timezone resolver all mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const jobManagerMock = vi.hoisted(() => ({
+  cancelRunOnceSession: vi.fn(),
+  scheduleRunOnceSession: vi.fn(),
+}))
+
+const schedulerMock = vi.hoisted(() => ({
+  getJobManager: vi.fn(async () => jobManagerMock),
+}))
+
+const helpersMock = vi.hoisted(() => ({
+  withHardwareClient: vi.fn(async (cb: (client: unknown) => Promise<unknown>) => {
+    const client = {
+      setPower: vi.fn(async () => undefined),
+    }
+    return cb(client)
+  }),
+}))
+
+const broadcastMock = vi.hoisted(() => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+const timeUtilsMock = vi.hoisted(() => ({
+  // Default: wake time 1 hour from now
+  timeToDate: vi.fn((_t: string, _tz: string, now: Date) => new Date(now.getTime() + 60 * 60 * 1000)),
+}))
+
+// DB mock with branchable behaviours per test. The router uses three patterns:
+//   1. db.transaction(tx => …) where tx exposes select/update with .all()/.run()
+//   2. db.select().from().limit() (await-thenable returning a deviceSettings row)
+//   3. db.insert().values().returning() (await-thenable returning [{ id }])
+//   4. db.update().set().where() (await-thenable, used by cancel)
+const dbMock = vi.hoisted(() => {
+  // settings select chain — used to fetch timezone
+  const settingsRow: { timezone: string | null } = { timezone: 'America/Los_Angeles' }
+  const limit = vi.fn(async () => [settingsRow])
+  const from = vi.fn(() => ({ limit }))
+  const select = vi.fn(() => ({ from }))
+
+  // insert chain — returns [{ id }] from .returning()
+  let nextInsertedId = 42
+  const returning = vi.fn(async () => [{ id: nextInsertedId }])
+  const values = vi.fn(() => ({ returning }))
+  const insert = vi.fn(() => ({ values }))
+
+  // update chain — cancel calls db.update(...).set(...).where(...)
+  const updateWhere = vi.fn(async () => undefined)
+  const updateSet = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set: updateSet }))
+
+  // transaction — synchronous, runs callback with a tx that exposes
+  // select/update with the chain ending in .all()/.run().
+  const txExisting: { id: number }[] = []
+  const txSelectAll = vi.fn(() => txExisting)
+  const txSelectWhere = vi.fn(() => ({ all: txSelectAll }))
+  const txSelectFrom = vi.fn(() => ({ where: txSelectWhere }))
+  const txSelect = vi.fn(() => ({ from: txSelectFrom }))
+  const txUpdateRun = vi.fn(() => undefined)
+  const txUpdateWhere = vi.fn(() => ({ run: txUpdateRun }))
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }))
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }))
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: txSelect,
+    update: txUpdate,
+  }))
+
+  return {
+    select, insert, update, transaction,
+    setNextInsertId: (id: number | null) => { nextInsertedId = id as number; returning.mockResolvedValue(id === null ? [] : [{ id }]) },
+    settingsRow, txExisting,
+    txUpdateRun, transactionFn: transaction,
+  }
+})
+
+vi.mock('@/src/scheduler', () => schedulerMock)
+vi.mock('@/src/server/helpers', () => helpersMock)
+vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
+vi.mock('@/src/scheduler/timeUtils', () => timeUtilsMock)
+vi.mock('@/src/db', () => ({
+  db: {
+    select: dbMock.select,
+    insert: dbMock.insert,
+    update: dbMock.update,
+    transaction: dbMock.transaction,
+  },
+  biometricsDb: {},
+}))
+
+const { runOnceRouter } = await import('@/src/server/routers/runOnce')
+const caller = runOnceRouter.createCaller({})
+
+beforeEach(() => {
+  jobManagerMock.cancelRunOnceSession.mockReset()
+  jobManagerMock.scheduleRunOnceSession.mockReset()
+  helpersMock.withHardwareClient.mockClear()
+  broadcastMock.broadcastMutationStatus.mockReset()
+  timeUtilsMock.timeToDate.mockReset().mockImplementation(
+    (_t, _tz, now) => new Date(now.getTime() + 60 * 60 * 1000),
+  )
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.update.mockClear()
+  dbMock.transactionFn.mockClear()
+  dbMock.txExisting.length = 0
+  dbMock.setNextInsertId(42)
+  dbMock.settingsRow.timezone = 'America/Los_Angeles'
+})
+
+describe('runOnce.start', () => {
+  it('powers on the side with the first set-point temperature, persists session, and schedules the rest', async () => {
+    const result = await caller.start({
+      side: 'left',
+      setPoints: [
+        { time: '23:00', temperature: 70 },
+        { time: '03:00', temperature: 65 },
+      ],
+      wakeTime: '07:00',
+    })
+
+    // Hardware was invoked with the first set-point temp
+    expect(helpersMock.withHardwareClient).toHaveBeenCalledTimes(1)
+
+    // Mutation broadcast for live UI
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', expect.objectContaining({
+      targetTemperature: 70,
+    }))
+
+    // Scheduler receives the *remaining* set points (slice 1) — the first
+    // already fired immediately.
+    expect(jobManagerMock.scheduleRunOnceSession).toHaveBeenCalledTimes(1)
+    const args = jobManagerMock.scheduleRunOnceSession.mock.calls[0]
+    expect(args[0]).toBe(42) // session id
+    expect(args[1]).toBe('left')
+    expect(args[2]).toEqual([{ time: '03:00', temperature: 65 }])
+    expect(args[3]).toBe('07:00')
+    expect(args[4]).toBe('America/Los_Angeles')
+
+    expect(result.sessionId).toBe(42)
+    expect(typeof result.expiresAt).toBe('number')
+  })
+
+  it('falls back to the default timezone when settings row is missing', async () => {
+    // No settings row found
+    dbMock.settingsRow.timezone = null as unknown as string
+    // Also exercise the empty-array path: replace from()→limit() with empty
+    const limit = vi.fn(async () => [])
+    const from = vi.fn(() => ({ limit }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    await caller.start({
+      side: 'right',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })
+
+    const args = jobManagerMock.scheduleRunOnceSession.mock.calls[0]
+    expect(args[4]).toBe('America/Los_Angeles')
+  })
+
+  it('rejects sessions longer than 14 hours (catches wake-time-already-passed bug)', async () => {
+    timeUtilsMock.timeToDate.mockImplementation(
+      (_t, _tz, now) => new Date(now.getTime() + 20 * 60 * 60 * 1000),
+    )
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Session too long/)
+
+    // Hardware must NOT be touched if validation rejects
+    expect(helpersMock.withHardwareClient).not.toHaveBeenCalled()
+    expect(jobManagerMock.scheduleRunOnceSession).not.toHaveBeenCalled()
+  })
+
+  it('throws when DB insert returns no row (e.g. constraint violation)', async () => {
+    dbMock.setNextInsertId(null)
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Failed to create run-once session/)
+  })
+
+  it('cancels any prior active session for the same side before starting', async () => {
+    // Pretend an existing active row exists for this side
+    dbMock.txExisting.push({ id: 7 }, { id: 9 })
+
+    await caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })
+
+    // Both prior rows were updated to cancelled (one .run() per row)
+    expect(dbMock.txUpdateRun).toHaveBeenCalledTimes(2)
+    expect(jobManagerMock.cancelRunOnceSession).toHaveBeenCalledWith('left')
+  })
+})
+
+describe('runOnce.getActive', () => {
+  it('returns null when no active session', async () => {
+    const limit = vi.fn(async () => [])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result).toBeNull()
+  })
+
+  it('parses persisted setPoints JSON', async () => {
+    const session = {
+      id: 99,
+      side: 'left' as const,
+      setPoints: JSON.stringify([{ time: '02:00', temperature: 67 }]),
+      wakeTime: '07:00',
+      startedAt: new Date(1700000000000),
+      expiresAt: new Date(1700100000000),
+      status: 'active' as const,
+    }
+    const limit = vi.fn(async () => [session])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(99)
+    expect(result?.setPoints).toEqual([{ time: '02:00', temperature: 67 }])
+    expect(result?.startedAt).toBe(Math.floor(1700000000000 / 1000))
+  })
+
+  it('returns empty setPoints when persisted JSON is malformed', async () => {
+    const session = {
+      id: 100,
+      side: 'left' as const,
+      setPoints: '{not json',
+      wakeTime: '07:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 1000),
+      status: 'active' as const,
+    }
+    const limit = vi.fn(async () => [session])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result?.setPoints).toEqual([])
+  })
+})
+
+describe('runOnce.cancel', () => {
+  it('marks active session cancelled, cancels scheduler jobs, broadcasts', async () => {
+    const result = await caller.cancel({ side: 'right' })
+
+    expect(dbMock.update).toHaveBeenCalledTimes(1)
+    expect(jobManagerMock.cancelRunOnceSession).toHaveBeenCalledWith('right')
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('right')
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -77,7 +77,10 @@ const dbMock = vi.hoisted(() => {
 
   return {
     select, insert, update, transaction,
-    setNextInsertId: (id: number | null) => { nextInsertedId = id as number; returning.mockResolvedValue(id === null ? [] : [{ id }]) },
+    setNextInsertId: (id: number | null) => {
+      nextInsertedId = id as number
+      returning.mockResolvedValue(id === null ? [] : [{ id }])
+    },
     settingsRow, txExisting,
     txUpdateRun, transactionFn: transaction,
   }

--- a/src/server/routers/tests/settings.test.ts
+++ b/src/server/routers/tests/settings.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for the settings router — getAll merges defaults, updateDevice
+ * persists + reloads scheduler + mirrors homekit lifecycle, updateSide
+ * rejects mutually-exclusive flags + validates away window, setAlwaysOn
+ * starts/stops keepalive, gesture CRUD.
+ *
+ * The DB transaction(cb) pattern is mocked synchronously: tx exposes
+ * select/update/insert/delete chains terminating in .all() which returns
+ * whatever each test queues into `txRows`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const schedulerMock = vi.hoisted(() => {
+  const jm = {
+    updateTimezone: vi.fn(async () => undefined),
+    reloadSchedules: vi.fn(async () => undefined),
+  }
+  return { getJobManager: vi.fn(async () => jm), jm }
+})
+
+const keepaliveMock = vi.hoisted(() => ({
+  startKeepalive: vi.fn(),
+  stopKeepalive: vi.fn(),
+}))
+
+const autoOffMock = vi.hoisted(() => ({
+  restartAutoOffTimers: vi.fn(),
+}))
+
+const homekitMock = vi.hoisted(() => ({
+  enable: vi.fn(async () => undefined),
+  disable: vi.fn(async () => undefined),
+}))
+
+// DB mock — supports both top-level db.select(…) chain (used by getAll +
+// updateDevice prior-row read) AND the transaction wrapper (which receives
+// a tx with .select / .update / .insert / .delete chains terminating in .all()).
+const dbState = vi.hoisted(() => ({
+  // Sequential queue for top-level db.select() chains
+  topRowsQueue: [] as unknown[][],
+  // Sequential queue for tx-scoped chains
+  txRowsQueue: [] as unknown[][],
+  // Sequential queue for db.update().set().where() awaitable result (lifecycle revert path)
+  topUpdateQueue: [] as Array<unknown>,
+  popTop(): unknown[] { return dbState.topRowsQueue.shift() ?? [] },
+  popTx(): unknown[] { return dbState.txRowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  // Top-level chain (await thenable)
+  const makeTopChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.popTop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    return chain
+  }
+
+  // Tx-scoped chain (sync — terminates in .all())
+  const makeTxChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.all = vi.fn(() => dbState.popTx())
+    chain.run = vi.fn(() => undefined)
+    return chain
+  }
+
+  const select = vi.fn(() => makeTopChain())
+  const update = vi.fn(() => makeTopChain())
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: vi.fn(() => makeTxChain()),
+    update: vi.fn(() => makeTxChain()),
+    insert: vi.fn(() => makeTxChain()),
+    delete: vi.fn(() => makeTxChain()),
+  }))
+
+  return { select, update, transaction }
+})
+
+vi.mock('@/src/scheduler', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/services/temperatureKeepalive', () => keepaliveMock)
+vi.mock('@/src/services/autoOffWatcher', () => autoOffMock)
+vi.mock('@/src/homekit', () => homekitMock)
+vi.mock('@/src/db', () => ({
+  db: { select: dbMock.select, update: dbMock.update, transaction: dbMock.transaction },
+  biometricsDb: {},
+}))
+
+const { settingsRouter } = await import('@/src/server/routers/settings')
+const caller = settingsRouter.createCaller({})
+
+beforeEach(() => {
+  schedulerMock.getJobManager.mockClear()
+  schedulerMock.jm.updateTimezone.mockReset().mockResolvedValue(undefined)
+  schedulerMock.jm.reloadSchedules.mockReset().mockResolvedValue(undefined)
+  keepaliveMock.startKeepalive.mockReset()
+  keepaliveMock.stopKeepalive.mockReset()
+  autoOffMock.restartAutoOffTimers.mockReset()
+  homekitMock.enable.mockReset().mockResolvedValue(undefined)
+  homekitMock.disable.mockReset().mockResolvedValue(undefined)
+  dbState.topRowsQueue.length = 0
+  dbState.txRowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.transaction.mockClear()
+})
+
+describe('settings.getAll', () => {
+  it('returns existing rows for device, sides, and gestures', async () => {
+    const device = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const sides = [
+      { side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+      { side: 'right', name: 'R', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+    ]
+    const gestures: unknown[] = []
+    dbState.topRowsQueue.push([device], sides, gestures)
+
+    const result = await caller.getAll({})
+    expect(result.device.timezone).toBe('UTC')
+    expect(result.sides.left.name).toBe('L')
+    expect(result.sides.right.name).toBe('R')
+    expect(result.gestures.left).toEqual([])
+  })
+
+  it('returns synthetic defaults when device row is missing', async () => {
+    dbState.topRowsQueue.push([], [], [])
+    const result = await caller.getAll({})
+    expect(result.device.timezone).toBe('America/Los_Angeles')
+    expect(result.sides.left.side).toBe('left')
+    expect(result.sides.right.side).toBe('right')
+  })
+})
+
+describe('settings.updateDevice', () => {
+  it('updates timezone and triggers updateTimezone reload', async () => {
+    // For 'homekitEnabled' check: not present, so no prior-row select.
+    // Tx: select(current) returns 1 row, update().returning().all() returns updated row.
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, timezone: 'America/New_York', updatedAt: new Date(1) }
+    dbState.txRowsQueue.push([current], [updated])
+
+    const result = await caller.updateDevice({ timezone: 'America/New_York' })
+    expect(result.timezone).toBe('America/New_York')
+    expect(schedulerMock.jm.updateTimezone).toHaveBeenCalledWith('America/New_York')
+    expect(schedulerMock.jm.reloadSchedules).not.toHaveBeenCalled()
+  })
+
+  it('triggers reloadSchedules for non-timezone scheduling fields', async () => {
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, primePodDaily: true, primePodTime: '15:00' }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateDevice({ primePodDaily: true, primePodTime: '15:00' })
+    expect(schedulerMock.jm.reloadSchedules).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects rebootDaily=true without a rebootTime', async () => {
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: null,
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateDevice({ rebootDaily: true })).rejects.toThrow(/rebootTime is required/)
+  })
+
+  it('mirrors homekit.enable() and rolls back DB on lifecycle failure', async () => {
+    // Top-level select for prior homekitEnabled
+    dbState.topRowsQueue.push([{ homekitEnabled: false }])
+    // Top-level update().set().where() for revert (await thenable resolves to anything)
+
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: null,
+      primePodDaily: false, primePodTime: null,
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, homekitEnabled: true }
+    dbState.txRowsQueue.push([current], [updated])
+
+    homekitMock.enable.mockRejectedValue(new Error('mDNS failed'))
+
+    await expect(caller.updateDevice({ homekitEnabled: true })).rejects.toThrow(/mDNS failed/)
+    // Revert should have been attempted (db.update was called)
+    expect(dbMock.update).toHaveBeenCalled()
+  })
+})
+
+describe('settings.updateSide', () => {
+  it('rejects alwaysOn + autoOffEnabled set true together', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateSide({ side: 'left', autoOffEnabled: true })).rejects.toThrow(/mutually exclusive/)
+  })
+
+  it('rejects awayReturn earlier than awayStart', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: '2025-01-10T00:00:00Z', awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateSide({
+      side: 'left',
+      awayReturn: '2025-01-01T00:00:00Z',
+    })).rejects.toThrow(/awayReturn must not be before awayStart/)
+  })
+
+  it('starts keepalive when alwaysOn=true', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, alwaysOn: true }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateSide({ side: 'left', alwaysOn: true })
+    expect(keepaliveMock.startKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('stops keepalive when alwaysOn=false', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, alwaysOn: false }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateSide({ side: 'left', alwaysOn: false })
+    expect(keepaliveMock.stopKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('throws NOT_FOUND when no row exists', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.updateSide({ side: 'left', name: 'New' })).rejects.toThrow(/Side settings for left not found/)
+  })
+})
+
+describe('settings.setAlwaysOn', () => {
+  it('starts keepalive when alwaysOn=true', async () => {
+    const updated = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+
+    await caller.setAlwaysOn({ side: 'left', alwaysOn: true })
+    expect(keepaliveMock.startKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('stops keepalive when alwaysOn=false', async () => {
+    const updated = {
+      side: 'right', name: 'R', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+
+    await caller.setAlwaysOn({ side: 'right', alwaysOn: false })
+    expect(keepaliveMock.stopKeepalive).toHaveBeenCalledWith('right')
+  })
+
+  it('throws NOT_FOUND when row missing', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.setAlwaysOn({ side: 'left', alwaysOn: true })).rejects.toThrow(/Side settings for left not found/)
+  })
+})
+
+describe('settings.setGesture / deleteGesture', () => {
+  it('creates a temperature gesture when none exists', async () => {
+    // tx.select existing → empty; tx.insert.values.returning.all → [created]
+    const created = {
+      id: 1, side: 'left', tapType: 'doubleTap', actionType: 'temperature',
+      temperatureChange: 'increment', temperatureAmount: 2,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([], [created])
+
+    const out = await caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'temperature',
+      temperatureChange: 'increment',
+      temperatureAmount: 2,
+    })
+    expect(out.id).toBe(1)
+  })
+
+  it('updates an alarm gesture when one already exists', async () => {
+    const existing = { id: 5, side: 'left', tapType: 'doubleTap' }
+    const updated = {
+      id: 5, side: 'left', tapType: 'doubleTap', actionType: 'alarm',
+      alarmBehavior: 'snooze',
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([existing], [updated])
+
+    const out = await caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'alarm',
+      alarmBehavior: 'snooze',
+    })
+    expect(out.id).toBe(5)
+  })
+
+  it('deleteGesture throws NOT_FOUND when no row deleted', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })).rejects.toThrow(/not found/)
+  })
+
+  it('deleteGesture returns success when a row was deleted', async () => {
+    dbState.txRowsQueue.push([{ id: 1 }])
+    const out = await caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })
+    expect(out).toEqual({ success: true })
+  })
+})

--- a/src/server/routers/tests/system.test.ts
+++ b/src/server/routers/tests/system.test.ts
@@ -118,7 +118,7 @@ describe('system.wifiStatus', () => {
 
   it('parses nmcli output and returns SSID + signal', async () => {
     queueExec(
-      (file) => file === 'nmcli',
+      file => file === 'nmcli',
       { stdout: 'no:OtherNet:50\nyes:HomeWiFi:80\n' },
     )
     const result = await caller.wifiStatus({})
@@ -129,7 +129,7 @@ describe('system.wifiStatus', () => {
 
   it('handles escaped colons in SSID', async () => {
     queueExec(
-      (file) => file === 'nmcli',
+      file => file === 'nmcli',
       { stdout: 'yes:My\\:Net:75\n' },
     )
     const result = await caller.wifiStatus({})
@@ -195,7 +195,7 @@ describe('system.getLogs', () => {
 
   it('reverses journalctl output to newest-first and exposes a cursor when more remain', async () => {
     queueExec(
-      (file) => file === 'journalctl',
+      file => file === 'journalctl',
       // 3 lines + cursor when only 2 requested → hasMore=true
       { stdout: 'line1\nline2\nline3\n-- cursor: s=abc\n' },
     )

--- a/src/server/routers/tests/system.test.ts
+++ b/src/server/routers/tests/system.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the system router — internetStatus, setInternetAccess (block/
+ * unblock + lock + error wrap), wifiStatus parsing, triggerUpdate spawn,
+ * getLogSources active flag, getLogs newest-first reversal + ENOENT fallback,
+ * getDiskUsage parse + dev fallback, getStorageBreakdown nullable mounts,
+ * getVersion git-info parse + fallback.
+ *
+ * child_process.execFile + spawn, fs/promises, and node:fs are mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execMock = vi.hoisted(() => ({
+  execFile: vi.fn((..._args: unknown[]) => {
+    const cb = _args[_args.length - 1] as (e: unknown, o: { stdout: string }) => void
+    cb(null, { stdout: '' })
+  }),
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    unref: vi.fn(),
+  })),
+}))
+
+const fsPromisesMock = vi.hoisted(() => ({
+  readdir: vi.fn(async () => []),
+  readFile: vi.fn(async () => ''),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+}))
+
+const fsSyncMock = vi.hoisted(() => ({
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execMock.execFile,
+  spawn: execMock.spawn,
+  default: { execFile: execMock.execFile, spawn: execMock.spawn },
+}))
+vi.mock('node:fs/promises', () => ({ ...fsPromisesMock, default: fsPromisesMock }))
+vi.mock('node:fs', () => ({ ...fsSyncMock, default: fsSyncMock }))
+
+const { systemRouter } = await import('@/src/server/routers/system')
+const caller = systemRouter.createCaller({})
+
+beforeEach(() => {
+  execMock.execFile.mockReset()
+  execMock.execFile.mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+    cb(null, { stdout: '' })
+  })
+  execMock.spawn.mockReset().mockReturnValue({ on: vi.fn(), unref: vi.fn() } as never)
+  fsPromisesMock.readdir.mockReset().mockResolvedValue([])
+  fsPromisesMock.readFile.mockReset().mockResolvedValue('')
+  fsPromisesMock.writeFile.mockReset().mockResolvedValue(undefined)
+  fsPromisesMock.mkdir.mockReset().mockResolvedValue(undefined)
+})
+
+// Helper: queue execFile responses by command-name match
+function queueExec(matcher: (file: string, args: string[]) => boolean, response: { stdout?: string, error?: Error }) {
+  execMock.execFile.mockImplementationOnce((...allArgs: unknown[]) => {
+    const file = allArgs[0] as string
+    const args = (allArgs[1] as string[]) ?? []
+    const cb = allArgs[allArgs.length - 1] as (e: unknown, o: { stdout: string }) => void
+    if (matcher(file, args)) {
+      if (response.error) cb(response.error, { stdout: '' })
+      else cb(null, { stdout: response.stdout ?? '' })
+    }
+    else {
+      cb(null, { stdout: '' })
+    }
+  })
+}
+
+describe('system.internetStatus', () => {
+  it('returns blocked=true when iptables -L OUTPUT shows DROP', async () => {
+    queueExec(
+      (_file, args) => args.includes('-L') && args.includes('OUTPUT'),
+      { stdout: 'DROP all -- 0.0.0.0/0\n' },
+    )
+    const result = await caller.internetStatus({})
+    expect(result.blocked).toBe(true)
+  })
+
+  it('returns blocked=false on iptables error (dev environment)', async () => {
+    queueExec(() => true, { error: new Error('iptables: command not found') })
+    const result = await caller.internetStatus({})
+    expect(result.blocked).toBe(false)
+  })
+})
+
+describe('system.setInternetAccess', () => {
+  it('unblocks WAN by flushing rules and re-checks state', async () => {
+    // After unblock, isWanBlocked should return false (no DROP)
+    const result = await caller.setInternetAccess({ blocked: false })
+    expect(result.blocked).toBe(false)
+  })
+
+  it('wraps execFile failures as INTERNAL_SERVER_ERROR', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('iptables boom'), { stdout: '' })
+    })
+    await expect(caller.setInternetAccess({ blocked: false })).rejects.toThrow(/Failed to update iptables/)
+  })
+})
+
+describe('system.wifiStatus', () => {
+  it('returns connected=false when nmcli is unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('nmcli not found'), { stdout: '' })
+    })
+    const result = await caller.wifiStatus({})
+    expect(result).toEqual({ connected: false, ssid: null, signal: null })
+  })
+
+  it('parses nmcli output and returns SSID + signal', async () => {
+    queueExec(
+      (file) => file === 'nmcli',
+      { stdout: 'no:OtherNet:50\nyes:HomeWiFi:80\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result.connected).toBe(true)
+    expect(result.ssid).toBe('HomeWiFi')
+    expect(result.signal).toBe(80)
+  })
+
+  it('handles escaped colons in SSID', async () => {
+    queueExec(
+      (file) => file === 'nmcli',
+      { stdout: 'yes:My\\:Net:75\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result.ssid).toBe('My:Net')
+    expect(result.signal).toBe(75)
+  })
+})
+
+describe('system.triggerUpdate', () => {
+  it('spawns sp-update with the requested branch', async () => {
+    const result = await caller.triggerUpdate({ branch: 'feature/cool' })
+    expect(execMock.spawn).toHaveBeenCalledWith('sudo',
+      ['-n', '/usr/local/bin/sp-update', 'feature/cool'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.branch).toBe('feature/cool')
+  })
+
+  it('defaults branch to "main" when omitted', async () => {
+    const result = await caller.triggerUpdate({})
+    expect(result.branch).toBe('main')
+    expect(execMock.spawn).toHaveBeenCalledWith('sudo',
+      ['-n', '/usr/local/bin/sp-update', 'main'],
+      expect.any(Object),
+    )
+  })
+
+  it('rejects branch names with invalid characters', async () => {
+    await expect(caller.triggerUpdate({ branch: 'evil; rm -rf /' })).rejects.toThrow(/Invalid branch name/)
+  })
+})
+
+describe('system.getLogSources', () => {
+  it('returns each unit with active=true when systemctl exits 0', async () => {
+    // All systemctl is-active calls succeed by default
+    const result = await caller.getLogSources({})
+    expect(result.sources).toHaveLength(4)
+    expect(result.sources.every(s => s.active)).toBe(true)
+  })
+
+  it('marks units inactive when systemctl errors', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('inactive'), { stdout: '' })
+    })
+    const result = await caller.getLogSources({})
+    expect(result.sources.every(s => !s.active)).toBe(true)
+  })
+})
+
+describe('system.getLogs', () => {
+  it('returns dev-friendly fallback when journalctl is missing', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      const err = Object.assign(new Error('not found'), { code: 'ENOENT' })
+      cb(err, { stdout: '' })
+    })
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 10 })
+    expect(result.lines[0]).toContain('not available')
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('reverses journalctl output to newest-first and exposes a cursor when more remain', async () => {
+    queueExec(
+      (file) => file === 'journalctl',
+      // 3 lines + cursor when only 2 requested → hasMore=true
+      { stdout: 'line1\nline2\nline3\n-- cursor: s=abc\n' },
+    )
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 2 })
+    expect(result.lines).toEqual(['line3', 'line2'])
+    expect(result.nextCursor).toBe('s=abc')
+  })
+
+  it('rejects unit names that do not match the sleepypod*.service pattern', async () => {
+    await expect(caller.getLogs({ unit: 'evil.service', lines: 10 })).rejects.toThrow(/Invalid unit name/)
+  })
+})
+
+describe('system.getDiskUsage', () => {
+  it('parses df totals when available', async () => {
+    queueExec(
+      (file, args) => file === 'df' && args.includes('/'),
+      { stdout: 'fs 1B-blocks Used Available Use% Mounted\n/dev 1000 200 800 20% /\n' },
+    )
+    const result = await caller.getDiskUsage({})
+    expect(result.totalBytes).toBe(1000)
+    expect(result.usedBytes).toBe(200)
+    expect(result.availableBytes).toBe(800)
+    expect(result.usedPercent).toBe(20)
+  })
+
+  it('returns zeros when df is unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('df not found'), { stdout: '' })
+    })
+    const result = await caller.getDiskUsage({})
+    expect(result).toEqual({ totalBytes: 0, usedBytes: 0, availableBytes: 0, usedPercent: 0 })
+  })
+})
+
+describe('system.getStorageBreakdown', () => {
+  it('returns zero sections when df + du are unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('not found'), { stdout: '' })
+    })
+    fsPromisesMock.readdir.mockResolvedValue([])
+
+    const result = await caller.getStorageBreakdown({})
+    expect(result.emmc.totalBytes).toBe(0)
+    expect(result.biometricsArchive).toEqual({ usedBytes: 0, fileCount: 0 })
+  })
+})
+
+describe('system.getVersion', () => {
+  it('parses .git-info when present', async () => {
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      branch: 'main',
+      commitHash: 'abc123',
+      commitTitle: 'fix: thing',
+      buildDate: '2026-04-01',
+    }))
+    const result = await caller.getVersion({})
+    expect(result).toEqual({
+      branch: 'main',
+      commitHash: 'abc123',
+      commitTitle: 'fix: thing',
+      buildDate: '2026-04-01',
+    })
+  })
+
+  it('returns "unknown" placeholders when .git-info is missing', async () => {
+    fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'))
+    const result = await caller.getVersion({})
+    expect(result).toEqual({
+      branch: 'unknown', commitHash: 'unknown',
+      commitTitle: 'unknown', buildDate: 'unknown',
+    })
+  })
+})

--- a/src/server/routers/tests/waterLevel.test.ts
+++ b/src/server/routers/tests/waterLevel.test.ts
@@ -109,10 +109,10 @@ describe('waterLevel.getTrend', () => {
       { level: 'ok', cnt: 50 },
       { level: 'low', cnt: 50 },
     ])
-    dbState.rowsQueue.push([{ cnt: 40 }])  // recentLow
-    dbState.rowsQueue.push([{ cnt: 10 }])  // olderLow
-    dbState.rowsQueue.push([{ cnt: 50 }])  // recentTotal
-    dbState.rowsQueue.push([{ cnt: 50 }])  // olderTotal
+    dbState.rowsQueue.push([{ cnt: 40 }]) // recentLow
+    dbState.rowsQueue.push([{ cnt: 10 }]) // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }]) // recentTotal
+    dbState.rowsQueue.push([{ cnt: 50 }]) // olderTotal
 
     const result = await caller.getTrend({ hours: 24 })
     expect(result.trend).toBe('declining')
@@ -124,8 +124,8 @@ describe('waterLevel.getTrend', () => {
       { level: 'ok', cnt: 50 },
       { level: 'low', cnt: 50 },
     ])
-    dbState.rowsQueue.push([{ cnt: 10 }])  // recentLow
-    dbState.rowsQueue.push([{ cnt: 40 }])  // olderLow
+    dbState.rowsQueue.push([{ cnt: 10 }]) // recentLow
+    dbState.rowsQueue.push([{ cnt: 40 }]) // olderLow
     dbState.rowsQueue.push([{ cnt: 50 }])
     dbState.rowsQueue.push([{ cnt: 50 }])
 

--- a/src/server/routers/tests/waterLevel.test.ts
+++ b/src/server/routers/tests/waterLevel.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the water-level router — happy path of every procedure plus the
+ * BAD_REQUEST date-range rejection (getHistory) and NOT_FOUND alert dismissal.
+ *
+ * biometricsDb is mocked with a thin chain that always terminates in an
+ * awaitable returning whatever the test queues into `nextRows`/`nextRow`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] {
+    return dbState.rowsQueue.shift() ?? []
+  },
+}))
+
+const dbMock = vi.hoisted(() => {
+  // Each query terminates in either .limit() or .orderBy() depending on the
+  // procedure. Both must be awaitable AND chainable. Use a thenable so an
+  // awaiter consumes the row queue.
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.groupBy = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    return chain
+  }
+
+  const select = vi.fn(() => makeChain())
+  const update = vi.fn(() => makeChain())
+  const insert = vi.fn(() => makeChain())
+  const del = vi.fn(() => makeChain())
+
+  return { select, update, insert, delete: del }
+})
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: dbMock,
+}))
+
+const { waterLevelRouter } = await import('@/src/server/routers/waterLevel')
+const caller = waterLevelRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.delete.mockClear()
+})
+
+describe('waterLevel.getHistory', () => {
+  it('returns rows when no date range is supplied', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, timestamp: new Date(0), level: 'ok' },
+      { id: 2, timestamp: new Date(1000), level: 'low' },
+    ])
+
+    const result = await caller.getHistory({ limit: 100 })
+    expect(result).toHaveLength(2)
+    expect(result[0].level).toBe('ok')
+  })
+
+  it('rejects inverted startDate / endDate as BAD_REQUEST', async () => {
+    await expect(caller.getHistory({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate must be before or equal to endDate/)
+  })
+})
+
+describe('waterLevel.getLatest', () => {
+  it('returns the latest row', async () => {
+    dbState.rowsQueue.push([{ id: 7, timestamp: new Date(0), level: 'ok' }])
+    const result = await caller.getLatest({})
+    expect(result?.id).toBe(7)
+  })
+
+  it('returns null when no rows', async () => {
+    dbState.rowsQueue.push([])
+    const result = await caller.getLatest({})
+    expect(result).toBeNull()
+  })
+})
+
+describe('waterLevel.getTrend', () => {
+  it('returns unknown trend when fewer than 2 readings', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 1 },
+    ])
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('unknown')
+    expect(result.totalReadings).toBe(1)
+    expect(result.okPercent).toBe(100)
+  })
+
+  it('computes declining trend when recent low rate exceeds older by >0.2', async () => {
+    // Order matters — totals first, then recentLow, olderLow, recentTotal, olderTotal
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 50 },
+      { level: 'low', cnt: 50 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 40 }])  // recentLow
+    dbState.rowsQueue.push([{ cnt: 10 }])  // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }])  // recentTotal
+    dbState.rowsQueue.push([{ cnt: 50 }])  // olderTotal
+
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('declining')
+    expect(result.totalReadings).toBe(100)
+  })
+
+  it('computes rising trend when recent low rate is much lower than older', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 50 },
+      { level: 'low', cnt: 50 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 10 }])  // recentLow
+    dbState.rowsQueue.push([{ cnt: 40 }])  // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }])
+    dbState.rowsQueue.push([{ cnt: 50 }])
+
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('rising')
+  })
+})
+
+describe('waterLevel.getAlerts', () => {
+  it('returns active (undismissed) alerts', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, type: 'low_sustained', startedAt: new Date(0),
+        dismissedAt: null, message: 'low for 30m', createdAt: new Date(0),
+      },
+    ])
+    const result = await caller.getAlerts({})
+    expect(result).toHaveLength(1)
+    expect(result[0].dismissedAt).toBeNull()
+  })
+})
+
+describe('waterLevel.dismissAlert', () => {
+  it('marks an alert dismissed', async () => {
+    dbState.rowsQueue.push([
+      { id: 5, type: 'low_sustained', startedAt: new Date(0), dismissedAt: new Date(), message: null, createdAt: new Date(0) },
+    ])
+    const result = await caller.dismissAlert({ id: 5 })
+    expect(result).toEqual({ success: true })
+  })
+
+  it('throws NOT_FOUND when nothing was updated', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.dismissAlert({ id: 999 })).rejects.toThrow(/Alert 999 not found/)
+  })
+})
+
+describe('waterLevel.getFlowReadings / getLatestFlowReading', () => {
+  it('returns flow rows for the requested window', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, timestamp: new Date(0), leftFlowrateCd: 100, rightFlowrateCd: 110, leftPumpRpm: 1500, rightPumpRpm: 1600 },
+    ])
+    const result = await caller.getFlowReadings({ hours: 24 })
+    expect(result).toHaveLength(1)
+    expect(result[0].leftFlowrateCd).toBe(100)
+  })
+
+  it('getLatestFlowReading returns null when no rows', async () => {
+    dbState.rowsQueue.push([])
+    const result = await caller.getLatestFlowReading({})
+    expect(result).toBeNull()
+  })
+
+  it('getLatestFlowReading returns the row when one exists', async () => {
+    dbState.rowsQueue.push([{ id: 9, timestamp: new Date(0), leftFlowrateCd: null, rightFlowrateCd: null, leftPumpRpm: null, rightPumpRpm: null }])
+    const result = await caller.getLatestFlowReading({})
+    expect(result?.id).toBe(9)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for previously 0%-covered tRPC routers
- Mirrors the mqtt/schedules router test pattern (vi.hoisted mocks, createCaller)
- Covers happy path + key error/branch logic per procedure

## Routers covered
- homekit, runOnce, calibration, waterLevel, raw, environment, device, health, settings, system, biometrics

## Test plan
- pnpm test run passes locally (57 files / 1062 tests, +11 files / +167 tests vs. baseline)
- pnpm tsc clean