### PR TITLE
test(hooks): cover untested custom hooks

### DIFF
--- a/src/hooks/tests/useDeviceStatus.test.ts
+++ b/src/hooks/tests/useDeviceStatus.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for useDeviceStatus — merges WebSocket-pushed deviceStatus frames
+ * with a tRPC HTTP fallback. WS becomes "sticky" once a frame arrives:
+ * subsequent transient WS gaps must not revert to HTTP polling.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sensorMock = vi.hoisted(() => {
+  const state: { frame: any } = { frame: undefined }
+  return {
+    state,
+    useSensorStream: vi.fn(),
+    useSensorFrame: vi.fn(() => state.frame),
+  }
+})
+
+const trpcMock = vi.hoisted(() => {
+  const state: { http: any, isLoading: boolean } = { http: undefined, isLoading: false }
+  const refetch = vi.fn(() => Promise.resolve('refetched'))
+  return {
+    state,
+    refetch,
+    trpc: {
+      device: {
+        getStatus: {
+          useQuery: vi.fn(() => ({
+            data: state.http,
+            isLoading: state.isLoading,
+            refetch,
+          })),
+        },
+      },
+    },
+  }
+})
+
+vi.mock('../useSensorStream', () => ({
+  useSensorStream: sensorMock.useSensorStream,
+  useSensorFrame: sensorMock.useSensorFrame,
+}))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useDeviceStatus } from '../useDeviceStatus'
+
+beforeEach(() => {
+  sensorMock.state.frame = undefined
+  trpcMock.state.http = undefined
+  trpcMock.state.isLoading = false
+})
+
+afterEach(() => {
+  sensorMock.useSensorStream.mockClear()
+  sensorMock.useSensorFrame.mockClear()
+  trpcMock.refetch.mockClear()
+})
+
+const wsFrame = {
+  type: 'deviceStatus' as const,
+  ts: 1,
+  leftSide: { currentTemperature: 20, targetTemperature: 22, currentLevel: 5, targetLevel: 6, isAlarmVibrating: false },
+  rightSide: { currentTemperature: 21, targetTemperature: 22, currentLevel: 4, targetLevel: 5, isAlarmVibrating: false },
+  waterLevel: 'ok' as const,
+  isPriming: false,
+  snooze: { left: null, right: null },
+}
+
+describe('useDeviceStatus', () => {
+  it('opens a WebSocket subscription scoped to deviceStatus', () => {
+    renderHook(() => useDeviceStatus())
+    expect(sensorMock.useSensorStream).toHaveBeenCalledWith({ sensors: ['deviceStatus'], enabled: true })
+  })
+
+  it('returns HTTP status when no WS frame has arrived', () => {
+    trpcMock.state.http = { fromHttp: true }
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.status).toEqual({ fromHttp: true })
+    expect(result.current.isStreaming).toBe(false)
+  })
+
+  it('reports loading from HTTP only until first WS frame', () => {
+    trpcMock.state.isLoading = true
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('returns merged WS frame data once received and reports streaming', () => {
+    sensorMock.state.frame = wsFrame
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.isStreaming).toBe(true)
+    expect(result.current.status?.leftSide.currentTemperature).toBe(20)
+    expect(result.current.status?.waterLevel).toBe('ok')
+    expect(result.current.status?.isPriming).toBe(false)
+  })
+
+  it('normalizes primeCompletedNotification.timestamp to a Date for numeric input', () => {
+    sensorMock.state.frame = { ...wsFrame, primeCompletedNotification: { timestamp: 1_700_000_000_000 } }
+    const { result } = renderHook(() => useDeviceStatus())
+    const ts = result.current.status?.primeCompletedNotification?.timestamp
+    expect(ts).toBeInstanceOf(Date)
+    expect((ts as Date).getTime()).toBe(1_700_000_000_000)
+  })
+
+  it('passes through an existing Date timestamp untouched', () => {
+    const date = new Date('2026-01-01T00:00:00Z')
+    sensorMock.state.frame = { ...wsFrame, primeCompletedNotification: { timestamp: date } }
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.status?.primeCompletedNotification?.timestamp).toBe(date)
+  })
+
+  it('refetch invokes the underlying tRPC refetch', async () => {
+    const { result } = renderHook(() => useDeviceStatus())
+    await result.current.refetch()
+    expect(trpcMock.refetch).toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useDualSideData.test.ts
+++ b/src/hooks/tests/useDualSideData.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for useDualSideData — fetches biometric data per active side and
+ * merges into a unified, side-labeled dataset. Verifies:
+ *  - per-side query enable flags follow activeSides
+ *  - merged datasets sort correctly (vitals/movement asc, sleep desc)
+ *  - per-side summaries / sleep stages are emitted as arrays
+ *  - utility functions (filterBySide, groupBySide, getSideColor, etc.)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { activeSides: Array<'left' | 'right'> } = { activeSides: ['left', 'right'] }
+  return { state }
+})
+
+const trpcMock = vi.hoisted(() => {
+  // Per-(method, side) overrides — tests can stub specific queries.
+  const overrides = new Map<string, any>()
+  const refetch = vi.fn()
+  const baseResult = (key: string) => {
+    const override = overrides.get(key)
+    return {
+      data: override?.data,
+      isLoading: override?.isLoading ?? false,
+      isError: override?.isError ?? false,
+      error: override?.error ?? null,
+      fetchStatus: override?.fetchStatus ?? 'idle',
+      refetch,
+    }
+  }
+  const methods = ['getVitals', 'getSleepRecords', 'getMovement', 'getVitalsSummary', 'getSleepStages']
+  const biometrics: any = {}
+  for (const m of methods) {
+    biometrics[m] = {
+      useQuery: vi.fn((input: any, opts: any) => {
+        const key = `${m}:${input.side}`
+        const result = baseResult(key)
+        // Mirror useQuery semantics: when disabled, fetchStatus is 'idle' regardless
+        if (opts?.enabled === false) {
+          return { ...result, isLoading: false, fetchStatus: 'idle' }
+        }
+        return result
+      }),
+    }
+  }
+  return {
+    overrides,
+    refetch,
+    biometrics,
+    trpc: { biometrics },
+  }
+})
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => ({ activeSides: sideMock.state.activeSides }),
+}))
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import {
+  filterBySide,
+  groupBySide,
+  getSideColor,
+  getSideColorClass,
+  getSideLabel,
+  useDualSideData,
+} from '../useDualSideData'
+
+afterEach(() => {
+  trpcMock.overrides.clear()
+  trpcMock.refetch.mockReset()
+  Object.values(trpcMock.biometrics).forEach((m: any) => m.useQuery.mockClear())
+  sideMock.state.activeSides = ['left', 'right']
+})
+
+describe('useDualSideData', () => {
+  it('returns empty arrays when both sides have no data', () => {
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitals).toEqual([])
+    expect(result.current.sleepRecords).toEqual([])
+    expect(result.current.movement).toEqual([])
+    expect(result.current.vitalsSummaries).toEqual([])
+    expect(result.current.sleepStages).toEqual([])
+    expect(result.current.activeSides).toEqual(['left', 'right'])
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('disables per-side queries when only one side is active', () => {
+    sideMock.state.activeSides = ['left']
+    renderHook(() => useDualSideData())
+    const calls = trpcMock.biometrics.getVitals.useQuery.mock.calls
+    const left = calls.find((c: any[]) => c[0].side === 'left')
+    const right = calls.find((c: any[]) => c[0].side === 'right')
+    expect(left?.[1].enabled).toBe(true)
+    expect(right?.[1].enabled).toBe(false)
+  })
+
+  it('respects include* flags by disabling those queries', () => {
+    renderHook(() => useDualSideData({ includeVitals: false }))
+    const calls = trpcMock.biometrics.getVitals.useQuery.mock.calls
+    expect(calls.every((c: any[]) => c[1].enabled === false)).toBe(true)
+  })
+
+  it('respects the global enabled=false flag', () => {
+    renderHook(() => useDualSideData({ enabled: false }))
+    const allEnabled = Object.values(trpcMock.biometrics)
+      .flatMap((m: any) => m.useQuery.mock.calls)
+      .map((c: any[]) => c[1].enabled)
+    expect(allEnabled.every(e => e === false)).toBe(true)
+  })
+
+  it('merges vitals from both sides ascending by timestamp with side labels', () => {
+    trpcMock.overrides.set('getVitals:left', {
+      data: [
+        { id: 1, timestamp: new Date('2026-01-01T10:00:00Z'), heartRate: 60, hrv: 40, breathingRate: 14 },
+      ],
+    })
+    trpcMock.overrides.set('getVitals:right', {
+      data: [
+        { id: 2, timestamp: new Date('2026-01-01T08:00:00Z'), heartRate: 70, hrv: 50, breathingRate: 16 },
+        { id: 3, timestamp: new Date('2026-01-01T11:00:00Z'), heartRate: 72, hrv: 52, breathingRate: 17 },
+      ],
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitals).toHaveLength(3)
+    expect(result.current.vitals.map(v => v.side)).toEqual(['right', 'left', 'right'])
+  })
+
+  it('merges sleep records descending by enteredBedAt', () => {
+    trpcMock.overrides.set('getSleepRecords:left', {
+      data: [{ id: 1, enteredBedAt: new Date('2026-01-01T22:00:00Z'), leftBedAt: new Date('2026-01-02T06:00:00Z'), sleepDurationSeconds: 28800, timesExitedBed: 0, presentIntervals: [], notPresentIntervals: [], createdAt: new Date() }],
+    })
+    trpcMock.overrides.set('getSleepRecords:right', {
+      data: [{ id: 2, enteredBedAt: new Date('2026-01-02T22:00:00Z'), leftBedAt: new Date('2026-01-03T06:00:00Z'), sleepDurationSeconds: 28800, timesExitedBed: 0, presentIntervals: [], notPresentIntervals: [], createdAt: new Date() }],
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.sleepRecords[0].side).toBe('right') // newest first
+    expect(result.current.sleepRecords[1].side).toBe('left')
+  })
+
+  it('emits one entry per active side in vitalsSummaries and sleepStages', () => {
+    trpcMock.overrides.set('getVitalsSummary:left', {
+      data: { avgHeartRate: 60, minHeartRate: 50, maxHeartRate: 70, avgHRV: 40, avgBreathingRate: 14, recordCount: 10 },
+    })
+    trpcMock.overrides.set('getSleepStages:right', {
+      data: { epochs: [], blocks: [], distribution: { wake: 0, light: 0, deep: 0, rem: 0 }, qualityScore: 80, totalSleepMs: 0, sleepRecordId: null, enteredBedAt: null, leftBedAt: null },
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitalsSummaries).toHaveLength(1)
+    expect(result.current.vitalsSummaries[0]).toMatchObject({ side: 'left', avgHeartRate: 60 })
+    expect(result.current.sleepStages).toHaveLength(1)
+    expect(result.current.sleepStages[0]).toMatchObject({ side: 'right', qualityScore: 80 })
+  })
+
+  it('aggregates loading state across active queries', () => {
+    trpcMock.overrides.set('getVitals:left', { isLoading: true, fetchStatus: 'fetching' })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('aggregates error state and surfaces error messages', () => {
+    trpcMock.overrides.set('getVitals:left', { isError: true, error: { message: 'left vitals failed' } })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.isError).toBe(true)
+    expect(result.current.errors).toContain('left vitals failed')
+  })
+
+  it('falls back to "Unknown error" when error has no message', () => {
+    trpcMock.overrides.set('getVitals:left', { error: {} })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.errors).toContain('Unknown error')
+  })
+
+  it('refetch fires refetch on every active query', () => {
+    const { result } = renderHook(() => useDualSideData())
+    result.current.refetch()
+    expect(trpcMock.refetch).toHaveBeenCalled()
+  })
+})
+
+describe('useDualSideData utility helpers', () => {
+  it('filterBySide returns only matching rows', () => {
+    const data = [
+      { side: 'left' as const, value: 1 },
+      { side: 'right' as const, value: 2 },
+      { side: 'left' as const, value: 3 },
+    ]
+    expect(filterBySide(data, 'left')).toEqual([
+      { side: 'left', value: 1 },
+      { side: 'left', value: 3 },
+    ])
+  })
+
+  it('groupBySide partitions into left/right', () => {
+    const data = [
+      { side: 'left' as const, value: 1 },
+      { side: 'right' as const, value: 2 },
+    ]
+    const grouped = groupBySide(data)
+    expect(grouped.left).toHaveLength(1)
+    expect(grouped.right).toHaveLength(1)
+  })
+
+  it('getSideColor returns sky/violet primary and muted variants', () => {
+    expect(getSideColor('left')).toBe('#38bdf8')
+    expect(getSideColor('right')).toBe('#a78bfa')
+    expect(getSideColor('left', 'muted')).toBe('#38bdf833')
+    expect(getSideColor('right', 'muted')).toBe('#a78bfa33')
+  })
+
+  it('getSideColorClass returns the right Tailwind class per type', () => {
+    expect(getSideColorClass('left')).toBe('text-sky-400')
+    expect(getSideColorClass('right', 'bg')).toBe('bg-violet-400')
+    expect(getSideColorClass('left', 'border')).toBe('border-sky-400')
+  })
+
+  it('getSideLabel returns Left/Right', () => {
+    expect(getSideLabel('left')).toBe('Left')
+    expect(getSideLabel('right')).toBe('Right')
+  })
+})

--- a/src/hooks/tests/useI18n.test.tsx
+++ b/src/hooks/tests/useI18n.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Tests for useI18n — wraps Lingui's useLingui hook to expose a simple
+ * { i18n, t, locale } interface where t() handles both raw strings and
+ * MessageDescriptor objects.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const linguiMock = vi.hoisted(() => {
+  const i18n = {
+    locale: 'en',
+    _: vi.fn((m: { id: string }) => `translated:${m.id}`),
+  }
+  return { i18n, useLingui: vi.fn(() => ({ i18n })) }
+})
+
+vi.mock('@lingui/react', () => ({ useLingui: linguiMock.useLingui }))
+
+import { useI18n } from '../useI18n'
+
+describe('useI18n', () => {
+  it('returns the i18n instance and locale', () => {
+    const { result } = renderHook(() => useI18n())
+    expect(result.current.i18n).toBe(linguiMock.i18n)
+    expect(result.current.locale).toBe('en')
+  })
+
+  it('t passes raw strings through unchanged', () => {
+    const { result } = renderHook(() => useI18n())
+    expect(result.current.t('hello world')).toBe('hello world')
+    expect(linguiMock.i18n._).not.toHaveBeenCalled()
+  })
+
+  it('t resolves MessageDescriptor via i18n._()', () => {
+    const { result } = renderHook(() => useI18n())
+    const descriptor = { id: 'greeting' }
+    expect(result.current.t(descriptor)).toBe('translated:greeting')
+    expect(linguiMock.i18n._).toHaveBeenCalledWith(descriptor)
+  })
+})

--- a/src/hooks/tests/usePullToRefresh.test.ts
+++ b/src/hooks/tests/usePullToRefresh.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for usePullToRefresh — touch handlers that translate finger
+ * pulls into a refresh gesture. Only fires when scrolled to the top.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePullToRefresh } from '../usePullToRefresh'
+
+function touchEvent(touches: Array<{ clientY: number }>): any {
+  return { touches, changedTouches: touches }
+}
+
+beforeEach(() => {
+  // Reset scroll position before each test.
+  Object.defineProperty(document.documentElement, 'scrollTop', {
+    configurable: true,
+    get: () => 0,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('usePullToRefresh', () => {
+  it('initializes idle', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+    expect(result.current.isPastThreshold).toBe(false)
+  })
+
+  it('tracks pull distance with resistance applied', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 100 }]))
+    })
+    // 100px pull * 0.4 resistance = 40px indicator travel
+    expect(result.current.pullDistance).toBe(40)
+    expect(result.current.isPastThreshold).toBe(true) // PULL_THRESHOLD * resistance = 32, 40 ≥ 32
+  })
+
+  it('caps pull distance at MAX_PULL', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 1000 }]))
+    })
+    expect(result.current.pullDistance).toBe(120)
+  })
+
+  it('ignores upward drags (deltaY < 0)', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 100 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 50 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('does nothing when disabled', () => {
+    const onRefresh = vi.fn(async () => {})
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, enabled: false }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('does not activate when scrolled away from the top', () => {
+    Object.defineProperty(document.documentElement, 'scrollTop', {
+      configurable: true,
+      get: () => 50,
+    })
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('ignores multi-touch gestures', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }, { clientY: 50 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 100 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('triggers onRefresh when threshold is crossed on touch end', async () => {
+    let resolve!: () => void
+    const onRefresh = vi.fn(() => new Promise<void>((r) => {
+      resolve = r
+    }))
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.isPastThreshold).toBe(true)
+    let endPromise!: Promise<void>
+    act(() => {
+      endPromise = result.current.pullHandlers.onTouchEnd()
+    })
+    await waitFor(() => expect(result.current.isRefreshing).toBe(true))
+    expect(onRefresh).toHaveBeenCalled()
+    await act(async () => {
+      resolve()
+      await endPromise
+    })
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('clears state when touch end fires below threshold', async () => {
+    const onRefresh = vi.fn(async () => {})
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 50 }])) // 50*0.4 = 20 < 32
+    })
+    expect(result.current.isPastThreshold).toBe(false)
+    await act(async () => {
+      await result.current.pullHandlers.onTouchEnd()
+    })
+    expect(onRefresh).not.toHaveBeenCalled()
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('still resets onRefresh even if it rejects', async () => {
+    const onRefresh = vi.fn(() => Promise.reject(new Error('boom')))
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    await act(async () => {
+      await result.current.pullHandlers.onTouchEnd().catch(() => {})
+    })
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+  })
+})

--- a/src/hooks/tests/useSchedule.test.ts
+++ b/src/hooks/tests/useSchedule.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for useSchedule — the larger schedule manager that coordinates
+ * temperature, power, and alarm schedules across days. Verifies derived
+ * state (isPowerEnabled, isGlobalEnabled, hasScheduleData), bulk toggles,
+ * curve save/delete, conflict detection, and apply-to-other-days flow.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { primarySide: 'left' | 'right', activeSides: Array<'left' | 'right'> }
+    = { primarySide: 'left', activeSides: ['left'] }
+  return { state }
+})
+
+const trpcMock = vi.hoisted(() => {
+  const overrides: Record<string, any> = { allLeft: undefined, allRight: undefined, day: undefined }
+  const utils = {
+    schedules: {
+      getAll: { invalidate: vi.fn() },
+      getByDay: { invalidate: vi.fn() },
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const batchMutate = vi.fn(async (_payload: any) => undefined)
+  const batchUpdate = { useMutation: vi.fn((opts: any) => ({
+    mutateAsync: batchMutate,
+    isPending: false,
+    onSuccess: opts.onSuccess,
+  })) }
+  // Default no-op mutations for the per-row endpoints
+  const noopMutation = { useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })) }
+  return {
+    overrides,
+    utils,
+    batchMutate,
+    trpc: {
+      useUtils: () => utils,
+      schedules: {
+        getAll: {
+          useQuery: vi.fn((input: any) => ({
+            data: input.side === 'left' ? overrides.allLeft : overrides.allRight,
+            isLoading: false,
+          })),
+        },
+        getByDay: {
+          useQuery: vi.fn(() => ({
+            data: overrides.day,
+            isLoading: false,
+          })),
+        },
+        createTemperatureSchedule: noopMutation,
+        updateTemperatureSchedule: noopMutation,
+        deleteTemperatureSchedule: noopMutation,
+        createPowerSchedule: noopMutation,
+        updatePowerSchedule: noopMutation,
+        deletePowerSchedule: noopMutation,
+        createAlarmSchedule: noopMutation,
+        updateAlarmSchedule: noopMutation,
+        deleteAlarmSchedule: noopMutation,
+        batchUpdate,
+      },
+    },
+  }
+})
+
+// Stable reference for getCurrentDay so tests don't depend on real time.
+const dayMock = vi.hoisted(() => ({ current: 'monday' as const }))
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => sideMock.state,
+}))
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('@/src/components/Schedule/DaySelector', () => ({
+  getCurrentDay: () => dayMock.current,
+}))
+vi.mock('@/src/lib/scheduleGrouping', () => ({
+  // Simple chronological sort; no overnight detection needed for these tests.
+  sortChronological: (points: any[]) =>
+    [...points].sort((a, b) => a.time.localeCompare(b.time)),
+}))
+
+import { useSchedule } from '../useSchedule'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  trpcMock.overrides.allLeft = undefined
+  trpcMock.overrides.allRight = undefined
+  trpcMock.overrides.day = undefined
+  trpcMock.batchMutate.mockClear()
+  trpcMock.utils.schedules.getAll.invalidate.mockReset()
+  trpcMock.utils.schedules.getByDay.invalidate.mockReset()
+  sideMock.state.primarySide = 'left'
+  sideMock.state.activeSides = ['left']
+})
+
+describe('useSchedule — derived state', () => {
+  it('initializes selectedDay to getCurrentDay()', () => {
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.selectedDay).toBe('monday')
+    expect(result.current.selectedDays.has('monday')).toBe(true)
+  })
+
+  it('isPowerEnabled is true when any power schedule for the day is enabled', () => {
+    trpcMock.overrides.day = {
+      temperature: [],
+      power: [{ id: 1, enabled: true }],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isPowerEnabled).toBe(true)
+  })
+
+  it('isPowerEnabled is false when no power rows or all disabled', () => {
+    trpcMock.overrides.day = { temperature: [], power: [{ enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isPowerEnabled).toBe(false)
+  })
+
+  it('isGlobalEnabled checks all schedule types across all days', () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 1, enabled: true }],
+      power: [{ enabled: false }],
+      alarm: [{ enabled: false }],
+    }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isGlobalEnabled).toBe(true)
+  })
+
+  it('hasScheduleData reports presence of any rows for the day', () => {
+    trpcMock.overrides.day = { temperature: [{ id: 1 }], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.hasScheduleData).toBe(true)
+  })
+})
+
+describe('useSchedule — bulk toggles', () => {
+  it('togglePowerSchedule updates existing rows and creates missing ones', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [],
+      power: [{ id: 1, dayOfWeek: 'monday', enabled: false }],
+      alarm: [],
+    }
+    trpcMock.overrides.day = { temperature: [], power: [{ id: 1, enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+      // Drain the timer so the confirm timeout doesn't leak
+      vi.runAllTimers()
+    })
+    expect(trpcMock.batchMutate).toHaveBeenCalled()
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.power).toEqual([{ id: 1, enabled: true }])
+  })
+
+  it('togglePowerSchedule creates a default 22:00–07:00 row for days with no power schedule', async () => {
+    trpcMock.overrides.allLeft = { temperature: [], power: [], alarm: [] }
+    trpcMock.overrides.day = { temperature: [], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.creates.power).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', enabled: true }),
+    ])
+  })
+
+  it('togglePowerSchedule does nothing without source data', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+
+  it('toggleAllSchedules flips temperature, power, and alarm rows together', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 10, dayOfWeek: 'monday', enabled: false }],
+      power: [{ id: 20, dayOfWeek: 'monday', enabled: false }],
+      alarm: [{ id: 30, dayOfWeek: 'monday', enabled: false }],
+    }
+    trpcMock.overrides.day = { temperature: [], power: [{ id: 20, enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.toggleAllSchedules()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.temperature).toEqual([{ id: 10, enabled: true }])
+    expect(arg.updates.power).toEqual([{ id: 20, enabled: true }])
+    expect(arg.updates.alarm).toEqual([{ id: 30, enabled: true }])
+  })
+
+  it('toggleGlobalSchedules disables every row when isGlobalEnabled is true', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 1, enabled: true }, { id: 2, enabled: true }],
+      power: [{ id: 3, enabled: false }],
+      alarm: [{ id: 4, enabled: true }],
+    }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.toggleGlobalSchedules()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.temperature).toEqual([
+      { id: 1, enabled: false },
+      { id: 2, enabled: false },
+    ])
+    expect(arg.updates.alarm).toEqual([{ id: 4, enabled: false }])
+  })
+})
+
+describe('useSchedule — curves', () => {
+  beforeEach(() => {
+    trpcMock.overrides.allLeft = {
+      temperature: [
+        { id: 1, dayOfWeek: 'monday', time: '07:00', temperature: 70, enabled: true },
+        { id: 2, dayOfWeek: 'tuesday', time: '07:00', temperature: 70, enabled: true },
+        { id: 3, dayOfWeek: 'wednesday', time: '08:00', temperature: 65, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+  })
+
+  it('getCurveForDay returns days sharing the same enabled set-point fingerprint', () => {
+    const { result } = renderHook(() => useSchedule())
+    const curve = result.current.getCurveForDay('monday')
+    expect(curve.days).toEqual(expect.arrayContaining(['monday', 'tuesday']))
+    expect(curve.setPoints).toEqual([{ time: '07:00', temperature: 70 }])
+  })
+
+  it('getCurveForDay returns just the day when no schedule data is loaded', () => {
+    trpcMock.overrides.allLeft = undefined
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.getCurveForDay('monday')).toEqual({ days: ['monday'], setPoints: [] })
+  })
+
+  it('detectCurveConflicts flags target days with existing enabled rows outside originalDays', () => {
+    const { result } = renderHook(() => useSchedule())
+    const conflicts = result.current.detectCurveConflicts(['wednesday', 'thursday'], ['monday'])
+    expect(conflicts).toEqual(['wednesday'])
+  })
+
+  it('detectCurveConflicts excludes days listed in originalDays', () => {
+    const { result } = renderHook(() => useSchedule())
+    const conflicts = result.current.detectCurveConflicts(['monday', 'wednesday'], ['monday', 'wednesday'])
+    expect(conflicts).toEqual([])
+  })
+
+  it('saveCurve clears matching days and writes new rows for each active side', async () => {
+    sideMock.state.activeSides = ['left']
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({
+        targetDays: ['monday'],
+        setPoints: [
+          { time: '07:00', temperature: 68 },
+          { time: '22:00', temperature: 60 },
+        ],
+        originalDays: ['monday'],
+      })
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([1])
+    expect(arg.creates.temperature).toHaveLength(2)
+    expect(arg.creates.power).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'monday', onTime: '07:00', offTime: '22:00', onTemperature: 68 }),
+    ])
+  })
+
+  it('saveCurve skips power create when only one set point is provided', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({
+        targetDays: ['monday'],
+        setPoints: [{ time: '07:00', temperature: 68 }],
+      })
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.creates.power).toEqual([])
+  })
+
+  it('saveCurve does nothing when both targetDays and originalDays are empty', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({ targetDays: [], setPoints: [] })
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+
+  it('deleteCurve removes temperature and power rows for the given days', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.deleteCurve(['monday', 'tuesday'])
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([1, 2])
+  })
+
+  it('deleteCurve no-ops on empty input', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.deleteCurve([])
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSchedule — applyToOtherDays', () => {
+  it('deletes target-day rows and recreates from source day', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [
+        { id: 100, dayOfWeek: 'tuesday', time: '06:00', temperature: 80, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+    trpcMock.overrides.day = {
+      temperature: [
+        { id: 1, side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 68, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays(['tuesday'])
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([100])
+    expect(arg.creates.temperature).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'tuesday', time: '07:00', temperature: 68, enabled: true }),
+    ])
+    expect(result.current.isApplying).toBe(false)
+  })
+
+  it('reports failure when batchUpdate throws and clears confirm timer', async () => {
+    trpcMock.batchMutate.mockRejectedValueOnce(new Error('db down'))
+    trpcMock.overrides.allLeft = { temperature: [], power: [], alarm: [] }
+    trpcMock.overrides.day = {
+      temperature: [{ id: 1, side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 68, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays(['tuesday'])
+    })
+    expect(result.current.confirmMessage).toMatch(/failed/i)
+    expect(result.current.isApplying).toBe(false)
+    errSpy.mockRestore()
+  })
+
+  it('does nothing when targetDays is empty', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays([])
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useScheduleActive.test.ts
+++ b/src/hooks/tests/useScheduleActive.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for useScheduleActive — finds the next upcoming temperature
+ * set point across the next 7 days. Reports active state and the next
+ * event with formatted 12h time.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      schedules: {
+        getAll: { useQuery: vi.fn(() => ({ data: state.data })) },
+      },
+    },
+  }
+})
+
+const sideMock = vi.hoisted(() => ({ side: 'left' as const }))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('../useSide', () => ({ useSide: () => ({ side: sideMock.side }) }))
+
+import { useScheduleActive } from '../useScheduleActive'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Wednesday, 2026-05-13 at 10:00 local time. JS Date uses local TZ so
+  // construct via setHours to keep the day-of-week stable across runners.
+  const d = new Date(2026, 4, 13, 10, 0, 0) // months are 0-indexed
+  vi.setSystemTime(d)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  trpcMock.state.data = undefined
+})
+
+describe('useScheduleActive', () => {
+  it('returns inactive when no data', () => {
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current).toEqual({ isActive: false, nextEvent: null, nextTime: null })
+  })
+
+  it('returns inactive when no temperature schedules are enabled', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: false, dayOfWeek: 'wednesday', time: '14:00', temperature: 70 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it('finds the next set point later today', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 }, // already passed
+        { enabled: true, dayOfWeek: 'wednesday', time: '14:30', temperature: 70 }, // next
+        { enabled: true, dayOfWeek: 'wednesday', time: '22:00', temperature: 60 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toEqual({ time: '2:30 PM', temperature: 70 })
+    expect(result.current.nextTime).toBe('2:30 PM')
+  })
+
+  it('walks forward to a later day when today has nothing left', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 }, // passed
+        { enabled: true, dayOfWeek: 'friday', time: '07:00', temperature: 68 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toEqual({ time: '7:00 AM', temperature: 68 })
+  })
+
+  it('reports active with no nextEvent when only past points exist', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toBeNull()
+  })
+})

--- a/src/hooks/tests/useSchedules.test.ts
+++ b/src/hooks/tests/useSchedules.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for useSchedules — the day-scoped temperature schedule manager
+ * with optimistic-update mutations. Verifies derived phase ordering, the
+ * convenience action wrappers, and that mutation onSuccess wiring is set
+ * up. Optimistic update logic is exercised by invoking the captured
+ * onMutate handlers directly against a fake utils cache.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const cache = new Map<string, any>()
+  const utils = {
+    schedules: {
+      getByDay: {
+        cancel: vi.fn(async () => {}),
+        getData: vi.fn(() => cache.get('byDay')),
+        setData: vi.fn((_k: any, updater: any) => {
+          const prev = cache.get('byDay')
+          const next = typeof updater === 'function' ? updater(prev) : updater
+          cache.set('byDay', next)
+        }),
+        invalidate: vi.fn(),
+      },
+      getAll: { invalidate: vi.fn() },
+    },
+  }
+  const queryState: { data: any, isLoading: boolean, error: any } = {
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }
+  const refetch = vi.fn()
+  // Capture mutation options so tests can fire onMutate/onError/onSettled
+  const captured: { create?: any, update?: any, delete?: any } = {}
+  const mutateFns = {
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+  const makeMutation = (key: 'create' | 'update' | 'delete') => {
+    return (opts: any) => {
+      captured[key] = opts
+      return {
+        mutate: mutateFns[key],
+        isPending: false,
+      }
+    }
+  }
+  const trpc = {
+    useUtils: () => utils,
+    schedules: {
+      getByDay: {
+        useQuery: vi.fn(() => ({
+          data: queryState.data,
+          isLoading: queryState.isLoading,
+          error: queryState.error,
+          refetch,
+        })),
+      },
+      createTemperatureSchedule: { useMutation: vi.fn(makeMutation('create')) },
+      updateTemperatureSchedule: { useMutation: vi.fn(makeMutation('update')) },
+      deleteTemperatureSchedule: { useMutation: vi.fn(makeMutation('delete')) },
+    },
+  }
+  return { trpc, utils, cache, queryState, captured, refetch, mutateFns }
+})
+
+const sideMock = vi.hoisted(() => ({ side: 'left' as 'left' | 'right' }))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('@/src/hooks/useSide', () => ({ useSide: () => ({ side: sideMock.side }) }))
+
+import { useSchedules } from '../useSchedules'
+
+afterEach(() => {
+  trpcMock.cache.clear()
+  trpcMock.queryState.data = undefined
+  trpcMock.queryState.isLoading = false
+  trpcMock.queryState.error = null
+  trpcMock.refetch.mockReset()
+  Object.values(trpcMock.utils.schedules.getByDay).forEach(fn => 'mockReset' in fn && (fn as any).mockReset())
+  trpcMock.utils.schedules.getAll.invalidate.mockReset()
+  trpcMock.captured.create = undefined
+  trpcMock.captured.update = undefined
+  trpcMock.captured.delete = undefined
+  trpcMock.mutateFns.create.mockReset()
+  trpcMock.mutateFns.update.mockReset()
+  trpcMock.mutateFns.delete.mockReset()
+  sideMock.side = 'left'
+})
+
+describe('useSchedules', () => {
+  it('returns empty phases when no data', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    expect(result.current.phases).toEqual([])
+    expect(result.current.scheduleData).toBeUndefined()
+  })
+
+  it('derives phases from temperature schedules sorted by time', () => {
+    trpcMock.queryState.data = {
+      temperature: [
+        { id: 2, time: '07:00', temperature: 68, enabled: true },
+        { id: 1, time: '22:00', temperature: 60, enabled: true },
+        { id: 3, time: '13:00', temperature: 75, enabled: false },
+      ],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    const phases = result.current.phases
+    expect(phases).toHaveLength(3)
+    expect(phases[0]).toMatchObject({ id: 2, time: '07:00', icon: 'sunrise', name: 'Morning' })
+    expect(phases[1]).toMatchObject({ id: 3, time: '13:00', icon: 'sun', name: 'Daytime' })
+    expect(phases[2]).toMatchObject({ id: 1, time: '22:00', icon: 'moon', name: 'Evening' })
+  })
+
+  it('createSetPoint forwards side, day, time and temperature to the mutation', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.createSetPoint('07:00', 70))
+    const create = trpcMock.captured.create
+    expect(create.onMutate).toBeTypeOf('function')
+    // ensure the mutate call shape is correct via the mock fn
+    const mutateFn = trpcMock.mutateFns.create
+    expect(mutateFn).toHaveBeenCalledWith({ side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 70, enabled: true })
+  })
+
+  it('updateSetPoint passes id and updates through to the mutation', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.updateSetPoint(42, { time: '08:00', temperature: 72 }))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 42, time: '08:00', temperature: 72 })
+  })
+
+  it('adjustTemperature clamps to 55..110 and updates by delta', () => {
+    trpcMock.queryState.data = {
+      temperature: [{ id: 1, time: '07:00', temperature: 70, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(1, 5))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 1, temperature: 75 })
+  })
+
+  it('adjustTemperature is a no-op for unknown phase ids', () => {
+    trpcMock.queryState.data = { temperature: [], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(999, 5))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).not.toHaveBeenCalled()
+  })
+
+  it('adjustTemperature clamps high values to 110', () => {
+    trpcMock.queryState.data = {
+      temperature: [{ id: 1, time: '07:00', temperature: 108, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(1, 10))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 1, temperature: 110 })
+  })
+
+  it('deleteSetPoint forwards id', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.deleteSetPoint(7))
+    const mutateFn = trpcMock.mutateFns.delete
+    expect(mutateFn).toHaveBeenCalledWith({ id: 7 })
+  })
+
+  it('create onMutate appends an optimistic row, onSettled invalidates', async () => {
+    trpcMock.cache.set('byDay', { temperature: [], power: [], alarm: [] })
+    renderHook(() => useSchedules('monday'))
+    const create = trpcMock.captured.create
+    await create.onMutate({ side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 70 })
+    const next = trpcMock.cache.get('byDay')
+    expect(next.temperature).toHaveLength(1)
+    expect(next.temperature[0]).toMatchObject({ side: 'left', time: '07:00', temperature: 70, enabled: true })
+    create.onSettled()
+    expect(trpcMock.utils.schedules.getByDay.invalidate).toHaveBeenCalled()
+    expect(trpcMock.utils.schedules.getAll.invalidate).toHaveBeenCalled()
+  })
+
+  it('create onError restores previous cache snapshot', async () => {
+    const prev = { temperature: [{ id: 1, time: '07:00', temperature: 70, enabled: true }], power: [], alarm: [] }
+    trpcMock.cache.set('byDay', prev)
+    renderHook(() => useSchedules('monday'))
+    const create = trpcMock.captured.create
+    const ctx = await create.onMutate({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 65 })
+    create.onError(new Error('boom'), {}, ctx)
+    expect(trpcMock.cache.get('byDay')).toBe(prev)
+  })
+
+  it('update onMutate patches the matching row in cache', async () => {
+    trpcMock.cache.set('byDay', {
+      temperature: [
+        { id: 1, time: '07:00', temperature: 70, enabled: true },
+        { id: 2, time: '22:00', temperature: 60, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    })
+    renderHook(() => useSchedules('monday'))
+    const update = trpcMock.captured.update
+    await update.onMutate({ id: 1, time: '08:00', temperature: 72, enabled: false })
+    const next = trpcMock.cache.get('byDay')
+    expect(next.temperature[0]).toMatchObject({ id: 1, time: '08:00', temperature: 72, enabled: false })
+    expect(next.temperature[1]).toMatchObject({ id: 2, time: '22:00', temperature: 60 })
+  })
+
+  it('delete onMutate removes the targeted row', async () => {
+    trpcMock.cache.set('byDay', {
+      temperature: [
+        { id: 1, time: '07:00', temperature: 70, enabled: true },
+        { id: 2, time: '22:00', temperature: 60, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    })
+    renderHook(() => useSchedules('monday'))
+    const del = trpcMock.captured.delete
+    await del.onMutate({ id: 1 })
+    expect(trpcMock.cache.get('byDay').temperature).toEqual([
+      expect.objectContaining({ id: 2 }),
+    ])
+  })
+})

--- a/src/hooks/tests/useSensorStream.test.ts
+++ b/src/hooks/tests/useSensorStream.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for useSensorStream and friends — covers the singleton WebSocket
+ * lifecycle (open, subscribe, message dispatch), per-sensor frame
+ * listeners, frame callbacks, and connection status snapshot.
+ *
+ * The global WebSocket constructor is replaced with a fake that captures
+ * sent messages and exposes triggers for open/message events.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useOnSensorFrame,
+  useSensorFrame,
+  useSensorStream,
+  useSensorStreamStatus,
+} from '../useSensorStream'
+
+interface FakeWS {
+  url: string
+  readyState: number
+  sent: string[]
+  onopen?: () => void
+  onmessage?: (e: { data: string }) => void
+  onclose?: () => void
+  onerror?: () => void
+  send: (data: string) => void
+  close: () => void
+  triggerOpen: () => void
+  triggerMessage: (msg: any) => void
+  triggerClose: () => void
+}
+
+const wsMock = vi.hoisted(() => {
+  const sockets: any[] = []
+  return { sockets }
+})
+
+beforeAll(() => {
+  ;(globalThis as any).WebSocket = class {
+    static OPEN = 1
+    static CONNECTING = 0
+    static CLOSED = 3
+    url: string
+    readyState = 0
+    sent: string[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onclose?: () => void
+    onerror?: () => void
+    constructor(url: string) {
+      this.url = url
+      wsMock.sockets.push(this)
+    }
+
+    send(data: string) {
+      this.sent.push(data)
+    }
+
+    close() {
+      this.readyState = 3
+      this.onclose?.()
+    }
+
+    triggerOpen() {
+      this.readyState = 1
+      this.onopen?.()
+    }
+
+    triggerMessage(msg: any) {
+      this.onmessage?.({ data: typeof msg === 'string' ? msg : JSON.stringify(msg) })
+    }
+
+    triggerClose() {
+      this.readyState = 3
+      this.onclose?.()
+    }
+  } as any
+  // jsdom doesn't set window.location.hostname uniformly; ensure ws URL builds
+  Object.defineProperty(window, 'location', {
+    value: { protocol: 'http:', hostname: 'localhost' },
+    writable: true,
+  })
+})
+
+beforeEach(() => {
+  // Reset singleton between tests
+  delete (globalThis as any).__sleepypod_sensorStream
+  wsMock.sockets.length = 0
+})
+
+afterEach(() => {
+  // Best-effort: clear any open sockets so reconnect timers don't fire
+  for (const ws of wsMock.sockets) {
+    try {
+      ws.triggerClose()
+    }
+    catch { /* noop */ }
+  }
+})
+
+describe('useSensorStream', () => {
+  it('opens a WebSocket on mount and reports connecting status', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    expect(result.current.status).toBe('connecting')
+    unmount()
+  })
+
+  it('transitions to connected on open and sends merged subscription', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    expect(result.current.status).toBe('connected')
+    const sent = ws.sent.map(s => JSON.parse(s))
+    expect(sent.some(m => m.type === 'subscribe' && m.sensors.includes('capSense'))).toBe(true)
+    unmount()
+  })
+
+  it('does not open when enabled=false', () => {
+    renderHook(() => useSensorStream({ enabled: false }))
+    expect(wsMock.sockets.length).toBe(0)
+  })
+
+  it('updates latestFrames when a sensor message arrives', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 100, right: 200 }))
+    await waitFor(() => expect(result.current.latestFrames.capSense).toBeDefined())
+    expect((result.current.latestFrames.capSense as any).type).toBe('capSense')
+    unmount()
+  })
+
+  it('records lastError and ignores non-frame error messages', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'error', message: 'bad subscribe' }))
+    await waitFor(() => expect(result.current.lastError).toBe('bad subscribe'))
+    unmount()
+  })
+
+  it('records subscribed sensors from server confirmation', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'subscribed', sensors: ['capSense', 'bedTemp'] }))
+    await waitFor(() => expect(result.current.subscribedSensors).toEqual(['capSense', 'bedTemp']))
+    unmount()
+  })
+
+  it('records timeRange and resolves pending getTimeRange promise', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    let resolved: any
+    const pending = result.current.getTimeRange().then((r) => {
+      resolved = r
+    })
+    act(() => ws.triggerMessage({ type: 'time_range', min: 100, max: 200, file: null }))
+    await pending
+    expect(resolved).toEqual({ min: 100, max: 200 })
+    expect(result.current.timeRange).toEqual({ min: 100, max: 200 })
+    unmount()
+  })
+
+  it('time_range with min=max=0 reports null range', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'time_range', min: 0, max: 0, file: null }))
+    await waitFor(() => expect(result.current.timeRange).toBeNull())
+    unmount()
+  })
+
+  it('seek_complete clears isSeeking', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => result.current.seek(123))
+    expect(result.current.isSeeking).toBe(true)
+    const lastSent = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'seek')
+    expect(lastSent).toEqual({ type: 'seek', timestamp: 123 })
+    act(() => ws.triggerMessage({ type: 'seek_complete' }))
+    await waitFor(() => expect(result.current.isSeeking).toBe(false))
+    unmount()
+  })
+
+  it('seek and getTimeRange no-op safely when socket is not open', async () => {
+    const { result } = renderHook(() => useSensorStream({ enabled: false }))
+    // No socket created, but the seek/getTimeRange functions still work
+    act(() => result.current.seek(456))
+    const range = await result.current.getTimeRange()
+    expect(range).toBeNull()
+  })
+
+  it('disconnects when last consumer unmounts', async () => {
+    const hook = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    hook.unmount()
+    expect(ws.readyState).toBe(3)
+  })
+
+  it('ignores non-JSON messages without crashing', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage('not json'))
+    expect(result.current.status).toBe('connected')
+    unmount()
+  })
+})
+
+describe('useSensorFrame', () => {
+  it('returns the latest frame for a specific sensor only', async () => {
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    const frame = renderHook(() => useSensorFrame('capSense'))
+    expect(frame.result.current).toBeUndefined()
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))
+    await waitFor(() => expect(frame.result.current).toBeDefined())
+    expect(frame.result.current?.type).toBe('capSense')
+    frame.unmount()
+    stream.unmount()
+  })
+})
+
+describe('useSensorStreamStatus', () => {
+  it('returns disconnected initially and connected after open', async () => {
+    const status = renderHook(() => useSensorStreamStatus())
+    expect(status.result.current).toBe('disconnected')
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    await waitFor(() => expect(status.result.current).toBe('connected'))
+    stream.unmount()
+    status.unmount()
+  })
+})
+
+describe('useOnSensorFrame', () => {
+  it('invokes the callback for every frame', async () => {
+    const cb = vi.fn()
+    const cbHook = renderHook(() => useOnSensorFrame(cb))
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 2, left: 3, right: 4 }))
+    expect(cb).toHaveBeenCalledTimes(2)
+    cbHook.unmount()
+    stream.unmount()
+  })
+
+  it('swallows callback errors', async () => {
+    const cb = vi.fn(() => {
+      throw new Error('callback boom')
+    })
+    const cbHook = renderHook(() => useOnSensorFrame(cb))
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    expect(() => act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))).not.toThrow()
+    cbHook.unmount()
+    stream.unmount()
+  })
+})

--- a/src/hooks/tests/useSide.test.ts
+++ b/src/hooks/tests/useSide.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the useSide compatibility shim — wraps SideProvider's context
+ * down to a simple { side, setSide, toggleSide } interface for legacy
+ * components that only need left/right selection.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { primarySide: 'left' | 'right' } = { primarySide: 'left' }
+  const selectSide = vi.fn((side: 'left' | 'right' | 'both') => {
+    if (side === 'left' || side === 'right') state.primarySide = side
+  })
+  return { state, selectSide }
+})
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => ({
+    primarySide: sideMock.state.primarySide,
+    selectSide: sideMock.selectSide,
+  }),
+}))
+
+import { useSide } from '../useSide'
+
+afterEach(() => {
+  sideMock.state.primarySide = 'left'
+  sideMock.selectSide.mockClear()
+})
+
+describe('useSide', () => {
+  it('returns the current primary side from context', () => {
+    sideMock.state.primarySide = 'right'
+    const { result } = renderHook(() => useSide())
+    expect(result.current.side).toBe('right')
+  })
+
+  it('setSide delegates to selectSide', () => {
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.setSide('right'))
+    expect(sideMock.selectSide).toHaveBeenCalledWith('right')
+  })
+
+  it('toggleSide flips left → right', () => {
+    sideMock.state.primarySide = 'left'
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.toggleSide())
+    expect(sideMock.selectSide).toHaveBeenLastCalledWith('right')
+  })
+
+  it('toggleSide flips right → left', () => {
+    sideMock.state.primarySide = 'right'
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.toggleSide())
+    expect(sideMock.selectSide).toHaveBeenLastCalledWith('left')
+  })
+})

--- a/src/hooks/tests/useSideNames.test.ts
+++ b/src/hooks/tests/useSideNames.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for useSideNames — surfaces left/right display names from
+ * settings.getAll, falling back to "Left"/"Right" when unset.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      settings: {
+        getAll: {
+          useQuery: vi.fn(() => ({ data: state.data })),
+        },
+      },
+    },
+  }
+})
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useSideNames } from '../useSideNames'
+
+afterEach(() => {
+  trpcMock.state.data = undefined
+})
+
+describe('useSideNames', () => {
+  it('falls back to Left/Right when no settings data', () => {
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Left')
+    expect(result.current.rightName).toBe('Right')
+    expect(result.current.sideName('left')).toBe('Left')
+    expect(result.current.sideName('right')).toBe('Right')
+  })
+
+  it('returns custom names from settings', () => {
+    trpcMock.state.data = { sides: { left: { name: 'Alice' }, right: { name: 'Bob' } } }
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Alice')
+    expect(result.current.rightName).toBe('Bob')
+    expect(result.current.sideName('left')).toBe('Alice')
+    expect(result.current.sideName('right')).toBe('Bob')
+  })
+
+  it('falls back per-side when only one name is set', () => {
+    trpcMock.state.data = { sides: { left: { name: 'Alice' }, right: {} } }
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Alice')
+    expect(result.current.rightName).toBe('Right')
+  })
+
+  it('falls back when sides object is missing', () => {
+    trpcMock.state.data = {}
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Left')
+    expect(result.current.rightName).toBe('Right')
+  })
+})

--- a/src/hooks/tests/useSwipeNavigation.test.ts
+++ b/src/hooks/tests/useSwipeNavigation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for useSwipeNavigation — horizontal swipes between the 5 main
+ * screens. Filters out vertical scroll, slow swipes, and gestures that
+ * start inside horizontally-scrollable elements.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navMock = vi.hoisted(() => ({
+  push: vi.fn(),
+  pathname: '/en/' as string,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navMock.push }),
+  usePathname: () => navMock.pathname,
+}))
+
+import { useSwipeNavigation } from '../useSwipeNavigation'
+
+function touchEvent(touches: Array<{ clientX: number, clientY: number }>, target?: any): any {
+  return {
+    touches,
+    changedTouches: touches,
+    target: target ?? { closest: () => null },
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  navMock.push.mockReset()
+  navMock.pathname = '/en/'
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useSwipeNavigation', () => {
+  it('navigates to the next screen on a leftward swipe', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledWith('/en/schedule')
+  })
+
+  it('navigates to the previous screen on a rightward swipe', () => {
+    navMock.pathname = '/en/schedule'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 50, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 200, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledWith('/en/')
+  })
+
+  it('does not navigate past the first screen', () => {
+    navMock.pathname = '/en/'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 50, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 200, clientY: 100 }])) // swipe right at index 0
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate past the last screen', () => {
+    navMock.pathname = '/en/settings'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }])) // swipe left at last
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes that are too vertical', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 50 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 200 }])) // 150px vertical > 80
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes shorter than the threshold', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 170, clientY: 100 }])) // 30 < 60
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes that take longer than 500ms', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+    })
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    act(() => {
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('ignores swipes inside horizontally-scrollable containers', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    const target = { closest: vi.fn(() => ({})) }
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }], target))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }], target))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('ignores multi-touch swipes', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([
+        { clientX: 200, clientY: 100 },
+        { clientX: 250, clientY: 100 },
+      ]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('locks navigation for 400ms after a successful swipe', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(1)
+
+    // Second swipe before the lock expires — should be ignored
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(1)
+
+    // After the lock expires, navigation works again
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing on touch end with no recorded start', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useTemperatureUnit.test.ts
+++ b/src/hooks/tests/useTemperatureUnit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for useTemperatureUnit — reads the user's preferred unit from
+ * settings.getAll and exposes Celsius→display conversion helpers. Internal
+ * data is always Celsius; the hook converts at display time.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      settings: {
+        getAll: { useQuery: vi.fn(() => ({ data: state.data })) },
+      },
+    },
+  }
+})
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useTemperatureUnit } from '../useTemperatureUnit'
+
+afterEach(() => {
+  trpcMock.state.data = undefined
+})
+
+describe('useTemperatureUnit', () => {
+  it('defaults to Fahrenheit when settings are unavailable', () => {
+    const { result } = renderHook(() => useTemperatureUnit())
+    expect(result.current.unit).toBe('F')
+    expect(result.current.suffix).toBe('°F')
+  })
+
+  it('uses Celsius when settings prefer C', () => {
+    trpcMock.state.data = { device: { temperatureUnit: 'C' } }
+    const { result } = renderHook(() => useTemperatureUnit())
+    expect(result.current.unit).toBe('C')
+    expect(result.current.suffix).toBe('°C')
+  })
+
+  describe('convert (Celsius → preferred unit)', () => {
+    it('converts Celsius to Fahrenheit', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(0)).toBe(32)
+      expect(result.current.convert(100)).toBe(212)
+      expect(result.current.convert(20)).toBe(68)
+    })
+
+    it('returns Celsius unchanged when unit is C', () => {
+      trpcMock.state.data = { device: { temperatureUnit: 'C' } }
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(20)).toBe(20)
+    })
+
+    it('returns null for null/undefined input', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(null)).toBeNull()
+      expect(result.current.convert(undefined)).toBeNull()
+    })
+  })
+
+  describe('formatTemp', () => {
+    it('formats with one decimal and unit suffix', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTemp(20)).toBe('68.0°F')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTemp(null)).toBe('--')
+      expect(result.current.formatTemp(undefined)).toBe('--')
+    })
+  })
+
+  describe('formatTempShort', () => {
+    it('rounds to integer with degree suffix only', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTempShort(20)).toBe('68°')
+      expect(result.current.formatTempShort(0)).toBe('32°')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTempShort(null)).toBe('--')
+    })
+  })
+
+  describe('formatConverted', () => {
+    it('formats an already-converted value with the preferred unit suffix', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatConverted(72.345)).toBe('72.3°F')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatConverted(null)).toBe('--')
+      expect(result.current.formatConverted(undefined)).toBe('--')
+    })
+  })
+})

--- a/src/hooks/tests/useWeekNavigator.test.ts
+++ b/src/hooks/tests/useWeekNavigator.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for useWeekNavigator — week-based date selection with prev/next/jump
+ * controls. The hook clamps forward navigation at the current week.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWeekNavigator } from '../useWeekNavigator'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Wednesday, 2026-05-13 at noon. Sunday-anchored week starts 2026-05-10.
+  vi.setSystemTime(new Date(2026, 4, 13, 12, 0, 0))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useWeekNavigator', () => {
+  it('initializes to the current Sunday-anchored week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    const start = result.current.weekStart
+    expect(start.getDay()).toBe(0) // Sunday
+    expect(start.getDate()).toBe(10)
+    expect(start.getMonth()).toBe(4)
+    expect(result.current.weekEnd.getDate()).toBe(16)
+    expect(result.current.weekEnd.getHours()).toBe(23)
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('formats a label spanning weekStart through weekEnd', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    expect(result.current.label).toContain('May 10')
+    expect(result.current.label).toContain('May 16')
+  })
+
+  it('goToPreviousWeek shifts back 7 days and clears isCurrentWeek', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek())
+    expect(result.current.weekStart.getDate()).toBe(3)
+    expect(result.current.isCurrentWeek).toBe(false)
+  })
+
+  it('goToNextWeek does not advance past the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToNextWeek())
+    expect(result.current.weekStart.getDate()).toBe(10) // unchanged
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('goToNextWeek advances when not on the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek()) // → May 3
+    act(() => result.current.goToPreviousWeek()) // → Apr 26
+    expect(result.current.weekStart.getDate()).toBe(26)
+    act(() => result.current.goToNextWeek()) // → May 3
+    expect(result.current.weekStart.getDate()).toBe(3)
+    expect(result.current.weekStart.getMonth()).toBe(4)
+  })
+
+  it('goToCurrentWeek snaps back to the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek())
+    expect(result.current.isCurrentWeek).toBe(false)
+    act(() => result.current.goToCurrentWeek())
+    expect(result.current.isCurrentWeek).toBe(true)
+    expect(result.current.weekStart.getDate()).toBe(10)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for previously 0%-covered custom hooks under `src/hooks/`
- Uses `renderHook` + `act` from `@testing-library/react` with mocked context/tRPC layers
- Covers initial state, key user interactions, and edge cases per hook

## Hooks covered
- `useSide` (compatibility shim over `SideProvider`)
- `useSideNames` (settings.getAll fallback)
- `useI18n` (Lingui wrapper)
- `useTemperatureUnit` (C↔F conversion + formatters)
- `useDeviceStatus` (WS frame ↔ HTTP fallback merge)
- `useScheduleActive` (next-event search across 7 days)
- `useWeekNavigator` (prev/next/jump with current-week clamp)
- `usePullToRefresh` (touch handlers, threshold, scroll-position gate)
- `useSwipeNavigation` (5-screen horizontal nav, lock window)
- `useSchedules` (day-scoped CRUD with optimistic updates)
- `useDualSideData` (per-side biometric merge, helpers)
- `useSensorStream` / `useSensorFrame` / `useSensorStreamStatus` / `useOnSensorFrame` (singleton WebSocket lifecycle, time-range/seek API, frame callbacks)
- `useSchedule` (bulk toggles, curve save/delete, conflict detection, applyToOtherDays)

## Test plan
- [x] `pnpm test run` passes locally (1022 passing, was 895 — delta +127)
- [x] `pnpm tsc` clean
- [x] `pnpm lint src/hooks/tests/` clean