### PR TITLE
fix: cut v2.0.1 — pod 5 classification + sp-* install ordering

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -322,12 +322,14 @@ jobs:
             core.setOutput('killed', String(totals.killed))
             core.setOutput('total', String(totals.total))
 
-      # Push notification so the weekly run isn't invisible. Gated to
-      # `schedule` only — manual reruns and PR-labeled runs would spam
-      # the channel. Uses Discord's `<url>` syntax to suppress preview
-      # embeds so the message stays one line.
-      - name: Notify Discord (scheduled runs only)
-        if: github.event_name == 'schedule' && steps.update-issue.outputs.score != ''
+      # Push notification so the weekly run isn't invisible. Fires on
+      # schedule and workflow_dispatch (manual reruns are rare and the
+      # ping is useful for verifying the webhook). PR-labeled runs are
+      # excluded so per-PR mutation tests don't spam the channel. Uses
+      # Discord's `<url>` syntax to suppress preview embeds so the
+      # message stays one line.
+      - name: Notify Discord
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.update-issue.outputs.score != ''
         env:
           WEBHOOK: ${{ secrets.DISCORD_MUTATION_WEBHOOK }}
           SCORE: ${{ steps.update-issue.outputs.score }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,31 +38,13 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          # Each shard's --mutate string is the include globs + the
-          # exclude globs (the CLI flag overrides the config's mutate
-          # block entirely, so excludes must be repeated per shard).
-          # Areas roughly grouped by code-cohesion + file count so wall
-          # time stays balanced across the matrix.
-          - name: lib-utils
-            mutate: "src/lib/**/*.{ts,tsx},src/utils/**/*.{ts,tsx},src/modules/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          # The --mutate CLI flag overrides the config's exclude patterns,
+          # so we have to repeat them here per shard. Keep these three
+          # exclusions in sync with stryker.config.mjs's mutate: block.
           - name: services-scheduler
-            mutate: "src/services/**/*.{ts,tsx},src/scheduler/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: hardware
-            mutate: "src/hardware/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: server-db
-            mutate: "src/server/**/*.{ts,tsx},src/db/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: streaming-homekit
-            mutate: "src/streaming/**/*.{ts,tsx},src/homekit/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: react-runtime
-            mutate: "src/hooks/**/*.{ts,tsx},src/providers/**/*.{ts,tsx},src/ui/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: app-routes
-            mutate: "app/**/*.{ts,tsx},!app/**/*.test.{ts,tsx},!app/**/*.d.ts"
-          - name: components-features
-            mutate: "src/components/Sensors/**/*.{ts,tsx},src/components/Schedule/**/*.{ts,tsx},src/components/biometrics/**/*.{ts,tsx},src/components/Settings/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: components-views
-            mutate: "src/components/status/**/*.{ts,tsx},src/components/SleepStages/**/*.{ts,tsx},src/components/Environment/**/*.{ts,tsx},src/components/TempScreen/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
-          - name: components-misc
-            mutate: "src/components/**/*.{ts,tsx},!src/components/Sensors/**,!src/components/Schedule/**,!src/components/biometrics/**,!src/components/Settings/**,!src/components/status/**,!src/components/SleepStages/**,!src/components/Environment/**,!src/components/TempScreen/**,!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+          - name: hardware-lib
+            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   pull-requests: write # for PR comment with the mutation summary
+  issues: write # for the pinned weekly tracking issue
 
 concurrency:
   group: mutation-${{ github.ref }}
@@ -131,9 +132,11 @@ jobs:
       - name: Build aggregated hit list
         run: |
           node scripts/mutation-hitlist.mjs shards/ > /tmp/hitlist.md || true
-          head -c 5000 /tmp/hitlist.md > /tmp/hitlist-trunc.md
+          # 30000 chars leaves headroom under GitHub's 65536-char issue body
+          # limit for the score table + footer that gets prepended.
+          head -c 30000 /tmp/hitlist.md > /tmp/hitlist-trunc.md
           echo "" >> /tmp/hitlist-trunc.md
-          if [ "$(wc -c < /tmp/hitlist.md)" -gt 5000 ]; then
+          if [ "$(wc -c < /tmp/hitlist.md)" -gt 30000 ]; then
             echo "*(truncated — full hit list in the \`mutation-hitlist\` artifact)*" >> /tmp/hitlist-trunc.md
           fi
 
@@ -191,6 +194,7 @@ jobs:
             })
 
       - name: Update pinned tracking issue (scheduled runs only)
+        id: update-issue
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/github-script@v7
         env:
@@ -287,6 +291,7 @@ jobs:
               hitlist,
             ].join('\n')
 
+            let issueNumber
             if (hit) {
               await github.rest.issues.update({
                 owner: context.repo.owner,
@@ -294,7 +299,8 @@ jobs:
                 issue_number: hit.number,
                 body,
               })
-              core.info(`Updated pinned issue #${hit.number}`)
+              issueNumber = hit.number
+              core.info(`Updated pinned issue #${issueNumber}`)
             } else {
               const created = await github.rest.issues.create({
                 owner: context.repo.owner,
@@ -303,5 +309,126 @@ jobs:
                 body,
                 labels: ['mutation-testing', 'tracking'],
               })
-              core.info(`Created pinned issue #${created.data.number}`)
+              issueNumber = created.data.number
+              core.info(`Created pinned issue #${issueNumber}`)
             }
+
+            // Export for downstream notification / baseline-recording steps.
+            core.setOutput('score', score)
+            core.setOutput('delta', deltaStr)
+            core.setOutput('issue_number', String(issueNumber))
+            core.setOutput('survived', String(totals.survived))
+            core.setOutput('no_coverage', String(totals.noCov))
+            core.setOutput('killed', String(totals.killed))
+            core.setOutput('total', String(totals.total))
+
+      # Push notification so the weekly run isn't invisible. Gated to
+      # `schedule` only — manual reruns and PR-labeled runs would spam
+      # the channel. Uses Discord's `<url>` syntax to suppress preview
+      # embeds so the message stays one line.
+      - name: Notify Discord (scheduled runs only)
+        if: github.event_name == 'schedule' && steps.update-issue.outputs.score != ''
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_MUTATION_WEBHOOK }}
+          SCORE: ${{ steps.update-issue.outputs.score }}
+          DELTA: ${{ steps.update-issue.outputs.delta }}
+          SURVIVED: ${{ steps.update-issue.outputs.survived }}
+          NO_COV: ${{ steps.update-issue.outputs.no_coverage }}
+          ISSUE_NUMBER: ${{ steps.update-issue.outputs.issue_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "$WEBHOOK" ]; then
+            echo "DISCORD_MUTATION_WEBHOOK secret is not set; skipping."
+            exit 0
+          fi
+          ISSUE_URL="${{ github.server_url }}/${{ github.repository }}/issues/${ISSUE_NUMBER}"
+          CONTENT="📊 Mutation **${SCORE}%**${DELTA} · ${SURVIVED} surviving · ${NO_COV} no-coverage · [run](<${RUN_URL}>) · [tracking](<${ISSUE_URL}>)"
+          jq -nc --arg content "$CONTENT" '{content: $content}' \
+            | curl -fsS -H "Content-Type: application/json" -X POST "$WEBHOOK" -d @-
+
+  # Permanent score history on a dedicated orphan branch. The 30-day
+  # artifact retention only gives a short trailing window; this branch
+  # carries score-history.jsonl forever for trend analysis, and a small
+  # latest.json for at-a-glance lookups (badges, dashboards, etc).
+  record-baseline:
+    needs: mutate
+    if: github.event_name == 'schedule' && !cancelled() && needs.mutate.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Download shard reports
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/shards/
+          pattern: mutation-report-*
+
+      - name: Compute aggregated row
+        id: compute
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+            const shards = fs.readdirSync('/tmp/shards').map(name => {
+              const p = path.join('/tmp/shards', name, 'mutation.json')
+              if (!fs.existsSync(p)) return null
+              const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+              const mutants = Object.values(data.files ?? {}).flatMap(f => f.mutants ?? [])
+              const count = s => mutants.filter(m => m.status === s).length
+              return {
+                killed: count('Killed'),
+                survived: count('Survived'),
+                noCov: count('NoCoverage'),
+                timeout: count('Timeout'),
+                compileError: count('CompileError'),
+                runtimeError: count('RuntimeError'),
+                total: mutants.length,
+              }
+            }).filter(Boolean)
+            const totals = shards.reduce((a, s) => {
+              for (const k of Object.keys(s)) a[k] = (a[k] || 0) + s[k]
+              return a
+            }, {})
+            const base = totals.killed + totals.survived + totals.timeout + totals.noCov
+            const score = base > 0 ? Number((totals.killed / base * 100).toFixed(2)) : 0
+            const row = {
+              date: new Date().toISOString(),
+              sha: context.sha,
+              run: context.runId,
+              score,
+              ...totals,
+            }
+            core.setOutput('row', JSON.stringify(row))
+
+      - name: Append to mutation-baseline branch
+        env:
+          ROW: ${{ steps.compute.outputs.row }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          if git ls-remote --exit-code --heads origin mutation-baseline >/dev/null 2>&1; then
+            git fetch origin mutation-baseline
+            git checkout -B mutation-baseline origin/mutation-baseline
+          else
+            # First run ever: create the orphan branch with an empty tree.
+            git checkout --orphan mutation-baseline
+            git rm -rf . >/dev/null 2>&1 || true
+            echo '# Mutation testing baseline' > README.md
+            echo 'Auto-managed by .github/workflows/mutation.yml. Do not edit by hand.' >> README.md
+            git add README.md
+          fi
+
+          echo "$ROW" >> score-history.jsonl
+          echo "$ROW" > latest.json
+          git add score-history.jsonl latest.json
+          git commit -m "chore(mutation): record $(date -u +%Y-%m-%d) baseline"
+          git push origin mutation-baseline

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -38,13 +38,31 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          # The --mutate CLI flag overrides the config's exclude patterns,
-          # so we have to repeat them here per shard. Keep these three
-          # exclusions in sync with stryker.config.mjs's mutate: block.
+          # Each shard's --mutate string is the include globs + the
+          # exclude globs (the CLI flag overrides the config's mutate
+          # block entirely, so excludes must be repeated per shard).
+          # Areas roughly grouped by code-cohesion + file count so wall
+          # time stays balanced across the matrix.
+          - name: lib-utils
+            mutate: "src/lib/**/*.{ts,tsx},src/utils/**/*.{ts,tsx},src/modules/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
           - name: services-scheduler
-            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
-          - name: hardware-lib
-            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+            mutate: "src/services/**/*.{ts,tsx},src/scheduler/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: hardware
+            mutate: "src/hardware/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: server-db
+            mutate: "src/server/**/*.{ts,tsx},src/db/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: streaming-homekit
+            mutate: "src/streaming/**/*.{ts,tsx},src/homekit/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: react-runtime
+            mutate: "src/hooks/**/*.{ts,tsx},src/providers/**/*.{ts,tsx},src/ui/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: app-routes
+            mutate: "app/**/*.{ts,tsx},!app/**/*.test.{ts,tsx},!app/**/*.d.ts"
+          - name: components-features
+            mutate: "src/components/Sensors/**/*.{ts,tsx},src/components/Schedule/**/*.{ts,tsx},src/components/biometrics/**/*.{ts,tsx},src/components/Settings/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: components-views
+            mutate: "src/components/status/**/*.{ts,tsx},src/components/SleepStages/**/*.{ts,tsx},src/components/Environment/**/*.{ts,tsx},src/components/TempScreen/**/*.{ts,tsx},!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
+          - name: components-misc
+            mutate: "src/components/**/*.{ts,tsx},!src/components/Sensors/**,!src/components/Schedule/**,!src/components/biometrics/**,!src/components/Settings/**,!src/components/status/**,!src/components/SleepStages/**,!src/components/Environment/**,!src/components/TempScreen/**,!src/**/tests/**,!src/**/*.test.{ts,tsx},!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/.github/workflows/python-modules.yml
+++ b/.github/workflows/python-modules.yml
@@ -1,0 +1,125 @@
+name: Python Modules
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'modules/**/*.py'
+      - 'modules/**/pyproject.toml'
+      - 'modules/**/uv.lock'
+      - '.github/workflows/python-modules.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'modules/**/*.py'
+      - 'modules/**/pyproject.toml'
+      - 'modules/**/uv.lock'
+      - '.github/workflows/python-modules.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.module.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          # `common` has no pyproject.toml; tests live under modules/common/
+          # and import `from common.X`, so they must run with cwd=modules/.
+          #
+          # We don't `pip install -e .` per module: each module is a flat
+          # layout with `main.py` + `test_main.py` at the top, which trips
+          # setuptools auto-discovery ("Multiple top-level modules"). Tests
+          # don't need the module installed anyway — they `from main import`
+          # via cwd. We just install the runtime deps main.py loads at
+          # import time (the rest are stubbed in sys.modules by the tests).
+          - name: common
+            workdir: modules
+            target: common
+            cov_source: common
+            deps: ""
+          - name: cover-buttons
+            workdir: modules/cover-buttons
+            target: .
+            cov_source: .
+            deps: ""
+          - name: environment-monitor
+            workdir: modules/environment-monitor
+            target: .
+            cov_source: .
+            deps: ""
+          - name: piezo-processor
+            workdir: modules/piezo-processor
+            target: .
+            cov_source: .
+            deps: "numpy scipy"
+          - name: sleep-detector
+            workdir: modules/sleep-detector
+            target: .
+            cov_source: .
+            deps: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          # Pod runtime is pinned to 3.10 by every module's pyproject
+          # (`requires-python = ">=3.9,<3.11"`). Match it in CI.
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install test deps
+        working-directory: ${{ matrix.module.workdir }}
+        run: |
+          uv venv .venv
+          # shellcheck source=/dev/null
+          . .venv/bin/activate
+          uv pip install pytest pytest-cov ${{ matrix.module.deps }}
+
+      - name: Run pytest with coverage
+        working-directory: ${{ matrix.module.workdir }}
+        run: |
+          # shellcheck source=/dev/null
+          . .venv/bin/activate
+          pytest ${{ matrix.module.target }} \
+            --cov=${{ matrix.module.cov_source }} \
+            --cov-report=xml:coverage.xml \
+            --junit-xml=junit.xml \
+            -o junit_family=legacy
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          slug: sleepypod/core
+          flags: python,${{ matrix.module.name }}
+          files: ${{ matrix.module.workdir }}/coverage.xml
+          # Coverage XML uses paths relative to the pytest run dir; tell
+          # Codecov where that was so report paths resolve to repo paths.
+          working-directory: ${{ matrix.module.workdir }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          use_oidc: true
+          slug: sleepypod/core
+          flags: python,${{ matrix.module.name }}
+          files: ${{ matrix.module.workdir }}/junit.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           use_oidc: true
           slug: sleepypod/core
+          flags: javascript
 
       - name: Upload test results to Codecov
         if: matrix.task.name == 'Unit Tests' && !cancelled()
@@ -76,3 +77,4 @@ jobs:
           use_oidc: true
           slug: sleepypod/core
           files: test-results/junit.xml
+          flags: javascript

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,73 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+      javascript:
+        flags:
+          - javascript
+        target: auto
+        threshold: 1%
+      python:
+        flags:
+          - python
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Carry forward each flag's last good coverage when its workflow didn't run
+# on this commit (e.g. python-modules.yml is path-filtered to modules/**, so
+# a TS-only PR must not show python coverage as 0%).
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: javascript
+      paths:
+        - src/
+        - app/
+        - lib/
+    - name: python
+      paths:
+        - modules/
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+  individual_components:
+    - component_id: javascript
+      name: TypeScript / React
+      paths:
+        - src/**
+        - app/**
+        - lib/**
+    - component_id: python
+      name: Pod Python modules
+      paths:
+        - modules/**
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/test_*.py"
+  - "**/tests/**"
+  - ".next/**"
+  - "node_modules/**"
+  - "scripts/**"

--- a/scripts/install
+++ b/scripts/install
@@ -865,6 +865,24 @@ MaxFileSec=1week
 JOURNALD
 systemctl restart systemd-journald 2>/dev/null || true
 
+# Install CLI tools from scripts/bin/ BEFORE the service starts. The systemd
+# unit's ExecStartPre references /usr/local/bin/sp-maintenance — if these
+# binaries aren't in place by the time systemctl restart fires below, the
+# service fails with "status=203/EXEC: No such file or directory".
+# /usr/local/bin is root-owned by default; copies inherit current uid (root,
+# since this script requires sudo) but we chown/chmod explicitly so the
+# installed file is guaranteed root:root 0755.
+if [ -d "$INSTALL_DIR/scripts/bin" ]; then
+  echo "Installing CLI tools..."
+  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
+    [ -f "$tool" ] || continue
+    target="/usr/local/bin/$(basename "$tool")"
+    cp "$tool" "$target"
+    chown root:root "$target"
+    chmod 0755 "$target"
+  done
+fi
+
 # Reload systemd and enable service
 echo "Enabling service..."
 systemctl daemon-reload
@@ -1186,22 +1204,6 @@ fi
 # On upgrades, old services (without UMask=0002) may have recreated WAL/SHM
 # files with 0644 between the initial fixup and the service restarts above.
 fix_db_permissions
-
-# Install CLI tools from scripts/bin/. /usr/local/bin is root-owned by
-# default — copies inherit current uid (root, since this script requires
-# sudo) but we chown/chmod explicitly so the file at the target path is
-# guaranteed root:root 0755 even if the source file under $INSTALL_DIR
-# has unusual ownership.
-if [ -d "$INSTALL_DIR/scripts/bin" ]; then
-  echo "Installing CLI tools..."
-  for tool in "$INSTALL_DIR/scripts/bin"/sp-*; do
-    [ -f "$tool" ] || continue
-    target="/usr/local/bin/$(basename "$tool")"
-    cp "$tool" "$target"
-    chown root:root "$target"
-    chmod 0755 "$target"
-  done
-fi
 
 # Optional SSH configuration
 if [ "$SKIP_SSH" = true ]; then

--- a/src/hardware/responseParser.ts
+++ b/src/hardware/responseParser.ts
@@ -84,21 +84,27 @@ function parseKeyValueResponse(response: string): Record<string, string> {
 
 /**
  * Extract pod version from sensor label.
- * Example: "8SLEEP-SN-12345-H00" -> Pod 3
+ *
+ * Sensor labels come in two observed shapes:
+ *   "8SLEEP-SN-12345-I00"      — revision code in the last segment (test sim)
+ *   "20600-0003-J55-B0708DE3"  — revision code in segment 3, serial in segment 4 (real Pod 5)
+ *
+ * Scan segments from the end and key off the first one shaped like a hardware
+ * revision code ([A-Z][0-9]{2}). Popping the final segment unconditionally
+ * misclassifies real Pod 5 hardware as Pod 3 because the trailing serial
+ * (`B0708DE3`) is alphabetically before `H00`.
  */
 function extractPodVersion(sensorLabel: string): PodVersion {
-  const hwRev = sensorLabel.split('-').pop() || ''
-
-  if (hwRev >= 'J00') {
-    return PodVersion.POD_5
+  const segments = sensorLabel.split('-')
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const seg = segments[i]
+    if (/^[A-Z]\d{2}$/.test(seg)) {
+      const letter = seg[0]
+      if (letter >= 'J') return PodVersion.POD_5
+      if (letter === 'I') return PodVersion.POD_4
+      if (letter === 'H') return PodVersion.POD_3
+    }
   }
-  else if (hwRev >= 'I00') {
-    return PodVersion.POD_4
-  }
-  else if (hwRev >= 'H00') {
-    return PodVersion.POD_3
-  }
-
   return PodVersion.POD_3
 }
 

--- a/src/hardware/tests/dacMonitor.test.ts
+++ b/src/hardware/tests/dacMonitor.test.ts
@@ -238,6 +238,63 @@ describe('DacMonitor', () => {
     )
   })
 
+  test('setPollInterval is a no-op when given the current interval', async () => {
+    const monitor = createMonitor(POLL_MS)
+    await monitor.start()
+    const updates: unknown[] = []
+    monitor.on('status:updated', s => updates.push(s))
+    await sleep(POLL_MS * 3 + 20)
+    const before = updates.length
+
+    monitor.setPollInterval(POLL_MS) // same value → early return
+    updates.length = 0
+    await sleep(POLL_MS * 3 + 20)
+
+    // Cadence unchanged: roughly the same number of polls in the same window
+    expect(updates.length).toBeGreaterThanOrEqual(before - 1)
+    expect(updates.length).toBeLessThanOrEqual(before + 1)
+  })
+
+  test('setPollInterval restarts the interval timer at the new cadence', async () => {
+    const monitor = createMonitor(200) // start slow
+    await monitor.start()
+    const updates: unknown[] = []
+    monitor.on('status:updated', s => updates.push(s))
+
+    monitor.setPollInterval(POLL_MS) // speed up to 50ms
+    await sleep(POLL_MS * 5 + 50)
+
+    // At 50ms cadence over ~300ms we should see at least 3 polls; at 200ms we'd see 1
+    expect(updates.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('setActive / setIdle reconfigure pollIntervalMs without crashing', async () => {
+    const monitor = createMonitor()
+    await monitor.start()
+    await waitFor(() => monitor.getLastStatus() !== null, 500)
+
+    monitor.setActive()
+    monitor.setIdle()
+    monitor.setActive()
+
+    expect(monitor.getStatus()).toBe('running')
+  })
+
+  test('start marks status degraded when daemon is unreachable', async () => {
+    const monitor = new DacMonitor({
+      socketPath: '/tmp/sleepypod-test-nonexistent.sock',
+      pollIntervalMs: POLL_MS,
+    })
+    monitors.push(monitor)
+    const errors: unknown[] = []
+    monitor.on('error', e => errors.push(e))
+
+    await monitor.start()
+
+    expect(monitor.getStatus()).toBe('degraded')
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+  })
+
   test('gesture:detected event includes timestamp', async () => {
     const monitor = createMonitor()
     const gestures: Array<{ timestamp: unknown }> = []

--- a/src/hardware/tests/responseParser.test.ts
+++ b/src/hardware/tests/responseParser.test.ts
@@ -125,7 +125,9 @@ priming = false
 
     const status = parseDeviceStatus(withQuotes)
     expect(status.sensorLabel).toBe('20600-0003-J55-B0708DE3')
-    expect(status.podVersion).toBe(PodVersion.POD_3)
+    // Real Pod 5 labels put the rev code (`J55`) in segment 3 and a serial
+    // (`B0708DE3`) in segment 4 — must classify as Pod 5, not Pod 3.
+    expect(status.podVersion).toBe(PodVersion.POD_5)
   })
 
   test('handles invalid gesture JSON', () => {

--- a/src/hooks/tests/useDeviceStatus.test.ts
+++ b/src/hooks/tests/useDeviceStatus.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for useDeviceStatus — merges WebSocket-pushed deviceStatus frames
+ * with a tRPC HTTP fallback. WS becomes "sticky" once a frame arrives:
+ * subsequent transient WS gaps must not revert to HTTP polling.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sensorMock = vi.hoisted(() => {
+  const state: { frame: any } = { frame: undefined }
+  return {
+    state,
+    useSensorStream: vi.fn(),
+    useSensorFrame: vi.fn(() => state.frame),
+  }
+})
+
+const trpcMock = vi.hoisted(() => {
+  const state: { http: any, isLoading: boolean } = { http: undefined, isLoading: false }
+  const refetch = vi.fn(() => Promise.resolve('refetched'))
+  return {
+    state,
+    refetch,
+    trpc: {
+      device: {
+        getStatus: {
+          useQuery: vi.fn(() => ({
+            data: state.http,
+            isLoading: state.isLoading,
+            refetch,
+          })),
+        },
+      },
+    },
+  }
+})
+
+vi.mock('../useSensorStream', () => ({
+  useSensorStream: sensorMock.useSensorStream,
+  useSensorFrame: sensorMock.useSensorFrame,
+}))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useDeviceStatus } from '../useDeviceStatus'
+
+beforeEach(() => {
+  sensorMock.state.frame = undefined
+  trpcMock.state.http = undefined
+  trpcMock.state.isLoading = false
+})
+
+afterEach(() => {
+  sensorMock.useSensorStream.mockClear()
+  sensorMock.useSensorFrame.mockClear()
+  trpcMock.refetch.mockClear()
+})
+
+const wsFrame = {
+  type: 'deviceStatus' as const,
+  ts: 1,
+  leftSide: { currentTemperature: 20, targetTemperature: 22, currentLevel: 5, targetLevel: 6, isAlarmVibrating: false },
+  rightSide: { currentTemperature: 21, targetTemperature: 22, currentLevel: 4, targetLevel: 5, isAlarmVibrating: false },
+  waterLevel: 'ok' as const,
+  isPriming: false,
+  snooze: { left: null, right: null },
+}
+
+describe('useDeviceStatus', () => {
+  it('opens a WebSocket subscription scoped to deviceStatus', () => {
+    renderHook(() => useDeviceStatus())
+    expect(sensorMock.useSensorStream).toHaveBeenCalledWith({ sensors: ['deviceStatus'], enabled: true })
+  })
+
+  it('returns HTTP status when no WS frame has arrived', () => {
+    trpcMock.state.http = { fromHttp: true }
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.status).toEqual({ fromHttp: true })
+    expect(result.current.isStreaming).toBe(false)
+  })
+
+  it('reports loading from HTTP only until first WS frame', () => {
+    trpcMock.state.isLoading = true
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('returns merged WS frame data once received and reports streaming', () => {
+    sensorMock.state.frame = wsFrame
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.isStreaming).toBe(true)
+    expect(result.current.status?.leftSide.currentTemperature).toBe(20)
+    expect(result.current.status?.waterLevel).toBe('ok')
+    expect(result.current.status?.isPriming).toBe(false)
+  })
+
+  it('normalizes primeCompletedNotification.timestamp to a Date for numeric input', () => {
+    sensorMock.state.frame = { ...wsFrame, primeCompletedNotification: { timestamp: 1_700_000_000_000 } }
+    const { result } = renderHook(() => useDeviceStatus())
+    const ts = result.current.status?.primeCompletedNotification?.timestamp
+    expect(ts).toBeInstanceOf(Date)
+    expect((ts as Date).getTime()).toBe(1_700_000_000_000)
+  })
+
+  it('passes through an existing Date timestamp untouched', () => {
+    const date = new Date('2026-01-01T00:00:00Z')
+    sensorMock.state.frame = { ...wsFrame, primeCompletedNotification: { timestamp: date } }
+    const { result } = renderHook(() => useDeviceStatus())
+    expect(result.current.status?.primeCompletedNotification?.timestamp).toBe(date)
+  })
+
+  it('refetch invokes the underlying tRPC refetch', async () => {
+    const { result } = renderHook(() => useDeviceStatus())
+    await result.current.refetch()
+    expect(trpcMock.refetch).toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useDualSideData.test.ts
+++ b/src/hooks/tests/useDualSideData.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for useDualSideData — fetches biometric data per active side and
+ * merges into a unified, side-labeled dataset. Verifies:
+ *  - per-side query enable flags follow activeSides
+ *  - merged datasets sort correctly (vitals/movement asc, sleep desc)
+ *  - per-side summaries / sleep stages are emitted as arrays
+ *  - utility functions (filterBySide, groupBySide, getSideColor, etc.)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { activeSides: Array<'left' | 'right'> } = { activeSides: ['left', 'right'] }
+  return { state }
+})
+
+const trpcMock = vi.hoisted(() => {
+  // Per-(method, side) overrides — tests can stub specific queries.
+  const overrides = new Map<string, any>()
+  const refetch = vi.fn()
+  const baseResult = (key: string) => {
+    const override = overrides.get(key)
+    return {
+      data: override?.data,
+      isLoading: override?.isLoading ?? false,
+      isError: override?.isError ?? false,
+      error: override?.error ?? null,
+      fetchStatus: override?.fetchStatus ?? 'idle',
+      refetch,
+    }
+  }
+  const methods = ['getVitals', 'getSleepRecords', 'getMovement', 'getVitalsSummary', 'getSleepStages']
+  const biometrics: any = {}
+  for (const m of methods) {
+    biometrics[m] = {
+      useQuery: vi.fn((input: any, opts: any) => {
+        const key = `${m}:${input.side}`
+        const result = baseResult(key)
+        // Mirror useQuery semantics: when disabled, fetchStatus is 'idle' regardless
+        if (opts?.enabled === false) {
+          return { ...result, isLoading: false, fetchStatus: 'idle' }
+        }
+        return result
+      }),
+    }
+  }
+  return {
+    overrides,
+    refetch,
+    biometrics,
+    trpc: { biometrics },
+  }
+})
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => ({ activeSides: sideMock.state.activeSides }),
+}))
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import {
+  filterBySide,
+  groupBySide,
+  getSideColor,
+  getSideColorClass,
+  getSideLabel,
+  useDualSideData,
+} from '../useDualSideData'
+
+afterEach(() => {
+  trpcMock.overrides.clear()
+  trpcMock.refetch.mockReset()
+  Object.values(trpcMock.biometrics).forEach((m: any) => m.useQuery.mockClear())
+  sideMock.state.activeSides = ['left', 'right']
+})
+
+describe('useDualSideData', () => {
+  it('returns empty arrays when both sides have no data', () => {
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitals).toEqual([])
+    expect(result.current.sleepRecords).toEqual([])
+    expect(result.current.movement).toEqual([])
+    expect(result.current.vitalsSummaries).toEqual([])
+    expect(result.current.sleepStages).toEqual([])
+    expect(result.current.activeSides).toEqual(['left', 'right'])
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('disables per-side queries when only one side is active', () => {
+    sideMock.state.activeSides = ['left']
+    renderHook(() => useDualSideData())
+    const calls = trpcMock.biometrics.getVitals.useQuery.mock.calls
+    const left = calls.find((c: any[]) => c[0].side === 'left')
+    const right = calls.find((c: any[]) => c[0].side === 'right')
+    expect(left?.[1].enabled).toBe(true)
+    expect(right?.[1].enabled).toBe(false)
+  })
+
+  it('respects include* flags by disabling those queries', () => {
+    renderHook(() => useDualSideData({ includeVitals: false }))
+    const calls = trpcMock.biometrics.getVitals.useQuery.mock.calls
+    expect(calls.every((c: any[]) => c[1].enabled === false)).toBe(true)
+  })
+
+  it('respects the global enabled=false flag', () => {
+    renderHook(() => useDualSideData({ enabled: false }))
+    const allEnabled = Object.values(trpcMock.biometrics)
+      .flatMap((m: any) => m.useQuery.mock.calls)
+      .map((c: any[]) => c[1].enabled)
+    expect(allEnabled.every(e => e === false)).toBe(true)
+  })
+
+  it('merges vitals from both sides ascending by timestamp with side labels', () => {
+    trpcMock.overrides.set('getVitals:left', {
+      data: [
+        { id: 1, timestamp: new Date('2026-01-01T10:00:00Z'), heartRate: 60, hrv: 40, breathingRate: 14 },
+      ],
+    })
+    trpcMock.overrides.set('getVitals:right', {
+      data: [
+        { id: 2, timestamp: new Date('2026-01-01T08:00:00Z'), heartRate: 70, hrv: 50, breathingRate: 16 },
+        { id: 3, timestamp: new Date('2026-01-01T11:00:00Z'), heartRate: 72, hrv: 52, breathingRate: 17 },
+      ],
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitals).toHaveLength(3)
+    expect(result.current.vitals.map(v => v.side)).toEqual(['right', 'left', 'right'])
+  })
+
+  it('merges sleep records descending by enteredBedAt', () => {
+    trpcMock.overrides.set('getSleepRecords:left', {
+      data: [{ id: 1, enteredBedAt: new Date('2026-01-01T22:00:00Z'), leftBedAt: new Date('2026-01-02T06:00:00Z'), sleepDurationSeconds: 28800, timesExitedBed: 0, presentIntervals: [], notPresentIntervals: [], createdAt: new Date() }],
+    })
+    trpcMock.overrides.set('getSleepRecords:right', {
+      data: [{ id: 2, enteredBedAt: new Date('2026-01-02T22:00:00Z'), leftBedAt: new Date('2026-01-03T06:00:00Z'), sleepDurationSeconds: 28800, timesExitedBed: 0, presentIntervals: [], notPresentIntervals: [], createdAt: new Date() }],
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.sleepRecords[0].side).toBe('right') // newest first
+    expect(result.current.sleepRecords[1].side).toBe('left')
+  })
+
+  it('emits one entry per active side in vitalsSummaries and sleepStages', () => {
+    trpcMock.overrides.set('getVitalsSummary:left', {
+      data: { avgHeartRate: 60, minHeartRate: 50, maxHeartRate: 70, avgHRV: 40, avgBreathingRate: 14, recordCount: 10 },
+    })
+    trpcMock.overrides.set('getSleepStages:right', {
+      data: { epochs: [], blocks: [], distribution: { wake: 0, light: 0, deep: 0, rem: 0 }, qualityScore: 80, totalSleepMs: 0, sleepRecordId: null, enteredBedAt: null, leftBedAt: null },
+    })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.vitalsSummaries).toHaveLength(1)
+    expect(result.current.vitalsSummaries[0]).toMatchObject({ side: 'left', avgHeartRate: 60 })
+    expect(result.current.sleepStages).toHaveLength(1)
+    expect(result.current.sleepStages[0]).toMatchObject({ side: 'right', qualityScore: 80 })
+  })
+
+  it('aggregates loading state across active queries', () => {
+    trpcMock.overrides.set('getVitals:left', { isLoading: true, fetchStatus: 'fetching' })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('aggregates error state and surfaces error messages', () => {
+    trpcMock.overrides.set('getVitals:left', { isError: true, error: { message: 'left vitals failed' } })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.isError).toBe(true)
+    expect(result.current.errors).toContain('left vitals failed')
+  })
+
+  it('falls back to "Unknown error" when error has no message', () => {
+    trpcMock.overrides.set('getVitals:left', { error: {} })
+    const { result } = renderHook(() => useDualSideData())
+    expect(result.current.errors).toContain('Unknown error')
+  })
+
+  it('refetch fires refetch on every active query', () => {
+    const { result } = renderHook(() => useDualSideData())
+    result.current.refetch()
+    expect(trpcMock.refetch).toHaveBeenCalled()
+  })
+})
+
+describe('useDualSideData utility helpers', () => {
+  it('filterBySide returns only matching rows', () => {
+    const data = [
+      { side: 'left' as const, value: 1 },
+      { side: 'right' as const, value: 2 },
+      { side: 'left' as const, value: 3 },
+    ]
+    expect(filterBySide(data, 'left')).toEqual([
+      { side: 'left', value: 1 },
+      { side: 'left', value: 3 },
+    ])
+  })
+
+  it('groupBySide partitions into left/right', () => {
+    const data = [
+      { side: 'left' as const, value: 1 },
+      { side: 'right' as const, value: 2 },
+    ]
+    const grouped = groupBySide(data)
+    expect(grouped.left).toHaveLength(1)
+    expect(grouped.right).toHaveLength(1)
+  })
+
+  it('getSideColor returns sky/violet primary and muted variants', () => {
+    expect(getSideColor('left')).toBe('#38bdf8')
+    expect(getSideColor('right')).toBe('#a78bfa')
+    expect(getSideColor('left', 'muted')).toBe('#38bdf833')
+    expect(getSideColor('right', 'muted')).toBe('#a78bfa33')
+  })
+
+  it('getSideColorClass returns the right Tailwind class per type', () => {
+    expect(getSideColorClass('left')).toBe('text-sky-400')
+    expect(getSideColorClass('right', 'bg')).toBe('bg-violet-400')
+    expect(getSideColorClass('left', 'border')).toBe('border-sky-400')
+  })
+
+  it('getSideLabel returns Left/Right', () => {
+    expect(getSideLabel('left')).toBe('Left')
+    expect(getSideLabel('right')).toBe('Right')
+  })
+})

--- a/src/hooks/tests/useI18n.test.tsx
+++ b/src/hooks/tests/useI18n.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Tests for useI18n — wraps Lingui's useLingui hook to expose a simple
+ * { i18n, t, locale } interface where t() handles both raw strings and
+ * MessageDescriptor objects.
+ */
+
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const linguiMock = vi.hoisted(() => {
+  const i18n = {
+    locale: 'en',
+    _: vi.fn((m: { id: string }) => `translated:${m.id}`),
+  }
+  return { i18n, useLingui: vi.fn(() => ({ i18n })) }
+})
+
+vi.mock('@lingui/react', () => ({ useLingui: linguiMock.useLingui }))
+
+import { useI18n } from '../useI18n'
+
+describe('useI18n', () => {
+  it('returns the i18n instance and locale', () => {
+    const { result } = renderHook(() => useI18n())
+    expect(result.current.i18n).toBe(linguiMock.i18n)
+    expect(result.current.locale).toBe('en')
+  })
+
+  it('t passes raw strings through unchanged', () => {
+    const { result } = renderHook(() => useI18n())
+    expect(result.current.t('hello world')).toBe('hello world')
+    expect(linguiMock.i18n._).not.toHaveBeenCalled()
+  })
+
+  it('t resolves MessageDescriptor via i18n._()', () => {
+    const { result } = renderHook(() => useI18n())
+    const descriptor = { id: 'greeting' }
+    expect(result.current.t(descriptor)).toBe('translated:greeting')
+    expect(linguiMock.i18n._).toHaveBeenCalledWith(descriptor)
+  })
+})

--- a/src/hooks/tests/usePullToRefresh.test.ts
+++ b/src/hooks/tests/usePullToRefresh.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for usePullToRefresh — touch handlers that translate finger
+ * pulls into a refresh gesture. Only fires when scrolled to the top.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePullToRefresh } from '../usePullToRefresh'
+
+function touchEvent(touches: Array<{ clientY: number }>): any {
+  return { touches, changedTouches: touches }
+}
+
+beforeEach(() => {
+  // Reset scroll position before each test.
+  Object.defineProperty(document.documentElement, 'scrollTop', {
+    configurable: true,
+    get: () => 0,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('usePullToRefresh', () => {
+  it('initializes idle', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+    expect(result.current.isPastThreshold).toBe(false)
+  })
+
+  it('tracks pull distance with resistance applied', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 100 }]))
+    })
+    // 100px pull * 0.4 resistance = 40px indicator travel
+    expect(result.current.pullDistance).toBe(40)
+    expect(result.current.isPastThreshold).toBe(true) // PULL_THRESHOLD * resistance = 32, 40 ≥ 32
+  })
+
+  it('caps pull distance at MAX_PULL', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 1000 }]))
+    })
+    expect(result.current.pullDistance).toBe(120)
+  })
+
+  it('ignores upward drags (deltaY < 0)', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 100 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 50 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('does nothing when disabled', () => {
+    const onRefresh = vi.fn(async () => {})
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh, enabled: false }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('does not activate when scrolled away from the top', () => {
+    Object.defineProperty(document.documentElement, 'scrollTop', {
+      configurable: true,
+      get: () => 50,
+    })
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('ignores multi-touch gestures', () => {
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh: vi.fn(async () => {}) }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }, { clientY: 50 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 100 }]))
+    })
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('triggers onRefresh when threshold is crossed on touch end', async () => {
+    let resolve!: () => void
+    const onRefresh = vi.fn(() => new Promise<void>((r) => {
+      resolve = r
+    }))
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    expect(result.current.isPastThreshold).toBe(true)
+    let endPromise!: Promise<void>
+    act(() => {
+      endPromise = result.current.pullHandlers.onTouchEnd()
+    })
+    await waitFor(() => expect(result.current.isRefreshing).toBe(true))
+    expect(onRefresh).toHaveBeenCalled()
+    await act(async () => {
+      resolve()
+      await endPromise
+    })
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('clears state when touch end fires below threshold', async () => {
+    const onRefresh = vi.fn(async () => {})
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 50 }])) // 50*0.4 = 20 < 32
+    })
+    expect(result.current.isPastThreshold).toBe(false)
+    await act(async () => {
+      await result.current.pullHandlers.onTouchEnd()
+    })
+    expect(onRefresh).not.toHaveBeenCalled()
+    expect(result.current.pullDistance).toBe(0)
+  })
+
+  it('still resets onRefresh even if it rejects', async () => {
+    const onRefresh = vi.fn(() => Promise.reject(new Error('boom')))
+    const { result } = renderHook(() => usePullToRefresh({ onRefresh }))
+    act(() => {
+      result.current.pullHandlers.onTouchStart(touchEvent([{ clientY: 0 }]))
+      result.current.pullHandlers.onTouchMove(touchEvent([{ clientY: 200 }]))
+    })
+    await act(async () => {
+      await result.current.pullHandlers.onTouchEnd().catch(() => {})
+    })
+    expect(result.current.isRefreshing).toBe(false)
+    expect(result.current.pullDistance).toBe(0)
+  })
+})

--- a/src/hooks/tests/useSchedule.test.ts
+++ b/src/hooks/tests/useSchedule.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for useSchedule — the larger schedule manager that coordinates
+ * temperature, power, and alarm schedules across days. Verifies derived
+ * state (isPowerEnabled, isGlobalEnabled, hasScheduleData), bulk toggles,
+ * curve save/delete, conflict detection, and apply-to-other-days flow.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { primarySide: 'left' | 'right', activeSides: Array<'left' | 'right'> }
+    = { primarySide: 'left', activeSides: ['left'] }
+  return { state }
+})
+
+const trpcMock = vi.hoisted(() => {
+  const overrides: Record<string, any> = { allLeft: undefined, allRight: undefined, day: undefined }
+  const utils = {
+    schedules: {
+      getAll: { invalidate: vi.fn() },
+      getByDay: { invalidate: vi.fn() },
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const batchMutate = vi.fn(async (_payload: any) => undefined)
+  const batchUpdate = { useMutation: vi.fn((opts: any) => ({
+    mutateAsync: batchMutate,
+    isPending: false,
+    onSuccess: opts.onSuccess,
+  })) }
+  // Default no-op mutations for the per-row endpoints
+  const noopMutation = { useMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })) }
+  return {
+    overrides,
+    utils,
+    batchMutate,
+    trpc: {
+      useUtils: () => utils,
+      schedules: {
+        getAll: {
+          useQuery: vi.fn((input: any) => ({
+            data: input.side === 'left' ? overrides.allLeft : overrides.allRight,
+            isLoading: false,
+          })),
+        },
+        getByDay: {
+          useQuery: vi.fn(() => ({
+            data: overrides.day,
+            isLoading: false,
+          })),
+        },
+        createTemperatureSchedule: noopMutation,
+        updateTemperatureSchedule: noopMutation,
+        deleteTemperatureSchedule: noopMutation,
+        createPowerSchedule: noopMutation,
+        updatePowerSchedule: noopMutation,
+        deletePowerSchedule: noopMutation,
+        createAlarmSchedule: noopMutation,
+        updateAlarmSchedule: noopMutation,
+        deleteAlarmSchedule: noopMutation,
+        batchUpdate,
+      },
+    },
+  }
+})
+
+// Stable reference for getCurrentDay so tests don't depend on real time.
+const dayMock = vi.hoisted(() => ({ current: 'monday' as const }))
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => sideMock.state,
+}))
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('@/src/components/Schedule/DaySelector', () => ({
+  getCurrentDay: () => dayMock.current,
+}))
+vi.mock('@/src/lib/scheduleGrouping', () => ({
+  // Simple chronological sort; no overnight detection needed for these tests.
+  sortChronological: (points: any[]) =>
+    [...points].sort((a, b) => a.time.localeCompare(b.time)),
+}))
+
+import { useSchedule } from '../useSchedule'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  trpcMock.overrides.allLeft = undefined
+  trpcMock.overrides.allRight = undefined
+  trpcMock.overrides.day = undefined
+  trpcMock.batchMutate.mockClear()
+  trpcMock.utils.schedules.getAll.invalidate.mockReset()
+  trpcMock.utils.schedules.getByDay.invalidate.mockReset()
+  sideMock.state.primarySide = 'left'
+  sideMock.state.activeSides = ['left']
+})
+
+describe('useSchedule — derived state', () => {
+  it('initializes selectedDay to getCurrentDay()', () => {
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.selectedDay).toBe('monday')
+    expect(result.current.selectedDays.has('monday')).toBe(true)
+  })
+
+  it('isPowerEnabled is true when any power schedule for the day is enabled', () => {
+    trpcMock.overrides.day = {
+      temperature: [],
+      power: [{ id: 1, enabled: true }],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isPowerEnabled).toBe(true)
+  })
+
+  it('isPowerEnabled is false when no power rows or all disabled', () => {
+    trpcMock.overrides.day = { temperature: [], power: [{ enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isPowerEnabled).toBe(false)
+  })
+
+  it('isGlobalEnabled checks all schedule types across all days', () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 1, enabled: true }],
+      power: [{ enabled: false }],
+      alarm: [{ enabled: false }],
+    }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.isGlobalEnabled).toBe(true)
+  })
+
+  it('hasScheduleData reports presence of any rows for the day', () => {
+    trpcMock.overrides.day = { temperature: [{ id: 1 }], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.hasScheduleData).toBe(true)
+  })
+})
+
+describe('useSchedule — bulk toggles', () => {
+  it('togglePowerSchedule updates existing rows and creates missing ones', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [],
+      power: [{ id: 1, dayOfWeek: 'monday', enabled: false }],
+      alarm: [],
+    }
+    trpcMock.overrides.day = { temperature: [], power: [{ id: 1, enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+      // Drain the timer so the confirm timeout doesn't leak
+      vi.runAllTimers()
+    })
+    expect(trpcMock.batchMutate).toHaveBeenCalled()
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.power).toEqual([{ id: 1, enabled: true }])
+  })
+
+  it('togglePowerSchedule creates a default 22:00–07:00 row for days with no power schedule', async () => {
+    trpcMock.overrides.allLeft = { temperature: [], power: [], alarm: [] }
+    trpcMock.overrides.day = { temperature: [], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.creates.power).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', enabled: true }),
+    ])
+  })
+
+  it('togglePowerSchedule does nothing without source data', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.togglePowerSchedule()
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+
+  it('toggleAllSchedules flips temperature, power, and alarm rows together', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 10, dayOfWeek: 'monday', enabled: false }],
+      power: [{ id: 20, dayOfWeek: 'monday', enabled: false }],
+      alarm: [{ id: 30, dayOfWeek: 'monday', enabled: false }],
+    }
+    trpcMock.overrides.day = { temperature: [], power: [{ id: 20, enabled: false }], alarm: [] }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.toggleAllSchedules()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.temperature).toEqual([{ id: 10, enabled: true }])
+    expect(arg.updates.power).toEqual([{ id: 20, enabled: true }])
+    expect(arg.updates.alarm).toEqual([{ id: 30, enabled: true }])
+  })
+
+  it('toggleGlobalSchedules disables every row when isGlobalEnabled is true', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [{ id: 1, enabled: true }, { id: 2, enabled: true }],
+      power: [{ id: 3, enabled: false }],
+      alarm: [{ id: 4, enabled: true }],
+    }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.toggleGlobalSchedules()
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.updates.temperature).toEqual([
+      { id: 1, enabled: false },
+      { id: 2, enabled: false },
+    ])
+    expect(arg.updates.alarm).toEqual([{ id: 4, enabled: false }])
+  })
+})
+
+describe('useSchedule — curves', () => {
+  beforeEach(() => {
+    trpcMock.overrides.allLeft = {
+      temperature: [
+        { id: 1, dayOfWeek: 'monday', time: '07:00', temperature: 70, enabled: true },
+        { id: 2, dayOfWeek: 'tuesday', time: '07:00', temperature: 70, enabled: true },
+        { id: 3, dayOfWeek: 'wednesday', time: '08:00', temperature: 65, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+  })
+
+  it('getCurveForDay returns days sharing the same enabled set-point fingerprint', () => {
+    const { result } = renderHook(() => useSchedule())
+    const curve = result.current.getCurveForDay('monday')
+    expect(curve.days).toEqual(expect.arrayContaining(['monday', 'tuesday']))
+    expect(curve.setPoints).toEqual([{ time: '07:00', temperature: 70 }])
+  })
+
+  it('getCurveForDay returns just the day when no schedule data is loaded', () => {
+    trpcMock.overrides.allLeft = undefined
+    const { result } = renderHook(() => useSchedule())
+    expect(result.current.getCurveForDay('monday')).toEqual({ days: ['monday'], setPoints: [] })
+  })
+
+  it('detectCurveConflicts flags target days with existing enabled rows outside originalDays', () => {
+    const { result } = renderHook(() => useSchedule())
+    const conflicts = result.current.detectCurveConflicts(['wednesday', 'thursday'], ['monday'])
+    expect(conflicts).toEqual(['wednesday'])
+  })
+
+  it('detectCurveConflicts excludes days listed in originalDays', () => {
+    const { result } = renderHook(() => useSchedule())
+    const conflicts = result.current.detectCurveConflicts(['monday', 'wednesday'], ['monday', 'wednesday'])
+    expect(conflicts).toEqual([])
+  })
+
+  it('saveCurve clears matching days and writes new rows for each active side', async () => {
+    sideMock.state.activeSides = ['left']
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({
+        targetDays: ['monday'],
+        setPoints: [
+          { time: '07:00', temperature: 68 },
+          { time: '22:00', temperature: 60 },
+        ],
+        originalDays: ['monday'],
+      })
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([1])
+    expect(arg.creates.temperature).toHaveLength(2)
+    expect(arg.creates.power).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'monday', onTime: '07:00', offTime: '22:00', onTemperature: 68 }),
+    ])
+  })
+
+  it('saveCurve skips power create when only one set point is provided', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({
+        targetDays: ['monday'],
+        setPoints: [{ time: '07:00', temperature: 68 }],
+      })
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.creates.power).toEqual([])
+  })
+
+  it('saveCurve does nothing when both targetDays and originalDays are empty', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.saveCurve({ targetDays: [], setPoints: [] })
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+
+  it('deleteCurve removes temperature and power rows for the given days', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.deleteCurve(['monday', 'tuesday'])
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([1, 2])
+  })
+
+  it('deleteCurve no-ops on empty input', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.deleteCurve([])
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSchedule — applyToOtherDays', () => {
+  it('deletes target-day rows and recreates from source day', async () => {
+    trpcMock.overrides.allLeft = {
+      temperature: [
+        { id: 100, dayOfWeek: 'tuesday', time: '06:00', temperature: 80, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+    trpcMock.overrides.day = {
+      temperature: [
+        { id: 1, side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 68, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays(['tuesday'])
+      vi.runAllTimers()
+    })
+    const arg = trpcMock.batchMutate.mock.calls[0][0]
+    expect(arg.deletes.temperature).toEqual([100])
+    expect(arg.creates.temperature).toEqual([
+      expect.objectContaining({ side: 'left', dayOfWeek: 'tuesday', time: '07:00', temperature: 68, enabled: true }),
+    ])
+    expect(result.current.isApplying).toBe(false)
+  })
+
+  it('reports failure when batchUpdate throws and clears confirm timer', async () => {
+    trpcMock.batchMutate.mockRejectedValueOnce(new Error('db down'))
+    trpcMock.overrides.allLeft = { temperature: [], power: [], alarm: [] }
+    trpcMock.overrides.day = {
+      temperature: [{ id: 1, side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 68, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays(['tuesday'])
+    })
+    expect(result.current.confirmMessage).toMatch(/failed/i)
+    expect(result.current.isApplying).toBe(false)
+    errSpy.mockRestore()
+  })
+
+  it('does nothing when targetDays is empty', async () => {
+    const { result } = renderHook(() => useSchedule())
+    await act(async () => {
+      await result.current.applyToOtherDays([])
+    })
+    expect(trpcMock.batchMutate).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useScheduleActive.test.ts
+++ b/src/hooks/tests/useScheduleActive.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for useScheduleActive — finds the next upcoming temperature
+ * set point across the next 7 days. Reports active state and the next
+ * event with formatted 12h time.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      schedules: {
+        getAll: { useQuery: vi.fn(() => ({ data: state.data })) },
+      },
+    },
+  }
+})
+
+const sideMock = vi.hoisted(() => ({ side: 'left' as const }))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('../useSide', () => ({ useSide: () => ({ side: sideMock.side }) }))
+
+import { useScheduleActive } from '../useScheduleActive'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Wednesday, 2026-05-13 at 10:00 local time. JS Date uses local TZ so
+  // construct via setHours to keep the day-of-week stable across runners.
+  const d = new Date(2026, 4, 13, 10, 0, 0) // months are 0-indexed
+  vi.setSystemTime(d)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  trpcMock.state.data = undefined
+})
+
+describe('useScheduleActive', () => {
+  it('returns inactive when no data', () => {
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current).toEqual({ isActive: false, nextEvent: null, nextTime: null })
+  })
+
+  it('returns inactive when no temperature schedules are enabled', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: false, dayOfWeek: 'wednesday', time: '14:00', temperature: 70 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it('finds the next set point later today', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 }, // already passed
+        { enabled: true, dayOfWeek: 'wednesday', time: '14:30', temperature: 70 }, // next
+        { enabled: true, dayOfWeek: 'wednesday', time: '22:00', temperature: 60 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toEqual({ time: '2:30 PM', temperature: 70 })
+    expect(result.current.nextTime).toBe('2:30 PM')
+  })
+
+  it('walks forward to a later day when today has nothing left', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 }, // passed
+        { enabled: true, dayOfWeek: 'friday', time: '07:00', temperature: 68 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toEqual({ time: '7:00 AM', temperature: 68 })
+  })
+
+  it('reports active with no nextEvent when only past points exist', () => {
+    trpcMock.state.data = {
+      temperature: [
+        { enabled: true, dayOfWeek: 'wednesday', time: '08:00', temperature: 65 },
+      ],
+    }
+    const { result } = renderHook(() => useScheduleActive())
+    expect(result.current.isActive).toBe(true)
+    expect(result.current.nextEvent).toBeNull()
+  })
+})

--- a/src/hooks/tests/useSchedules.test.ts
+++ b/src/hooks/tests/useSchedules.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for useSchedules — the day-scoped temperature schedule manager
+ * with optimistic-update mutations. Verifies derived phase ordering, the
+ * convenience action wrappers, and that mutation onSuccess wiring is set
+ * up. Optimistic update logic is exercised by invoking the captured
+ * onMutate handlers directly against a fake utils cache.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const cache = new Map<string, any>()
+  const utils = {
+    schedules: {
+      getByDay: {
+        cancel: vi.fn(async () => {}),
+        getData: vi.fn(() => cache.get('byDay')),
+        setData: vi.fn((_k: any, updater: any) => {
+          const prev = cache.get('byDay')
+          const next = typeof updater === 'function' ? updater(prev) : updater
+          cache.set('byDay', next)
+        }),
+        invalidate: vi.fn(),
+      },
+      getAll: { invalidate: vi.fn() },
+    },
+  }
+  const queryState: { data: any, isLoading: boolean, error: any } = {
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }
+  const refetch = vi.fn()
+  // Capture mutation options so tests can fire onMutate/onError/onSettled
+  const captured: { create?: any, update?: any, delete?: any } = {}
+  const mutateFns = {
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+  const makeMutation = (key: 'create' | 'update' | 'delete') => {
+    return (opts: any) => {
+      captured[key] = opts
+      return {
+        mutate: mutateFns[key],
+        isPending: false,
+      }
+    }
+  }
+  const trpc = {
+    useUtils: () => utils,
+    schedules: {
+      getByDay: {
+        useQuery: vi.fn(() => ({
+          data: queryState.data,
+          isLoading: queryState.isLoading,
+          error: queryState.error,
+          refetch,
+        })),
+      },
+      createTemperatureSchedule: { useMutation: vi.fn(makeMutation('create')) },
+      updateTemperatureSchedule: { useMutation: vi.fn(makeMutation('update')) },
+      deleteTemperatureSchedule: { useMutation: vi.fn(makeMutation('delete')) },
+    },
+  }
+  return { trpc, utils, cache, queryState, captured, refetch, mutateFns }
+})
+
+const sideMock = vi.hoisted(() => ({ side: 'left' as 'left' | 'right' }))
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+vi.mock('@/src/hooks/useSide', () => ({ useSide: () => ({ side: sideMock.side }) }))
+
+import { useSchedules } from '../useSchedules'
+
+afterEach(() => {
+  trpcMock.cache.clear()
+  trpcMock.queryState.data = undefined
+  trpcMock.queryState.isLoading = false
+  trpcMock.queryState.error = null
+  trpcMock.refetch.mockReset()
+  Object.values(trpcMock.utils.schedules.getByDay).forEach(fn => 'mockReset' in fn && (fn as any).mockReset())
+  trpcMock.utils.schedules.getAll.invalidate.mockReset()
+  trpcMock.captured.create = undefined
+  trpcMock.captured.update = undefined
+  trpcMock.captured.delete = undefined
+  trpcMock.mutateFns.create.mockReset()
+  trpcMock.mutateFns.update.mockReset()
+  trpcMock.mutateFns.delete.mockReset()
+  sideMock.side = 'left'
+})
+
+describe('useSchedules', () => {
+  it('returns empty phases when no data', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    expect(result.current.phases).toEqual([])
+    expect(result.current.scheduleData).toBeUndefined()
+  })
+
+  it('derives phases from temperature schedules sorted by time', () => {
+    trpcMock.queryState.data = {
+      temperature: [
+        { id: 2, time: '07:00', temperature: 68, enabled: true },
+        { id: 1, time: '22:00', temperature: 60, enabled: true },
+        { id: 3, time: '13:00', temperature: 75, enabled: false },
+      ],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    const phases = result.current.phases
+    expect(phases).toHaveLength(3)
+    expect(phases[0]).toMatchObject({ id: 2, time: '07:00', icon: 'sunrise', name: 'Morning' })
+    expect(phases[1]).toMatchObject({ id: 3, time: '13:00', icon: 'sun', name: 'Daytime' })
+    expect(phases[2]).toMatchObject({ id: 1, time: '22:00', icon: 'moon', name: 'Evening' })
+  })
+
+  it('createSetPoint forwards side, day, time and temperature to the mutation', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.createSetPoint('07:00', 70))
+    const create = trpcMock.captured.create
+    expect(create.onMutate).toBeTypeOf('function')
+    // ensure the mutate call shape is correct via the mock fn
+    const mutateFn = trpcMock.mutateFns.create
+    expect(mutateFn).toHaveBeenCalledWith({ side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 70, enabled: true })
+  })
+
+  it('updateSetPoint passes id and updates through to the mutation', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.updateSetPoint(42, { time: '08:00', temperature: 72 }))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 42, time: '08:00', temperature: 72 })
+  })
+
+  it('adjustTemperature clamps to 55..110 and updates by delta', () => {
+    trpcMock.queryState.data = {
+      temperature: [{ id: 1, time: '07:00', temperature: 70, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(1, 5))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 1, temperature: 75 })
+  })
+
+  it('adjustTemperature is a no-op for unknown phase ids', () => {
+    trpcMock.queryState.data = { temperature: [], power: [], alarm: [] }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(999, 5))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).not.toHaveBeenCalled()
+  })
+
+  it('adjustTemperature clamps high values to 110', () => {
+    trpcMock.queryState.data = {
+      temperature: [{ id: 1, time: '07:00', temperature: 108, enabled: true }],
+      power: [],
+      alarm: [],
+    }
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.adjustTemperature(1, 10))
+    const mutateFn = trpcMock.mutateFns.update
+    expect(mutateFn).toHaveBeenCalledWith({ id: 1, temperature: 110 })
+  })
+
+  it('deleteSetPoint forwards id', () => {
+    const { result } = renderHook(() => useSchedules('monday'))
+    act(() => result.current.deleteSetPoint(7))
+    const mutateFn = trpcMock.mutateFns.delete
+    expect(mutateFn).toHaveBeenCalledWith({ id: 7 })
+  })
+
+  it('create onMutate appends an optimistic row, onSettled invalidates', async () => {
+    trpcMock.cache.set('byDay', { temperature: [], power: [], alarm: [] })
+    renderHook(() => useSchedules('monday'))
+    const create = trpcMock.captured.create
+    await create.onMutate({ side: 'left', dayOfWeek: 'monday', time: '07:00', temperature: 70 })
+    const next = trpcMock.cache.get('byDay')
+    expect(next.temperature).toHaveLength(1)
+    expect(next.temperature[0]).toMatchObject({ side: 'left', time: '07:00', temperature: 70, enabled: true })
+    create.onSettled()
+    expect(trpcMock.utils.schedules.getByDay.invalidate).toHaveBeenCalled()
+    expect(trpcMock.utils.schedules.getAll.invalidate).toHaveBeenCalled()
+  })
+
+  it('create onError restores previous cache snapshot', async () => {
+    const prev = { temperature: [{ id: 1, time: '07:00', temperature: 70, enabled: true }], power: [], alarm: [] }
+    trpcMock.cache.set('byDay', prev)
+    renderHook(() => useSchedules('monday'))
+    const create = trpcMock.captured.create
+    const ctx = await create.onMutate({ side: 'left', dayOfWeek: 'monday', time: '08:00', temperature: 65 })
+    create.onError(new Error('boom'), {}, ctx)
+    expect(trpcMock.cache.get('byDay')).toBe(prev)
+  })
+
+  it('update onMutate patches the matching row in cache', async () => {
+    trpcMock.cache.set('byDay', {
+      temperature: [
+        { id: 1, time: '07:00', temperature: 70, enabled: true },
+        { id: 2, time: '22:00', temperature: 60, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    })
+    renderHook(() => useSchedules('monday'))
+    const update = trpcMock.captured.update
+    await update.onMutate({ id: 1, time: '08:00', temperature: 72, enabled: false })
+    const next = trpcMock.cache.get('byDay')
+    expect(next.temperature[0]).toMatchObject({ id: 1, time: '08:00', temperature: 72, enabled: false })
+    expect(next.temperature[1]).toMatchObject({ id: 2, time: '22:00', temperature: 60 })
+  })
+
+  it('delete onMutate removes the targeted row', async () => {
+    trpcMock.cache.set('byDay', {
+      temperature: [
+        { id: 1, time: '07:00', temperature: 70, enabled: true },
+        { id: 2, time: '22:00', temperature: 60, enabled: true },
+      ],
+      power: [],
+      alarm: [],
+    })
+    renderHook(() => useSchedules('monday'))
+    const del = trpcMock.captured.delete
+    await del.onMutate({ id: 1 })
+    expect(trpcMock.cache.get('byDay').temperature).toEqual([
+      expect.objectContaining({ id: 2 }),
+    ])
+  })
+})

--- a/src/hooks/tests/useSensorStream.test.ts
+++ b/src/hooks/tests/useSensorStream.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for useSensorStream and friends — covers the singleton WebSocket
+ * lifecycle (open, subscribe, message dispatch), per-sensor frame
+ * listeners, frame callbacks, and connection status snapshot.
+ *
+ * The global WebSocket constructor is replaced with a fake that captures
+ * sent messages and exposes triggers for open/message events.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useOnSensorFrame,
+  useSensorFrame,
+  useSensorStream,
+  useSensorStreamStatus,
+} from '../useSensorStream'
+
+interface FakeWS {
+  url: string
+  readyState: number
+  sent: string[]
+  onopen?: () => void
+  onmessage?: (e: { data: string }) => void
+  onclose?: () => void
+  onerror?: () => void
+  send: (data: string) => void
+  close: () => void
+  triggerOpen: () => void
+  triggerMessage: (msg: any) => void
+  triggerClose: () => void
+}
+
+const wsMock = vi.hoisted(() => {
+  const sockets: any[] = []
+  return { sockets }
+})
+
+beforeAll(() => {
+  ;(globalThis as any).WebSocket = class {
+    static OPEN = 1
+    static CONNECTING = 0
+    static CLOSED = 3
+    url: string
+    readyState = 0
+    sent: string[] = []
+    onopen?: () => void
+    onmessage?: (e: { data: string }) => void
+    onclose?: () => void
+    onerror?: () => void
+    constructor(url: string) {
+      this.url = url
+      wsMock.sockets.push(this)
+    }
+
+    send(data: string) {
+      this.sent.push(data)
+    }
+
+    close() {
+      this.readyState = 3
+      this.onclose?.()
+    }
+
+    triggerOpen() {
+      this.readyState = 1
+      this.onopen?.()
+    }
+
+    triggerMessage(msg: any) {
+      this.onmessage?.({ data: typeof msg === 'string' ? msg : JSON.stringify(msg) })
+    }
+
+    triggerClose() {
+      this.readyState = 3
+      this.onclose?.()
+    }
+  } as any
+  // jsdom doesn't set window.location.hostname uniformly; ensure ws URL builds
+  Object.defineProperty(window, 'location', {
+    value: { protocol: 'http:', hostname: 'localhost' },
+    writable: true,
+  })
+})
+
+beforeEach(() => {
+  // Reset singleton between tests
+  delete (globalThis as any).__sleepypod_sensorStream
+  wsMock.sockets.length = 0
+})
+
+afterEach(() => {
+  // Best-effort: clear any open sockets so reconnect timers don't fire
+  for (const ws of wsMock.sockets) {
+    try {
+      ws.triggerClose()
+    }
+    catch { /* noop */ }
+  }
+})
+
+describe('useSensorStream', () => {
+  it('opens a WebSocket on mount and reports connecting status', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    expect(result.current.status).toBe('connecting')
+    unmount()
+  })
+
+  it('transitions to connected on open and sends merged subscription', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    expect(result.current.status).toBe('connected')
+    const sent = ws.sent.map(s => JSON.parse(s))
+    expect(sent.some(m => m.type === 'subscribe' && m.sensors.includes('capSense'))).toBe(true)
+    unmount()
+  })
+
+  it('does not open when enabled=false', () => {
+    renderHook(() => useSensorStream({ enabled: false }))
+    expect(wsMock.sockets.length).toBe(0)
+  })
+
+  it('updates latestFrames when a sensor message arrives', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 100, right: 200 }))
+    await waitFor(() => expect(result.current.latestFrames.capSense).toBeDefined())
+    expect((result.current.latestFrames.capSense as any).type).toBe('capSense')
+    unmount()
+  })
+
+  it('records lastError and ignores non-frame error messages', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'error', message: 'bad subscribe' }))
+    await waitFor(() => expect(result.current.lastError).toBe('bad subscribe'))
+    unmount()
+  })
+
+  it('records subscribed sensors from server confirmation', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream({ sensors: ['capSense'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'subscribed', sensors: ['capSense', 'bedTemp'] }))
+    await waitFor(() => expect(result.current.subscribedSensors).toEqual(['capSense', 'bedTemp']))
+    unmount()
+  })
+
+  it('records timeRange and resolves pending getTimeRange promise', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    let resolved: any
+    const pending = result.current.getTimeRange().then((r) => {
+      resolved = r
+    })
+    act(() => ws.triggerMessage({ type: 'time_range', min: 100, max: 200, file: null }))
+    await pending
+    expect(resolved).toEqual({ min: 100, max: 200 })
+    expect(result.current.timeRange).toEqual({ min: 100, max: 200 })
+    unmount()
+  })
+
+  it('time_range with min=max=0 reports null range', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'time_range', min: 0, max: 0, file: null }))
+    await waitFor(() => expect(result.current.timeRange).toBeNull())
+    unmount()
+  })
+
+  it('seek_complete clears isSeeking', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => result.current.seek(123))
+    expect(result.current.isSeeking).toBe(true)
+    const lastSent = ws.sent.map(s => JSON.parse(s)).find(m => m.type === 'seek')
+    expect(lastSent).toEqual({ type: 'seek', timestamp: 123 })
+    act(() => ws.triggerMessage({ type: 'seek_complete' }))
+    await waitFor(() => expect(result.current.isSeeking).toBe(false))
+    unmount()
+  })
+
+  it('seek and getTimeRange no-op safely when socket is not open', async () => {
+    const { result } = renderHook(() => useSensorStream({ enabled: false }))
+    // No socket created, but the seek/getTimeRange functions still work
+    act(() => result.current.seek(456))
+    const range = await result.current.getTimeRange()
+    expect(range).toBeNull()
+  })
+
+  it('disconnects when last consumer unmounts', async () => {
+    const hook = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    hook.unmount()
+    expect(ws.readyState).toBe(3)
+  })
+
+  it('ignores non-JSON messages without crashing', async () => {
+    const { result, unmount } = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage('not json'))
+    expect(result.current.status).toBe('connected')
+    unmount()
+  })
+})
+
+describe('useSensorFrame', () => {
+  it('returns the latest frame for a specific sensor only', async () => {
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    const frame = renderHook(() => useSensorFrame('capSense'))
+    expect(frame.result.current).toBeUndefined()
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))
+    await waitFor(() => expect(frame.result.current).toBeDefined())
+    expect(frame.result.current?.type).toBe('capSense')
+    frame.unmount()
+    stream.unmount()
+  })
+})
+
+describe('useSensorStreamStatus', () => {
+  it('returns disconnected initially and connected after open', async () => {
+    const status = renderHook(() => useSensorStreamStatus())
+    expect(status.result.current).toBe('disconnected')
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    await waitFor(() => expect(status.result.current).toBe('connected'))
+    stream.unmount()
+    status.unmount()
+  })
+})
+
+describe('useOnSensorFrame', () => {
+  it('invokes the callback for every frame', async () => {
+    const cb = vi.fn()
+    const cbHook = renderHook(() => useOnSensorFrame(cb))
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 2, left: 3, right: 4 }))
+    expect(cb).toHaveBeenCalledTimes(2)
+    cbHook.unmount()
+    stream.unmount()
+  })
+
+  it('swallows callback errors', async () => {
+    const cb = vi.fn(() => {
+      throw new Error('callback boom')
+    })
+    const cbHook = renderHook(() => useOnSensorFrame(cb))
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    expect(() => act(() => ws.triggerMessage({ type: 'capSense', ts: 1, left: 1, right: 2 }))).not.toThrow()
+    cbHook.unmount()
+    stream.unmount()
+  })
+})

--- a/src/hooks/tests/useSide.test.ts
+++ b/src/hooks/tests/useSide.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the useSide compatibility shim — wraps SideProvider's context
+ * down to a simple { side, setSide, toggleSide } interface for legacy
+ * components that only need left/right selection.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sideMock = vi.hoisted(() => {
+  const state: { primarySide: 'left' | 'right' } = { primarySide: 'left' }
+  const selectSide = vi.fn((side: 'left' | 'right' | 'both') => {
+    if (side === 'left' || side === 'right') state.primarySide = side
+  })
+  return { state, selectSide }
+})
+
+vi.mock('@/src/providers/SideProvider', () => ({
+  useSide: () => ({
+    primarySide: sideMock.state.primarySide,
+    selectSide: sideMock.selectSide,
+  }),
+}))
+
+import { useSide } from '../useSide'
+
+afterEach(() => {
+  sideMock.state.primarySide = 'left'
+  sideMock.selectSide.mockClear()
+})
+
+describe('useSide', () => {
+  it('returns the current primary side from context', () => {
+    sideMock.state.primarySide = 'right'
+    const { result } = renderHook(() => useSide())
+    expect(result.current.side).toBe('right')
+  })
+
+  it('setSide delegates to selectSide', () => {
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.setSide('right'))
+    expect(sideMock.selectSide).toHaveBeenCalledWith('right')
+  })
+
+  it('toggleSide flips left → right', () => {
+    sideMock.state.primarySide = 'left'
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.toggleSide())
+    expect(sideMock.selectSide).toHaveBeenLastCalledWith('right')
+  })
+
+  it('toggleSide flips right → left', () => {
+    sideMock.state.primarySide = 'right'
+    const { result } = renderHook(() => useSide())
+    act(() => result.current.toggleSide())
+    expect(sideMock.selectSide).toHaveBeenLastCalledWith('left')
+  })
+})

--- a/src/hooks/tests/useSideNames.test.ts
+++ b/src/hooks/tests/useSideNames.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for useSideNames — surfaces left/right display names from
+ * settings.getAll, falling back to "Left"/"Right" when unset.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      settings: {
+        getAll: {
+          useQuery: vi.fn(() => ({ data: state.data })),
+        },
+      },
+    },
+  }
+})
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useSideNames } from '../useSideNames'
+
+afterEach(() => {
+  trpcMock.state.data = undefined
+})
+
+describe('useSideNames', () => {
+  it('falls back to Left/Right when no settings data', () => {
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Left')
+    expect(result.current.rightName).toBe('Right')
+    expect(result.current.sideName('left')).toBe('Left')
+    expect(result.current.sideName('right')).toBe('Right')
+  })
+
+  it('returns custom names from settings', () => {
+    trpcMock.state.data = { sides: { left: { name: 'Alice' }, right: { name: 'Bob' } } }
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Alice')
+    expect(result.current.rightName).toBe('Bob')
+    expect(result.current.sideName('left')).toBe('Alice')
+    expect(result.current.sideName('right')).toBe('Bob')
+  })
+
+  it('falls back per-side when only one name is set', () => {
+    trpcMock.state.data = { sides: { left: { name: 'Alice' }, right: {} } }
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Alice')
+    expect(result.current.rightName).toBe('Right')
+  })
+
+  it('falls back when sides object is missing', () => {
+    trpcMock.state.data = {}
+    const { result } = renderHook(() => useSideNames())
+    expect(result.current.leftName).toBe('Left')
+    expect(result.current.rightName).toBe('Right')
+  })
+})

--- a/src/hooks/tests/useSwipeNavigation.test.ts
+++ b/src/hooks/tests/useSwipeNavigation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for useSwipeNavigation — horizontal swipes between the 5 main
+ * screens. Filters out vertical scroll, slow swipes, and gestures that
+ * start inside horizontally-scrollable elements.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navMock = vi.hoisted(() => ({
+  push: vi.fn(),
+  pathname: '/en/' as string,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navMock.push }),
+  usePathname: () => navMock.pathname,
+}))
+
+import { useSwipeNavigation } from '../useSwipeNavigation'
+
+function touchEvent(touches: Array<{ clientX: number, clientY: number }>, target?: any): any {
+  return {
+    touches,
+    changedTouches: touches,
+    target: target ?? { closest: () => null },
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  navMock.push.mockReset()
+  navMock.pathname = '/en/'
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useSwipeNavigation', () => {
+  it('navigates to the next screen on a leftward swipe', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledWith('/en/schedule')
+  })
+
+  it('navigates to the previous screen on a rightward swipe', () => {
+    navMock.pathname = '/en/schedule'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 50, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 200, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledWith('/en/')
+  })
+
+  it('does not navigate past the first screen', () => {
+    navMock.pathname = '/en/'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 50, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 200, clientY: 100 }])) // swipe right at index 0
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate past the last screen', () => {
+    navMock.pathname = '/en/settings'
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }])) // swipe left at last
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes that are too vertical', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 50 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 200 }])) // 150px vertical > 80
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes shorter than the threshold', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 170, clientY: 100 }])) // 30 < 60
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('rejects swipes that take longer than 500ms', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+    })
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    act(() => {
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('ignores swipes inside horizontally-scrollable containers', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    const target = { closest: vi.fn(() => ({})) }
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }], target))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }], target))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('ignores multi-touch swipes', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([
+        { clientX: 200, clientY: 100 },
+        { clientX: 250, clientY: 100 },
+      ]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+
+  it('locks navigation for 400ms after a successful swipe', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(1)
+
+    // Second swipe before the lock expires — should be ignored
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(1)
+
+    // After the lock expires, navigation works again
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    act(() => {
+      result.current.onTouchStart(touchEvent([{ clientX: 200, clientY: 100 }]))
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing on touch end with no recorded start', () => {
+    const { result } = renderHook(() => useSwipeNavigation())
+    act(() => {
+      result.current.onTouchEnd(touchEvent([{ clientX: 50, clientY: 100 }]))
+    })
+    expect(navMock.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/tests/useTemperatureUnit.test.ts
+++ b/src/hooks/tests/useTemperatureUnit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for useTemperatureUnit — reads the user's preferred unit from
+ * settings.getAll and exposes Celsius→display conversion helpers. Internal
+ * data is always Celsius; the hook converts at display time.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const state: { data: any } = { data: undefined }
+  return {
+    state,
+    trpc: {
+      settings: {
+        getAll: { useQuery: vi.fn(() => ({ data: state.data })) },
+      },
+    },
+  }
+})
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { useTemperatureUnit } from '../useTemperatureUnit'
+
+afterEach(() => {
+  trpcMock.state.data = undefined
+})
+
+describe('useTemperatureUnit', () => {
+  it('defaults to Fahrenheit when settings are unavailable', () => {
+    const { result } = renderHook(() => useTemperatureUnit())
+    expect(result.current.unit).toBe('F')
+    expect(result.current.suffix).toBe('°F')
+  })
+
+  it('uses Celsius when settings prefer C', () => {
+    trpcMock.state.data = { device: { temperatureUnit: 'C' } }
+    const { result } = renderHook(() => useTemperatureUnit())
+    expect(result.current.unit).toBe('C')
+    expect(result.current.suffix).toBe('°C')
+  })
+
+  describe('convert (Celsius → preferred unit)', () => {
+    it('converts Celsius to Fahrenheit', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(0)).toBe(32)
+      expect(result.current.convert(100)).toBe(212)
+      expect(result.current.convert(20)).toBe(68)
+    })
+
+    it('returns Celsius unchanged when unit is C', () => {
+      trpcMock.state.data = { device: { temperatureUnit: 'C' } }
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(20)).toBe(20)
+    })
+
+    it('returns null for null/undefined input', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.convert(null)).toBeNull()
+      expect(result.current.convert(undefined)).toBeNull()
+    })
+  })
+
+  describe('formatTemp', () => {
+    it('formats with one decimal and unit suffix', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTemp(20)).toBe('68.0°F')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTemp(null)).toBe('--')
+      expect(result.current.formatTemp(undefined)).toBe('--')
+    })
+  })
+
+  describe('formatTempShort', () => {
+    it('rounds to integer with degree suffix only', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTempShort(20)).toBe('68°')
+      expect(result.current.formatTempShort(0)).toBe('32°')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatTempShort(null)).toBe('--')
+    })
+  })
+
+  describe('formatConverted', () => {
+    it('formats an already-converted value with the preferred unit suffix', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatConverted(72.345)).toBe('72.3°F')
+    })
+
+    it('returns -- for null/undefined', () => {
+      const { result } = renderHook(() => useTemperatureUnit())
+      expect(result.current.formatConverted(null)).toBe('--')
+      expect(result.current.formatConverted(undefined)).toBe('--')
+    })
+  })
+})

--- a/src/hooks/tests/useWeekNavigator.test.ts
+++ b/src/hooks/tests/useWeekNavigator.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for useWeekNavigator — week-based date selection with prev/next/jump
+ * controls. The hook clamps forward navigation at the current week.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWeekNavigator } from '../useWeekNavigator'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Wednesday, 2026-05-13 at noon. Sunday-anchored week starts 2026-05-10.
+  vi.setSystemTime(new Date(2026, 4, 13, 12, 0, 0))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useWeekNavigator', () => {
+  it('initializes to the current Sunday-anchored week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    const start = result.current.weekStart
+    expect(start.getDay()).toBe(0) // Sunday
+    expect(start.getDate()).toBe(10)
+    expect(start.getMonth()).toBe(4)
+    expect(result.current.weekEnd.getDate()).toBe(16)
+    expect(result.current.weekEnd.getHours()).toBe(23)
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('formats a label spanning weekStart through weekEnd', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    expect(result.current.label).toContain('May 10')
+    expect(result.current.label).toContain('May 16')
+  })
+
+  it('goToPreviousWeek shifts back 7 days and clears isCurrentWeek', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek())
+    expect(result.current.weekStart.getDate()).toBe(3)
+    expect(result.current.isCurrentWeek).toBe(false)
+  })
+
+  it('goToNextWeek does not advance past the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToNextWeek())
+    expect(result.current.weekStart.getDate()).toBe(10) // unchanged
+    expect(result.current.isCurrentWeek).toBe(true)
+  })
+
+  it('goToNextWeek advances when not on the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek()) // → May 3
+    act(() => result.current.goToPreviousWeek()) // → Apr 26
+    expect(result.current.weekStart.getDate()).toBe(26)
+    act(() => result.current.goToNextWeek()) // → May 3
+    expect(result.current.weekStart.getDate()).toBe(3)
+    expect(result.current.weekStart.getMonth()).toBe(4)
+  })
+
+  it('goToCurrentWeek snaps back to the current week', () => {
+    const { result } = renderHook(() => useWeekNavigator())
+    act(() => result.current.goToPreviousWeek())
+    expect(result.current.isCurrentWeek).toBe(false)
+    act(() => result.current.goToCurrentWeek())
+    expect(result.current.isCurrentWeek).toBe(true)
+    expect(result.current.weekStart.getDate()).toBe(10)
+  })
+})

--- a/src/lib/sleepCurve/tempColor.test.ts
+++ b/src/lib/sleepCurve/tempColor.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest'
+import { colorForTempF, colorForTempOffset, tempGradientStops } from './tempColor'
+
+describe('colorForTempOffset', () => {
+  // Inclusive upper-bound bands ported from iOS TempColor
+  test.each([
+    [-100, '#2563eb'],
+    [-8, '#2563eb'],
+    [-7.99, '#4a90d9'],
+    [-5, '#4a90d9'],
+    [-4.99, '#7ab5e0'],
+    [-2, '#7ab5e0'],
+    [-1.99, '#9ca3af'],
+    [0, '#9ca3af'],
+    [1, '#9ca3af'],
+    [1.01, '#e0976a'],
+    [4, '#e0976a'],
+    [4.01, '#dc6646'],
+    [7, '#dc6646'],
+    [7.01, '#dc2626'],
+    [100, '#dc2626'],
+  ])('offset=%s → %s', (offset, expected) => {
+    expect(colorForTempOffset(offset)).toBe(expected)
+  })
+})
+
+describe('colorForTempF', () => {
+  test('delegates to colorForTempOffset using 80°F as base', () => {
+    expect(colorForTempF(80)).toBe(colorForTempOffset(0))
+    expect(colorForTempF(72)).toBe(colorForTempOffset(-8))
+    expect(colorForTempF(85)).toBe(colorForTempOffset(5))
+    expect(colorForTempF(90)).toBe(colorForTempOffset(10))
+  })
+})
+
+describe('tempGradientStops', () => {
+  test('returns the colour stops within the (range ± 2) window', () => {
+    const stops = tempGradientStops(-2, 2).split(', ').map(s => s.split(' '))
+    // Predefined stops sit at -8, -5, -2, 0, 2, 5, 8. With ±2 buffer the
+    // [-4, 4] window admits the -2/0/+2 stops.
+    const colours = stops.map(s => s[0])
+    expect(colours).toEqual(['#7ab5e0', '#9ca3af', '#e0976a'])
+  })
+
+  test('emits percentages clamped to [0, 100]', () => {
+    const stops = tempGradientStops(-2, 2).split(', ').map(s => s.split(' '))
+    for (const [, pctText] of stops) {
+      const pct = Number.parseFloat(pctText)
+      expect(pct).toBeGreaterThanOrEqual(0)
+      expect(pct).toBeLessThanOrEqual(100)
+    }
+  })
+
+  test('handles a zero-width range without dividing by zero', () => {
+    const result = tempGradientStops(0, 0)
+    // Should still return a string, with all stops clamped to 0 or 100
+    expect(typeof result).toBe('string')
+    const stops = result.split(', ').map(s => s.split(' '))
+    for (const [, pctText] of stops) {
+      const pct = Number.parseFloat(pctText)
+      expect(pct).toBeGreaterThanOrEqual(0)
+      expect(pct).toBeLessThanOrEqual(100)
+    }
+  })
+
+  test('renders the cool end of the spectrum for a fully cold range', () => {
+    const result = tempGradientStops(-10, -5)
+    expect(result).toContain('#2563eb')
+    expect(result).toContain('#4a90d9')
+    // Warm-end colours should be excluded
+    expect(result).not.toContain('#dc2626')
+  })
+})

--- a/src/lib/tests/movement.test.ts
+++ b/src/lib/tests/movement.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+import {
+  MOVEMENT_BUCKET_DAY_SECONDS,
+  MOVEMENT_BUCKET_WEEK_SECONDS,
+  pickMovementBucketSeconds,
+  POSITION_CHANGE_SCORE_MIN,
+  RESTLESS_SCORE_MIN,
+} from '../movement'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+describe('movement constants', () => {
+  test('thresholds match the docs/sleep-detector.md score bands', () => {
+    expect(RESTLESS_SCORE_MIN).toBe(50)
+    expect(POSITION_CHANGE_SCORE_MIN).toBe(200)
+  })
+
+  test('bucket sizes match the documented day vs week defaults', () => {
+    expect(MOVEMENT_BUCKET_DAY_SECONDS).toBe(5 * 60)
+    expect(MOVEMENT_BUCKET_WEEK_SECONDS).toBe(30 * 60)
+  })
+})
+
+describe('pickMovementBucketSeconds', () => {
+  test('uses day buckets for ranges of one day or less', () => {
+    expect(pickMovementBucketSeconds(60_000)).toBe(MOVEMENT_BUCKET_DAY_SECONDS)
+    expect(pickMovementBucketSeconds(ONE_DAY_MS)).toBe(MOVEMENT_BUCKET_DAY_SECONDS)
+  })
+
+  test('uses week buckets for ranges longer than one day', () => {
+    expect(pickMovementBucketSeconds(ONE_DAY_MS + 1)).toBe(MOVEMENT_BUCKET_WEEK_SECONDS)
+    expect(pickMovementBucketSeconds(7 * ONE_DAY_MS)).toBe(MOVEMENT_BUCKET_WEEK_SECONDS)
+  })
+})

--- a/src/lib/tests/scheduleGrouping.test.ts
+++ b/src/lib/tests/scheduleGrouping.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'vitest'
+import { groupDaysBySharedCurve, sortChronological } from '../scheduleGrouping'
+
+describe('sortChronological', () => {
+  test('returns a copy (does not mutate input) when length <= 1', () => {
+    const single = [{ time: '08:00', temperature: 70 }]
+    const result = sortChronological(single)
+    expect(result).toEqual(single)
+    expect(result).not.toBe(single)
+    expect(sortChronological([])).toEqual([])
+  })
+
+  test('sorts a normal daytime schedule chronologically', () => {
+    const points = [
+      { time: '14:00', temperature: 72 },
+      { time: '08:00', temperature: 70 },
+      { time: '20:00', temperature: 68 },
+    ]
+    expect(sortChronological(points)).toEqual([
+      { time: '08:00', temperature: 70 },
+      { time: '14:00', temperature: 72 },
+      { time: '20:00', temperature: 68 },
+    ])
+  })
+
+  test('shifts early-morning times after evening for overnight schedules', () => {
+    const points = [
+      { time: '00:30', temperature: 65 },
+      { time: '06:00', temperature: 68 },
+      { time: '22:00', temperature: 72 },
+    ]
+    // Gap > 12h between 06:00 and 22:00 → overnight; 22:00 sorts first.
+    expect(sortChronological(points)).toEqual([
+      { time: '22:00', temperature: 72 },
+      { time: '00:30', temperature: 65 },
+      { time: '06:00', temperature: 68 },
+    ])
+  })
+
+  test('treats schedules without a >12h gap as plain daytime sort', () => {
+    const points = [
+      { time: '23:00', temperature: 68 },
+      { time: '12:00', temperature: 72 },
+    ]
+    // 12:00 → 23:00 = 11h gap, so plain chronological
+    expect(sortChronological(points)).toEqual([
+      { time: '12:00', temperature: 72 },
+      { time: '23:00', temperature: 68 },
+    ])
+  })
+})
+
+describe('groupDaysBySharedCurve', () => {
+  test('returns a single empty group for no schedules', () => {
+    const groups = groupDaysBySharedCurve([])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].days).toEqual([
+      'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday',
+    ])
+    expect(groups[0].setPoints).toEqual([])
+    expect(groups[0].allDisabled).toBeUndefined()
+  })
+
+  test('groups identical curves across days regardless of input ordering', () => {
+    const schedules = [
+      { dayOfWeek: 'monday', time: '08:00', temperature: 70, enabled: true },
+      { dayOfWeek: 'monday', time: '22:00', temperature: 65, enabled: true },
+      // Tuesday has the same set points entered in reverse order
+      { dayOfWeek: 'tuesday', time: '22:00', temperature: 65, enabled: true },
+      { dayOfWeek: 'tuesday', time: '08:00', temperature: 70, enabled: true },
+    ]
+    const groups = groupDaysBySharedCurve(schedules)
+    const matched = groups.find(g => g.days.includes('monday'))
+    expect(matched).toBeDefined()
+    if (!matched) return
+    expect(matched.days).toEqual(['monday', 'tuesday'])
+  })
+
+  test('keeps days with paused schedules separate from active days', () => {
+    const schedules = [
+      { dayOfWeek: 'monday', time: '08:00', temperature: 70, enabled: true },
+      { dayOfWeek: 'tuesday', time: '08:00', temperature: 70, enabled: false },
+    ]
+    const groups = groupDaysBySharedCurve(schedules)
+    const monday = groups.find(g => g.days.includes('monday'))
+    const tuesday = groups.find(g => g.days.includes('tuesday'))
+    expect(monday).toBeDefined()
+    expect(tuesday).toBeDefined()
+    if (!monday || !tuesday) return
+    expect(monday.allDisabled).toBeUndefined()
+    expect(tuesday.allDisabled).toBe(true)
+    // Paused days still surface their saved curve
+    expect(tuesday.setPoints).toEqual([{ time: '08:00', temperature: 70 }])
+  })
+
+  test('paused days with different saved curves form separate groups', () => {
+    const schedules = [
+      { dayOfWeek: 'monday', time: '08:00', temperature: 70, enabled: false },
+      { dayOfWeek: 'tuesday', time: '09:00', temperature: 72, enabled: false },
+    ]
+    const groups = groupDaysBySharedCurve(schedules)
+    const monday = groups.find(g => g.days.includes('monday'))
+    const tuesday = groups.find(g => g.days.includes('tuesday'))
+    expect(monday).toBeDefined()
+    expect(tuesday).toBeDefined()
+    if (!monday || !tuesday) return
+    expect(monday).not.toBe(tuesday)
+    expect(monday.allDisabled).toBe(true)
+    expect(tuesday.allDisabled).toBe(true)
+  })
+
+  test('sorts active groups before disabled, then by day count, then by earliest day', () => {
+    const schedules = [
+      { dayOfWeek: 'monday', time: '08:00', temperature: 70, enabled: true },
+      { dayOfWeek: 'tuesday', time: '08:00', temperature: 70, enabled: true },
+      { dayOfWeek: 'wednesday', time: '08:00', temperature: 70, enabled: true },
+      // single active day with a different curve
+      { dayOfWeek: 'thursday', time: '09:00', temperature: 75, enabled: true },
+      // disabled day
+      { dayOfWeek: 'friday', time: '08:00', temperature: 70, enabled: false },
+    ]
+    const groups = groupDaysBySharedCurve(schedules)
+    // Active groups first
+    expect(groups[0].setPoints.length).toBeGreaterThan(0)
+    expect(groups[0].allDisabled).toBeUndefined()
+    // Most-days-active group is first
+    expect(groups[0].days).toEqual(['monday', 'tuesday', 'wednesday'])
+    // Disabled is later than active
+    const disabledIdx = groups.findIndex(g => g.allDisabled)
+    const emptyIdx = groups.findIndex(g => g.setPoints.length === 0 && !g.allDisabled)
+    expect(disabledIdx).toBeGreaterThan(0)
+    if (emptyIdx >= 0) expect(emptyIdx).toBeGreaterThan(disabledIdx)
+  })
+
+  test('sorts an overnight curve correctly inside the group', () => {
+    const schedules = [
+      { dayOfWeek: 'monday', time: '06:00', temperature: 68, enabled: true },
+      { dayOfWeek: 'monday', time: '22:00', temperature: 72, enabled: true },
+      { dayOfWeek: 'monday', time: '00:30', temperature: 65, enabled: true },
+    ]
+    const groups = groupDaysBySharedCurve(schedules)
+    const monday = groups.find(g => g.days.includes('monday'))
+    expect(monday).toBeDefined()
+    if (!monday) return
+    expect(monday.setPoints.map(p => p.time)).toEqual(['22:00', '00:30', '06:00'])
+  })
+})

--- a/src/lib/tests/tempColors.test.ts
+++ b/src/lib/tests/tempColors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest'
+import { colorForDelta, glowColorForDelta, offsetDisplay, TEMP, tempFToOffset, theme } from '../tempColors'
+
+describe('colorForDelta', () => {
+  // Banding boundaries — verify each step uses an inclusive upper bound.
+  test.each([
+    [-100, '#2563eb'],
+    [-8, '#2563eb'],
+    [-7.99, '#4a90d9'],
+    [-5, '#4a90d9'],
+    [-4.99, '#7ab5e0'],
+    [-2, '#7ab5e0'],
+    [-1.99, '#9ca3af'],
+    [0, '#9ca3af'],
+    [1, '#9ca3af'],
+    [1.01, '#e0976a'],
+    [4, '#e0976a'],
+    [4.01, '#dc6646'],
+    [7, '#dc6646'],
+    [7.01, '#dc2626'],
+    [100, '#dc2626'],
+  ])('delta=%s → %s', (delta, expected) => {
+    expect(colorForDelta(delta)).toBe(expected)
+  })
+})
+
+describe('glowColorForDelta', () => {
+  test('delta of 0 picks the neutral colour and the floor opacity', () => {
+    expect(glowColorForDelta(0)).toEqual({ color: '#9ca3af', opacity: 0.3 })
+  })
+
+  test('opacity scales with magnitude up to its 0.8 ceiling', () => {
+    const small = glowColorForDelta(2)
+    expect(small.color).toBe('#e0976a')
+    // |2|/8 * 0.8 = 0.2, but floor is 0.3
+    expect(small.opacity).toBe(0.3)
+
+    const mid = glowColorForDelta(4)
+    // |4|/8 * 0.8 = 0.4
+    expect(mid.color).toBe('#e0976a')
+    expect(mid.opacity).toBeCloseTo(0.4, 5)
+
+    const max = glowColorForDelta(8)
+    expect(max.color).toBe('#dc2626')
+    expect(max.opacity).toBeCloseTo(0.8, 5)
+  })
+
+  test('caps opacity at 0.8 even when delta exceeds 8', () => {
+    expect(glowColorForDelta(20).opacity).toBeCloseTo(0.8, 5)
+    expect(glowColorForDelta(-20).opacity).toBeCloseTo(0.8, 5)
+  })
+
+  test('uses absolute value of delta when picking opacity', () => {
+    const negative = glowColorForDelta(-4)
+    expect(negative.opacity).toBeCloseTo(0.4, 5)
+    expect(negative.color).toBe('#7ab5e0')
+  })
+})
+
+describe('tempFToOffset', () => {
+  test('subtracts the 80°F base', () => {
+    expect(tempFToOffset(80)).toBe(0)
+    expect(tempFToOffset(95)).toBe(15)
+    expect(tempFToOffset(60)).toBe(-20)
+  })
+})
+
+describe('offsetDisplay', () => {
+  test.each([
+    [5, '+5'],
+    [12, '+12'],
+    [0, '0'],
+    [-3, '-3'],
+    [-15, '-15'],
+  ])('offset=%s → %s', (offset, expected) => {
+    expect(offsetDisplay(offset)).toBe(expected)
+  })
+})
+
+describe('TEMP constants', () => {
+  test('expose the iOS conversion contract', () => {
+    expect(TEMP.BASE_F).toBe(80)
+    expect(TEMP.MIN_F).toBe(55)
+    expect(TEMP.MAX_F).toBe(110)
+    expect(TEMP.MIN_OFFSET).toBe(-20)
+    expect(TEMP.MAX_OFFSET).toBe(20)
+  })
+})
+
+describe('theme palette', () => {
+  test('contains the documented colour tokens', () => {
+    // Spot-check a few load-bearing tokens — full equality would just mirror
+    // the implementation, but these names are referenced from components.
+    expect(theme.background).toBe('#0a0a0a')
+    expect(theme.warming).toBe('#dc6646')
+    expect(theme.cooling).toBe('#4a90d9')
+    expect(theme.healthy).toBe('#50c878')
+  })
+})

--- a/src/lib/tests/tempUtils.test.ts
+++ b/src/lib/tests/tempUtils.test.ts
@@ -3,10 +3,12 @@ import {
   centiDegreesToC,
   centiDegreesToF,
   centiPercentToPercent,
-  toF,
-  toC,
+  determineTrend,
   ensureF,
+  formatTemp,
   mapToEightSleepScale,
+  toC,
+  toF,
 } from '../tempUtils'
 
 describe('centiDegreesToC', () => {
@@ -82,6 +84,47 @@ describe('ensureF', () => {
 
   test('defaults to Fahrenheit', () => {
     expect(ensureF(72)).toBe(72)
+  })
+})
+
+describe('formatTemp', () => {
+  test('rounds to nearest integer and defaults to Fahrenheit', () => {
+    expect(formatTemp(72.4)).toBe('72°F')
+    expect(formatTemp(72.6)).toBe('73°F')
+  })
+
+  test('rounds .5 upward (Math.round semantics)', () => {
+    expect(formatTemp(72.5)).toBe('73°F')
+  })
+
+  test('honours Celsius unit', () => {
+    expect(formatTemp(22.3, 'C')).toBe('22°C')
+  })
+
+  test('handles negative values', () => {
+    expect(formatTemp(-5.4, 'C')).toBe('-5°C')
+  })
+})
+
+describe('determineTrend', () => {
+  test('"up" when target is more than 0.5° above current', () => {
+    expect(determineTrend(70, 71)).toBe('up')
+  })
+
+  test('"down" when target is more than 0.5° below current', () => {
+    expect(determineTrend(72, 70)).toBe('down')
+  })
+
+  test('"stable" when |diff| <= 0.5°', () => {
+    expect(determineTrend(70, 70)).toBe('stable')
+    expect(determineTrend(70, 70.5)).toBe('stable')
+    expect(determineTrend(70.5, 70)).toBe('stable')
+  })
+
+  test('thresholds are exclusive (exactly 0.5 is stable, not up/down)', () => {
+    expect(determineTrend(70, 70.5)).toBe('stable')
+    expect(determineTrend(70, 70.51)).toBe('up')
+    expect(determineTrend(70.51, 70)).toBe('down')
   })
 })
 

--- a/src/lib/tests/vibrationPatterns.test.ts
+++ b/src/lib/tests/vibrationPatterns.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import { VIBRATION_PRESETS } from '../vibrationPatterns'
+
+describe('VIBRATION_PRESETS', () => {
+  test('exposes a non-empty preset list', () => {
+    expect(VIBRATION_PRESETS.length).toBeGreaterThan(0)
+  })
+
+  test('every preset has the required shape and uses a known pattern', () => {
+    for (const preset of VIBRATION_PRESETS) {
+      expect(typeof preset.name).toBe('string')
+      expect(preset.name.length).toBeGreaterThan(0)
+      expect(typeof preset.description).toBe('string')
+      expect(['rise', 'double']).toContain(preset.pattern)
+      expect(Number.isFinite(preset.intensity)).toBe(true)
+      expect(preset.intensity).toBeGreaterThanOrEqual(1)
+      expect(preset.intensity).toBeLessThanOrEqual(100)
+      expect(preset.duration).toBeGreaterThan(0)
+    }
+  })
+
+  test('preset names are unique — they double as React keys in selectors', () => {
+    const names = VIBRATION_PRESETS.map(p => p.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -71,6 +71,7 @@ vi.mock('@/src/services/autoOffWatcher', () => ({
 }))
 
 import { JobManager } from '../jobManager'
+import { JobType } from '../types'
 
 /**
  * Count reload cycles by spying on Scheduler.cancelRecurringJobs, which is
@@ -235,5 +236,139 @@ describe('JobManager public surface (stub DB)', () => {
     await manager.shutdown()
     await manager.shutdown()
     // afterEach will call once more
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Heartbeat liveness — pins the staleness arithmetic, RUN_ONCE skip, null
+// nextInvocation skip, and the reload-cooldown branch so a node-schedule
+// freeze (no fires, no exception) still triggers a recovery reload.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager.checkLiveness', () => {
+  const STALE_MS = 90_000
+  let manager: JobManager
+
+  beforeEach(() => {
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: STALE_MS,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+    vi.restoreAllMocks()
+  })
+
+  // ScheduledJob shape stripped to what checkLiveness reads (id + type).
+  const fakeJob = (id: string, type: JobType): any => ({ id, type, schedule: '', job: {} })
+
+  function stubScheduler(jobs: Array<{ id: string, type: JobType }>, nextAt: (id: string) => Date | null) {
+    const scheduler = manager.getScheduler()
+    vi.spyOn(scheduler, 'getJobs').mockReturnValue(jobs.map(j => fakeJob(j.id, j.type)))
+    vi.spyOn(scheduler, 'getNextInvocation').mockImplementation((id: string) => nextAt(id))
+  }
+
+  it('returns empty list and does not reload when all jobs fire in the future', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() + 60_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark future jobs stale — arithmetic is `now - staleMs`, not `now + staleMs`', async () => {
+    // Kills `now - staleMs` → `now + staleMs` mutator: under the mutation a job
+    // ~30s in the future would satisfy `nextMs < now + 90_000` and reload-spam.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() + 30_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT mark a job at exactly the staleness boundary — comparison is strict `<`', async () => {
+    // Kills `<` → `<=`: at nextMs === now - staleMs, strict `<` is false.
+    const fixedNow = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(fixedNow)
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(fixedNow - STALE_MS),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('marks a recurring job overdue past the stale window and forces a reload', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual(['temp-1'])
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips RUN_ONCE jobs even when their next invocation is overdue', async () => {
+    // Kills mutating the RUN_ONCE guard to a no-op or its conditional to true/false:
+    // a one-shot whose Date has passed must NOT be force-reloaded — node-schedule
+    // already retires it after firing.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'runonce-1-0', type: JobType.RUN_ONCE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores jobs whose getNextInvocation returns null', async () => {
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => null,
+    )
+
+    expect(await manager.checkLiveness()).toEqual([])
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('suppresses follow-up reloads while the cooldown window is open', async () => {
+    // Kills `cooldownLeft > 0` → `false` and removing the cooldown branch:
+    // a persistent freeze should NOT spin reload on every tick.
+    const reloadSpy = vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    await manager.checkLiveness() // first detection — reloads
+    await manager.checkLiveness() // still inside 5-min cooldown
+    await manager.checkLiveness()
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the stale id list even when suppressed by cooldown', async () => {
+    // The function returns `stale` from the cooldown branch (line 296), not [].
+    // Mutating that return to `[]` would break health endpoints that read the list.
+    vi.spyOn(manager, 'reloadSchedules').mockResolvedValue()
+    stubScheduler(
+      [{ id: 'temp-1', type: JobType.TEMPERATURE }],
+      () => new Date(Date.now() - STALE_MS - 5_000),
+    )
+
+    await manager.checkLiveness() // first call sets cooldown
+    expect(await manager.checkLiveness()).toEqual(['temp-1'])
   })
 })

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -23,12 +23,14 @@ vi.mock('@/src/hardware/dacTransport', () => ({
   sendCommand: vi.fn(async () => {}),
 }))
 
+const broadcastMutationStatus = vi.fn<(side: 'left' | 'right', patch: Record<string, unknown>) => void>()
 vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
-  broadcastMutationStatus: vi.fn(),
+  broadcastMutationStatus: (side: 'left' | 'right', patch: Record<string, unknown>) => broadcastMutationStatus(side, patch),
 }))
 
+const cancelAutoOffTimer = vi.fn<(side: 'left' | 'right') => void>()
 vi.mock('@/src/services/autoOffWatcher', () => ({
-  cancelAutoOffTimer: vi.fn(),
+  cancelAutoOffTimer: (side: 'left' | 'right') => cancelAutoOffTimer(side),
 }))
 
 // Mock child_process.exec so executeReboot tests never spawn systemctl.
@@ -67,6 +69,7 @@ vi.mock('@/src/db', async () => {
 
 import * as dbModule from '@/src/db'
 import { JobManager } from '../jobManager'
+import { fahrenheitToLevel } from '@/src/hardware/types'
 const { sqlite } = dbModule as typeof dbModule & { sqlite: BetterSqlite3.Database }
 
 function resetSchema(): void {
@@ -360,6 +363,11 @@ describe('JobManager — job ordering and gating', () => {
     setPower.mockClear()
     setAlarm.mockClear()
     connect.mockClear()
+    broadcastMutationStatus.mockClear()
+    cancelAutoOffTimer.mockClear()
+    setTemperature.mockImplementation(async () => {})
+    setPower.mockImplementation(async () => {})
+    setAlarm.mockImplementation(async () => {})
     manager = new JobManager('America/Los_Angeles', {
       heartbeatIntervalMs: 60_000,
       heartbeatStaleMs: 90_000,
@@ -1713,5 +1721,196 @@ describe('JobManager handler closures', () => {
 
     // loadSchedules must not throw — initial brightness apply is wrapped in try/catch
     await expect(manager.loadSchedules()).resolves.toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// broadcastMutationStatus payload shape + downstream side-effects.
+//
+// Mutation testing flagged the broadcastMutationStatus(...) object literals
+// (lines 349, 384, 420, 436 of jobManager.ts) and the `onTemperature ?? 75`
+// fallback (line 383) as surviving — existing tests covered the hardware
+// client calls but did not assert on the streaming payload itself.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager — streaming + downstream side-effects', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    resetSchema()
+    setTemperature.mockClear()
+    setPower.mockClear()
+    setAlarm.mockClear()
+    connect.mockClear()
+    broadcastMutationStatus.mockClear()
+    cancelAutoOffTimer.mockClear()
+    setTemperature.mockImplementation(async () => {})
+    setPower.mockImplementation(async () => {})
+    setAlarm.mockImplementation(async () => {})
+    manager = new JobManager('UTC', {
+      heartbeatIntervalMs: 1_000_000,
+      heartbeatStaleMs: 90_000,
+    })
+  })
+
+  afterEach(async () => {
+    await manager.shutdown()
+  })
+
+  it('runTemperatureJob broadcasts targetTemperature + targetLevel after setTemperature', async () => {
+    seedSidePowered('left', true)
+
+    await manager.runTemperatureJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      time: '08:00',
+      temperature: 78,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', {
+      targetTemperature: 78,
+      targetLevel: fahrenheitToLevel(78),
+    })
+  })
+
+  it('runTemperatureJob does NOT broadcast when the side is unpowered', async () => {
+    seedSidePowered('left', false)
+
+    await manager.runTemperatureJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      time: '08:00',
+      temperature: 78,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
+  })
+
+  it('runPowerOnJob broadcasts targetTemperature matching onTemperature when set', async () => {
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 84,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+      targetTemperature: 84,
+      targetLevel: fahrenheitToLevel(84),
+    })
+    expect(cancelAutoOffTimer).toHaveBeenCalledWith('right')
+  })
+
+  it('runPowerOnJob falls back to 75°F in the BROADCAST when onTemperature is null', async () => {
+    // Kills `??` → `&&` mutator at jobManager.ts:383. Under `&&`, a null
+    // onTemperature would propagate to the broadcast as null/undefined; under
+    // `??`, the fallback 75 must surface in targetTemperature + targetLevel.
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: null as unknown as number,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', {
+      targetTemperature: 75,
+      targetLevel: fahrenheitToLevel(75),
+    })
+  })
+
+  it('runPowerOffJob broadcasts targetLevel:0 (and no temperature key)', async () => {
+    seedSidePowered('left', true)
+
+    await manager.runPowerOffJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+  })
+
+  it('runAlarmJob broadcasts alarm temperature + isAlarmVibrating:true', async () => {
+    seedSidePowered('right', true)
+
+    await manager.runAlarmJob({
+      id: 1,
+      side: 'right',
+      dayOfWeek: 'thursday' as const,
+      time: '06:30',
+      alarmTemperature: 88,
+      vibrationIntensity: 90,
+      vibrationPattern: 'rise' as const,
+      duration: 30,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+      targetTemperature: 88,
+      targetLevel: fahrenheitToLevel(88),
+      isAlarmVibrating: true,
+    })
+    // setAlarm forwarded the exact vibration parameters from the schedule
+    expect(setAlarm).toHaveBeenCalledWith('right', {
+      vibrationIntensity: 90,
+      vibrationPattern: 'rise',
+      duration: 30,
+    })
+  })
+
+  it('runPowerOnJob does NOT cancelAutoOffTimer when a run-once session is active', async () => {
+    insertRunOnceSession({
+      side: 'left',
+      setPoints: '[]',
+      wakeTime: '08:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60 * 60_000),
+      status: 'active',
+    })
+
+    await manager.runPowerOnJob({
+      id: 1,
+      side: 'left',
+      dayOfWeek: 'monday' as const,
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    expect(cancelAutoOffTimer).not.toHaveBeenCalled()
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
   })
 })

--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for the biometrics router. Covers happy path of every procedure
+ * plus key branches: BAD_REQUEST date-range checks, NOT_FOUND for missing
+ * IDs, sleep-stage fallback paths.
+ *
+ * biometricsDb (thenable chain + transaction), db (top-level select for
+ * device timezone), raw helper, and sleep-stages classifier are mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  txRowsQueue: [] as unknown[][],
+  popRows(): unknown[] { return dbState.rowsQueue.shift() ?? [] },
+  popTx(): unknown[] { return dbState.txRowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.popRows()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.onConflictDoNothing = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.groupBy = vi.fn(() => chain)
+    return chain
+  }
+
+  const makeTxChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.all = vi.fn(() => dbState.popTx())
+    return chain
+  }
+
+  const select = vi.fn(() => makeChain())
+  const insert = vi.fn(() => makeChain())
+  const update = vi.fn(() => makeChain())
+  const del = vi.fn(() => makeChain())
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: vi.fn(() => makeTxChain()),
+    update: vi.fn(() => makeTxChain()),
+  }))
+
+  return { select, insert, update, delete: del, transaction }
+})
+
+// Top-level db mock for device settings (timezone fetch in getSleepStages default)
+const topDbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve([{ timezone: 'America/Los_Angeles' }]).then(resolve)
+    chain.from = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    return chain
+  }
+  return { select: vi.fn(() => makeChain()) }
+})
+
+const rawMock = vi.hoisted(() => ({
+  listRawFiles: vi.fn(async () => [] as { name: string, sizeBytes: number, modifiedAt: string }[]),
+}))
+
+const sleepStagesMock = vi.hoisted(() => ({
+  classifySleepStages: vi.fn(() => [] as { start: number, duration: number, stage: 'wake' | 'light' | 'deep' | 'rem', heartRate: number | null, hrv: number | null, breathingRate: number | null, movement: number | null }[]),
+  mergeIntoBlocks: vi.fn(() => [] as { start: number, end: number, stage: 'wake' | 'light' | 'deep' | 'rem' }[]),
+  calculateDistribution: vi.fn(() => ({ wake: 0, light: 0, deep: 0, rem: 0 })),
+  calculateQualityScore: vi.fn(() => 0),
+}))
+
+vi.mock('@/src/db', () => ({
+  db: topDbMock,
+  biometricsDb: dbMock,
+}))
+
+vi.mock('@/src/server/routers/raw', () => rawMock)
+vi.mock('@/src/lib/sleep-stages', () => sleepStagesMock)
+
+const { biometricsRouter } = await import('@/src/server/routers/biometrics')
+const caller = biometricsRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbState.txRowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.update.mockClear()
+  dbMock.delete.mockClear()
+  dbMock.transaction.mockClear()
+  topDbMock.select.mockClear()
+  rawMock.listRawFiles.mockReset().mockResolvedValue([])
+  sleepStagesMock.classifySleepStages.mockReset().mockReturnValue([])
+  sleepStagesMock.mergeIntoBlocks.mockReset().mockReturnValue([])
+  sleepStagesMock.calculateDistribution.mockReset().mockReturnValue({ wake: 0, light: 0, deep: 0, rem: 0 })
+  sleepStagesMock.calculateQualityScore.mockReset().mockReturnValue(0)
+})
+
+describe('biometrics.getSleepRecords', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, side: 'left', enteredBedAt: new Date(0), leftBedAt: new Date(1000),
+        sleepDurationSeconds: 1, timesExitedBed: 0,
+        presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0),
+      },
+    ])
+    const out = await caller.getSleepRecords({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getSleepRecords({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.getVitals', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, side: 'left', timestamp: new Date(0), heartRate: 60, hrv: 50, breathingRate: 14 },
+    ])
+    const out = await caller.getVitals({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getVitals({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.getMovement / getMovementBuckets / getMovementSummary', () => {
+  it('getMovement returns rows', async () => {
+    dbState.rowsQueue.push([{ id: 1, side: 'left', timestamp: new Date(0), totalMovement: 100 }])
+    const out = await caller.getMovement({ limit: 10 })
+    expect(out).toHaveLength(1)
+  })
+
+  it('getMovement rejects inverted date range', async () => {
+    await expect(caller.getMovement({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+
+  it('getMovementBuckets coerces SQL bucketStart to a Date', async () => {
+    dbState.rowsQueue.push([
+      { bucketStart: 1700000, totalMovement: 250, eventCount: 1, sampleCount: 5 },
+    ])
+    const out = await caller.getMovementBuckets({ side: 'left', bucketSeconds: 60, limit: 100 })
+    expect(out).toHaveLength(1)
+    expect(out[0].bucketStart).toBeInstanceOf(Date)
+    expect(out[0].totalMovement).toBe(250)
+  })
+
+  it('getMovementBuckets rejects inverted date range', async () => {
+    await expect(caller.getMovementBuckets({
+      side: 'left', bucketSeconds: 60, limit: 10,
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+
+  it('getMovementSummary aggregates row to numbers', async () => {
+    dbState.rowsQueue.push([{ positionChanges: '4', restlessMinutes: '20', sampleCount: '60' }])
+    const out = await caller.getMovementSummary({ side: 'left' })
+    expect(out).toEqual({ positionChanges: 4, restlessMinutes: 20, sampleCount: 60 })
+  })
+
+  it('getMovementSummary handles empty result', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getMovementSummary({ side: 'left' })
+    expect(out).toEqual({ positionChanges: 0, restlessMinutes: 0, sampleCount: 0 })
+  })
+})
+
+describe('biometrics.getLatestSleep', () => {
+  it('returns null when no record', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestSleep({ side: 'left' })
+    expect(out).toBeNull()
+  })
+
+  it('returns latest record when present', async () => {
+    dbState.rowsQueue.push([
+      { id: 5, side: 'left', enteredBedAt: new Date(0), leftBedAt: null,
+        sleepDurationSeconds: 0, timesExitedBed: 0,
+        presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0) },
+    ])
+    const out = await caller.getLatestSleep({ side: 'left' })
+    expect(out?.id).toBe(5)
+  })
+})
+
+describe('biometrics.getVitalsSummary', () => {
+  it('returns null when recordCount=0', async () => {
+    dbState.rowsQueue.push([{
+      avgHeartRate: null, minHeartRate: null, maxHeartRate: null,
+      avgHRV: null, avgBreathingRate: null, recordCount: 0,
+    }])
+    const out = await caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns aggregated stats when records present', async () => {
+    dbState.rowsQueue.push([{
+      avgHeartRate: '60', minHeartRate: 50, maxHeartRate: 80,
+      avgHRV: '40', avgBreathingRate: '14', recordCount: 10,
+    }])
+    const out = await caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out?.avgHeartRate).toBe(60)
+    expect(out?.recordCount).toBe(10)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics.reportVitals / reportVitalsBatch', () => {
+  it('reportVitals returns written:1', async () => {
+    const out = await caller.reportVitals({
+      side: 'left',
+      timestamp: 1700000000,
+      heartRate: 60, hrv: 50, breathingRate: 14,
+    })
+    expect(out).toEqual({ written: 1 })
+  })
+
+  it('reportVitalsBatch returns the count of inserted rows', async () => {
+    // The chain await resolves to whatever popRows returns from .returning()
+    dbState.rowsQueue.push([{ id: 1 }, { id: 2 }])
+    const out = await caller.reportVitalsBatch({
+      vitals: [
+        { side: 'left', timestamp: 1700000000, heartRate: 60, hrv: 50, breathingRate: 14 },
+        { side: 'left', timestamp: 1700000300, heartRate: 61, hrv: 51, breathingRate: 14 },
+      ],
+    })
+    expect(out).toEqual({ written: 2 })
+  })
+})
+
+describe('biometrics.getFileCount', () => {
+  it('aggregates raw file count and total MB', async () => {
+    rawMock.listRawFiles.mockResolvedValue([
+      { name: 'a.RAW', sizeBytes: 1024 * 1024, modifiedAt: 'x' },
+      { name: 'b.RAW', sizeBytes: 2 * 1024 * 1024, modifiedAt: 'y' },
+    ])
+    const out = await caller.getFileCount({})
+    expect(out.rawFiles).toEqual({ left: 2, right: 2 })
+    expect(out.totalSizeMB).toBe(3)
+  })
+
+  it('returns zeros on listRawFiles error', async () => {
+    rawMock.listRawFiles.mockRejectedValue(new Error('ENOENT'))
+    const out = await caller.getFileCount({})
+    expect(out).toEqual({ rawFiles: { left: 0, right: 0 }, totalSizeMB: 0 })
+  })
+})
+
+describe('biometrics.updateSleepRecord', () => {
+  it('rejects when no fields supplied', async () => {
+    await expect(caller.updateSleepRecord({ id: 1 })).rejects.toThrow(/No fields to update/)
+  })
+
+  it('throws NOT_FOUND when record missing during recompute', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.updateSleepRecord({
+      id: 1,
+      enteredBedAt: new Date('2025-01-01T00:00:00Z'),
+    })).rejects.toThrow(/Sleep record 1 not found/)
+  })
+
+  it('rejects leftBedAt at or before enteredBedAt', async () => {
+    dbState.txRowsQueue.push([
+      { id: 1, side: 'left', enteredBedAt: new Date('2025-01-01T00:00:00Z'), leftBedAt: new Date('2025-01-01T08:00:00Z') },
+    ])
+    await expect(caller.updateSleepRecord({
+      id: 1,
+      enteredBedAt: new Date('2025-01-01T10:00:00Z'),
+    })).rejects.toThrow(/leftBedAt must be after enteredBedAt/)
+  })
+
+  it('updates timesExitedBed when only it is provided (skips duration recompute)', async () => {
+    const updated = {
+      id: 1, side: 'left',
+      enteredBedAt: new Date(0), leftBedAt: new Date(1000),
+      sleepDurationSeconds: 1, timesExitedBed: 7,
+      presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+    const out = await caller.updateSleepRecord({ id: 1, timesExitedBed: 7 })
+    expect(out.timesExitedBed).toBe(7)
+  })
+})
+
+describe('biometrics.deleteSleepRecord', () => {
+  it('returns success when a row was deleted', async () => {
+    dbState.rowsQueue.push([{ id: 1 }])
+    const out = await caller.deleteSleepRecord({ id: 1 })
+    expect(out).toEqual({ success: true })
+  })
+
+  it('throws NOT_FOUND when nothing was deleted', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.deleteSleepRecord({ id: 99 })).rejects.toThrow(/Sleep record 99 not found/)
+  })
+})
+
+describe('biometrics.getSleepStages', () => {
+  it('rejects when both sleepRecordId and date range are provided', async () => {
+    await expect(caller.getSleepStages({
+      side: 'left',
+      sleepRecordId: 1,
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Provide either sleepRecordId or startDate/)
+  })
+
+  it('throws NOT_FOUND when sleepRecordId missing', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.getSleepStages({ side: 'left', sleepRecordId: 99 })).rejects.toThrow(/Sleep record 99 not found/)
+  })
+
+  it('returns empty result when no recent records exist (default branch)', async () => {
+    // Recent records query returns []
+    dbState.rowsQueue.push([])
+    const out = await caller.getSleepStages({ side: 'left' })
+    expect(out.epochs).toEqual([])
+    expect(out.sleepRecordId).toBeNull()
+  })
+
+  it('classifies stages from a sleepRecordId-supplied window', async () => {
+    const record = {
+      id: 1, side: 'left',
+      enteredBedAt: new Date('2025-01-01T22:00:00Z'),
+      leftBedAt: new Date('2025-01-02T07:00:00Z'),
+    }
+    // Three queries: record lookup, vitals window, movement window
+    dbState.rowsQueue.push([record])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), heartRate: 60, hrv: 50, breathingRate: 14 }])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), totalMovement: 100 }])
+
+    sleepStagesMock.classifySleepStages.mockReturnValue([
+      { start: 0, duration: 300_000, stage: 'light', heartRate: 60, hrv: 50, breathingRate: 14, movement: 100 },
+    ])
+    sleepStagesMock.mergeIntoBlocks.mockReturnValue([{ start: 0, end: 300_000, stage: 'light' }])
+    sleepStagesMock.calculateDistribution.mockReturnValue({ wake: 0, light: 1, deep: 0, rem: 0 })
+    sleepStagesMock.calculateQualityScore.mockReturnValue(80)
+
+    const out = await caller.getSleepStages({ side: 'left', sleepRecordId: 1 })
+    expect(out.sleepRecordId).toBe(1)
+    expect(out.epochs).toHaveLength(1)
+    expect(out.qualityScore).toBe(80)
+    expect(out.totalSleepMs).toBe(300_000)
+  })
+
+  it('rejects an inverted custom date range', async () => {
+    await expect(caller.getSleepStages({
+      side: 'left',
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})

--- a/src/server/routers/tests/calibration.test.ts
+++ b/src/server/routers/tests/calibration.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the calibration router — getStatus pivots rows by sensor type,
+ * getHistory passes filters, triggerCalibration writes atomic .tmp+rename,
+ * triggerFullCalibration writes "all/all", getVitalsQuality respects date
+ * range. fs/promises and biometricsDb fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMock = vi.hoisted(() => ({
+  writeFile: vi.fn<(...args: unknown[]) => Promise<void>>(async () => undefined),
+  rename: vi.fn<(...args: unknown[]) => Promise<void>>(async () => undefined),
+}))
+
+// biometricsDb chain — supports both query (select→from→where→orderBy→limit)
+// and insert (.insert→.values→.onConflictDoUpdate)
+const dbMock = vi.hoisted(() => {
+  // Default rows returned per table — overridable per test
+  const profileRows: unknown[] = []
+  const runRows: unknown[] = []
+  const qualityRows: unknown[] = []
+  let activeTable: 'profiles' | 'runs' | 'quality' = 'profiles'
+
+  // chains terminate at: where (for getStatus), .limit (for history/quality)
+  const limitProfiles = vi.fn(async () => profileRows)
+  const limitRuns = vi.fn(async () => runRows)
+  const limitQuality = vi.fn(async () => qualityRows)
+
+  const orderRuns = vi.fn(() => ({ limit: limitRuns }))
+  const orderQuality = vi.fn(() => ({ limit: limitQuality }))
+
+  // For getStatus: where() resolves directly (await on chain after where)
+  const whereProfilesAwait = vi.fn(async () => profileRows)
+  // For getHistory/getVitalsQuality: where().orderBy().limit()
+  const whereRuns = vi.fn(() => ({ orderBy: orderRuns }))
+  const whereQuality = vi.fn(() => ({ orderBy: orderQuality }))
+
+  const from = vi.fn(() => {
+    if (activeTable === 'profiles') return { where: whereProfilesAwait, limit: limitProfiles }
+    if (activeTable === 'runs') return { where: whereRuns, orderBy: orderRuns, limit: limitRuns }
+    return { where: whereQuality, orderBy: orderQuality, limit: limitQuality }
+  })
+  const select = vi.fn(() => ({ from }))
+
+  // Insert chain
+  const onConflict = vi.fn(async () => undefined)
+  const values = vi.fn(() => ({ onConflictDoUpdate: onConflict }))
+  const insert = vi.fn(() => ({ values }))
+
+  return {
+    select, insert, values, onConflict,
+    profileRows, runRows, qualityRows,
+    setActive: (t: 'profiles' | 'runs' | 'quality') => { activeTable = t },
+  }
+})
+
+vi.mock('node:fs/promises', () => ({ ...fsMock, default: fsMock }))
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: {
+    select: dbMock.select,
+    insert: dbMock.insert,
+  },
+}))
+
+const { calibrationRouter } = await import('@/src/server/routers/calibration')
+const caller = calibrationRouter.createCaller({})
+
+beforeEach(() => {
+  fsMock.writeFile.mockReset().mockResolvedValue(undefined)
+  fsMock.rename.mockReset().mockResolvedValue(undefined)
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.values.mockClear()
+  dbMock.onConflict.mockClear()
+  dbMock.profileRows.length = 0
+  dbMock.runRows.length = 0
+  dbMock.qualityRows.length = 0
+  dbMock.setActive('profiles')
+})
+
+describe('calibration.getStatus', () => {
+  it('pivots profile rows by sensor type and returns nulls for missing ones', async () => {
+    dbMock.setActive('profiles')
+    dbMock.profileRows.push({
+      id: 1, side: 'left', sensorType: 'piezo', status: 'completed',
+      qualityScore: 0.97, samplesUsed: 1024,
+      createdAt: new Date(0), expiresAt: null, errorMessage: null,
+    })
+
+    const result = await caller.getStatus({ side: 'left' })
+    expect(result.piezo?.status).toBe('completed')
+    expect(result.capacitance).toBeNull()
+    expect(result.temperature).toBeNull()
+  })
+})
+
+describe('calibration.getHistory', () => {
+  it('passes through limit and orders desc by createdAt', async () => {
+    dbMock.setActive('runs')
+    dbMock.runRows.push({
+      id: 1, side: 'left', sensorType: 'piezo', status: 'completed',
+      parameters: {}, qualityScore: 0.9,
+      sourceWindowStart: 0, sourceWindowEnd: 100,
+      samplesUsed: 50, errorMessage: null, durationMs: 10,
+      triggeredBy: 'manual', createdAt: new Date(0),
+    })
+
+    const out = await caller.getHistory({ side: 'left', limit: 5 })
+    expect(out).toHaveLength(1)
+    expect(out[0].sensorType).toBe('piezo')
+  })
+
+  it('with no sensorType filter still resolves', async () => {
+    dbMock.setActive('runs')
+    const out = await caller.getHistory({ side: 'right', sensorType: 'capacitance', limit: 1 })
+    expect(out).toEqual([])
+  })
+})
+
+describe('calibration.triggerCalibration', () => {
+  it('writes the trigger payload atomically (write tmp → rename) and queues pending row', async () => {
+    const result = await caller.triggerCalibration({ side: 'left', sensorType: 'piezo' })
+
+    // Atomic write pattern: writeFile to .tmp first, then rename
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1)
+    expect(fsMock.rename).toHaveBeenCalledTimes(1)
+    const [tmpPath, payload] = fsMock.writeFile.mock.calls[0]
+    expect(typeof tmpPath).toBe('string')
+    expect(String(tmpPath)).toMatch(/\.tmp$/)
+    const parsed = JSON.parse(String(payload))
+    expect(parsed.side).toBe('left')
+    expect(parsed.sensor_type).toBe('piezo')
+    expect(typeof parsed.ts).toBe('number')
+
+    // The rename target must drop the .tmp suffix
+    const [renameSrc, renameDst] = fsMock.rename.mock.calls[0]
+    expect(renameSrc).toBe(tmpPath)
+    expect(String(renameDst)).not.toMatch(/\.tmp$/)
+
+    // Pending row inserted with onConflictDoUpdate
+    expect(dbMock.insert).toHaveBeenCalledTimes(1)
+    expect(dbMock.onConflict).toHaveBeenCalledTimes(1)
+
+    expect(result.triggered).toBe(true)
+    expect(result.message).toContain('left')
+    expect(result.message).toContain('piezo')
+  })
+
+  it('wraps fs failures as INTERNAL_SERVER_ERROR', async () => {
+    fsMock.writeFile.mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(
+      caller.triggerCalibration({ side: 'left', sensorType: 'piezo' }),
+    ).rejects.toThrow(/Failed to trigger calibration: disk full/)
+  })
+})
+
+describe('calibration.triggerFullCalibration', () => {
+  it('writes the all/all payload', async () => {
+    const result = await caller.triggerFullCalibration({})
+
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1)
+    const payload = JSON.parse(String(fsMock.writeFile.mock.calls[0][1]))
+    expect(payload.side).toBe('all')
+    expect(payload.sensor_type).toBe('all')
+    expect(result.triggered).toBe(true)
+  })
+
+  it('wraps fs failures', async () => {
+    fsMock.rename.mockRejectedValueOnce(new Error('boom'))
+    await expect(caller.triggerFullCalibration({})).rejects.toThrow(/Failed to trigger calibration/)
+  })
+})
+
+describe('calibration.getVitalsQuality', () => {
+  it('returns rows for a side with no date range', async () => {
+    dbMock.setActive('quality')
+    dbMock.qualityRows.push({
+      id: 1, vitalsId: 100, side: 'left',
+      timestamp: new Date(0), qualityScore: 0.88, flags: {},
+      hrRaw: 70, createdAt: new Date(0),
+    })
+
+    const out = await caller.getVitalsQuality({ side: 'left', limit: 100 })
+    expect(out).toHaveLength(1)
+    expect(out[0].side).toBe('left')
+  })
+
+  it('with startDate + endDate still resolves', async () => {
+    dbMock.setActive('quality')
+    const out = await caller.getVitalsQuality({
+      side: 'right',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-02-01'),
+      limit: 50,
+    })
+    expect(out).toEqual([])
+  })
+})

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the device router. Exercises every procedure's happy path plus
+ * a key branch (debounce coalesce, snooze timestamp, raw command allowlist).
+ *
+ * Hardware client, DB, broadcast helper, snooze/prime modules and the raw
+ * dac transport are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const helpersMock = vi.hoisted(() => {
+  const client = {
+    getDeviceStatus: vi.fn(),
+    setPower: vi.fn(),
+    setTemperature: vi.fn(),
+    setAlarm: vi.fn(),
+    clearAlarm: vi.fn(),
+    startPriming: vi.fn(),
+  }
+  const withHardwareClient = vi.fn(async (cb: (c: typeof client) => Promise<unknown>) => cb(client))
+  return { withHardwareClient, client }
+})
+
+const primeMock = vi.hoisted(() => ({
+  getPrimeCompletedAt: vi.fn(),
+  dismissPrimeNotification: vi.fn(),
+}))
+
+const snoozeMock = vi.hoisted(() => ({
+  snoozeAlarm: vi.fn(),
+  cancelSnooze: vi.fn(),
+  getSnoozeStatus: vi.fn<(side?: string) => { active: boolean, snoozeUntil: number | null }>(() => ({ active: false, snoozeUntil: null })),
+}))
+
+const broadcastMock = vi.hoisted(() => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+const transportMock = vi.hoisted(() => ({
+  sendCommand: vi.fn(),
+}))
+
+const stateSyncMock = vi.hoisted(() => ({
+  markSideMutated: vi.fn(),
+}))
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] { return dbState.rowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.onConflictDoUpdate = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    return chain
+  }
+  return {
+    select: vi.fn(() => makeChain()),
+    update: vi.fn(() => makeChain()),
+    insert: vi.fn(() => makeChain()),
+  }
+})
+
+vi.mock('@/src/server/helpers', () => ({ withHardwareClient: helpersMock.withHardwareClient }))
+vi.mock('@/src/hardware/primeNotification', () => primeMock)
+vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
+vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
+vi.mock('@/src/hardware/dacTransport', () => transportMock)
+vi.mock('@/src/hardware/deviceStateSync', () => stateSyncMock)
+vi.mock('@/src/db', () => ({
+  db: dbMock,
+  biometricsDb: {},
+}))
+
+const { deviceRouter } = await import('@/src/server/routers/device')
+const caller = deviceRouter.createCaller({})
+
+beforeEach(() => {
+  helpersMock.withHardwareClient.mockClear()
+  Object.values(helpersMock.client).forEach(fn => fn.mockReset())
+  helpersMock.client.getDeviceStatus.mockResolvedValue({
+    leftSide: { currentTemperature: 80, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+    rightSide: { currentTemperature: 80, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+    waterLevel: 'ok',
+    isPriming: false,
+    podVersion: 'I00',
+    sensorLabel: 'pod-test',
+  })
+  helpersMock.client.setPower.mockResolvedValue(undefined)
+  helpersMock.client.setTemperature.mockResolvedValue(undefined)
+  helpersMock.client.setAlarm.mockResolvedValue(undefined)
+  helpersMock.client.clearAlarm.mockResolvedValue(undefined)
+  helpersMock.client.startPriming.mockResolvedValue(undefined)
+
+  primeMock.getPrimeCompletedAt.mockReset().mockReturnValue(null)
+  primeMock.dismissPrimeNotification.mockReset()
+  snoozeMock.snoozeAlarm.mockReset()
+  snoozeMock.cancelSnooze.mockReset()
+  snoozeMock.getSnoozeStatus.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
+  broadcastMock.broadcastMutationStatus.mockReset()
+  transportMock.sendCommand.mockReset()
+  stateSyncMock.markSideMutated.mockReset()
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.insert.mockClear()
+})
+
+describe('device.getStatus', () => {
+  it('returns status with snooze block and converts to F by default', async () => {
+    primeMock.getPrimeCompletedAt.mockReturnValue(1700000000000)
+    snoozeMock.getSnoozeStatus.mockReturnValueOnce({ active: true, snoozeUntil: 1700001000000 })
+    snoozeMock.getSnoozeStatus.mockReturnValueOnce({ active: false, snoozeUntil: null })
+
+    const result = await caller.getStatus({})
+    expect(result.leftSide.currentTemperature).toBe(80)
+    expect(result.snooze.left.active).toBe(true)
+    expect(result.primeCompletedNotification?.timestamp).toBe(1700000000000)
+  })
+
+  it('converts to Celsius when unit=C', async () => {
+    const result = await caller.getStatus({ unit: 'C' })
+    // 80°F → 26.7°C (rounded to one decimal by router)
+    expect(result.leftSide.currentTemperature).toBeCloseTo(26.7, 1)
+  })
+})
+
+describe('device.setTemperature', () => {
+  it('debounces and resolves after timer fires', async () => {
+    vi.useFakeTimers()
+    try {
+      // Provide a prior deviceState row for the prev lookup
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+
+      const promise = caller.setTemperature({ side: 'left', temperature: 70 })
+      await vi.advanceTimersByTimeAsync(250)
+      const result = await promise
+
+      expect(result).toEqual({ success: true })
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledTimes(1)
+      expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalled()
+      expect(stateSyncMock.markSideMutated).toHaveBeenCalledWith('left')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('coalesces a second call into one hardware command (last value wins)', async () => {
+    vi.useFakeTimers()
+    try {
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+      dbState.rowsQueue.push([{ isPowered: true, poweredOnAt: new Date() }])
+
+      // Start call 1 and let it register its pending entry (await microtasks
+      // so the async DB lookup before pendingTemps.set has a chance to settle).
+      const p1 = caller.setTemperature({ side: 'left', temperature: 70 })
+      await vi.advanceTimersByTimeAsync(0)
+      // Call 2 now sees the pending entry and cancels the first timer.
+      const p2 = caller.setTemperature({ side: 'left', temperature: 75 })
+      await vi.advanceTimersByTimeAsync(250)
+      const [r1, r2] = await Promise.all([p1, p2])
+      expect(r1).toEqual({ success: true })
+      expect(r2).toEqual({ success: true })
+      // Only the second call's value reaches hardware
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledTimes(1)
+      expect(helpersMock.client.setTemperature).toHaveBeenCalledWith('left', 75, undefined)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('device.setPower', () => {
+  it('powers on with the provided temperature, broadcasts, syncs DB', async () => {
+    dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+
+    const result = await caller.setPower({ side: 'left', powered: true, temperature: 72 })
+    expect(result).toEqual({ success: true })
+    expect(helpersMock.client.setPower).toHaveBeenCalledWith('left', true, 72)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', expect.objectContaining({
+      targetTemperature: 72,
+    }))
+  })
+
+  it('powers off and broadcasts targetLevel: 0', async () => {
+    dbState.rowsQueue.push([{ isPowered: true, poweredOnAt: new Date() }])
+
+    await caller.setPower({ side: 'left', powered: false })
+    expect(helpersMock.client.setPower).toHaveBeenCalledWith('left', false, undefined)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+  })
+})
+
+describe('device.setAlarm / clearAlarm / snoozeAlarm', () => {
+  it('setAlarm passes config to hardware and broadcasts vibrating=true', async () => {
+    await caller.setAlarm({
+      side: 'left',
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 60,
+    })
+
+    expect(snoozeMock.cancelSnooze).toHaveBeenCalledWith('left')
+    expect(helpersMock.client.setAlarm).toHaveBeenCalledWith('left', {
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 60,
+    })
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { isAlarmVibrating: true })
+  })
+
+  it('clearAlarm hits hardware and broadcasts vibrating=false', async () => {
+    await caller.clearAlarm({ side: 'right' })
+    expect(helpersMock.client.clearAlarm).toHaveBeenCalledWith('right')
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('right', { isAlarmVibrating: false })
+  })
+
+  it('snoozeAlarm clears alarm + invokes snoozeManager and returns timestamp', async () => {
+    const snoozeUntil = new Date(1700000000000)
+    snoozeMock.snoozeAlarm.mockReturnValue(snoozeUntil)
+
+    const result = await caller.snoozeAlarm({ side: 'left', duration: 300 })
+    expect(helpersMock.client.clearAlarm).toHaveBeenCalledWith('left')
+    expect(snoozeMock.snoozeAlarm).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.snoozeUntil).toBe(Math.floor(snoozeUntil.getTime() / 1000))
+  })
+})
+
+describe('device.startPriming / dismissPrimeNotification', () => {
+  it('startPriming hits hardware', async () => {
+    const result = await caller.startPriming({})
+    expect(helpersMock.client.startPriming).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('dismissPrimeNotification calls the helper', async () => {
+    const result = await caller.dismissPrimeNotification({})
+    expect(primeMock.dismissPrimeNotification).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('device.execute (raw command)', () => {
+  it('passes the command name through and returns disclaimer', async () => {
+    transportMock.sendCommand.mockResolvedValue('{ "ok": true }')
+
+    const result = await caller.execute({ command: 'DEVICE_STATUS' })
+    expect(result.command).toBe('DEVICE_STATUS')
+    expect(result.args).toBeNull()
+    expect(result.response).toBe('{ "ok": true }')
+    expect(result.disclaimer).toContain('Raw command execution')
+  })
+
+  it('rejects unknown command via Zod enum', async () => {
+    await expect(caller.execute({ command: 'BOGUS' as never })).rejects.toThrow()
+  })
+
+  it('wraps transport errors as INTERNAL_SERVER_ERROR', async () => {
+    transportMock.sendCommand.mockRejectedValue(new Error('socket dead'))
+    await expect(caller.execute({ command: 'DEVICE_STATUS' })).rejects.toThrow(/Failed to execute raw command: socket dead/)
+  })
+})

--- a/src/server/routers/tests/environment.test.ts
+++ b/src/server/routers/tests/environment.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the environment router — bedTemp/freezerTemp date-range queries
+ * with F/C unit conversion, latest fetchers, and the bed+freezer summary
+ * pair (Promise.all chain). biometricsDb mocked via a thenable chain.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] {
+    return dbState.rowsQueue.shift() ?? []
+  },
+}))
+
+const dbMock = vi.hoisted(() => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    return chain
+  }
+  return { select: vi.fn(() => makeChain()) }
+})
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: dbMock,
+}))
+
+const { environmentRouter } = await import('@/src/server/routers/environment')
+const caller = environmentRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+})
+
+describe('environment.getBedTemp', () => {
+  it('returns rows with Fahrenheit conversion by default', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, mcuTemp: 2500, humidity: 5000,
+        leftOuterTemp: 2100, leftCenterTemp: 2200, leftInnerTemp: 2300,
+        rightOuterTemp: 2400, rightCenterTemp: 2500, rightInnerTemp: 2600,
+      },
+    ])
+
+    const out = await caller.getBedTemp({ limit: 10 })
+    expect(out).toHaveLength(1)
+    // 20°C = 68°F (centidegrees 2000 -> 20°C -> 68°F)
+    expect(out[0].ambientTemp).toBe(68)
+    expect(out[0].humidity).toBe(50)
+  })
+
+  it('returns Celsius when unit=C', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, mcuTemp: null, humidity: null,
+        leftOuterTemp: null, leftCenterTemp: null, leftInnerTemp: null,
+        rightOuterTemp: null, rightCenterTemp: null, rightInnerTemp: null,
+      },
+    ])
+
+    const out = await caller.getBedTemp({ limit: 10, unit: 'C' })
+    expect(out[0].ambientTemp).toBe(20)
+    expect(out[0].mcuTemp).toBeNull()
+  })
+
+  it('rejects inverted date range as BAD_REQUEST', async () => {
+    await expect(caller.getBedTemp({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate must be before or equal to endDate/)
+  })
+})
+
+describe('environment.getFreezerTemp', () => {
+  it('returns rows with C conversion', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, timestamp: new Date(0),
+        ambientTemp: 2000, heatsinkTemp: 3000, leftWaterTemp: 1500, rightWaterTemp: 1600,
+      },
+    ])
+
+    const out = await caller.getFreezerTemp({ limit: 10, unit: 'C' })
+    expect(out[0].ambientTemp).toBe(20)
+    expect(out[0].heatsinkTemp).toBe(30)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getFreezerTemp({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getLatestBedTemp / getLatestFreezerTemp', () => {
+  it('returns null when no row', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestBedTemp({})
+    expect(out).toBeNull()
+  })
+
+  it('latest bed temp returns the row', async () => {
+    dbState.rowsQueue.push([{
+      id: 7, timestamp: new Date(0),
+      ambientTemp: 2000, mcuTemp: null, humidity: null,
+      leftOuterTemp: null, leftCenterTemp: null, leftInnerTemp: null,
+      rightOuterTemp: null, rightCenterTemp: null, rightInnerTemp: null,
+    }])
+    const out = await caller.getLatestBedTemp({})
+    expect(out?.id).toBe(7)
+  })
+
+  it('latest freezer temp returns null when missing', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestFreezerTemp({})
+    expect(out).toBeNull()
+  })
+
+  it('latest freezer temp returns the row', async () => {
+    dbState.rowsQueue.push([{
+      id: 1, timestamp: new Date(0),
+      ambientTemp: 2000, heatsinkTemp: null, leftWaterTemp: null, rightWaterTemp: null,
+    }])
+    const out = await caller.getLatestFreezerTemp({ unit: 'C' })
+    expect(out?.ambientTemp).toBe(20)
+  })
+})
+
+describe('environment.getSummary', () => {
+  it('returns nulls for sections with no records', async () => {
+    // Both summary queries fire in Promise.all → push two responses
+    dbState.rowsQueue.push([{ avgAmbient: null, minAmbient: null, maxAmbient: null, avgHumidity: null, avgLeftCenter: null, avgRightCenter: null, recordCount: 0 }])
+    dbState.rowsQueue.push([{ avgAmbient: null, avgHeatsink: null, avgLeftWater: null, avgRightWater: null, recordCount: 0 }])
+
+    const out = await caller.getSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out.bedTemp).toBeNull()
+    expect(out.freezerTemp).toBeNull()
+  })
+
+  it('returns aggregated values when records present', async () => {
+    dbState.rowsQueue.push([{
+      avgAmbient: '2000', minAmbient: 1500, maxAmbient: 2500,
+      avgHumidity: '5000', avgLeftCenter: '2100', avgRightCenter: '2200',
+      recordCount: 60,
+    }])
+    dbState.rowsQueue.push([{
+      avgAmbient: '1000', avgHeatsink: '3000', avgLeftWater: '500', avgRightWater: '600',
+      recordCount: 60,
+    }])
+
+    const out = await caller.getSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+      unit: 'C',
+    })
+    expect(out.bedTemp?.avgAmbientTemp).toBe(20) // 2000 cdeg = 20°C
+    expect(out.bedTemp?.avgHumidity).toBe(50)
+    expect(out.bedTemp?.recordCount).toBe(60)
+    expect(out.freezerTemp?.avgAmbientTemp).toBe(10)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getSummary({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getAmbientLight', () => {
+  it('returns rows', async () => {
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(0), lux: 100 }])
+    const out = await caller.getAmbientLight({ limit: 10 })
+    expect(out).toHaveLength(1)
+    expect(out[0].lux).toBe(100)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getAmbientLight({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('environment.getLatestAmbientLight', () => {
+  it('returns null when no row', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getLatestAmbientLight({})
+    expect(out).toBeNull()
+  })
+
+  it('returns row when present', async () => {
+    dbState.rowsQueue.push([{ id: 5, timestamp: new Date(0), lux: 50 }])
+    const out = await caller.getLatestAmbientLight({})
+    expect(out?.id).toBe(5)
+  })
+})
+
+describe('environment.getAmbientLightSummary', () => {
+  it('returns null when recordCount=0', async () => {
+    dbState.rowsQueue.push([{ avgLux: null, minLux: null, maxLux: null, recordCount: 0 }])
+    const out = await caller.getAmbientLightSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns summary stats when present', async () => {
+    dbState.rowsQueue.push([{ avgLux: '120', minLux: 5, maxLux: 500, recordCount: 144 }])
+    const out = await caller.getAmbientLightSummary({
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out?.avgLux).toBe(120)
+    expect(out?.recordCount).toBe(144)
+  })
+
+  it('rejects inverted date range', async () => {
+    await expect(caller.getAmbientLightSummary({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the health router — scheduler counts, system db+drift checks,
+ * dacMonitor passthrough, hardware socket probe.
+ *
+ * Scheduler, db (sqlite + drizzle chain), shared hardware client, dacMonitor
+ * accessor, and iptablesCheck are mocked. Drift auto-reload import path is
+ * mocked too.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const schedulerMock = vi.hoisted(() => {
+  const scheduler = {
+    isEnabled: vi.fn(() => true),
+    getJobs: vi.fn(() => [] as { id: string, type: string, metadata?: { side?: string } }[]),
+    getNextInvocation: vi.fn<(id: string) => Date | null>(() => null),
+  }
+  const jobManager = {
+    getScheduler: vi.fn(() => scheduler),
+    reloadSchedules: vi.fn(async () => undefined),
+  }
+  const getJobManager = vi.fn(async () => jobManager)
+  return { getJobManager, scheduler, jobManager }
+})
+
+// db-related — sqlite.pragma + db.select chain (uses .all())
+const dbMock = vi.hoisted(() => {
+  const sqlitePragma = vi.fn()
+  const allSchedules = { temp: [] as unknown[], pow: [] as unknown[], alm: [] as unknown[] }
+  let activeTable: 'temp' | 'pow' | 'alm' = 'temp'
+
+  const all = vi.fn(() => {
+    if (activeTable === 'temp') return allSchedules.temp
+    if (activeTable === 'pow') return allSchedules.pow
+    return allSchedules.alm
+  })
+  const where = vi.fn(() => ({ all }))
+  const from = vi.fn((table: unknown) => {
+    // Detect which schedule table is being queried
+    const name = String(table?.constructor?.name ?? '')
+    if (name.includes('Power')) activeTable = 'pow'
+    else if (name.includes('Alarm')) activeTable = 'alm'
+    else activeTable = 'temp'
+    return { where }
+  })
+  const select = vi.fn(() => ({ from }))
+
+  return {
+    db: { select },
+    sqlite: { pragma: sqlitePragma },
+    sqlitePragma,
+    allSchedules,
+    setActive: (t: 'temp' | 'pow' | 'alm') => { activeTable = t },
+  }
+})
+
+const sharedClientMock = vi.hoisted(() => {
+  const client = { connect: vi.fn(async () => undefined) }
+  return {
+    getSharedHardwareClient: vi.fn(() => client),
+    getDacMonitorIfRunning: vi.fn(),
+    client,
+  }
+})
+
+const iptablesMock = vi.hoisted(() => ({
+  checkIptables: vi.fn(() => ({ ok: true, rules: [] })),
+}))
+
+vi.mock('@/src/scheduler', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/scheduler/instance', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/db', () => ({
+  db: dbMock.db,
+  sqlite: dbMock.sqlite,
+  biometricsDb: {},
+}))
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: sharedClientMock.getSharedHardwareClient,
+  getDacMonitorIfRunning: sharedClientMock.getDacMonitorIfRunning,
+}))
+vi.mock('@/src/hardware/iptablesCheck', () => iptablesMock)
+
+const { healthRouter } = await import('@/src/server/routers/health')
+const caller = healthRouter.createCaller({})
+
+beforeEach(() => {
+  schedulerMock.scheduler.isEnabled.mockReset().mockReturnValue(true)
+  schedulerMock.scheduler.getJobs.mockReset().mockReturnValue([])
+  schedulerMock.scheduler.getNextInvocation.mockReset().mockReturnValue(null)
+  schedulerMock.jobManager.reloadSchedules.mockReset().mockResolvedValue(undefined)
+  dbMock.sqlitePragma.mockReset()
+  dbMock.allSchedules.temp.length = 0
+  dbMock.allSchedules.pow.length = 0
+  dbMock.allSchedules.alm.length = 0
+  sharedClientMock.client.connect.mockReset().mockResolvedValue(undefined)
+  sharedClientMock.getDacMonitorIfRunning.mockReset()
+  iptablesMock.checkIptables.mockReset().mockReturnValue({ ok: true, rules: [] })
+})
+
+describe('health.scheduler', () => {
+  it('returns counts and unhealthy=true when scheduler enabled but empty', async () => {
+    schedulerMock.scheduler.isEnabled.mockReturnValue(true)
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.scheduler({})
+    expect(result.enabled).toBe(true)
+    expect(result.jobCounts.total).toBe(0)
+    // The point: enabled with zero jobs → unhealthy
+    expect(result.healthy).toBe(false)
+  })
+
+  it('returns healthy=true when scheduler is disabled regardless of count', async () => {
+    schedulerMock.scheduler.isEnabled.mockReturnValue(false)
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.scheduler({})
+    expect(result.healthy).toBe(true)
+  })
+
+  it('counts jobs by type and emits sorted upcoming list', async () => {
+    schedulerMock.scheduler.getJobs.mockReturnValue([
+      { id: 't-1', type: 'temperature', metadata: { side: 'left' } },
+      { id: 'p-on-1', type: 'power_on', metadata: { side: 'left' } },
+      { id: 'p-off-1', type: 'power_off', metadata: { side: 'left' } },
+      { id: 'a-1', type: 'alarm', metadata: { side: 'right' } },
+      { id: 'pr-1', type: 'prime' },
+      { id: 'rb-1', type: 'reboot' },
+    ])
+    const now = Date.now()
+    schedulerMock.scheduler.getNextInvocation.mockImplementation((id: string) => {
+      const offsets: Record<string, number> = {
+        't-1': 1000,
+        'p-on-1': 500,
+        'p-off-1': 2000,
+        'a-1': 100,
+        'pr-1': 10000,
+        'rb-1': 50000,
+      }
+      return new Date(now + offsets[id])
+    })
+
+    const result = await caller.scheduler({})
+    expect(result.jobCounts).toEqual({
+      temperature: 1, powerOn: 1, powerOff: 1, alarm: 1,
+      prime: 1, reboot: 1, total: 6,
+    })
+    // Sorted ascending: a-1 (100ms), p-on-1, t-1, p-off-1, pr-1, rb-1
+    expect(result.upcomingJobs.map(j => j.id)).toEqual(['a-1', 'p-on-1', 't-1', 'p-off-1', 'pr-1', 'rb-1'])
+    expect(result.healthy).toBe(true)
+  })
+
+  it('wraps internal errors as INTERNAL_SERVER_ERROR', async () => {
+    schedulerMock.getJobManager.mockRejectedValueOnce(new Error('scheduler down'))
+
+    await expect(caller.scheduler({})).rejects.toThrow(/Failed to get scheduler health/)
+  })
+})
+
+describe('health.system', () => {
+  it('reports ok when db responds and scheduler matches DB schedules', async () => {
+    dbMock.sqlitePragma.mockReturnValue(undefined)
+    dbMock.allSchedules.temp.push({ id: 1 })
+    dbMock.allSchedules.pow.push({ id: 1 })
+    dbMock.allSchedules.alm.push({ id: 1 })
+    // Expected: 1 temp + (1 power * 2) + 1 alarm = 4 user jobs
+    schedulerMock.scheduler.getJobs.mockReturnValue([
+      { id: 'a', type: 'temperature' },
+      { id: 'b', type: 'power_on' },
+      { id: 'c', type: 'power_off' },
+      { id: 'd', type: 'alarm' },
+    ])
+
+    const result = await caller.system({})
+    expect(result.status).toBe('ok')
+    expect(result.database.status).toBe('ok')
+    expect(result.scheduler.enabled).toBe(true)
+    expect(result.scheduler.drift?.drifted).toBe(false)
+    expect(result.iptables.ok).toBe(true)
+  })
+
+  it('reports degraded when sqlite pragma throws', async () => {
+    dbMock.sqlitePragma.mockImplementation(() => {
+      throw new Error('db locked')
+    })
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.system({})
+    expect(result.database.status).toBe('degraded')
+    expect(result.database.error).toBe('db locked')
+    expect(result.status).toBe('degraded')
+  })
+})
+
+describe('health.dacMonitor', () => {
+  it('returns not_initialized when monitor is null', async () => {
+    sharedClientMock.getDacMonitorIfRunning.mockReturnValue(null)
+    const result = await caller.dacMonitor({})
+    expect(result).toEqual({ status: 'not_initialized', podVersion: null, gesturesSupported: false })
+  })
+
+  it('returns monitor status + gestures flag when running', async () => {
+    sharedClientMock.getDacMonitorIfRunning.mockReturnValue({
+      getStatus: () => 'running',
+      getLastStatus: () => ({ podVersion: 'I00', gestures: { doubleTap: { l: 1, r: 0 } } }),
+    })
+
+    const result = await caller.dacMonitor({})
+    expect(result.status).toBe('running')
+    expect(result.podVersion).toBe('I00')
+    expect(result.gesturesSupported).toBe(true)
+  })
+})
+
+describe('health.hardware', () => {
+  it('returns ok with measured latency when connect resolves', async () => {
+    const result = await caller.hardware({})
+    expect(result.status).toBe('ok')
+    expect(typeof result.latencyMs).toBe('number')
+    expect(result.error).toBeUndefined()
+  })
+
+  it('returns degraded with error message when connect fails', async () => {
+    sharedClientMock.client.connect.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const result = await caller.hardware({})
+    expect(result.status).toBe('degraded')
+    expect(result.error).toBe('ECONNREFUSED')
+  })
+})

--- a/src/server/routers/tests/homekit.test.ts
+++ b/src/server/routers/tests/homekit.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the HomeKit router — buildStatus shape, setEnabled lifecycle
+ * (DB persists after enable/disable, rollback on persist failure),
+ * unpair/regenerate passthrough, and seedProbe legacy detection.
+ *
+ * The homekit module + storage probes + qrcode + db are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const homekitMock = vi.hoisted(() => ({
+  enable: vi.fn(),
+  disable: vi.fn(),
+  regeneratePairing: vi.fn(),
+  status: vi.fn(),
+  unpair: vi.fn(),
+}))
+
+const storageMock = vi.hoisted(() => ({
+  probeSeedSources: vi.fn(),
+  readIdentityIfPresent: vi.fn(),
+}))
+
+const qrcodeMock = vi.hoisted(() => ({
+  toDataURL: vi.fn(async () => 'data:image/png;base64,FAKE'),
+}))
+
+// db.select chain returns a row with homekitEnabled. db.update chain swallows
+// the set/where pair.
+const dbMock = vi.hoisted(() => {
+  const selectRow: { homekitEnabled: boolean } = { homekitEnabled: false }
+  const limit = vi.fn(async () => [selectRow])
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+
+  const setSpy = vi.fn<(updates: Record<string, unknown>) => { where: ReturnType<typeof vi.fn> }>(
+    () => ({ where: vi.fn(async () => undefined) }),
+  )
+  const update = vi.fn(() => ({ set: setSpy }))
+
+  return { select, update, setSpy, selectRow, limit, where, from }
+})
+
+vi.mock('@/src/homekit', () => homekitMock)
+vi.mock('@/src/homekit/storage', () => storageMock)
+vi.mock('qrcode', () => ({ default: qrcodeMock }))
+
+vi.mock('@/src/db', () => ({
+  db: { select: dbMock.select, update: dbMock.update },
+  biometricsDb: {},
+}))
+
+const { homekitRouter } = await import('@/src/server/routers/homekit')
+const caller = homekitRouter.createCaller({})
+
+beforeEach(() => {
+  homekitMock.enable.mockReset().mockResolvedValue(undefined)
+  homekitMock.disable.mockReset().mockResolvedValue(undefined)
+  homekitMock.regeneratePairing.mockReset().mockResolvedValue(undefined)
+  homekitMock.unpair.mockReset().mockResolvedValue(undefined)
+  homekitMock.status.mockReset().mockReturnValue({
+    running: false,
+    pincode: null,
+    setupId: null,
+    setupURI: null,
+    pairedControllers: [],
+  })
+  storageMock.probeSeedSources.mockReset()
+  storageMock.readIdentityIfPresent.mockReset()
+  qrcodeMock.toDataURL.mockClear().mockResolvedValue('data:image/png;base64,FAKE')
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.setSpy.mockClear()
+  dbMock.selectRow.homekitEnabled = false
+})
+
+describe('homekit.getStatus', () => {
+  it('returns flat status with qrDataUrl=null when setupURI is null', async () => {
+    dbMock.selectRow.homekitEnabled = false
+    homekitMock.status.mockReturnValue({
+      running: false,
+      pincode: null,
+      setupId: null,
+      setupURI: null,
+      pairedControllers: [],
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(result).toEqual({
+      enabled: false,
+      running: false,
+      pincode: null,
+      setupId: null,
+      setupURI: null,
+      qrDataUrl: null,
+      pairedControllers: [],
+    })
+    expect(qrcodeMock.toDataURL).not.toHaveBeenCalled()
+  })
+
+  it('encodes setupURI as a QR data URL when present and reflects DB enabled flag', async () => {
+    dbMock.selectRow.homekitEnabled = true
+    homekitMock.status.mockReturnValue({
+      running: true,
+      pincode: '111-22-333',
+      setupId: 'XYZ1',
+      setupURI: 'X-HM://0024K0R3F',
+      pairedControllers: ['controllerA'],
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(result.enabled).toBe(true)
+    expect(result.running).toBe(true)
+    expect(result.pincode).toBe('111-22-333')
+    expect(result.qrDataUrl).toBe('data:image/png;base64,FAKE')
+    expect(qrcodeMock.toDataURL).toHaveBeenCalledWith(
+      'X-HM://0024K0R3F',
+      { errorCorrectionLevel: 'Q', margin: 1 },
+    )
+    expect(result.pairedControllers).toEqual(['controllerA'])
+  })
+})
+
+describe('homekit.setEnabled', () => {
+  it('enables HomeKit then persists the flag', async () => {
+    await caller.setEnabled({ enabled: true })
+
+    expect(homekitMock.enable).toHaveBeenCalledTimes(1)
+    expect(homekitMock.disable).not.toHaveBeenCalled()
+    // Update should set homekitEnabled=true
+    expect(dbMock.setSpy).toHaveBeenCalled()
+    const setUpdates = dbMock.setSpy.mock.calls.at(-1)?.[0]
+    expect(setUpdates).toMatchObject({ homekitEnabled: true })
+    expect(setUpdates?.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('disables HomeKit then persists the flag', async () => {
+    dbMock.selectRow.homekitEnabled = true
+
+    await caller.setEnabled({ enabled: false })
+
+    expect(homekitMock.disable).toHaveBeenCalledTimes(1)
+    expect(homekitMock.enable).not.toHaveBeenCalled()
+    const setUpdates = dbMock.setSpy.mock.calls.at(-1)?.[0]
+    expect(setUpdates).toMatchObject({ homekitEnabled: false })
+  })
+
+  it('reverts the lifecycle when the DB persist fails (was disabled → enable rollback to disable)', async () => {
+    // Prior state was disabled. Caller is enabling; persist throws; router
+    // should call disableHomeKit again to roll back the runtime state.
+    dbMock.selectRow.homekitEnabled = false
+    dbMock.setSpy.mockReturnValueOnce({
+      where: vi.fn(async () => { throw new Error('disk full') }),
+    })
+
+    await expect(caller.setEnabled({ enabled: true })).rejects.toThrow(/Failed to toggle HomeKit/)
+
+    expect(homekitMock.enable).toHaveBeenCalledTimes(1)
+    // Rollback: prior wasEnabled=false → disable() runs again
+    expect(homekitMock.disable).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps lifecycle errors as INTERNAL_SERVER_ERROR', async () => {
+    homekitMock.enable.mockRejectedValueOnce(new Error('mDNS failure'))
+
+    await expect(caller.setEnabled({ enabled: true })).rejects.toThrow(/Failed to toggle HomeKit: mDNS failure/)
+  })
+})
+
+describe('homekit.unpair / regenerate', () => {
+  it('unpair calls homekit.unpair() and returns status', async () => {
+    const result = await caller.unpair({})
+    expect(homekitMock.unpair).toHaveBeenCalledTimes(1)
+    expect(result.enabled).toBe(false)
+  })
+
+  it('regenerate calls homekit.regeneratePairing() and returns status', async () => {
+    const result = await caller.regenerate({})
+    expect(homekitMock.regeneratePairing).toHaveBeenCalledTimes(1)
+    expect(result.enabled).toBe(false)
+  })
+})
+
+describe('homekit.seedProbe', () => {
+  it('passes through resolved + sources and reports identity present and non-legacy', async () => {
+    storageMock.probeSeedSources.mockReturnValue({
+      resolved: 'machineId',
+      sources: [
+        { source: 'machineId', path: '/etc/machine-id', present: true, readable: true, looksDegenerate: false },
+        { source: 'serial', path: null, present: false, readable: false, looksDegenerate: false },
+      ],
+    })
+    storageMock.readIdentityIfPresent.mockReturnValue({
+      derivedFrom: 'machineId',
+      rotation: 1,
+      derivedAt: 1700000000,
+    })
+
+    const result = await caller.seedProbe({})
+
+    expect(result.resolved).toBe('machineId')
+    expect(result.sources).toHaveLength(2)
+    expect(result.identity).toEqual({
+      derivedFrom: 'machineId',
+      rotation: 1,
+      derivedAt: 1700000000,
+      legacy: false,
+    })
+  })
+
+  it('returns null identity fields when no identity file is present', async () => {
+    storageMock.probeSeedSources.mockReturnValue({
+      resolved: 'random',
+      sources: [],
+    })
+    storageMock.readIdentityIfPresent.mockReturnValue(null)
+
+    const result = await caller.seedProbe({})
+
+    expect(result.identity).toEqual({
+      derivedFrom: null,
+      rotation: null,
+      derivedAt: null,
+      legacy: false,
+    })
+  })
+
+  it('marks identity legacy when derivedFrom is missing on the file', async () => {
+    storageMock.probeSeedSources.mockReturnValue({ resolved: 'machineId', sources: [] })
+    // Legacy identity files predate ADR 0020 — derivedFrom undefined.
+    storageMock.readIdentityIfPresent.mockReturnValue({})
+
+    const result = await caller.seedProbe({})
+
+    expect(result.identity.legacy).toBe(true)
+    expect(result.identity.derivedFrom).toBe(null)
+    expect(result.identity.rotation).toBe(null)
+  })
+})

--- a/src/server/routers/tests/raw.test.ts
+++ b/src/server/routers/tests/raw.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the raw router — files filters/sorts safely-named .RAW entries,
+ * deleteFile rejects bad filenames, symlinks, and the active/newest file,
+ * diskUsage falls back gracefully when df is unavailable.
+ *
+ * fs/promises and child_process.execFile are fully mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMock = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  lstat: vi.fn(),
+  realpath: vi.fn(),
+  unlink: vi.fn(),
+}))
+
+const execMock = vi.hoisted(() => ({
+  execFile: vi.fn((_file: string, _args: string[], _opts: unknown, cb: (err: unknown, out: { stdout: string }) => void) => {
+    // default: succeed with empty df output
+    cb(null, { stdout: '' })
+  }),
+}))
+
+vi.mock('node:fs/promises', () => ({ ...fsMock, default: fsMock }))
+vi.mock('node:child_process', () => ({ execFile: execMock.execFile, default: { execFile: execMock.execFile } }))
+
+const { rawRouter, listRawFiles } = await import('@/src/server/routers/raw')
+const caller = rawRouter.createCaller({})
+
+beforeEach(() => {
+  fsMock.readdir.mockReset()
+  fsMock.stat.mockReset()
+  fsMock.lstat.mockReset()
+  fsMock.realpath.mockReset()
+  fsMock.unlink.mockReset()
+  execMock.execFile.mockReset()
+  execMock.execFile.mockImplementation((_f, _a, _o, cb) => cb(null, { stdout: '' }))
+})
+
+describe('listRawFiles helper', () => {
+  it('filters non-RAW files and sorts newest first', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW', 'README.txt', 'evil/../escape.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      if (name === 'a.RAW') return { size: 100, mtime: new Date('2025-01-01') } as never
+      return { size: 200, mtime: new Date('2025-02-01') } as never
+    })
+
+    const out = await listRawFiles()
+    // README.txt drops; the path-traversing entry doesn't match SAFE_FILENAME
+    expect(out.map(f => f.name)).toEqual(['b.RAW', 'a.RAW'])
+    expect(out[0].sizeBytes).toBe(200)
+  })
+
+  it('returns [] on ENOENT', async () => {
+    const err = Object.assign(new Error('no dir'), { code: 'ENOENT' })
+    fsMock.readdir.mockRejectedValue(err)
+
+    const out = await listRawFiles()
+    expect(out).toEqual([])
+  })
+
+  it('rethrows non-ENOENT errors', async () => {
+    fsMock.readdir.mockRejectedValue(new Error('permission denied'))
+    await expect(listRawFiles()).rejects.toThrow(/permission denied/)
+  })
+})
+
+describe('raw.files', () => {
+  it('passes through listRawFiles output', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW'] as never)
+    fsMock.stat.mockResolvedValue({ size: 50, mtime: new Date('2025-01-01') } as never)
+
+    const out = await caller.files({})
+    expect(out).toHaveLength(1)
+    expect(out[0].name).toBe('a.RAW')
+  })
+
+  it('wraps unexpected errors', async () => {
+    fsMock.readdir.mockRejectedValue(new Error('disk dead'))
+    await expect(caller.files({})).rejects.toThrow(/Failed to list RAW files/)
+  })
+})
+
+describe('raw.deleteFile', () => {
+  it('rejects path-traversal-style names BEFORE touching fs', async () => {
+    await expect(caller.deleteFile({ filename: '../escape.RAW' })).rejects.toThrow(/Invalid filename/)
+    expect(fsMock.lstat).not.toHaveBeenCalled()
+  })
+
+  it('rejects names without a .RAW suffix', async () => {
+    await expect(caller.deleteFile({ filename: 'random.txt' })).rejects.toThrow(/Invalid filename/)
+  })
+
+  it('rejects symlinks', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => true } as never)
+    await expect(caller.deleteFile({ filename: 'a.RAW' })).rejects.toThrow(/Path traversal detected/)
+  })
+
+  it('rejects when canonical path escapes RAW_DIR', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      // canonical of file lands outside canonical of dir
+      if (String(p).endsWith('a.RAW')) return '/elsewhere/a.RAW'
+      return '/persistent'
+    })
+    await expect(caller.deleteFile({ filename: 'a.RAW' })).rejects.toThrow(/Path traversal detected/)
+  })
+
+  it('refuses to delete the active (newest) file', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith('a.RAW')) return '/persistent/a.RAW'
+      return '/persistent'
+    })
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      // a.RAW is the newest (highest mtime ISO)
+      return { size: 1, mtime: name === 'a.RAW' ? new Date('2025-02-01') : new Date('2025-01-01') } as never
+    })
+
+    const result = await caller.deleteFile({ filename: 'a.RAW' })
+    expect(result).toEqual({ deleted: false, message: 'Cannot delete the active (newest) RAW file' })
+    expect(fsMock.unlink).not.toHaveBeenCalled()
+  })
+
+  it('returns "File not found" on ENOENT during the lstat probe', async () => {
+    const err = Object.assign(new Error('no'), { code: 'ENOENT' })
+    fsMock.lstat.mockRejectedValue(err)
+
+    const result = await caller.deleteFile({ filename: 'a.RAW' })
+    expect(result).toEqual({ deleted: false, message: 'File not found' })
+  })
+
+  it('deletes a non-active file', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith('b.RAW')) return '/persistent/b.RAW'
+      return '/persistent'
+    })
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      return { size: 1, mtime: name === 'a.RAW' ? new Date('2025-02-01') : new Date('2025-01-01') } as never
+    })
+    fsMock.unlink.mockResolvedValue(undefined as never)
+
+    const result = await caller.deleteFile({ filename: 'b.RAW' })
+    expect(result).toEqual({ deleted: true, message: 'Deleted b.RAW' })
+    expect(fsMock.unlink).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('raw.diskUsage', () => {
+  it('parses df output when available and aggregates raw bytes', async () => {
+    fsMock.readdir.mockResolvedValue(['a.RAW'] as never)
+    fsMock.stat.mockResolvedValue({ size: 1234, mtime: new Date(0) } as never)
+    execMock.execFile.mockImplementation((_f, _a, _o, cb) => {
+      cb(null, { stdout: 'Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/sda1 1000 200 800 20% /persistent\n' })
+    })
+
+    const result = await caller.diskUsage({})
+    expect(result.totalBytes).toBe(1000)
+    expect(result.usedBytes).toBe(200)
+    expect(result.availableBytes).toBe(800)
+    expect(result.rawFileCount).toBe(1)
+    expect(result.rawBytes).toBe(1234)
+  })
+
+  it('falls back to zero df totals when df is unavailable', async () => {
+    fsMock.readdir.mockResolvedValue([] as never)
+    execMock.execFile.mockImplementation((_f, _a, _o, cb) => cb(new Error('df: command not found'), { stdout: '' }))
+
+    const result = await caller.diskUsage({})
+    expect(result.totalBytes).toBe(0)
+    expect(result.rawFileCount).toBe(0)
+  })
+})

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the runOnce router — start (validates duration cap, primes hardware
+ * BEFORE inserting session, schedules remaining set points), getActive (parses
+ * setPoints JSON or returns empty on malformed), cancel.
+ *
+ * Db (better-sqlite3 chain), scheduler, hardware client, broadcaster, and
+ * timezone resolver all mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const jobManagerMock = vi.hoisted(() => ({
+  cancelRunOnceSession: vi.fn(),
+  scheduleRunOnceSession: vi.fn(),
+}))
+
+const schedulerMock = vi.hoisted(() => ({
+  getJobManager: vi.fn(async () => jobManagerMock),
+}))
+
+const helpersMock = vi.hoisted(() => ({
+  withHardwareClient: vi.fn(async (cb: (client: unknown) => Promise<unknown>) => {
+    const client = {
+      setPower: vi.fn(async () => undefined),
+    }
+    return cb(client)
+  }),
+}))
+
+const broadcastMock = vi.hoisted(() => ({
+  broadcastMutationStatus: vi.fn(),
+}))
+
+const timeUtilsMock = vi.hoisted(() => ({
+  // Default: wake time 1 hour from now
+  timeToDate: vi.fn((_t: string, _tz: string, now: Date) => new Date(now.getTime() + 60 * 60 * 1000)),
+}))
+
+// DB mock with branchable behaviours per test. The router uses three patterns:
+//   1. db.transaction(tx => …) where tx exposes select/update with .all()/.run()
+//   2. db.select().from().limit() (await-thenable returning a deviceSettings row)
+//   3. db.insert().values().returning() (await-thenable returning [{ id }])
+//   4. db.update().set().where() (await-thenable, used by cancel)
+const dbMock = vi.hoisted(() => {
+  // settings select chain — used to fetch timezone
+  const settingsRow: { timezone: string | null } = { timezone: 'America/Los_Angeles' }
+  const limit = vi.fn(async () => [settingsRow])
+  const from = vi.fn(() => ({ limit }))
+  const select = vi.fn(() => ({ from }))
+
+  // insert chain — returns [{ id }] from .returning()
+  let nextInsertedId = 42
+  const returning = vi.fn(async () => [{ id: nextInsertedId }])
+  const values = vi.fn(() => ({ returning }))
+  const insert = vi.fn(() => ({ values }))
+
+  // update chain — cancel calls db.update(...).set(...).where(...)
+  const updateWhere = vi.fn(async () => undefined)
+  const updateSet = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set: updateSet }))
+
+  // transaction — synchronous, runs callback with a tx that exposes
+  // select/update with the chain ending in .all()/.run().
+  const txExisting: { id: number }[] = []
+  const txSelectAll = vi.fn(() => txExisting)
+  const txSelectWhere = vi.fn(() => ({ all: txSelectAll }))
+  const txSelectFrom = vi.fn(() => ({ where: txSelectWhere }))
+  const txSelect = vi.fn(() => ({ from: txSelectFrom }))
+  const txUpdateRun = vi.fn(() => undefined)
+  const txUpdateWhere = vi.fn(() => ({ run: txUpdateRun }))
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }))
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }))
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: txSelect,
+    update: txUpdate,
+  }))
+
+  return {
+    select, insert, update, transaction,
+    setNextInsertId: (id: number | null) => {
+      nextInsertedId = id as number
+      returning.mockResolvedValue(id === null ? [] : [{ id }])
+    },
+    settingsRow, txExisting,
+    txUpdateRun, transactionFn: transaction,
+  }
+})
+
+vi.mock('@/src/scheduler', () => schedulerMock)
+vi.mock('@/src/server/helpers', () => helpersMock)
+vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
+vi.mock('@/src/scheduler/timeUtils', () => timeUtilsMock)
+vi.mock('@/src/db', () => ({
+  db: {
+    select: dbMock.select,
+    insert: dbMock.insert,
+    update: dbMock.update,
+    transaction: dbMock.transaction,
+  },
+  biometricsDb: {},
+}))
+
+const { runOnceRouter } = await import('@/src/server/routers/runOnce')
+const caller = runOnceRouter.createCaller({})
+
+beforeEach(() => {
+  jobManagerMock.cancelRunOnceSession.mockReset()
+  jobManagerMock.scheduleRunOnceSession.mockReset()
+  helpersMock.withHardwareClient.mockClear()
+  broadcastMock.broadcastMutationStatus.mockReset()
+  timeUtilsMock.timeToDate.mockReset().mockImplementation(
+    (_t, _tz, now) => new Date(now.getTime() + 60 * 60 * 1000),
+  )
+  dbMock.select.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.update.mockClear()
+  dbMock.transactionFn.mockClear()
+  dbMock.txExisting.length = 0
+  dbMock.setNextInsertId(42)
+  dbMock.settingsRow.timezone = 'America/Los_Angeles'
+})
+
+describe('runOnce.start', () => {
+  it('powers on the side with the first set-point temperature, persists session, and schedules the rest', async () => {
+    const result = await caller.start({
+      side: 'left',
+      setPoints: [
+        { time: '23:00', temperature: 70 },
+        { time: '03:00', temperature: 65 },
+      ],
+      wakeTime: '07:00',
+    })
+
+    // Hardware was invoked with the first set-point temp
+    expect(helpersMock.withHardwareClient).toHaveBeenCalledTimes(1)
+
+    // Mutation broadcast for live UI
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', expect.objectContaining({
+      targetTemperature: 70,
+    }))
+
+    // Scheduler receives the *remaining* set points (slice 1) — the first
+    // already fired immediately.
+    expect(jobManagerMock.scheduleRunOnceSession).toHaveBeenCalledTimes(1)
+    const args = jobManagerMock.scheduleRunOnceSession.mock.calls[0]
+    expect(args[0]).toBe(42) // session id
+    expect(args[1]).toBe('left')
+    expect(args[2]).toEqual([{ time: '03:00', temperature: 65 }])
+    expect(args[3]).toBe('07:00')
+    expect(args[4]).toBe('America/Los_Angeles')
+
+    expect(result.sessionId).toBe(42)
+    expect(typeof result.expiresAt).toBe('number')
+  })
+
+  it('falls back to the default timezone when settings row is missing', async () => {
+    // No settings row found
+    dbMock.settingsRow.timezone = null as unknown as string
+    // Also exercise the empty-array path: replace from()→limit() with empty
+    const limit = vi.fn(async () => [])
+    const from = vi.fn(() => ({ limit }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    await caller.start({
+      side: 'right',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })
+
+    const args = jobManagerMock.scheduleRunOnceSession.mock.calls[0]
+    expect(args[4]).toBe('America/Los_Angeles')
+  })
+
+  it('rejects sessions longer than 14 hours (catches wake-time-already-passed bug)', async () => {
+    timeUtilsMock.timeToDate.mockImplementation(
+      (_t, _tz, now) => new Date(now.getTime() + 20 * 60 * 60 * 1000),
+    )
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Session too long/)
+
+    // Hardware must NOT be touched if validation rejects
+    expect(helpersMock.withHardwareClient).not.toHaveBeenCalled()
+    expect(jobManagerMock.scheduleRunOnceSession).not.toHaveBeenCalled()
+  })
+
+  it('throws when DB insert returns no row (e.g. constraint violation)', async () => {
+    dbMock.setNextInsertId(null)
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Failed to create run-once session/)
+  })
+
+  it('cancels any prior active session for the same side before starting', async () => {
+    // Pretend an existing active row exists for this side
+    dbMock.txExisting.push({ id: 7 }, { id: 9 })
+
+    await caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })
+
+    // Both prior rows were updated to cancelled (one .run() per row)
+    expect(dbMock.txUpdateRun).toHaveBeenCalledTimes(2)
+    expect(jobManagerMock.cancelRunOnceSession).toHaveBeenCalledWith('left')
+  })
+})
+
+describe('runOnce.getActive', () => {
+  it('returns null when no active session', async () => {
+    const limit = vi.fn(async () => [])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result).toBeNull()
+  })
+
+  it('parses persisted setPoints JSON', async () => {
+    const session = {
+      id: 99,
+      side: 'left' as const,
+      setPoints: JSON.stringify([{ time: '02:00', temperature: 67 }]),
+      wakeTime: '07:00',
+      startedAt: new Date(1700000000000),
+      expiresAt: new Date(1700100000000),
+      status: 'active' as const,
+    }
+    const limit = vi.fn(async () => [session])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(99)
+    expect(result?.setPoints).toEqual([{ time: '02:00', temperature: 67 }])
+    expect(result?.startedAt).toBe(Math.floor(1700000000000 / 1000))
+  })
+
+  it('returns empty setPoints when persisted JSON is malformed', async () => {
+    const session = {
+      id: 100,
+      side: 'left' as const,
+      setPoints: '{not json',
+      wakeTime: '07:00',
+      startedAt: new Date(),
+      expiresAt: new Date(Date.now() + 1000),
+      status: 'active' as const,
+    }
+    const limit = vi.fn(async () => [session])
+    const where = vi.fn(() => ({ limit }))
+    const from = vi.fn(() => ({ where }))
+    dbMock.select.mockReturnValueOnce({ from } as never)
+
+    const result = await caller.getActive({ side: 'left' })
+    expect(result?.setPoints).toEqual([])
+  })
+})
+
+describe('runOnce.cancel', () => {
+  it('marks active session cancelled, cancels scheduler jobs, broadcasts', async () => {
+    const result = await caller.cancel({ side: 'right' })
+
+    expect(dbMock.update).toHaveBeenCalledTimes(1)
+    expect(jobManagerMock.cancelRunOnceSession).toHaveBeenCalledWith('right')
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('right')
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/src/server/routers/tests/settings.test.ts
+++ b/src/server/routers/tests/settings.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for the settings router — getAll merges defaults, updateDevice
+ * persists + reloads scheduler + mirrors homekit lifecycle, updateSide
+ * rejects mutually-exclusive flags + validates away window, setAlwaysOn
+ * starts/stops keepalive, gesture CRUD.
+ *
+ * The DB transaction(cb) pattern is mocked synchronously: tx exposes
+ * select/update/insert/delete chains terminating in .all() which returns
+ * whatever each test queues into `txRows`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const schedulerMock = vi.hoisted(() => {
+  const jm = {
+    updateTimezone: vi.fn(async () => undefined),
+    reloadSchedules: vi.fn(async () => undefined),
+  }
+  return { getJobManager: vi.fn(async () => jm), jm }
+})
+
+const keepaliveMock = vi.hoisted(() => ({
+  startKeepalive: vi.fn(),
+  stopKeepalive: vi.fn(),
+}))
+
+const autoOffMock = vi.hoisted(() => ({
+  restartAutoOffTimers: vi.fn(),
+}))
+
+const homekitMock = vi.hoisted(() => ({
+  enable: vi.fn(async () => undefined),
+  disable: vi.fn(async () => undefined),
+}))
+
+// DB mock — supports both top-level db.select(…) chain (used by getAll +
+// updateDevice prior-row read) AND the transaction wrapper (which receives
+// a tx with .select / .update / .insert / .delete chains terminating in .all()).
+const dbState = vi.hoisted(() => ({
+  // Sequential queue for top-level db.select() chains
+  topRowsQueue: [] as unknown[][],
+  // Sequential queue for tx-scoped chains
+  txRowsQueue: [] as unknown[][],
+  // Sequential queue for db.update().set().where() awaitable result (lifecycle revert path)
+  topUpdateQueue: [] as Array<unknown>,
+  popTop(): unknown[] { return dbState.topRowsQueue.shift() ?? [] },
+  popTx(): unknown[] { return dbState.txRowsQueue.shift() ?? [] },
+}))
+
+const dbMock = vi.hoisted(() => {
+  // Top-level chain (await thenable)
+  const makeTopChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.popTop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    return chain
+  }
+
+  // Tx-scoped chain (sync — terminates in .all())
+  const makeTxChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.where = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    chain.all = vi.fn(() => dbState.popTx())
+    chain.run = vi.fn(() => undefined)
+    return chain
+  }
+
+  const select = vi.fn(() => makeTopChain())
+  const update = vi.fn(() => makeTopChain())
+  const transaction = vi.fn((cb: (tx: unknown) => unknown) => cb({
+    select: vi.fn(() => makeTxChain()),
+    update: vi.fn(() => makeTxChain()),
+    insert: vi.fn(() => makeTxChain()),
+    delete: vi.fn(() => makeTxChain()),
+  }))
+
+  return { select, update, transaction }
+})
+
+vi.mock('@/src/scheduler', () => ({ getJobManager: schedulerMock.getJobManager }))
+vi.mock('@/src/services/temperatureKeepalive', () => keepaliveMock)
+vi.mock('@/src/services/autoOffWatcher', () => autoOffMock)
+vi.mock('@/src/homekit', () => homekitMock)
+vi.mock('@/src/db', () => ({
+  db: { select: dbMock.select, update: dbMock.update, transaction: dbMock.transaction },
+  biometricsDb: {},
+}))
+
+const { settingsRouter } = await import('@/src/server/routers/settings')
+const caller = settingsRouter.createCaller({})
+
+beforeEach(() => {
+  schedulerMock.getJobManager.mockClear()
+  schedulerMock.jm.updateTimezone.mockReset().mockResolvedValue(undefined)
+  schedulerMock.jm.reloadSchedules.mockReset().mockResolvedValue(undefined)
+  keepaliveMock.startKeepalive.mockReset()
+  keepaliveMock.stopKeepalive.mockReset()
+  autoOffMock.restartAutoOffTimers.mockReset()
+  homekitMock.enable.mockReset().mockResolvedValue(undefined)
+  homekitMock.disable.mockReset().mockResolvedValue(undefined)
+  dbState.topRowsQueue.length = 0
+  dbState.txRowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.transaction.mockClear()
+})
+
+describe('settings.getAll', () => {
+  it('returns existing rows for device, sides, and gestures', async () => {
+    const device = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const sides = [
+      { side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+      { side: 'right', name: 'R', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+    ]
+    const gestures: unknown[] = []
+    dbState.topRowsQueue.push([device], sides, gestures)
+
+    const result = await caller.getAll({})
+    expect(result.device.timezone).toBe('UTC')
+    expect(result.sides.left.name).toBe('L')
+    expect(result.sides.right.name).toBe('R')
+    expect(result.gestures.left).toEqual([])
+  })
+
+  it('returns synthetic defaults when device row is missing', async () => {
+    dbState.topRowsQueue.push([], [], [])
+    const result = await caller.getAll({})
+    expect(result.device.timezone).toBe('America/Los_Angeles')
+    expect(result.sides.left.side).toBe('left')
+    expect(result.sides.right.side).toBe('right')
+  })
+})
+
+describe('settings.updateDevice', () => {
+  it('updates timezone and triggers updateTimezone reload', async () => {
+    // For 'homekitEnabled' check: not present, so no prior-row select.
+    // Tx: select(current) returns 1 row, update().returning().all() returns updated row.
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, timezone: 'America/New_York', updatedAt: new Date(1) }
+    dbState.txRowsQueue.push([current], [updated])
+
+    const result = await caller.updateDevice({ timezone: 'America/New_York' })
+    expect(result.timezone).toBe('America/New_York')
+    expect(schedulerMock.jm.updateTimezone).toHaveBeenCalledWith('America/New_York')
+    expect(schedulerMock.jm.reloadSchedules).not.toHaveBeenCalled()
+  })
+
+  it('triggers reloadSchedules for non-timezone scheduling fields', async () => {
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: '03:00',
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, primePodDaily: true, primePodTime: '15:00' }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateDevice({ primePodDaily: true, primePodTime: '15:00' })
+    expect(schedulerMock.jm.reloadSchedules).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects rebootDaily=true without a rebootTime', async () => {
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: null,
+      primePodDaily: false, primePodTime: '14:00',
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateDevice({ rebootDaily: true })).rejects.toThrow(/rebootTime is required/)
+  })
+
+  it('mirrors homekit.enable() and rolls back DB on lifecycle failure', async () => {
+    // Top-level select for prior homekitEnabled
+    dbState.topRowsQueue.push([{ homekitEnabled: false }])
+    // Top-level update().set().where() for revert (await thenable resolves to anything)
+
+    const current = {
+      id: 1, timezone: 'UTC', temperatureUnit: 'F',
+      rebootDaily: false, rebootTime: null,
+      primePodDaily: false, primePodTime: null,
+      ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+      ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+      globalMaxOnHours: null, homekitEnabled: false,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, homekitEnabled: true }
+    dbState.txRowsQueue.push([current], [updated])
+
+    homekitMock.enable.mockRejectedValue(new Error('mDNS failed'))
+
+    await expect(caller.updateDevice({ homekitEnabled: true })).rejects.toThrow(/mDNS failed/)
+    // Revert should have been attempted (db.update was called)
+    expect(dbMock.update).toHaveBeenCalled()
+  })
+})
+
+describe('settings.updateSide', () => {
+  it('rejects alwaysOn + autoOffEnabled set true together', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateSide({ side: 'left', autoOffEnabled: true })).rejects.toThrow(/mutually exclusive/)
+  })
+
+  it('rejects awayReturn earlier than awayStart', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: '2025-01-10T00:00:00Z', awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([current])
+
+    await expect(caller.updateSide({
+      side: 'left',
+      awayReturn: '2025-01-01T00:00:00Z',
+    })).rejects.toThrow(/awayReturn must not be before awayStart/)
+  })
+
+  it('starts keepalive when alwaysOn=true', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, alwaysOn: true }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateSide({ side: 'left', alwaysOn: true })
+    expect(keepaliveMock.startKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('stops keepalive when alwaysOn=false', async () => {
+    const current = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    const updated = { ...current, alwaysOn: false }
+    dbState.txRowsQueue.push([current], [updated])
+
+    await caller.updateSide({ side: 'left', alwaysOn: false })
+    expect(keepaliveMock.stopKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('throws NOT_FOUND when no row exists', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.updateSide({ side: 'left', name: 'New' })).rejects.toThrow(/Side settings for left not found/)
+  })
+})
+
+describe('settings.setAlwaysOn', () => {
+  it('starts keepalive when alwaysOn=true', async () => {
+    const updated = {
+      side: 'left', name: 'L', awayMode: false, alwaysOn: true, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+
+    await caller.setAlwaysOn({ side: 'left', alwaysOn: true })
+    expect(keepaliveMock.startKeepalive).toHaveBeenCalledWith('left')
+  })
+
+  it('stops keepalive when alwaysOn=false', async () => {
+    const updated = {
+      side: 'right', name: 'R', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30,
+      awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([updated])
+
+    await caller.setAlwaysOn({ side: 'right', alwaysOn: false })
+    expect(keepaliveMock.stopKeepalive).toHaveBeenCalledWith('right')
+  })
+
+  it('throws NOT_FOUND when row missing', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.setAlwaysOn({ side: 'left', alwaysOn: true })).rejects.toThrow(/Side settings for left not found/)
+  })
+})
+
+describe('settings.setGesture / deleteGesture', () => {
+  it('creates a temperature gesture when none exists', async () => {
+    // tx.select existing → empty; tx.insert.values.returning.all → [created]
+    const created = {
+      id: 1, side: 'left', tapType: 'doubleTap', actionType: 'temperature',
+      temperatureChange: 'increment', temperatureAmount: 2,
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([], [created])
+
+    const out = await caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'temperature',
+      temperatureChange: 'increment',
+      temperatureAmount: 2,
+    })
+    expect(out.id).toBe(1)
+  })
+
+  it('updates an alarm gesture when one already exists', async () => {
+    const existing = { id: 5, side: 'left', tapType: 'doubleTap' }
+    const updated = {
+      id: 5, side: 'left', tapType: 'doubleTap', actionType: 'alarm',
+      alarmBehavior: 'snooze',
+      createdAt: new Date(0), updatedAt: new Date(0),
+    }
+    dbState.txRowsQueue.push([existing], [updated])
+
+    const out = await caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'alarm',
+      alarmBehavior: 'snooze',
+    })
+    expect(out.id).toBe(5)
+  })
+
+  it('deleteGesture throws NOT_FOUND when no row deleted', async () => {
+    dbState.txRowsQueue.push([])
+    await expect(caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })).rejects.toThrow(/not found/)
+  })
+
+  it('deleteGesture returns success when a row was deleted', async () => {
+    dbState.txRowsQueue.push([{ id: 1 }])
+    const out = await caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })
+    expect(out).toEqual({ success: true })
+  })
+})

--- a/src/server/routers/tests/system.test.ts
+++ b/src/server/routers/tests/system.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the system router — internetStatus, setInternetAccess (block/
+ * unblock + lock + error wrap), wifiStatus parsing, triggerUpdate spawn,
+ * getLogSources active flag, getLogs newest-first reversal + ENOENT fallback,
+ * getDiskUsage parse + dev fallback, getStorageBreakdown nullable mounts,
+ * getVersion git-info parse + fallback.
+ *
+ * child_process.execFile + spawn, fs/promises, and node:fs are mocked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execMock = vi.hoisted(() => ({
+  execFile: vi.fn((..._args: unknown[]) => {
+    const cb = _args[_args.length - 1] as (e: unknown, o: { stdout: string }) => void
+    cb(null, { stdout: '' })
+  }),
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    unref: vi.fn(),
+  })),
+}))
+
+const fsPromisesMock = vi.hoisted(() => ({
+  readdir: vi.fn(async () => []),
+  readFile: vi.fn(async () => ''),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+}))
+
+const fsSyncMock = vi.hoisted(() => ({
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execMock.execFile,
+  spawn: execMock.spawn,
+  default: { execFile: execMock.execFile, spawn: execMock.spawn },
+}))
+vi.mock('node:fs/promises', () => ({ ...fsPromisesMock, default: fsPromisesMock }))
+vi.mock('node:fs', () => ({ ...fsSyncMock, default: fsSyncMock }))
+
+const { systemRouter } = await import('@/src/server/routers/system')
+const caller = systemRouter.createCaller({})
+
+beforeEach(() => {
+  execMock.execFile.mockReset()
+  execMock.execFile.mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+    cb(null, { stdout: '' })
+  })
+  execMock.spawn.mockReset().mockReturnValue({ on: vi.fn(), unref: vi.fn() } as never)
+  fsPromisesMock.readdir.mockReset().mockResolvedValue([])
+  fsPromisesMock.readFile.mockReset().mockResolvedValue('')
+  fsPromisesMock.writeFile.mockReset().mockResolvedValue(undefined)
+  fsPromisesMock.mkdir.mockReset().mockResolvedValue(undefined)
+})
+
+// Helper: queue execFile responses by command-name match
+function queueExec(matcher: (file: string, args: string[]) => boolean, response: { stdout?: string, error?: Error }) {
+  execMock.execFile.mockImplementationOnce((...allArgs: unknown[]) => {
+    const file = allArgs[0] as string
+    const args = (allArgs[1] as string[]) ?? []
+    const cb = allArgs[allArgs.length - 1] as (e: unknown, o: { stdout: string }) => void
+    if (matcher(file, args)) {
+      if (response.error) cb(response.error, { stdout: '' })
+      else cb(null, { stdout: response.stdout ?? '' })
+    }
+    else {
+      cb(null, { stdout: '' })
+    }
+  })
+}
+
+describe('system.internetStatus', () => {
+  it('returns blocked=true when iptables -L OUTPUT shows DROP', async () => {
+    queueExec(
+      (_file, args) => args.includes('-L') && args.includes('OUTPUT'),
+      { stdout: 'DROP all -- 0.0.0.0/0\n' },
+    )
+    const result = await caller.internetStatus({})
+    expect(result.blocked).toBe(true)
+  })
+
+  it('returns blocked=false on iptables error (dev environment)', async () => {
+    queueExec(() => true, { error: new Error('iptables: command not found') })
+    const result = await caller.internetStatus({})
+    expect(result.blocked).toBe(false)
+  })
+})
+
+describe('system.setInternetAccess', () => {
+  it('unblocks WAN by flushing rules and re-checks state', async () => {
+    // After unblock, isWanBlocked should return false (no DROP)
+    const result = await caller.setInternetAccess({ blocked: false })
+    expect(result.blocked).toBe(false)
+  })
+
+  it('wraps execFile failures as INTERNAL_SERVER_ERROR', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('iptables boom'), { stdout: '' })
+    })
+    await expect(caller.setInternetAccess({ blocked: false })).rejects.toThrow(/Failed to update iptables/)
+  })
+})
+
+describe('system.wifiStatus', () => {
+  it('returns connected=false when nmcli is unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('nmcli not found'), { stdout: '' })
+    })
+    const result = await caller.wifiStatus({})
+    expect(result).toEqual({ connected: false, ssid: null, signal: null })
+  })
+
+  it('parses nmcli output and returns SSID + signal', async () => {
+    queueExec(
+      file => file === 'nmcli',
+      { stdout: 'no:OtherNet:50\nyes:HomeWiFi:80\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result.connected).toBe(true)
+    expect(result.ssid).toBe('HomeWiFi')
+    expect(result.signal).toBe(80)
+  })
+
+  it('handles escaped colons in SSID', async () => {
+    queueExec(
+      file => file === 'nmcli',
+      { stdout: 'yes:My\\:Net:75\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result.ssid).toBe('My:Net')
+    expect(result.signal).toBe(75)
+  })
+})
+
+describe('system.triggerUpdate', () => {
+  it('spawns sp-update with the requested branch', async () => {
+    const result = await caller.triggerUpdate({ branch: 'feature/cool' })
+    expect(execMock.spawn).toHaveBeenCalledWith('sudo',
+      ['-n', '/usr/local/bin/sp-update', 'feature/cool'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    )
+    expect(result.triggered).toBe(true)
+    expect(result.branch).toBe('feature/cool')
+  })
+
+  it('defaults branch to "main" when omitted', async () => {
+    const result = await caller.triggerUpdate({})
+    expect(result.branch).toBe('main')
+    expect(execMock.spawn).toHaveBeenCalledWith('sudo',
+      ['-n', '/usr/local/bin/sp-update', 'main'],
+      expect.any(Object),
+    )
+  })
+
+  it('rejects branch names with invalid characters', async () => {
+    await expect(caller.triggerUpdate({ branch: 'evil; rm -rf /' })).rejects.toThrow(/Invalid branch name/)
+  })
+})
+
+describe('system.getLogSources', () => {
+  it('returns each unit with active=true when systemctl exits 0', async () => {
+    // All systemctl is-active calls succeed by default
+    const result = await caller.getLogSources({})
+    expect(result.sources).toHaveLength(4)
+    expect(result.sources.every(s => s.active)).toBe(true)
+  })
+
+  it('marks units inactive when systemctl errors', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('inactive'), { stdout: '' })
+    })
+    const result = await caller.getLogSources({})
+    expect(result.sources.every(s => !s.active)).toBe(true)
+  })
+})
+
+describe('system.getLogs', () => {
+  it('returns dev-friendly fallback when journalctl is missing', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      const err = Object.assign(new Error('not found'), { code: 'ENOENT' })
+      cb(err, { stdout: '' })
+    })
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 10 })
+    expect(result.lines[0]).toContain('not available')
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('reverses journalctl output to newest-first and exposes a cursor when more remain', async () => {
+    queueExec(
+      file => file === 'journalctl',
+      // 3 lines + cursor when only 2 requested → hasMore=true
+      { stdout: 'line1\nline2\nline3\n-- cursor: s=abc\n' },
+    )
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 2 })
+    expect(result.lines).toEqual(['line3', 'line2'])
+    expect(result.nextCursor).toBe('s=abc')
+  })
+
+  it('rejects unit names that do not match the sleepypod*.service pattern', async () => {
+    await expect(caller.getLogs({ unit: 'evil.service', lines: 10 })).rejects.toThrow(/Invalid unit name/)
+  })
+})
+
+describe('system.getDiskUsage', () => {
+  it('parses df totals when available', async () => {
+    queueExec(
+      (file, args) => file === 'df' && args.includes('/'),
+      { stdout: 'fs 1B-blocks Used Available Use% Mounted\n/dev 1000 200 800 20% /\n' },
+    )
+    const result = await caller.getDiskUsage({})
+    expect(result.totalBytes).toBe(1000)
+    expect(result.usedBytes).toBe(200)
+    expect(result.availableBytes).toBe(800)
+    expect(result.usedPercent).toBe(20)
+  })
+
+  it('returns zeros when df is unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('df not found'), { stdout: '' })
+    })
+    const result = await caller.getDiskUsage({})
+    expect(result).toEqual({ totalBytes: 0, usedBytes: 0, availableBytes: 0, usedPercent: 0 })
+  })
+})
+
+describe('system.getStorageBreakdown', () => {
+  it('returns zero sections when df + du are unavailable', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('not found'), { stdout: '' })
+    })
+    fsPromisesMock.readdir.mockResolvedValue([])
+
+    const result = await caller.getStorageBreakdown({})
+    expect(result.emmc.totalBytes).toBe(0)
+    expect(result.biometricsArchive).toEqual({ usedBytes: 0, fileCount: 0 })
+  })
+})
+
+describe('system.getVersion', () => {
+  it('parses .git-info when present', async () => {
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      branch: 'main',
+      commitHash: 'abc123',
+      commitTitle: 'fix: thing',
+      buildDate: '2026-04-01',
+    }))
+    const result = await caller.getVersion({})
+    expect(result).toEqual({
+      branch: 'main',
+      commitHash: 'abc123',
+      commitTitle: 'fix: thing',
+      buildDate: '2026-04-01',
+    })
+  })
+
+  it('returns "unknown" placeholders when .git-info is missing', async () => {
+    fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'))
+    const result = await caller.getVersion({})
+    expect(result).toEqual({
+      branch: 'unknown', commitHash: 'unknown',
+      commitTitle: 'unknown', buildDate: 'unknown',
+    })
+  })
+})

--- a/src/server/routers/tests/waterLevel.test.ts
+++ b/src/server/routers/tests/waterLevel.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the water-level router — happy path of every procedure plus the
+ * BAD_REQUEST date-range rejection (getHistory) and NOT_FOUND alert dismissal.
+ *
+ * biometricsDb is mocked with a thin chain that always terminates in an
+ * awaitable returning whatever the test queues into `nextRows`/`nextRow`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbState = vi.hoisted(() => ({
+  rowsQueue: [] as unknown[][],
+  pop(): unknown[] {
+    return dbState.rowsQueue.shift() ?? []
+  },
+}))
+
+const dbMock = vi.hoisted(() => {
+  // Each query terminates in either .limit() or .orderBy() depending on the
+  // procedure. Both must be awaitable AND chainable. Use a thenable so an
+  // awaiter consumes the row queue.
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.pop()).then(resolve)
+    chain.where = vi.fn(() => chain)
+    chain.orderBy = vi.fn(() => chain)
+    chain.limit = vi.fn(() => chain)
+    chain.groupBy = vi.fn(() => chain)
+    chain.from = vi.fn(() => chain)
+    chain.values = vi.fn(() => chain)
+    chain.set = vi.fn(() => chain)
+    chain.returning = vi.fn(() => chain)
+    return chain
+  }
+
+  const select = vi.fn(() => makeChain())
+  const update = vi.fn(() => makeChain())
+  const insert = vi.fn(() => makeChain())
+  const del = vi.fn(() => makeChain())
+
+  return { select, update, insert, delete: del }
+})
+
+vi.mock('@/src/db', () => ({
+  db: {},
+  biometricsDb: dbMock,
+}))
+
+const { waterLevelRouter } = await import('@/src/server/routers/waterLevel')
+const caller = waterLevelRouter.createCaller({})
+
+beforeEach(() => {
+  dbState.rowsQueue.length = 0
+  dbMock.select.mockClear()
+  dbMock.update.mockClear()
+  dbMock.insert.mockClear()
+  dbMock.delete.mockClear()
+})
+
+describe('waterLevel.getHistory', () => {
+  it('returns rows when no date range is supplied', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, timestamp: new Date(0), level: 'ok' },
+      { id: 2, timestamp: new Date(1000), level: 'low' },
+    ])
+
+    const result = await caller.getHistory({ limit: 100 })
+    expect(result).toHaveLength(2)
+    expect(result[0].level).toBe('ok')
+  })
+
+  it('rejects inverted startDate / endDate as BAD_REQUEST', async () => {
+    await expect(caller.getHistory({
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+      limit: 10,
+    })).rejects.toThrow(/startDate must be before or equal to endDate/)
+  })
+})
+
+describe('waterLevel.getLatest', () => {
+  it('returns the latest row', async () => {
+    dbState.rowsQueue.push([{ id: 7, timestamp: new Date(0), level: 'ok' }])
+    const result = await caller.getLatest({})
+    expect(result?.id).toBe(7)
+  })
+
+  it('returns null when no rows', async () => {
+    dbState.rowsQueue.push([])
+    const result = await caller.getLatest({})
+    expect(result).toBeNull()
+  })
+})
+
+describe('waterLevel.getTrend', () => {
+  it('returns unknown trend when fewer than 2 readings', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 1 },
+    ])
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('unknown')
+    expect(result.totalReadings).toBe(1)
+    expect(result.okPercent).toBe(100)
+  })
+
+  it('computes declining trend when recent low rate exceeds older by >0.2', async () => {
+    // Order matters — totals first, then recentLow, olderLow, recentTotal, olderTotal
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 50 },
+      { level: 'low', cnt: 50 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 40 }]) // recentLow
+    dbState.rowsQueue.push([{ cnt: 10 }]) // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }]) // recentTotal
+    dbState.rowsQueue.push([{ cnt: 50 }]) // olderTotal
+
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('declining')
+    expect(result.totalReadings).toBe(100)
+  })
+
+  it('computes rising trend when recent low rate is much lower than older', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 50 },
+      { level: 'low', cnt: 50 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 10 }]) // recentLow
+    dbState.rowsQueue.push([{ cnt: 40 }]) // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }])
+    dbState.rowsQueue.push([{ cnt: 50 }])
+
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('rising')
+  })
+})
+
+describe('waterLevel.getAlerts', () => {
+  it('returns active (undismissed) alerts', async () => {
+    dbState.rowsQueue.push([
+      {
+        id: 1, type: 'low_sustained', startedAt: new Date(0),
+        dismissedAt: null, message: 'low for 30m', createdAt: new Date(0),
+      },
+    ])
+    const result = await caller.getAlerts({})
+    expect(result).toHaveLength(1)
+    expect(result[0].dismissedAt).toBeNull()
+  })
+})
+
+describe('waterLevel.dismissAlert', () => {
+  it('marks an alert dismissed', async () => {
+    dbState.rowsQueue.push([
+      { id: 5, type: 'low_sustained', startedAt: new Date(0), dismissedAt: new Date(), message: null, createdAt: new Date(0) },
+    ])
+    const result = await caller.dismissAlert({ id: 5 })
+    expect(result).toEqual({ success: true })
+  })
+
+  it('throws NOT_FOUND when nothing was updated', async () => {
+    dbState.rowsQueue.push([])
+    await expect(caller.dismissAlert({ id: 999 })).rejects.toThrow(/Alert 999 not found/)
+  })
+})
+
+describe('waterLevel.getFlowReadings / getLatestFlowReading', () => {
+  it('returns flow rows for the requested window', async () => {
+    dbState.rowsQueue.push([
+      { id: 1, timestamp: new Date(0), leftFlowrateCd: 100, rightFlowrateCd: 110, leftPumpRpm: 1500, rightPumpRpm: 1600 },
+    ])
+    const result = await caller.getFlowReadings({ hours: 24 })
+    expect(result).toHaveLength(1)
+    expect(result[0].leftFlowrateCd).toBe(100)
+  })
+
+  it('getLatestFlowReading returns null when no rows', async () => {
+    dbState.rowsQueue.push([])
+    const result = await caller.getLatestFlowReading({})
+    expect(result).toBeNull()
+  })
+
+  it('getLatestFlowReading returns the row when one exists', async () => {
+    dbState.rowsQueue.push([{ id: 9, timestamp: new Date(0), leftFlowrateCd: null, rightFlowrateCd: null, leftPumpRpm: null, rightPumpRpm: null }])
+    const result = await caller.getLatestFlowReading({})
+    expect(result?.id).toBe(9)
+  })
+})

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { getBaseUrl } from './url'
+
+describe('getBaseUrl', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    vi.unstubAllGlobals()
+  })
+
+  describe('in the browser (window defined)', () => {
+    test('returns an empty string so requests stay relative', () => {
+      // jsdom provides `window`; ignore env vars on this branch
+      delete process.env.VERCEL_URL
+      delete process.env.PORT
+      expect(getBaseUrl()).toBe('')
+    })
+  })
+
+  describe('on the server (no window)', () => {
+    beforeEach(() => {
+      // Hide window so the function takes the server-side branch.
+      vi.stubGlobal('window', undefined)
+    })
+
+    test('uses VERCEL_URL with https when present', () => {
+      process.env.VERCEL_URL = 'preview-abc.vercel.app'
+      delete process.env.PORT
+      expect(getBaseUrl()).toBe('https://preview-abc.vercel.app')
+    })
+
+    test('falls back to localhost on the configured PORT', () => {
+      delete process.env.VERCEL_URL
+      process.env.PORT = '4000'
+      expect(getBaseUrl()).toBe('http://localhost:4000')
+    })
+
+    test('defaults to localhost:3000 when neither env var is set', () => {
+      delete process.env.VERCEL_URL
+      delete process.env.PORT
+      expect(getBaseUrl()).toBe('http://localhost:3000')
+    })
+
+    test('prefers VERCEL_URL over PORT when both are set', () => {
+      process.env.VERCEL_URL = 'app.example.com'
+      process.env.PORT = '4000'
+      expect(getBaseUrl()).toBe('https://app.example.com')
+    })
+  })
+})

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,19 +16,17 @@ export default {
     configFile: 'vitest.config.mts',
   },
 
-  // Start narrow: mutate only the modules that have real unit test coverage.
-  // Next.js app code (app/, components/, hooks/, utils/) is under-tested
-  // and would add hours of wall-clock time to each mutation run without
-  // telling us anything useful. Expand once we're confident the report is
-  // actionable.
+  // Mutate everything under src/ and app/. NoCoverage / Survived counts
+  // surface exactly the areas that need more tests — filtering them out
+  // hides the signal. CI splits this into area shards (see mutation.yml)
+  // so wall-clock stays manageable; local runs use this full list.
   mutate: [
-    'src/services/**/*.ts',
-    'src/scheduler/**/*.ts',
-    'src/hardware/**/*.ts',
-    'src/lib/**/*.ts',
+    'src/**/*.{ts,tsx}',
+    'app/**/*.{ts,tsx}',
     '!src/**/tests/**',
-    '!src/**/*.test.ts',
+    '!src/**/*.test.{ts,tsx}',
     '!src/**/*.d.ts',
+    '!app/**/*.d.ts',
   ],
 
   // Skip "static mutants" — mutations inside module-level / constant

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,17 +16,19 @@ export default {
     configFile: 'vitest.config.mts',
   },
 
-  // Mutate everything under src/ and app/. NoCoverage / Survived counts
-  // surface exactly the areas that need more tests — filtering them out
-  // hides the signal. CI splits this into area shards (see mutation.yml)
-  // so wall-clock stays manageable; local runs use this full list.
+  // Start narrow: mutate only the modules that have real unit test coverage.
+  // Next.js app code (app/, components/, hooks/, utils/) is under-tested
+  // and would add hours of wall-clock time to each mutation run without
+  // telling us anything useful. Expand once we're confident the report is
+  // actionable.
   mutate: [
-    'src/**/*.{ts,tsx}',
-    'app/**/*.{ts,tsx}',
+    'src/services/**/*.ts',
+    'src/scheduler/**/*.ts',
+    'src/hardware/**/*.ts',
+    'src/lib/**/*.ts',
     '!src/**/tests/**',
-    '!src/**/*.test.{ts,tsx}',
+    '!src/**/*.test.ts',
     '!src/**/*.d.ts',
-    '!app/**/*.d.ts',
   ],
 
   // Skip "static mutants" — mutations inside module-level / constant


### PR DESCRIPTION
## Summary

Patch release rolling up everything merged to `dev` since v2.0.0.

### User-visible fixes
- **fix(hardware): classify real Pod 5 sensor labels as Pod 5, not Pod 3** (#550) — `extractPodVersion` now scans every sensor-label segment for a `[A-Z][0-9]{2}` revision code instead of only the trailing segment. Real Pod 5 hardware emits `20600-0003-J55-B0708DE3`; the old `split('-').pop()` saw the serial and fell through to the `POD_3` default. Verified on 192.168.1.88 — currently serves `podVersion: "H00"`; after deploy it returns `POD_5`.
- **fix(install): install sp-* CLI tools before starting service** (#547)

### Coverage / CI
- test(server): cover untested tRPC routers (#552)
- test(hooks): cover untested custom hooks (#553)
- test(lib): cover untested lib utils and url helper (#551)
- test(scheduler): cover checkLiveness, broadcast payload shape, onTemp fallback (#549)
- test(lib,hardware): cover formatTemp, determineTrend, dacMonitor knobs (#548)
- ci(mutation): fire Discord webhook on workflow_dispatch too (#546)
- ci(codecov): add pytest workflow + flag-scoped reports (#544)
- ci(mutation): fix scheduled runs and add reporting outputs (#541)
- Revert "ci(mutation): mutate whole repo across 10 area shards" (#545) — reverted (#542)

## Test plan
- [x] CI green on dev (build / typecheck / lint / unit + python coverage)
- [x] Pod 5 mis-classification reproduced on real device (192.168.1.88)
- [ ] After merge: semantic-release tags v2.0.1 and publishes `sleepypod-core.tar.gz`
- [ ] `ssh -p 8822 root@192.168.1.88 sp-update` pulls the release; `curl :3000/api/device/status` returns `podVersion: "J00"`