### PR TITLE
feat(alarms): UI for creating, editing, and testing scheduled alarms

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,26 @@ project_name: "sleepypod-core"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -59,53 +64,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -116,11 +85,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -150,3 +122,19 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sp-freesleep      # mirror of the above in the other direction
 
 - **Temperature scheduling** — set per-side temperature programs by day and time
 - **Power scheduling** — automatic on/off with optional warm-up temperature
-- **Alarm management** — vibration alarms with configurable intensity and pattern
+- **Alarm management** — vibration alarms with configurable duration (intensity/pattern accepted by the API; cover MCU clamps both on Pod 5 J55 — see `docs/hardware/alarms.md`)
 - **Biometrics** — heart rate, HRV, breathing rate, sleep session tracking, and movement from the Pod's own sensors
 - **Daily maintenance** — automated priming and system reboots on a schedule
 - **Local web UI** — accessible on your home network, no cloud required

--- a/docs/adr/0021-alarm-solo-trigger.md
+++ b/docs/adr/0021-alarm-solo-trigger.md
@@ -1,0 +1,83 @@
+# ADR 0021: Use `ALARM_SOLO` (cmd 2) for cover-only Pod 5 vibration alarms
+
+**Status:** SUPERSEDED 2026-05-11 — see "Correction" below.
+
+## Correction (2026-05-11)
+
+The original decision in this ADR is wrong. Re-verified live on
+`eight-pod` (Pod 5 J55, cover only, no Pillow), 2026-05-11:
+
+- `cmd 5` (`ALARM_LEFT`) and `cmd 6` (`ALARM_RIGHT`) with hex-CBOR **do
+  fire the cover motor** on cover-only pods. The Pillow.cpp:383 "label
+  uninitialized" log line appears, but it does NOT gate the cover-motor
+  write. `Sensor.cpp:1221 triggerVibrationAlarm` runs first and
+  unconditionally drives the cover via `Sensor.cpp:257 sendCommand
+  [alarm io]`; the pillow path is consulted afterward and noisily
+  rejects on cover-only pods, but the cover motor has already started.
+- `cmd 2` (`ALARM_SOLO`) — what this ADR previously decreed as the
+  correct path — has **no registered spark function** on this firmware.
+  frank's `dac_loop` logs the incoming frame, then nothing else: no
+  `sparkAlarmS` invocation, no motor write, silent drop. The DAC
+  response is `0` because no registered function ran (returning
+  default), giving the false impression of success at the API layer.
+
+The original "live diagnosis" in this ADR conflated the Pillow.cpp
+warning with the cover motor failing to fire. With more frank logging
+(`journalctl -u frank` shows the full `triggerVibrationAlarm` →
+`alarm io` → `alarm[side] start` chain), it became clear the cover
+write was already happening — the user's "no buzz" reports must have
+had another cause (cover MCU state, dismiss-clear race, deploy stomp on
+the DAC singleton).
+
+**Current decision:** `HardwareClient.setAlarm()` routes to
+`ALARM_LEFT` / `ALARM_RIGHT` based on `side`, with the hex-CBOR payload
+from `encodeAlarmPayload()`. See `src/hardware/sharedClient.ts`.
+
+The frank-log debugging technique (the only reliable signal — DAC
+response codes lie) is documented in
+`docs/hardware/dac-socket-takeover.md`.
+
+## Original context (preserved for the record)
+
+The vibration alarm is the wake-up surface for the alarms feature
+(`AlarmSection` UI → `device.setAlarm` tRPC → `HardwareClient.setAlarm` →
+DAC socket). The hypothesis was that the per-side commands route
+through `Pillow.cpp::triggerVibrationAlarm`, which gates on
+`leftPillowLabel` / `rightPillowLabel`, and that those being `null` on
+cover-only pods would refuse to drive the motor. The hypothesis was
+half-true: the pillow path does reject, but the firmware writes to the
+cover motor BEFORE consulting the pillow path, so the rejection is
+cosmetic.
+
+Reverse-engineering frankenfirmware's string table surfaced strings
+suggesting a third "solo" path:
+
+```
+[alarm] vib. solo: time %u, power %u, pattern %s, dur %u
+[alarm] set to solo trigger
+[sensor] enabling Pod 2.0 vibration (simultaneous motors)
+setHighCurrentVibration
+```
+
+These strings exist in the binary but the corresponding spark function
+is not registered with the DAC. Either it's planned/dead code, or the
+registration was removed in a firmware update we don't have. Either
+way, cmd 2 doesn't drive the motors on the current J55 firmware.
+
+## Consequences of the correction
+
+- Per-side alarms now work: a left alarm at 6am buzzes only left, a
+  right alarm at 7am buzzes only right.
+- `alarm_schedules` rows with `side` are honored correctly without
+  jobManager dedupe.
+- Pillow accessory detection becomes irrelevant for the cover-vibration
+  feature — cmd 5/6 + CBOR already works on cover-only pods.
+
+## References
+
+- Live re-verification logs: `eight-pod` journalctl 2026-05-11 ~06:53 UTC.
+  `dac_loop command: 5` → `sparkAlarmL` → `triggerVibrationAlarm side
+  left` → `[alarm io] side 0 power 80 pattern 0 for 30` → user felt the
+  buzz.
+- Tech doc: [`docs/hardware/alarms.md`](../hardware/alarms.md).
+- frank log debugging technique: [`docs/hardware/dac-socket-takeover.md`](../hardware/dac-socket-takeover.md).

--- a/docs/hardware/alarms.md
+++ b/docs/hardware/alarms.md
@@ -219,7 +219,7 @@ without a registered spark function, masking a silent drop. The ground
 truth is in `journalctl -u frank` on the pod. The full chain on a
 working cover-motor write looks like:
 
-```
+```text
 dac_loop command: 5 payload: b9...
 [alarm] vib. left: time …, power …, pattern double, dur …
 Sensor.cpp:1221 triggerVibrationAlarm side left

--- a/docs/hardware/alarms.md
+++ b/docs/hardware/alarms.md
@@ -1,0 +1,269 @@
+# Alarm system
+
+How a user-configured alarm becomes a buzz on the cover. Covers the three
+documented firmware alarm opcodes, which of them actually fires the
+cover motor on Pod 5 J55 firmware, the CBOR wire format, and the live
+diagnosis technique. The original "use solo" decision in
+[ADR 0021](../adr/0021-alarm-solo-trigger.md) was wrong and is now
+superseded — see that ADR's "Correction" section and the
+[Reality check](#reality-check-pod-5-j55-firmware) below.
+
+## End-to-end flow
+
+```mermaid
+flowchart LR
+    UI["AlarmEditor / AlarmSection"]
+    Trpc["device.setAlarm tRPC mutation"]
+    Sched["jobManager (cron)"]
+    Client["sharedClient.ts<br/>HardwareClient.setAlarm()"]
+    Encode["alarmPayload.ts<br/>encodeAlarmPayload()"]
+    Dac["dacTransport<br/>sendCommand()"]
+    Sock["/persistent/deviceinfo/dac.sock"]
+    Frank["frankenfirmware"]
+    LP5009L["LP5009 left<br/>(cover motor driver)"]
+    LP5009R["LP5009 right<br/>(cover motor driver)"]
+
+    UI -->|"Test button"| Trpc
+    Sched -->|"scheduled fire"| Client
+    Trpc --> Client
+    Client --> Encode
+    Encode -->|"hex-CBOR string"| Dac
+    Dac -->|"{cmd}\n{arg}\n\n"| Sock
+    Sock --> Frank
+    Frank -->|"sparkAlarmL / triggerVibrationAlarm<br/>(side: 'left')"| LP5009L
+    Frank -->|"sparkAlarmR / triggerVibrationAlarm<br/>(side: 'right')"| LP5009R
+```
+
+The UI calls `device.setAlarm` for immediate tests; the scheduler calls
+`setAlarm()` directly when an `alarm_schedules` row fires. Both end up at
+the same hardware client, with the same per-side opcode (`ALARM_LEFT`
+cmd 5 or `ALARM_RIGHT` cmd 6).
+
+## The documented alarm opcodes
+
+frankenfirmware's binary references three alarm-related code paths. Same
+wire format on all three; the command code selects the path. Live
+behavior on Pod 5 J55 firmware:
+
+```mermaid
+flowchart TB
+    Cmd2["cmd 2 ALARM_SOLO<br/>(documented in binary,<br/>NOT registered with DAC)"]
+    Cmd5["cmd 5 ALARM_LEFT<br/>(registered, drives cover)"]
+    Cmd6["cmd 6 ALARM_RIGHT<br/>(registered, drives cover)"]
+
+    Drop["frank dac_loop logs frame,<br/>no spark function fires,<br/>silently dropped<br/>(DAC returns 0 anyway)"]
+    SparkL["sparkAlarmL<br/>main.cpp:212"]
+    SparkR["sparkAlarmR<br/>main.cpp:234"]
+
+    Trigger["Sensor.cpp:1221<br/>triggerVibrationAlarm side X"]
+    AlarmIO["Sensor.cpp:257<br/>sendCommand [alarm io]<br/>writes to cover MCU → LP5009"]
+    PillowAfter["Pillow.cpp:383<br/>triggerVibrationAlarm<br/>(consulted AFTER cover write)"]
+    PillowMotor["Pillow accessory motor<br/>(UART/LSP)"]
+    PillowReject["label uninitialized →<br/>warning logged, returns,<br/>cover motor already firing"]
+
+    Cmd2 --> Drop
+    Cmd5 --> SparkL
+    Cmd6 --> SparkR
+
+    SparkL --> Trigger
+    SparkR --> Trigger
+    Trigger --> AlarmIO
+    AlarmIO --> PillowAfter
+    PillowAfter -->|"label set (pillow attached)"| PillowMotor
+    PillowAfter -->|"label null (cover only)"| PillowReject
+```
+
+### Reality check: Pod 5 J55 firmware
+
+- **`ALARM_SOLO` (cmd 2) silently drops.** The strings
+  `sparkAlarmS`, `[alarm] vib. solo`, `setHighCurrentVibration`,
+  `enabling Pod 2.0 vibration (simultaneous motors)` are present in the
+  binary, but the spark function is not registered with the DAC on this
+  firmware. frank's `dac_loop` logs the incoming frame and nothing else
+  — no motor write. The DAC response is `0` (default for an unregistered
+  opcode), which makes the call look successful to the API layer.
+- **`ALARM_LEFT` / `ALARM_RIGHT` (cmd 5 / 6) fire the cover motor on
+  cover-only pods.** The pillow label gate (`Pillow.cpp:383`) only
+  affects the separate pillow-accessory motor; it runs AFTER the cover
+  motor write (`Sensor.cpp:1221 triggerVibrationAlarm` →
+  `Sensor.cpp:257 [alarm io] side N power P pattern X for D`). The
+  "label uninitialized or does not support vibration" log line that
+  appears in cover-only setups is cosmetic from the alarm system's
+  point of view — the cover has already been told to vibrate.
+
+**Routing:** `HardwareClient.setAlarm()` uses `ALARM_LEFT` (cmd 5) for
+`side: 'left'` and `ALARM_RIGHT` (cmd 6) for `side: 'right'`, both with
+the hex-CBOR payload from `encodeAlarmPayload()`. Per-side independence
+is real.
+
+## CBOR payload
+
+Every alarm command takes a single string argument: the hex encoding of a
+CBOR-serialized map. Four Particle-Spark-style short keys.
+
+| Key  | Type   | Range / format        | Meaning                                                                              |
+|------|--------|-----------------------|--------------------------------------------------------------------------------------|
+| `pl` | uint   | 1–100                 | Power level (intensity %). Hardware-enforced; >100 rejected at parse. **No perceived effect on Pod 5 J55** — see [Empirical behavior](#empirical-behavior-pl-and-pi). |
+| `du` | uint   | 10–180 (seconds)      | Duration. Firmware silently ignores values below 10s — the motor won't engage. We clamp client-side. **Only field with a user-meaningful effect** on Pod 5 J55. |
+| `pi` | string | `"rise"` \| `"double"`| Vibration pattern. `rise` is documented as soft→strong ramp, `double` as two firm bursts — but both feel identical on Pod 5 J55. See [Empirical behavior](#empirical-behavior-pl-and-pi). |
+| `tt` | uint   | unix epoch seconds    | Trigger time. Firmware uses it for retry windows and dismiss correlation.            |
+
+### Empirical behavior: `pl` and `pi`
+
+Live tested on Pod 5 J55 (192.168.1.88) — 2026-05-12:
+
+- **`pl` (intensity) has no perceptible effect.** `pl=1` and `pl=100`
+  produce indistinguishable buzz. frank logs echo the correct power
+  value, so the truncation happens downstream in the cover MCU (the
+  separate firmware blob that drives the LP5009). The MCU appears to
+  run a fixed motor envelope regardless of the power argument.
+- **`pi='rise'` and `pi='double'` feel the same.** Both patterns
+  produce the same buzz profile. The firmware log line
+  `Sensor.cpp:257 [alarm io] … pattern X` echoes the value, but the
+  cover MCU does not appear to switch envelope shapes.
+- **Net: `du` (duration) is the only user-meaningful field.** The UI
+  exposes intensity and pattern controls, but they are cosmetic on the
+  current firmware. Document this in any user-facing setting and
+  consider hiding or disabling the controls until firmware behavior
+  is confirmed on other pod versions.
+
+Reverse-engineering the cover MCU envelope tables is a separate effort
+— frank doesn't have visibility into it.
+
+Encoding (`src/hardware/alarmPayload.ts`):
+
+```typescript
+const encoder = new Encoder({ useRecords: false })
+
+export function encodeAlarmPayload(config: AlarmConfig): string {
+  const payload = {
+    pl: config.vibrationIntensity,
+    du: Math.max(10, config.duration),
+    pi: config.vibrationPattern,
+    tt: Math.floor(Date.now() / 1000),
+  }
+  return Buffer.from(encoder.encode(payload)).toString('hex')
+}
+```
+
+### Worked example
+
+`config = { vibrationIntensity: 60, vibrationPattern: 'rise', duration: 15 }` at
+unix time `1778486725` encodes to:
+
+```text
+b9000462706c183c6264750f62706964726973656274741a6a018d52
+```
+
+Decoded byte-by-byte:
+
+| Bytes           | CBOR meaning              |
+|-----------------|---------------------------|
+| `b9 0004`       | map with 4 entries        |
+| `62 70 6c`      | text(2) = `"pl"`          |
+| `18 3c`         | uint(0x3c) = 60           |
+| `62 64 75`      | text(2) = `"du"`          |
+| `0f`            | uint(15)                  |
+| `62 70 69`      | text(2) = `"pi"`          |
+| `64 72697365`   | text(4) = `"rise"`        |
+| `62 74 74`      | text(2) = `"tt"`          |
+| `1a 6a018d52`   | uint(0x6a018d52) = epoch  |
+
+### Earlier (broken) format
+
+The original implementation sent a comma string —
+`"{intensity},{patternCode},{duration}"` where `patternCode` was `'0'` or
+`'1'`. The firmware's registered function (`SensorAlarm.h::
+trySparkParseAlarmSettings`) rejected this with:
+
+```text
+ERR SensorAlarm.h:39 trySparkParseAlarmSettings|alarm settings args: 80,0,10
+WRN device_api_client.cpp:26 receive|receive: 5 registered-function returned err:-1
+```
+
+The CBOR map is what the firmware (and the official 8 Sleep cloud) expects.
+
+## Wire framing
+
+The DAC socket is a Unix stream socket at
+`/persistent/deviceinfo/dac.sock`. Frames are text:
+
+```text
+{command-code}\n{argument}\n\n
+```
+
+`\n\n` is the message delimiter. The argument is the hex-CBOR string for
+alarm commands, a plain integer for temperature setpoints, etc. See
+`docs/hardware/DAC-PROTOCOL.md` for the full command table.
+
+## Clearing the alarm
+
+The `ALARM_CLEAR` command (cmd `16`) takes a single character argument:
+`'0'` = clear left, `'1'` = clear right. It works regardless of which
+opcode started the alarm (firmware's clear path doesn't consult pillow
+labels). `device.clearAlarm` uses this directly; `snoozeAlarm` clears,
+schedules a setTimeout, and re-sends the same alarm config when the
+timer fires (`src/hardware/snoozeManager.ts`).
+
+**Cover-motor startup race:** the cover MCU needs a non-trivial time to
+ramp the LP5009 from a clear state to motor-running. Sending
+`ALARM_CLEAR` within ~100ms of `ALARM_LEFT`/`RIGHT` cancels the buzz
+before the user feels it (verified live — `alarm[left] start` log line
+appears, but the next line is `alarm[left] off` from the clear). Probe
+scripts must let the buzz run before clearing.
+
+## Diagnosing "API returns success but no buzz"
+
+The DAC response code is unreliable — frank returns `0` for any opcode
+without a registered spark function, masking a silent drop. The ground
+truth is in `journalctl -u frank` on the pod. The full chain on a
+working cover-motor write looks like:
+
+```
+dac_loop command: 5 payload: b9...
+[alarm] vib. left: time …, power …, pattern double, dur …
+Sensor.cpp:1221 triggerVibrationAlarm side left
+Sensor.cpp:257 sendCommand [alarm io] side 0 power … pattern … for …
+Pillow.cpp:383 left label uninitialized or does not support vibration   ← cosmetic, ignore
+Sensor.cpp:614 [sensor] -> FW: … alarm[left] start: power … dur … ms
+```
+
+If `sparkAlarmL` / `sparkAlarmR` (or `triggerVibrationAlarm`) does not
+appear after `dac_loop command: N`, the opcode has no registered
+handler. If `alarm[left] start` appears followed quickly by
+`alarm[left] off`, a clear races the start.
+
+## Why two layers of motor drivers?
+
+The cover has two **LP5009** chips — one per side — that drive both LEDs
+and the vibration motor on that side. Button-press haptic feedback is
+generated locally by the cover MCU writing to the LP5009; the pod never
+sees those motor commands. The alarm path is the other direction: the pod
+tells the cover MCU "vibrate now", and the cover MCU writes the
+intensity/pattern envelope to its local LP5009.
+
+The Pillow accessory has its own MCU and its own motor on a separate
+UART link. The firmware's `Pillow.cpp` path is what drives it. The cover
+motors are accessible via `ALARM_LEFT`/`ALARM_RIGHT` (cmd 5/6) — the
+pillow code path runs after the cover write and is a no-op on cover-only
+pods (a warning logs but the cover motor has already started).
+
+## Files
+
+- `src/hardware/alarmPayload.ts` — `encodeAlarmPayload()` (single source of truth)
+- `src/hardware/sharedClient.ts` — production write path (`getSharedHardwareClient`)
+- `src/hardware/client.ts` — dev/test write path
+- `src/hardware/types.ts` — `HardwareCommand.ALARM_LEFT/RIGHT/CLEAR` (the
+  enum's `ALARM_SOLO` entry maps to cmd 2 but is a dead opcode on the
+  current firmware — see [Reality check](#reality-check-pod-5-j55-firmware))
+- `src/server/routers/device.ts` — `setAlarm` / `clearAlarm` / `snoozeAlarm` tRPC procedures + `execute` raw passthrough
+- `src/scheduler/jobManager.ts` — fires scheduled `alarm_schedules` rows
+- `src/components/Schedule/AlarmEditor.tsx` — UI Test button + persistence
+
+## Open work
+
+- Confirm `ALARM_LEFT` / `ALARM_RIGHT` cover-motor write works on Pod 3
+  and Pod 4 firmware (verified on Pod 5 J55 only).
+- Investigate why `sparkAlarmS` (cmd 2) is unregistered. Strings remain
+  in the binary but no spark function attaches. Could be an 8 Sleep
+  firmware change between releases; worth re-probing if firmware updates.

--- a/docs/hardware/dac-socket-takeover.md
+++ b/docs/hardware/dac-socket-takeover.md
@@ -1,0 +1,303 @@
+# DAC socket takeover — investigation technique and findings
+
+Reference notes for the next agent that needs to probe frankenfirmware
+behavior directly. Written 2026-05-12 during an attempt to diagnose
+why `ALARM_SOLO` (cmd 2) stopped buzzing on `eight-pod` (Pod 5,
+cover-only, no Pillow). The technique works; some firmware-side gotchas
+made it less useful than expected.
+
+## Why take over the socket
+
+sleepypod-core owns `/persistent/deviceinfo/dac.sock` — it listens,
+frankenfirmware connects as the client. Everything the app sends to
+the firmware goes over that one socket, and `device.execute` is the
+only way to send arbitrary cmd/payload pairs through it. But:
+
+- `device.execute` is restricted to a Zod enum of command names — adding
+  a side hint or probing arbitrary cmd numbers requires a code change.
+- A separate Turbopack bug (see [Open issues](#open-issues)) makes
+  `device.execute` fail with `[DAC] not connected — call connectDac() first`
+  because the raw path doesn't share the warmed `transport` module
+  state with `withHardwareClient`.
+- The firmware logs `dac_loop command: N payload: …` for received
+  commands but does **not** consistently log what happens next. To know
+  whether the firmware accepted, rejected, or silently dropped a
+  payload, we need to send a wide sweep of variants and watch firmware
+  state directly.
+
+Taking over the socket gives us cmd/payload-level control from a
+~70-line Python script — no rebuild, no chunk patching.
+
+## The technique
+
+```mermaid
+sequenceDiagram
+    participant op as Operator
+    participant sp as sleepypod.service
+    participant py as probe.py
+    participant fr as frank.service
+
+    op->>sp: systemctl stop
+    Note over sp: releases /persistent/deviceinfo/dac.sock
+    op->>py: python3 /tmp/dac-probe.py
+    py->>py: bind(SOCK), chmod 770, chown 1000:1000, listen()
+    op->>fr: systemctl restart frank
+    fr->>py: connect to dac.sock
+    py->>fr: cmd N payload P (write \n\n-framed)
+    fr-->>py: response (\n\n-framed)
+    py->>py: log RX, sleep 8s
+    py->>fr: next cmd
+    Note over op,fr: repeat for sweep
+    op->>sp: systemctl start sleepypod
+    op->>fr: systemctl restart frank
+```
+
+Operator steps (on the pod, as root):
+
+1. `systemctl stop sleepypod.service` — releases the socket.
+2. Run a Python script that recreates the socket file at the canonical
+   path, listens, accepts the first incoming connection, and runs a
+   labeled sequence of `(cmd, payload)` writes with ~8s gaps.
+3. `systemctl restart frank.service` — forces frankenfirmware to
+   reconnect immediately (without this it can take ≥60s to retry).
+4. Script writes, reads, prints. Operator listens for buzzes.
+5. `systemctl start sleepypod.service`; `systemctl restart frank.service`
+   to ensure the firmware reconnects to sleepypod-core.
+
+Recipe for the operator orchestration that handles steps 1, 3, and 5
+in one go is in `git show` for this commit at
+`scripts/probe-dac.sh` if it lands; otherwise inline it. The Python
+script lives at `/tmp/dac-probe.py` on the pod during a probe session
+and is deleted after — it is intentionally not committed because it
+mutates a privileged socket and should never run automatically.
+
+## Wire framing
+
+Every frame is text:
+
+```
+{command-number}\n{argument}\n\n
+```
+
+`\n\n` is the message delimiter on both directions. The argument is a
+hex string for alarm-style commands, a plain integer for temp
+setpoints, etc. For commands with no argument the second `\n` is still
+required: `14\n\n\n` is a valid DEVICE_STATUS request (cmd, empty arg,
+separator). See [DAC-PROTOCOL.md](./DAC-PROTOCOL.md) for the full
+command table.
+
+## CBOR encoding gotcha (the only durable finding)
+
+**The firmware requires the non-canonical `b9 NNNN`
+(uint16-length) form for CBOR map headers. Sending the canonical
+short form (e.g. `a4` for a 4-entry map) makes the firmware close the
+socket on read.**
+
+`cbor-x` (used by `src/hardware/alarmPayload.ts`) happens to emit the
+long form by default:
+
+```text
+b9 00 04 | map(4)
+62 70 6c | text(2) "pl"
+18 3c    | uint(60)
+…
+```
+
+A hand-rolled CBOR encoder that emits canonical headers (`a4 …` for
+maps of length 4–23) will look fine on the wire and pass any standard
+CBOR decoder, but frankenfirmware's parser blows up on it. Symptoms:
+
+- `BrokenPipeError` on the next `sendall()` from the probe side.
+- `dac_loop err: asio.system:22 while trying to read command`
+  (`EINVAL`) or `asio.misc:2` (EOF) in the firmware journal.
+- frankenfirmware exits; systemd (`Restart=always`) brings it back
+  within ~1s.
+
+If you write a new probe, hard-code the long form:
+
+```python
+def cbor_map(entries):
+    n = len(entries)
+    hdr = bytes([0xb9, (n >> 8) & 0xff, n & 0xff])
+    body = b""
+    for k, v in entries:
+        body += cbor_tstr(k)
+        body += cbor_uint(v) if isinstance(v, int) else cbor_tstr(v)
+    return hdr + body
+```
+
+This matches what cbor-x emits and what
+[`alarms.md`](./alarms.md) documents as the wire format.
+
+## Firmware restart sensitivity
+
+Even with correct framing and correct CBOR, the firmware is **not
+robust** to the probe disconnecting between commands:
+
+- Closing the socket after a single command sequence triggers
+  `dac_loop err` on the firmware's next read.
+- frankenfirmware exits; systemd restarts it.
+- The new firmware instance reconnects to whatever is listening on
+  `dac.sock` (probe or sleepypod-core).
+
+Consequence for probe design: a sweep MUST run to completion in a
+single connection. If the probe writes cmd A, then writes cmd B and B
+is malformed, the firmware exits and we lose any in-flight effects of
+cmd A. Some specific gotchas:
+
+- The dac_loop `command: N payload: …` echo line is **buffered** and
+  may be lost when the firmware exits. We could not reliably confirm
+  whether the firmware processed our cmd 2 before the restart, because
+  the journal entry never made it out.
+- `ALARM_SOLO` (cmd 2), even with the correct CBOR payload, caused a
+  graceful firmware exit on the next read. The same exact bytes sent
+  by sleepypod-core's `sendCommand` do NOT cause the exit. The
+  difference is unclear; likely sleepypod-core keeps the connection
+  open between commands so the firmware never sees EOF.
+
+The practical takeaway: **takeover probes are good for one-shot reads
+(DEVICE_STATUS) but unreliable for sequences of write-side
+experiments**. For arbitrary-command testing, prefer modifying
+`src/hardware/sharedClient.ts` or adding a transient `device.execute`
+variant that goes through `withHardwareClient`, rebuilding, and
+deploying. The Turbopack module-duplication bug in `device.execute`
+should be fixed regardless (see Open issues).
+
+## Findings about labels and the Pillow path
+
+Background from
+[ADR 0021](../adr/0021-alarm-solo-trigger.md): three alarm commands
+exist (`ALARM_SOLO`=2, `ALARM_LEFT`=5, `ALARM_RIGHT`=6). The per-side
+commands route through `Pillow.cpp:383 triggerVibrationAlarm` which
+gates on `leftPillowLabel` / `rightPillowLabel`. On cover-only pods
+those labels stay `null` and the firmware rejects per-side alarm
+triggers with `err:-1`.
+
+The investigation surfaced a parallel gate:
+**`Sensor.cpp:1218 triggerVibrationAlarm` exists in the same firmware,
+guarded by a different label — `sensorLabel`.** The two gates fire at
+the same timestamp during firmware init, suggesting both paths are
+invoked from a shared alarm dispatcher:
+
+```text
+WRN:369664291 Sensor.cpp:1218 triggerVibrationAlarm|[sensor] sensor label uninitialized or does not support vibration
+WRN:369664291 Sensor.cpp:1218 triggerVibrationAlarm|[sensor] sensor label uninitialized or does not support vibration
+INF:369664291 Pillow.cpp:383 triggerVibrationAlarm|left label uninitialized or does not support vibration
+INF:369664291 Pillow.cpp:383 triggerVibrationAlarm|right label uninitialized or does not support vibration
+```
+
+On a healthy pod after init, `sensorLabel` is populated (verified via
+`device.getStatus` → `sensorLabel: "20600-0003-J55-B0708DE3"` on
+`eight-pod`) while the pillow labels stay `null`. This means the
+**Sensor.cpp path's preconditions are satisfied even on cover-only
+hardware** — if we can find the command code or payload variant that
+routes through `Sensor.cpp:1218` instead of (or in addition to)
+`Pillow.cpp:383`, per-side vibration on the cover should be reachable
+without a Pillow accessory.
+
+What we have NOT yet found:
+
+- Which exact command number (or CBOR payload key) selects the
+  Sensor.cpp path. The three known alarm cmds (2/5/6) all appear to
+  fan out through Pillow.cpp.
+- Whether `setHighCurrentVibration` (the function `ALARM_SOLO` is
+  documented to call on a healthy pod) is still being reached on
+  `eight-pod`. The journal shows it firing exactly **once** at boot
+  during `Sensor.cpp:1175 startSampling`, never from a subsequent
+  alarm command. This is suspicious — either the log line was removed
+  / demoted in this firmware build, or `ALARM_SOLO` is no longer
+  reaching that function.
+
+### Spark variable spoofing — already rejected
+
+ADR 0021 rejected the approach of forcing `leftPillowLabel` to a
+non-null value via the `dac setVariable` API: that API only accepts
+writes from `SubsysConnectionManager` (the pillow-connect handler
+inside the firmware). External `setVariable` calls are silently
+ignored. The boot log
+`dac setVariable var: leftPillowLabel val: null` is the firmware
+**writing to itself** during init, not an externally-controllable
+knob.
+
+## Live test result (eight-pod, 2026-05-12)
+
+Probe sweep on `eight-pod` (Pod 5, cover-only, sensorLabel set, pillow
+labels null) sent the following while operator listened at the pod:
+
+| Test | Cmd | Payload                                          | Buzz? |
+|------|-----|--------------------------------------------------|-------|
+| 1    | 14  | DEVICE_STATUS (no arg)                           | n/a — got status response |
+| 2    | 2   | `b9 0004 pl=80 du=15 pi="rise" tt=…` (basic)     | no    |
+| 3    | 2   | basic + `s:0`                                    | not reached (firmware exit on test 2) |
+| 4–10 | 2   | side hints (`s`, `side`, `m`, `bedside`)         | not reached |
+
+Test 2 caused `dac_loop err: asio.misc:2` (EOF on next read) and a
+clean firmware exit. None of the cmd 2 variants reached the operator's
+ears, but the firmware exit immediately after the first cmd 2 write
+means we cannot conclude the payload was rejected — only that the
+firmware exited before either buzzing or logging.
+
+A parallel hardware check: cover-button haptic feedback was tested
+manually (two button presses). Result pending; this datapoint
+distinguishes between "LP5009 motor drivers are stuck" (no button
+haptic) and "firmware alarm path is broken" (button haptic works).
+
+## Where to look next
+
+The remaining open hypothesis is that there is a fourth alarm
+command — or a CBOR field hint on cmd 2 — that selects the
+Sensor.cpp path. Useful next steps that do NOT require the fragile
+takeover technique:
+
+1. **Disassemble `/opt/eight/bin/frankenfirmware`** (ARM aarch64, 4.9MB,
+   stripped) off-pod with radare2 / Ghidra. Find xrefs to
+   `Sensor.cpp::triggerVibrationAlarm` to determine whether it is
+   called from `sparkAlarmS` (cmd 2), one of `sparkAlarmL`/`R` (5/6),
+   or a different dispatcher entirely.
+2. **Grep the binary for additional Spark function names** —
+   `helloFrank`, `clear_alarm_settings`, `sparkSetHeatingLeft`,
+   `sparkParseBedside`, and the three `sparkAlarmS/L/R` are confirmed;
+   anything else surfaced by `strings -n 4 | grep -E "^spark[A-Z]"`
+   may be a registered handler we haven't tried.
+3. **Modify `sharedClient.ts` for an in-place A/B**: swap `ALARM_SOLO`
+   for `ALARM_LEFT` temporarily, rebuild, deploy, observe whether
+   `Pillow.cpp:383` rejection re-appears in the firmware journal. If
+   it does, the firmware logging path is alive but cmd 2's handler is
+   silent — pointing to a regression in `sparkAlarmS`'s log emission
+   or its handler itself.
+
+## Open issues
+
+- `device.execute` raw command endpoint fails with
+  `[DAC] not connected — call connectDac() first` even when the
+  shared client is warmed. Root cause: Turbopack module-duplicates
+  `src/hardware/dacTransport.ts`. `device.ts` imports it as
+  `@/src/hardware/dacTransport` (absolute alias) while
+  `sharedClient.ts` and `dacMonitor.instance.ts` import it as
+  `./dacTransport` (relative). The two resolutions land in separate
+  module instances with separate `transport` module-locals; the
+  shared-client path warms one, the execute path reads the other.
+  Either pin a single resolution form (all-relative or all-aliased
+  across the hardware folder) or move `transport` to `globalThis`
+  like `dacMonitor.instance.ts` already does for its singletons.
+- The dac_loop `command: …` echo is buffered; on a firmware exit the
+  line never reaches the journal. If we plan to keep using this for
+  debugging, ask whether the firmware has a flush-on-exit hook or run
+  it under `stdbuf -oL` from the systemd unit.
+- `setHighCurrentVibration` is called once at boot and never again.
+  Either it's idempotent and stays enabled forever (likely — the
+  string is `enabling Pod 2.0 vibration (simultaneous motors)`,
+  suggesting a one-time mode switch), or there's a state regression
+  on this specific pod. Worth verifying on a second cover-only Pod 5
+  to distinguish.
+
+## Files referenced
+
+- `/persistent/deviceinfo/dac.sock` — the Unix socket
+- `/opt/eight/bin/frankenfirmware` — the firmware binary
+- `/etc/systemd/system/frank.service` — `Restart=always`
+- `src/hardware/dacTransport.ts` — sleepypod-core's transport
+- `src/hardware/alarmPayload.ts` — CBOR encoder
+- `docs/hardware/alarms.md` — wire format reference
+- `docs/hardware/DAC-PROTOCOL.md` — full command table
+- `docs/adr/0021-alarm-solo-trigger.md` — the SOLO routing decision

--- a/docs/hardware/dac-socket-takeover.md
+++ b/docs/hardware/dac-socket-takeover.md
@@ -75,7 +75,7 @@ mutates a privileged socket and should never run automatically.
 
 Every frame is text:
 
-```
+```text
 {command-number}\n{argument}\n\n
 ```
 

--- a/scripts/probe-cover-side.ts
+++ b/scripts/probe-cover-side.ts
@@ -1,0 +1,139 @@
+/**
+ * Probe Pod 5 cover for a per-side vibration command.
+ *
+ * Background: ALARM_SOLO (cmd 2) buzzes both LP5009 motor drivers
+ * simultaneously. ALARM_LEFT/RIGHT (5/6) reject on cover-only pods
+ * (pillow label gate). docs/hardware/alarms.md "Open work" section flags
+ * "probe additional CBOR field names (s, m, side, motor) to see if
+ * ALARM_SOLO quietly respects a side hint we haven't found yet" — this
+ * script does that, plus probes undocumented opcodes near the known ones.
+ *
+ * Usage:
+ *   npx tsx scripts/probe-cover-side.ts [POD_URL]
+ *
+ * After each probe the script pauses so you can listen / observe and
+ * type y/n/q before continuing. Defaults to http://192.168.1.88:3000.
+ */
+
+import { Encoder } from 'cbor-x'
+
+const POD_URL = process.argv[2] || 'http://192.168.1.88:3000'
+const BUZZ_SECONDS = 10 // firmware silently ignores < 10
+const SETTLE_SECONDS = 4 // gap after clear, before next
+const encoder = new Encoder({ useRecords: false })
+
+const t0 = Date.now()
+const stamp = () => `t+${Math.round((Date.now() - t0) / 100) / 10}s`.padEnd(8)
+
+interface Probe {
+  label: string
+  command: string // opcode string or allowlisted name
+  payload: Record<string, unknown>
+}
+
+const base = (extra: Record<string, unknown> = {}) => ({
+  pl: 40,
+  du: BUZZ_SECONDS,
+  pi: 'double', // double = two firm bursts; easier to localize than 'rise'
+  tt: Math.floor(Date.now() / 1000),
+  ...extra,
+})
+
+const probes: Probe[] = [
+  // ── baseline ───────────────────────────────────────────────────────────
+  { label: 'ALARM_SOLO baseline (both motors expected)', command: 'ALARM_SOLO', payload: base() },
+
+  // ── side hints on SOLO ────────────────────────────────────────────────
+  { label: 'ALARM_SOLO + s:"l" (string left)', command: 'ALARM_SOLO', payload: base({ s: 'l' }) },
+  { label: 'ALARM_SOLO + s:0 (int 0=left convention)', command: 'ALARM_SOLO', payload: base({ s: 0 }) },
+  { label: 'ALARM_SOLO + side:"left"', command: 'ALARM_SOLO', payload: base({ side: 'left' }) },
+  { label: 'ALARM_SOLO + m:"l"', command: 'ALARM_SOLO', payload: base({ m: 'l' }) },
+  { label: 'ALARM_SOLO + motor:"left"', command: 'ALARM_SOLO', payload: base({ motor: 'left' }) },
+  { label: 'ALARM_SOLO + ch:0 (channel index)', command: 'ALARM_SOLO', payload: base({ ch: 0 }) },
+
+  // ── confirm rejection of per-side without pillow ─────────────────────
+  { label: 'ALARM_LEFT (expected: err:-1 on cover-only Pod 5)', command: 'ALARM_LEFT', payload: base() },
+
+  // ── undocumented opcodes between known commands ──────────────────────
+  { label: 'opcode 3 (between SOLO=2 and ALARM_LEFT=5)', command: '3', payload: base() },
+  { label: 'opcode 4', command: '4', payload: base() },
+  { label: 'opcode 7 (after ALARM_RIGHT=6)', command: '7', payload: base() },
+  { label: 'opcode 15 (between DEVICE_STATUS=14 and ALARM_CLEAR=16)', command: '15', payload: base() },
+  { label: 'opcode 17 (free-sleep had ALARM_SOLO commented at 17)', command: '17', payload: base() },
+  { label: 'opcode 18', command: '18', payload: base() },
+  { label: 'opcode 19', command: '19', payload: base() },
+  { label: 'opcode 20', command: '20', payload: base() },
+]
+
+function encode(payload: Record<string, unknown>): string {
+  return Buffer.from(encoder.encode(payload)).toString('hex')
+}
+
+async function send(probe: Probe): Promise<{ http: number, body: string }> {
+  const args = encode(probe.payload)
+  const body = JSON.stringify({ json: { command: probe.command, args } })
+
+  const res = await fetch(`${POD_URL}/api/trpc/device.execute`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  })
+  const text = await res.text()
+  return { http: res.status, body: text.slice(0, 240) }
+}
+
+async function clearAlarms(): Promise<void> {
+  for (const side of ['0', '1']) {
+    try {
+      await fetch(`${POD_URL}/api/trpc/device.execute`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ json: { command: 'ALARM_CLEAR', args: side } }),
+      })
+    }
+    catch { /* ignore — best-effort */ }
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`Probing ${POD_URL} — ${probes.length} probes, ~${probes.length * (BUZZ_SECONDS + SETTLE_SECONDS)}s total`)
+  console.log(`buzz=${BUZZ_SECONDS}s gap=${SETTLE_SECONDS}s pl=40 pi=double`)
+  console.log(`Listen for which motor fires (left / right / both / nothing) at each timestamp.`)
+  console.log()
+
+  for (let i = 0; i < probes.length; i++) {
+    const probe = probes[i]
+    const fireStart = stamp()
+    let result: { http: number, body: string } | { error: string }
+    try {
+      result = await send(probe)
+    }
+    catch (e) {
+      result = { error: e instanceof Error ? e.message : String(e) }
+    }
+
+    const fireEnd = stamp()
+    const ok = 'http' in result && result.http >= 200 && result.http < 300
+    const tag = ok ? 'OK ' : 'ERR'
+    console.log(`[${i + 1}/${probes.length}] ${fireStart} → ${fireEnd}  ${tag}  cmd=${probe.command.padEnd(12)} ${probe.label}`)
+    console.log(`              payload=${JSON.stringify(probe.payload)}`)
+    if ('error' in result) {
+      console.log(`              error: ${result.error}`)
+    }
+    else {
+      console.log(`              http=${result.http} body=${result.body}`)
+    }
+
+    // Let the buzz play out before clearing
+    await new Promise(r => setTimeout(r, BUZZ_SECONDS * 1000))
+    await clearAlarms()
+    await new Promise(r => setTimeout(r, SETTLE_SECONDS * 1000))
+  }
+
+  console.log('\nDone. Match observed sides to the timestamps above.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/probe-cover-side.ts
+++ b/scripts/probe-cover-side.ts
@@ -11,8 +11,9 @@
  * Usage:
  *   npx tsx scripts/probe-cover-side.ts [POD_URL]
  *
- * After each probe the script pauses so you can listen / observe and
- * type y/n/q before continuing. Defaults to http://192.168.1.88:3000.
+ * Each probe runs for BUZZ_SECONDS, clears, then waits SETTLE_SECONDS before
+ * the next probe — listen / observe while it runs. Defaults to
+ * http://192.168.1.88:3000.
  */
 
 import { Encoder } from 'cbor-x'
@@ -35,7 +36,6 @@ const base = (extra: Record<string, unknown> = {}) => ({
   pl: 40,
   du: BUZZ_SECONDS,
   pi: 'double', // double = two firm bursts; easier to localize than 'rise'
-  tt: Math.floor(Date.now() / 1000),
   ...extra,
 })
 
@@ -70,7 +70,9 @@ function encode(payload: Record<string, unknown>): string {
 }
 
 async function send(probe: Probe): Promise<{ http: number, body: string }> {
-  const args = encode(probe.payload)
+  // tt is the firmware's retry/dismiss correlator — stamp it at send-time so
+  // it reflects when the probe actually fires, not when the list was built.
+  const args = encode({ ...probe.payload, tt: Math.floor(Date.now() / 1000) })
   const body = JSON.stringify({ json: { command: probe.command, args } })
 
   const res = await fetch(`${POD_URL}/api/trpc/device.execute`, {

--- a/scripts/probe-formats.ts
+++ b/scripts/probe-formats.ts
@@ -1,0 +1,34 @@
+import { Encoder } from 'cbor-x'
+
+const enc = new Encoder({ useRecords: false })
+const cborPayload = Buffer.from(enc.encode({ pl: 80, du: 30, pi: 'double', tt: Math.floor(Date.now() / 1000) })).toString('hex')
+
+const probes = [
+  { label: 'cmd5 LEFT + CBOR', cmd: 'ALARM_LEFT', args: cborPayload },
+  { label: 'cmd6 RIGHT + comma', cmd: 'ALARM_RIGHT', args: '80,0,30' },
+  { label: 'cmd6 RIGHT + CBOR', cmd: 'ALARM_RIGHT', args: cborPayload },
+  { label: 'cmd2 SOLO + comma', cmd: 'ALARM_SOLO', args: '80,0,30' },
+  { label: 'cmd2 SOLO + CBOR', cmd: 'ALARM_SOLO', args: cborPayload },
+  { label: 'cmd5 LEFT + alt comma 80,1,30 (rise)', cmd: 'ALARM_LEFT', args: '80,1,30' },
+]
+
+async function main() {
+  for (const p of probes) {
+    const res = await fetch('http://192.168.1.88:3000/api/trpc/device.execute', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ json: { command: p.cmd, args: p.args } }),
+    })
+    const body = await res.text()
+    const m = body.match(/"response":"([^"]*)"/)
+    console.log(`${p.label.padEnd(48)} → response=${m?.[1] ?? '?'}`)
+    // wait between probes for clear
+    await fetch('http://192.168.1.88:3000/api/trpc/device.execute', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ json: { command: 'ALARM_CLEAR', args: '0' } }),
+    })
+    await new Promise(r => setTimeout(r, 2000))
+  }
+}
+main()

--- a/src/components/Schedule/AlarmCard.tsx
+++ b/src/components/Schedule/AlarmCard.tsx
@@ -50,12 +50,6 @@ function formatDayRange(days: DayOfWeek[]): string {
   return ordered.map(d => DAY_SHORT[d]).join(', ')
 }
 
-function intensityColor(intensity: number): string {
-  if (intensity <= 30) return 'bg-green-500'
-  if (intensity <= 60) return 'bg-amber-500'
-  return 'bg-red-500'
-}
-
 export function AlarmCard({ group, onEdit, onDelete, onTest, isTesting = false }: AlarmCardProps) {
   const label = formatDayRange(group.days)
 
@@ -84,29 +78,14 @@ export function AlarmCard({ group, onEdit, onDelete, onTest, isTesting = false }
           <p className="mt-0.5 text-[11px] text-zinc-400">{label}</p>
 
           <div className="mt-2 flex items-center gap-2 text-[11px] text-zinc-500">
-            <span className="capitalize">{group.vibrationPattern}</span>
-            <span>·</span>
             <span>
               {group.duration}
-              s
+              s buzz
             </span>
             <span>·</span>
             <span>
               {group.alarmTemperature}
               °F
-            </span>
-          </div>
-
-          <div className="mt-2 flex items-center gap-1.5">
-            <div className="h-1 flex-1 rounded-full bg-zinc-800 overflow-hidden">
-              <div
-                className={clsx('h-full rounded-full transition-all', intensityColor(group.vibrationIntensity))}
-                style={{ width: `${group.vibrationIntensity}%` }}
-              />
-            </div>
-            <span className="text-[9px] font-medium tabular-nums text-zinc-400">
-              {group.vibrationIntensity}
-              %
             </span>
           </div>
         </div>

--- a/src/components/Schedule/AlarmCard.tsx
+++ b/src/components/Schedule/AlarmCard.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { Bell, Pencil, Play, Trash2 } from 'lucide-react'
+import clsx from 'clsx'
+import type { DayOfWeek } from './DaySelector'
+import { formatTime12h } from './TimeInput'
+
+export interface AlarmGroup {
+  /** All underlying alarm_schedules row ids in this group */
+  ids: number[]
+  days: DayOfWeek[]
+  time: string
+  vibrationIntensity: number
+  vibrationPattern: 'rise' | 'double'
+  duration: number
+  alarmTemperature: number
+  enabled: boolean
+}
+
+interface AlarmCardProps {
+  group: AlarmGroup
+  onEdit: () => void
+  onDelete: () => void
+  onTest: () => void
+  isTesting?: boolean
+}
+
+const DAY_SHORT: Record<DayOfWeek, string> = {
+  sunday: 'Sun', monday: 'Mon', tuesday: 'Tue', wednesday: 'Wed',
+  thursday: 'Thu', friday: 'Fri', saturday: 'Sat',
+}
+
+const DAY_ORDER: DayOfWeek[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+const WEEKDAYS: DayOfWeek[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday']
+const WEEKENDS: DayOfWeek[] = ['saturday', 'sunday']
+
+function formatDayRange(days: DayOfWeek[]): string {
+  if (days.length === 0) return ''
+  if (days.length === 7) return 'Every day'
+  const set = new Set(days)
+  if (WEEKDAYS.every(d => set.has(d)) && set.size === 5) return 'Weekdays'
+  if (WEEKENDS.every(d => set.has(d)) && set.size === 2) return 'Weekends'
+
+  const ordered = DAY_ORDER.filter(d => set.has(d))
+  const indices = ordered.map(d => DAY_ORDER.indexOf(d))
+  const isContiguous = indices.every((idx, i) => i === 0 || idx === indices[i - 1] + 1)
+  if (isContiguous && ordered.length > 2) {
+    return `${DAY_SHORT[ordered[0]]}–${DAY_SHORT[ordered[ordered.length - 1]]}`
+  }
+  return ordered.map(d => DAY_SHORT[d]).join(', ')
+}
+
+function intensityColor(intensity: number): string {
+  if (intensity <= 30) return 'bg-green-500'
+  if (intensity <= 60) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+export function AlarmCard({ group, onEdit, onDelete, onTest, isTesting = false }: AlarmCardProps) {
+  const label = formatDayRange(group.days)
+
+  return (
+    <div
+      className={clsx(
+        'rounded-2xl border p-3 sm:p-4',
+        group.enabled
+          ? 'border-zinc-800 bg-zinc-900'
+          : 'border-dashed border-amber-500/30 bg-zinc-900/50',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Bell size={18} className="mt-1 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-base font-semibold text-white">
+              {formatTime12h(group.time)}
+            </span>
+            {!group.enabled && (
+              <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[9px] font-medium uppercase text-amber-500">
+                Paused
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-[11px] text-zinc-400">{label}</p>
+
+          <div className="mt-2 flex items-center gap-2 text-[11px] text-zinc-500">
+            <span className="capitalize">{group.vibrationPattern}</span>
+            <span>·</span>
+            <span>
+              {group.duration}
+              s
+            </span>
+            <span>·</span>
+            <span>
+              {group.alarmTemperature}
+              °F
+            </span>
+          </div>
+
+          <div className="mt-2 flex items-center gap-1.5">
+            <div className="h-1 flex-1 rounded-full bg-zinc-800 overflow-hidden">
+              <div
+                className={clsx('h-full rounded-full transition-all', intensityColor(group.vibrationIntensity))}
+                style={{ width: `${group.vibrationIntensity}%` }}
+              />
+            </div>
+            <span className="text-[9px] font-medium tabular-nums text-zinc-400">
+              {group.vibrationIntensity}
+              %
+            </span>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            onClick={onTest}
+            disabled={isTesting}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-amber-400 transition-colors active:bg-zinc-800 disabled:opacity-50"
+            aria-label={`Test ${label} alarm`}
+          >
+            <Play size={14} />
+          </button>
+          <button
+            onClick={onEdit}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors active:bg-zinc-800 active:text-sky-400"
+            aria-label={`Edit ${label} alarm`}
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={onDelete}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-600 transition-colors active:bg-zinc-800 active:text-red-400"
+            aria-label={`Delete ${label} alarm`}
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Schedule/AlarmEditor.tsx
+++ b/src/components/Schedule/AlarmEditor.tsx
@@ -4,13 +4,12 @@ import { useCallback, useEffect, useState } from 'react'
 import { X, Vibrate, Bell, Loader2, Trash2 } from 'lucide-react'
 import clsx from 'clsx'
 import { trpc } from '@/src/utils/trpc'
-import { VIBRATION_PRESETS } from '@/src/lib/vibrationPatterns'
+import { FIXED_INTENSITY, FIXED_PATTERN, VIBRATION_PRESETS } from '@/src/lib/vibrationPatterns'
 import { DAYS, type DayOfWeek } from './DaySelector'
 import { TimeInput } from './TimeInput'
 import type { AlarmGroup } from './AlarmCard'
 
 type Side = 'left' | 'right'
-type Pattern = 'rise' | 'double'
 
 interface AlarmEditorProps {
   open: boolean
@@ -23,25 +22,11 @@ interface AlarmEditorProps {
 }
 
 const DEFAULT_TIME = '07:00'
-const DEFAULT_INTENSITY = 50
-const DEFAULT_PATTERN: Pattern = 'rise'
 const DEFAULT_DURATION = 30
 const DEFAULT_TEMP = 75
 
 const MIN_TEMP = 55
 const MAX_TEMP = 110
-
-function intensityColor(intensity: number): string {
-  if (intensity <= 30) return 'bg-green-500'
-  if (intensity <= 60) return 'bg-amber-500'
-  return 'bg-red-500'
-}
-
-function intensityTextColor(intensity: number): string {
-  if (intensity <= 30) return 'text-green-400'
-  if (intensity <= 60) return 'text-amber-400'
-  return 'text-red-400'
-}
 
 /**
  * Full-screen editor for creating or editing an alarm.
@@ -60,8 +45,6 @@ export function AlarmEditor({
 
   const [days, setDays] = useState<Set<DayOfWeek>>(new Set())
   const [time, setTime] = useState(DEFAULT_TIME)
-  const [intensity, setIntensity] = useState(DEFAULT_INTENSITY)
-  const [pattern, setPattern] = useState<Pattern>(DEFAULT_PATTERN)
   const [duration, setDuration] = useState(DEFAULT_DURATION)
   const [temperature, setTemperature] = useState(DEFAULT_TEMP)
   const [saveError, setSaveError] = useState<string | null>(null)
@@ -73,16 +56,12 @@ export function AlarmEditor({
     if (existingGroup) {
       setDays(new Set(existingGroup.days))
       setTime(existingGroup.time)
-      setIntensity(existingGroup.vibrationIntensity)
-      setPattern(existingGroup.vibrationPattern)
       setDuration(existingGroup.duration)
       setTemperature(Math.round(existingGroup.alarmTemperature))
     }
     else {
       setDays(new Set())
       setTime(DEFAULT_TIME)
-      setIntensity(DEFAULT_INTENSITY)
-      setPattern(DEFAULT_PATTERN)
       setDuration(DEFAULT_DURATION)
       setTemperature(DEFAULT_TEMP)
     }
@@ -117,14 +96,12 @@ export function AlarmEditor({
   }, [])
 
   const applyPreset = useCallback((preset: typeof VIBRATION_PRESETS[number]) => {
-    setIntensity(preset.intensity)
-    setPattern(preset.pattern)
     setDuration(preset.duration)
   }, [])
 
   const handleTest = useCallback(() => {
-    testAlarm.mutate({ side, vibrationIntensity: intensity, vibrationPattern: pattern, duration })
-  }, [testAlarm, side, intensity, pattern, duration])
+    testAlarm.mutate({ side, vibrationIntensity: FIXED_INTENSITY, vibrationPattern: FIXED_PATTERN, duration })
+  }, [testAlarm, side, duration])
 
   const handleStopTest = useCallback(() => {
     clearAlarm.mutate({ side })
@@ -144,8 +121,8 @@ export function AlarmEditor({
       side,
       dayOfWeek,
       time,
-      vibrationIntensity: intensity,
-      vibrationPattern: pattern,
+      vibrationIntensity: FIXED_INTENSITY,
+      vibrationPattern: FIXED_PATTERN,
       duration,
       alarmTemperature: temperature,
       enabled,
@@ -164,7 +141,7 @@ export function AlarmEditor({
     catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to save alarm')
     }
-  }, [days, side, time, intensity, pattern, duration, temperature, existingGroup, batchUpdate, utils, onSaved, onClose])
+  }, [days, side, time, duration, temperature, existingGroup, batchUpdate, utils, onSaved, onClose])
 
   const handleDelete = useCallback(async () => {
     if (!existingGroup) return
@@ -254,67 +231,23 @@ export function AlarmEditor({
                 onClick={() => applyPreset(p)}
                 className={clsx(
                   'rounded-full border px-3 py-1.5 text-[11px] font-medium transition-colors',
-                  intensity === p.intensity && pattern === p.pattern && duration === p.duration
+                  duration === p.duration
                     ? 'border-sky-500/60 bg-sky-500/15 text-sky-300'
                     : 'border-zinc-700 bg-zinc-900 text-zinc-400 active:bg-zinc-800',
                 )}
               >
                 {p.name}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Intensity */}
-        <div>
-          <div className="mb-1 flex items-center justify-between">
-            <span className="text-xs font-medium text-zinc-400">Intensity</span>
-            <span className={clsx('text-xs font-medium', intensityTextColor(intensity))}>
-              {intensity}
-              %
-            </span>
-          </div>
-          <div className="relative">
-            <div className="absolute top-1/2 left-0 right-0 h-1.5 -translate-y-1/2 rounded-full bg-zinc-700 overflow-hidden pointer-events-none">
-              <div
-                className={clsx('h-full rounded-full transition-all', intensityColor(intensity))}
-                style={{ width: `${intensity}%` }}
-              />
-            </div>
-            <input
-              type="range"
-              min={1}
-              max={100}
-              step={1}
-              value={intensity}
-              onChange={e => setIntensity(parseInt(e.target.value, 10))}
-              className="relative z-10 h-1.5 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow"
-            />
-          </div>
-        </div>
-
-        {/* Pattern */}
-        <div>
-          <span className="mb-1.5 block text-xs font-medium text-zinc-400">Pattern</span>
-          <div className="grid grid-cols-2 gap-2">
-            {(['rise', 'double'] as const).map(pat => (
-              <button
-                key={pat}
-                onClick={() => setPattern(pat)}
-                className={clsx(
-                  'flex min-h-[44px] flex-col items-center justify-center rounded-lg border py-2 text-xs font-medium capitalize transition-colors',
-                  pattern === pat
-                    ? 'border-sky-500/50 bg-sky-500/10 text-sky-400'
-                    : 'border-zinc-700 bg-zinc-800/50 text-zinc-400 active:bg-zinc-700',
-                )}
-              >
-                <span>{pat}</span>
-                <span className="text-[9px] font-normal text-zinc-500">
-                  {pat === 'rise' ? 'Soft → strong ramp' : 'Two strong bursts'}
+                {' '}
+                <span className="text-[9px] opacity-60">
+                  {p.duration}
+                  s
                 </span>
               </button>
             ))}
           </div>
+          <p className="mt-1.5 text-[10px] text-zinc-600">
+            Intensity and pattern are firmware-clamped on Pod 5 — only duration affects the buzz.
+          </p>
         </div>
 
         {/* Duration */}

--- a/src/components/Schedule/AlarmEditor.tsx
+++ b/src/components/Schedule/AlarmEditor.tsx
@@ -1,0 +1,429 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { X, Vibrate, Bell, Loader2, Trash2 } from 'lucide-react'
+import clsx from 'clsx'
+import { trpc } from '@/src/utils/trpc'
+import { VIBRATION_PRESETS } from '@/src/lib/vibrationPatterns'
+import { DAYS, type DayOfWeek } from './DaySelector'
+import { TimeInput } from './TimeInput'
+import type { AlarmGroup } from './AlarmCard'
+
+type Side = 'left' | 'right'
+type Pattern = 'rise' | 'double'
+
+interface AlarmEditorProps {
+  open: boolean
+  onClose: () => void
+  side: Side
+  /** When provided, editor opens in edit mode for this group. */
+  existingGroup?: AlarmGroup | null
+  /** Called after a successful save so the parent can refetch. */
+  onSaved?: () => void
+}
+
+const DEFAULT_TIME = '07:00'
+const DEFAULT_INTENSITY = 50
+const DEFAULT_PATTERN: Pattern = 'rise'
+const DEFAULT_DURATION = 30
+const DEFAULT_TEMP = 75
+
+const MIN_TEMP = 55
+const MAX_TEMP = 110
+
+function intensityColor(intensity: number): string {
+  if (intensity <= 30) return 'bg-green-500'
+  if (intensity <= 60) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+function intensityTextColor(intensity: number): string {
+  if (intensity <= 30) return 'text-green-400'
+  if (intensity <= 60) return 'text-amber-400'
+  return 'text-red-400'
+}
+
+/**
+ * Full-screen editor for creating or editing an alarm.
+ * - Each saved alarm produces one row per selected day (same time/pattern/intensity/duration/temp).
+ * - "Test" fires `device.setAlarm` immediately so the user can feel the pattern.
+ * - On save, delete-then-create: removes existing rows for this group then writes new ones.
+ */
+export function AlarmEditor({
+  open,
+  onClose,
+  side,
+  existingGroup = null,
+  onSaved,
+}: AlarmEditorProps) {
+  const isEdit = existingGroup !== null
+
+  const [days, setDays] = useState<Set<DayOfWeek>>(new Set())
+  const [time, setTime] = useState(DEFAULT_TIME)
+  const [intensity, setIntensity] = useState(DEFAULT_INTENSITY)
+  const [pattern, setPattern] = useState<Pattern>(DEFAULT_PATTERN)
+  const [duration, setDuration] = useState(DEFAULT_DURATION)
+  const [temperature, setTemperature] = useState(DEFAULT_TEMP)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Reset local state when opening
+  useEffect(() => {
+    if (!open) return
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (existingGroup) {
+      setDays(new Set(existingGroup.days))
+      setTime(existingGroup.time)
+      setIntensity(existingGroup.vibrationIntensity)
+      setPattern(existingGroup.vibrationPattern)
+      setDuration(existingGroup.duration)
+      setTemperature(Math.round(existingGroup.alarmTemperature))
+    }
+    else {
+      setDays(new Set())
+      setTime(DEFAULT_TIME)
+      setIntensity(DEFAULT_INTENSITY)
+      setPattern(DEFAULT_PATTERN)
+      setDuration(DEFAULT_DURATION)
+      setTemperature(DEFAULT_TEMP)
+    }
+    setSaveError(null)
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [open, existingGroup])
+
+  // Lock body scroll
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  const batchUpdate = trpc.schedules.batchUpdate.useMutation()
+  const testAlarm = trpc.device.setAlarm.useMutation()
+  const clearAlarm = trpc.device.clearAlarm.useMutation()
+  const utils = trpc.useUtils()
+
+  const isMutating = batchUpdate.isPending
+
+  const toggleDay = useCallback((day: DayOfWeek) => {
+    setDays((prev) => {
+      const next = new Set(prev)
+      if (next.has(day)) next.delete(day)
+      else next.add(day)
+      return next
+    })
+  }, [])
+
+  const applyPreset = useCallback((preset: typeof VIBRATION_PRESETS[number]) => {
+    setIntensity(preset.intensity)
+    setPattern(preset.pattern)
+    setDuration(preset.duration)
+  }, [])
+
+  const handleTest = useCallback(() => {
+    testAlarm.mutate({ side, vibrationIntensity: intensity, vibrationPattern: pattern, duration })
+  }, [testAlarm, side, intensity, pattern, duration])
+
+  const handleStopTest = useCallback(() => {
+    clearAlarm.mutate({ side })
+  }, [clearAlarm, side])
+
+  const handleSave = useCallback(async () => {
+    if (days.size === 0) {
+      setSaveError('Pick at least one day')
+      return
+    }
+    setSaveError(null)
+
+    const targetDays = Array.from(days)
+    // Preserve enabled state when editing a paused alarm; new alarms default to enabled.
+    const enabled = existingGroup?.enabled ?? true
+    const creates = targetDays.map(dayOfWeek => ({
+      side,
+      dayOfWeek,
+      time,
+      vibrationIntensity: intensity,
+      vibrationPattern: pattern,
+      duration,
+      alarmTemperature: temperature,
+      enabled,
+    }))
+
+    try {
+      await batchUpdate.mutateAsync({
+        deletes: { alarm: existingGroup?.ids ?? [] },
+        creates: { alarm: creates },
+      })
+      void utils.schedules.getAll.invalidate()
+      void utils.schedules.getByDay.invalidate()
+      onSaved?.()
+      onClose()
+    }
+    catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save alarm')
+    }
+  }, [days, side, time, intensity, pattern, duration, temperature, existingGroup, batchUpdate, utils, onSaved, onClose])
+
+  const handleDelete = useCallback(async () => {
+    if (!existingGroup) return
+    setSaveError(null)
+    try {
+      await batchUpdate.mutateAsync({
+        deletes: { alarm: existingGroup.ids },
+      })
+      void utils.schedules.getAll.invalidate()
+      void utils.schedules.getByDay.invalidate()
+      onSaved?.()
+      onClose()
+    }
+    catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to delete alarm')
+    }
+  }, [existingGroup, batchUpdate, utils, onSaved, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-zinc-950">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+        <button
+          onClick={onClose}
+          disabled={isMutating}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-zinc-400 active:bg-zinc-800 disabled:opacity-50"
+          aria-label="Close"
+        >
+          <X size={18} />
+        </button>
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
+          <Bell size={14} className="text-amber-400" />
+          {isEdit ? 'Edit Alarm' : 'New Alarm'}
+        </h2>
+        <button
+          onClick={() => void handleSave()}
+          disabled={isMutating || days.size === 0}
+          className="flex h-9 items-center gap-1.5 rounded-full bg-sky-500 px-4 text-xs font-semibold text-white active:bg-sky-600 disabled:opacity-50"
+        >
+          {isMutating ? <Loader2 size={12} className="animate-spin" /> : null}
+          Save
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-5">
+        {/* Time */}
+        <div>
+          <TimeInput label="Wake at" value={time} onChange={setTime} disabled={isMutating} />
+        </div>
+
+        {/* Days */}
+        <div>
+          <span className="mb-2 block text-xs font-medium text-zinc-400">Repeat</span>
+          <div className="flex items-center justify-between gap-0.5 sm:gap-1">
+            {DAYS.map(({ key, short, label }) => {
+              const selected = days.has(key)
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => toggleDay(key)}
+                  aria-label={label}
+                  aria-pressed={selected}
+                  className={clsx(
+                    'flex h-11 w-11 items-center justify-center rounded-full text-[13px] font-semibold transition-all',
+                    selected
+                      ? 'bg-sky-500 text-white'
+                      : 'bg-zinc-900 text-zinc-500 active:bg-zinc-800',
+                  )}
+                >
+                  {short}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Presets */}
+        <div>
+          <span className="mb-2 block text-xs font-medium text-zinc-400">Quick pick</span>
+          <div className="flex flex-wrap gap-1.5">
+            {VIBRATION_PRESETS.map(p => (
+              <button
+                key={p.name}
+                onClick={() => applyPreset(p)}
+                className={clsx(
+                  'rounded-full border px-3 py-1.5 text-[11px] font-medium transition-colors',
+                  intensity === p.intensity && pattern === p.pattern && duration === p.duration
+                    ? 'border-sky-500/60 bg-sky-500/15 text-sky-300'
+                    : 'border-zinc-700 bg-zinc-900 text-zinc-400 active:bg-zinc-800',
+                )}
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Intensity */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs font-medium text-zinc-400">Intensity</span>
+            <span className={clsx('text-xs font-medium', intensityTextColor(intensity))}>
+              {intensity}
+              %
+            </span>
+          </div>
+          <div className="relative">
+            <div className="absolute top-1/2 left-0 right-0 h-1.5 -translate-y-1/2 rounded-full bg-zinc-700 overflow-hidden pointer-events-none">
+              <div
+                className={clsx('h-full rounded-full transition-all', intensityColor(intensity))}
+                style={{ width: `${intensity}%` }}
+              />
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={100}
+              step={1}
+              value={intensity}
+              onChange={e => setIntensity(parseInt(e.target.value, 10))}
+              className="relative z-10 h-1.5 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow"
+            />
+          </div>
+        </div>
+
+        {/* Pattern */}
+        <div>
+          <span className="mb-1.5 block text-xs font-medium text-zinc-400">Pattern</span>
+          <div className="grid grid-cols-2 gap-2">
+            {(['rise', 'double'] as const).map(pat => (
+              <button
+                key={pat}
+                onClick={() => setPattern(pat)}
+                className={clsx(
+                  'flex min-h-[44px] flex-col items-center justify-center rounded-lg border py-2 text-xs font-medium capitalize transition-colors',
+                  pattern === pat
+                    ? 'border-sky-500/50 bg-sky-500/10 text-sky-400'
+                    : 'border-zinc-700 bg-zinc-800/50 text-zinc-400 active:bg-zinc-700',
+                )}
+              >
+                <span>{pat}</span>
+                <span className="text-[9px] font-normal text-zinc-500">
+                  {pat === 'rise' ? 'Soft → strong ramp' : 'Two strong bursts'}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Duration */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs font-medium text-zinc-400">Duration</span>
+            <span className="text-xs font-medium text-white">
+              {duration}
+              s
+            </span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={180}
+            step={1}
+            value={duration}
+            onChange={e => setDuration(parseInt(e.target.value, 10))}
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-700 accent-sky-500 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500"
+          />
+          <div className="flex justify-between text-[10px] text-zinc-600">
+            <span>1s</span>
+            <span>180s</span>
+          </div>
+        </div>
+
+        {/* Temperature */}
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs font-medium text-zinc-400">Bed temperature at wake</span>
+            <span className="text-xs font-medium text-white">
+              {temperature}
+              °F
+            </span>
+          </div>
+          <input
+            type="range"
+            min={MIN_TEMP}
+            max={MAX_TEMP}
+            step={1}
+            value={temperature}
+            onChange={e => setTemperature(parseInt(e.target.value, 10))}
+            className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-700 accent-sky-500 [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500"
+          />
+          <div className="flex justify-between text-[10px] text-zinc-600">
+            <span>
+              {MIN_TEMP}
+              °F
+            </span>
+            <span>
+              {MAX_TEMP}
+              °F
+            </span>
+          </div>
+        </div>
+
+        {/* Test row */}
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900 p-3">
+          <div className="flex items-center gap-2">
+            <Vibrate size={14} className="text-amber-400" />
+            <p className="flex-1 text-xs text-zinc-300">
+              Test this pattern on the
+              {' '}
+              {side}
+              {' '}
+              side
+            </p>
+            {testAlarm.isPending && (
+              <Loader2 size={12} className="animate-spin text-zinc-400" />
+            )}
+          </div>
+          <div className="mt-2 flex gap-2">
+            <button
+              onClick={handleTest}
+              disabled={testAlarm.isPending}
+              className="flex flex-1 min-h-[40px] items-center justify-center gap-1.5 rounded-lg bg-sky-500/20 text-xs font-medium text-sky-400 transition-colors active:bg-sky-500/30 disabled:opacity-50"
+            >
+              <Vibrate size={12} />
+              Test
+            </button>
+            <button
+              onClick={handleStopTest}
+              disabled={clearAlarm.isPending}
+              className="flex flex-1 min-h-[40px] items-center justify-center gap-1.5 rounded-lg bg-zinc-800 text-xs font-medium text-zinc-300 transition-colors active:bg-zinc-700 disabled:opacity-50"
+            >
+              Stop
+            </button>
+          </div>
+          {testAlarm.error && (
+            <p className="mt-1.5 text-[11px] text-red-400">{testAlarm.error.message}</p>
+          )}
+        </div>
+
+        {/* Delete (edit mode) */}
+        {isEdit && (
+          <button
+            onClick={() => void handleDelete()}
+            disabled={isMutating}
+            className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-xl border border-red-500/20 bg-red-500/5 text-sm font-medium text-red-400 active:bg-red-500/10 disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+            Delete alarm
+          </button>
+        )}
+
+        {saveError && (
+          <p className="text-xs text-red-400">{saveError}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Schedule/AlarmSection.tsx
+++ b/src/components/Schedule/AlarmSection.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { Plus, Bell } from 'lucide-react'
+import { trpc } from '@/src/utils/trpc'
+import type { DayOfWeek } from './DaySelector'
+import { AlarmCard, type AlarmGroup } from './AlarmCard'
+import { AlarmEditor } from './AlarmEditor'
+import { ConfirmDialog } from './ConfirmDialog'
+
+type Side = 'left' | 'right'
+type Pattern = 'rise' | 'double'
+
+interface AlarmRow {
+  id: number
+  side: Side
+  dayOfWeek: DayOfWeek
+  time: string
+  vibrationIntensity: number
+  vibrationPattern: Pattern
+  duration: number
+  alarmTemperature: number
+  enabled: boolean
+}
+
+const DAY_ORDER: DayOfWeek[] = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+
+/**
+ * Group alarm_schedules rows that share every field except day-of-week.
+ * Rows are bucketed by a deterministic signature so "wake at 7am Mon–Fri" renders
+ * as one card backed by five row ids.
+ */
+function groupAlarms(rows: AlarmRow[]): AlarmGroup[] {
+  const buckets = new Map<string, AlarmGroup>()
+  for (const r of rows) {
+    const key = [
+      r.time,
+      r.vibrationIntensity,
+      r.vibrationPattern,
+      r.duration,
+      r.alarmTemperature,
+      r.enabled ? 1 : 0,
+    ].join('|')
+    const existing = buckets.get(key)
+    if (existing) {
+      existing.ids.push(r.id)
+      existing.days.push(r.dayOfWeek)
+    }
+    else {
+      buckets.set(key, {
+        ids: [r.id],
+        days: [r.dayOfWeek],
+        time: r.time,
+        vibrationIntensity: r.vibrationIntensity,
+        vibrationPattern: r.vibrationPattern,
+        duration: r.duration,
+        alarmTemperature: r.alarmTemperature,
+        enabled: r.enabled,
+      })
+    }
+  }
+  const groups = Array.from(buckets.values())
+  for (const g of groups) {
+    g.days.sort((a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b))
+  }
+  groups.sort((a, b) => a.time.localeCompare(b.time))
+  return groups
+}
+
+interface AlarmSectionProps {
+  side: Side
+}
+
+/**
+ * Alarms list + editor section. Lives on the schedule page below temperature curves.
+ * Reads `schedules.getAll.alarm`, groups identical rows across days into single cards,
+ * and routes create/edit through `AlarmEditor`.
+ */
+export function AlarmSection({ side }: AlarmSectionProps) {
+  const { data, isLoading } = trpc.schedules.getAll.useQuery({ side })
+  const utils = trpc.useUtils()
+
+  const [editing, setEditing] = useState<AlarmGroup | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<AlarmGroup | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [testingId, setTestingId] = useState<string | null>(null)
+
+  const batchUpdate = trpc.schedules.batchUpdate.useMutation()
+  const setAlarm = trpc.device.setAlarm.useMutation()
+
+  const groups = useMemo<AlarmGroup[]>(() => {
+    const alarms = (data?.alarm ?? []) as AlarmRow[]
+    return groupAlarms(alarms)
+  }, [data?.alarm])
+
+  const handleCreate = useCallback(() => {
+    setEditing(null)
+    setCreating(true)
+  }, [])
+
+  const handleEdit = useCallback((group: AlarmGroup) => {
+    setEditing(group)
+    setCreating(false)
+  }, [])
+
+  const handleCloseEditor = useCallback(() => {
+    setEditing(null)
+    setCreating(false)
+  }, [])
+
+  const handleTest = useCallback((group: AlarmGroup) => {
+    const id = group.ids.join(',')
+    setTestingId(id)
+    setAlarm.mutate(
+      {
+        side,
+        vibrationIntensity: group.vibrationIntensity,
+        vibrationPattern: group.vibrationPattern,
+        duration: group.duration,
+      },
+      { onSettled: () => setTestingId(null) },
+    )
+  }, [setAlarm, side])
+
+  const confirmDelete = useCallback(async () => {
+    if (!pendingDelete) return
+    setDeleteError(null)
+    try {
+      await batchUpdate.mutateAsync({
+        deletes: { alarm: pendingDelete.ids },
+      })
+      void utils.schedules.getAll.invalidate()
+      void utils.schedules.getByDay.invalidate()
+      setPendingDelete(null)
+    }
+    catch (err) {
+      // Keep the dialog open so the user can retry or cancel. Surface the failure
+      // in a banner — silently closing the dialog after a failed delete leaves the
+      // alarm row visible but with no signal to the user that the delete didn't take.
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete alarm')
+    }
+  }, [pendingDelete, batchUpdate, utils])
+
+  const cancelDelete = useCallback(() => {
+    setPendingDelete(null)
+    setDeleteError(null)
+  }, [])
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+          <Bell size={11} />
+          Alarms
+        </p>
+      </div>
+
+      {isLoading && !data && (
+        <div className="h-20 animate-pulse rounded-2xl bg-zinc-900" />
+      )}
+
+      {!isLoading && groups.length === 0 && (
+        <div className="rounded-2xl border border-dashed border-amber-500/30 bg-amber-500/5 p-5 text-center">
+          <p className="text-sm font-medium text-white">No alarms yet</p>
+          <p className="mt-1 text-xs text-zinc-400">
+            Set a wake-up alarm — the cover buzzes you awake.
+          </p>
+          <button
+            onClick={handleCreate}
+            className="mt-3 inline-flex h-10 items-center gap-1.5 rounded-xl bg-amber-500 px-4 text-sm font-semibold text-zinc-950 active:bg-amber-600"
+          >
+            <Plus size={14} />
+            Add alarm
+          </button>
+        </div>
+      )}
+
+      {groups.length > 0 && (
+        <>
+          <div className="space-y-2">
+            {groups.map(group => (
+              <AlarmCard
+                key={group.ids.join(',')}
+                group={group}
+                onEdit={() => handleEdit(group)}
+                onDelete={() => setPendingDelete(group)}
+                onTest={() => handleTest(group)}
+                isTesting={testingId === group.ids.join(',')}
+              />
+            ))}
+          </div>
+          <button
+            onClick={handleCreate}
+            className="flex h-11 w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-zinc-700 text-sm font-medium text-zinc-400 active:bg-zinc-900"
+          >
+            <Plus size={14} />
+            Add another alarm
+          </button>
+        </>
+      )}
+
+      <AlarmEditor
+        open={creating || editing !== null}
+        onClose={handleCloseEditor}
+        side={side}
+        existingGroup={editing}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete alarm?"
+        message={
+          deleteError
+            ? `Couldn't delete: ${deleteError}. Try again, or cancel.`
+            : `This will remove the alarm for ${pendingDelete?.days.length === 7 ? 'every day' : `${pendingDelete?.days.length ?? 0} day${(pendingDelete?.days.length ?? 0) === 1 ? '' : 's'}`}. The cover will no longer buzz at this time.`
+        }
+        confirmLabel={deleteError ? 'Retry' : 'Delete'}
+        variant="danger"
+        onConfirm={() => void confirmDelete()}
+        onCancel={cancelDelete}
+      />
+    </div>
+  )
+}

--- a/src/components/Schedule/SchedulePage.tsx
+++ b/src/components/Schedule/SchedulePage.tsx
@@ -18,6 +18,7 @@ import { CurveEditor } from './CurveEditor'
 import { ConfirmDialog } from './ConfirmDialog'
 import { ScheduleToggle } from './ScheduleToggle'
 import { SchedulerConfirmation } from './SchedulerConfirmation'
+import { AlarmSection } from './AlarmSection'
 
 /**
  * Read-only schedule view: lists curves (groups of days sharing a temperature
@@ -184,6 +185,9 @@ export function SchedulePage() {
           </button>
         </>
       )}
+
+      {/* Alarms — wake the user with a cover vibration at a scheduled time */}
+      <AlarmSection side={side} />
 
       {/* Edit / Create editor */}
       <CurveEditor

--- a/src/components/Settings/HapticsTestCard.tsx
+++ b/src/components/Settings/HapticsTestCard.tsx
@@ -5,24 +5,7 @@ import { Vibrate, Play, Square, ChevronDown } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
 import { useSide } from '@/src/hooks/useSide'
 import clsx from 'clsx'
-import { VIBRATION_PRESETS } from '@/src/lib/vibrationPatterns'
-
-// ---------------------------------------------------------------------------
-// Intensity color helpers
-// ---------------------------------------------------------------------------
-
-/** Returns a tailwind-compatible color class based on intensity level. */
-function intensityColor(intensity: number): string {
-  if (intensity <= 30) return 'bg-green-500'
-  if (intensity <= 60) return 'bg-amber-500'
-  return 'bg-red-500'
-}
-
-function intensityTextColor(intensity: number): string {
-  if (intensity <= 30) return 'text-green-400'
-  if (intensity <= 60) return 'text-amber-400'
-  return 'text-red-400'
-}
+import { FIXED_INTENSITY, FIXED_PATTERN, VIBRATION_PRESETS } from '@/src/lib/vibrationPatterns'
 
 // ---------------------------------------------------------------------------
 // Component
@@ -32,8 +15,6 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
   const { side: contextSide } = useSide()
   const side = filterSide ?? contextSide
   const [customExpanded, setCustomExpanded] = useState(false)
-  const [customIntensity, setCustomIntensity] = useState(50)
-  const [customPattern, setCustomPattern] = useState<'rise' | 'double'>('rise')
   const [customDuration, setCustomDuration] = useState(10)
   const [activePattern, setActivePattern] = useState<string | null>(null)
 
@@ -50,11 +31,11 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
 
   const isMutating = setAlarm.isPending || clearAlarm.isPending
 
-  function handleTest(intensity: number, pattern: 'rise' | 'double', duration: number, label?: string) {
+  function handleTest(duration: number, label?: string) {
     setAlarm.mutate({
       side,
-      vibrationIntensity: intensity,
-      vibrationPattern: pattern,
+      vibrationIntensity: FIXED_INTENSITY,
+      vibrationPattern: FIXED_PATTERN,
       duration,
     })
     setActivePattern(label ?? 'custom')
@@ -65,7 +46,7 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
   }
 
   function handleQuickTest() {
-    handleTest(30, 'rise', 2, 'quick')
+    handleTest(10, 'quick')
   }
 
   return (
@@ -121,31 +102,15 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
               <div className="flex items-center gap-2">
                 <span className="text-xs font-medium text-zinc-200">{p.name}</span>
                 <span className="text-[9px] text-zinc-600">
-                  {p.pattern}
-                  {' '}
-                  &middot;
                   {p.duration}
                   s
                 </span>
               </div>
               <p className="text-[10px] text-zinc-500 truncate">{p.description}</p>
-              {/* Intensity bar */}
-              <div className="mt-1 flex items-center gap-1.5">
-                <div className="h-1 flex-1 rounded-full bg-zinc-700 overflow-hidden">
-                  <div
-                    className={clsx('h-full rounded-full transition-all', intensityColor(p.intensity))}
-                    style={{ width: `${p.intensity}%` }}
-                  />
-                </div>
-                <span className={clsx('text-[9px] font-medium tabular-nums', intensityTextColor(p.intensity))}>
-                  {p.intensity}
-                  %
-                </span>
-              </div>
             </div>
             {/* Play button */}
             <button
-              onClick={() => handleTest(p.intensity, p.pattern, p.duration, p.name)}
+              onClick={() => handleTest(p.duration, p.name)}
               disabled={isMutating}
               className={clsx(
                 'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-colors disabled:opacity-50',
@@ -159,6 +124,9 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
           </div>
         ))}
       </div>
+      <p className="text-[10px] text-zinc-600">
+        Intensity and pattern are firmware-clamped on Pod 5 — only duration affects the buzz.
+      </p>
 
       {/* Custom controls (collapsible) */}
       <div>
@@ -175,59 +143,6 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
 
         {customExpanded && (
           <div className="space-y-3 rounded-xl border border-zinc-800 bg-zinc-900 p-3 mt-1">
-            {/* Intensity slider */}
-            <div>
-              <div className="mb-1 flex items-center justify-between">
-                <span className="text-xs font-medium text-zinc-400">Intensity</span>
-                <span className={clsx('text-xs font-medium', intensityTextColor(customIntensity))}>
-                  {customIntensity}
-                  %
-                </span>
-              </div>
-              <div className="relative">
-                <div className="absolute top-1/2 left-0 right-0 h-1.5 -translate-y-1/2 rounded-full bg-zinc-700 overflow-hidden pointer-events-none">
-                  <div
-                    className={clsx('h-full rounded-full transition-all', intensityColor(customIntensity))}
-                    style={{ width: `${customIntensity}%` }}
-                  />
-                </div>
-                <input
-                  type="range"
-                  min={1}
-                  max={100}
-                  step={1}
-                  value={customIntensity}
-                  onChange={e => setCustomIntensity(parseInt(e.target.value, 10))}
-                  className="relative z-10 h-1.5 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:h-7 [&::-webkit-slider-thumb]:w-7 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow"
-                />
-              </div>
-              <div className="flex justify-between text-[10px] text-zinc-600">
-                <span>1%</span>
-                <span>100%</span>
-              </div>
-            </div>
-
-            {/* Pattern toggle */}
-            <div>
-              <span className="mb-1.5 block text-xs font-medium text-zinc-400">Pattern</span>
-              <div className="grid grid-cols-2 gap-2">
-                {(['double', 'rise'] as const).map(pat => (
-                  <button
-                    key={pat}
-                    onClick={() => setCustomPattern(pat)}
-                    className={clsx(
-                      'flex min-h-[44px] items-center justify-center rounded-lg border py-2.5 text-xs font-medium capitalize transition-colors',
-                      customPattern === pat
-                        ? 'border-sky-500/50 bg-sky-500/10 text-sky-400'
-                        : 'border-zinc-700 bg-zinc-800/50 text-zinc-400 active:bg-zinc-700'
-                    )}
-                  >
-                    {pat}
-                  </button>
-                ))}
-              </div>
-            </div>
-
             {/* Duration slider */}
             <div>
               <div className="mb-1 flex items-center justify-between">
@@ -254,7 +169,7 @@ export function HapticsTestCard({ filterSide }: { filterSide?: 'left' | 'right' 
 
             {/* Test button */}
             <button
-              onClick={() => handleTest(customIntensity, customPattern, customDuration)}
+              onClick={() => handleTest(customDuration)}
               disabled={isMutating}
               className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-lg bg-sky-500/20 py-2.5 text-sm font-medium text-sky-400 transition-colors active:bg-sky-500/30 disabled:opacity-50"
             >

--- a/src/hardware/alarmPayload.ts
+++ b/src/hardware/alarmPayload.ts
@@ -1,0 +1,31 @@
+import { Encoder } from 'cbor-x'
+import type { AlarmConfig } from './types'
+
+const encoder = new Encoder({ useRecords: false })
+
+/**
+ * Build the wire payload for any of the three alarm commands —
+ * `ALARM_LEFT` (5), `ALARM_RIGHT` (6), `ALARM_SOLO` (17).
+ *
+ * Pod 5 frankenfirmware (SensorAlarm.h::trySparkParseAlarmSettings) expects
+ * a hex-encoded CBOR map with Particle Spark short keys:
+ *   pl = power level / intensity (1..100)
+ *   du = duration in seconds (firmware ignores < 10s — motor won't engage)
+ *   pi = pattern string: 'rise' | 'double'
+ *   tt = trigger time (unix epoch seconds; firmware uses it for retries / dismiss windows)
+ *
+ * The earlier comma-string format ("intensity,pattern,duration") returned
+ * err:-1 from the firmware's registered function — verified live on Pod 5.
+ *
+ * Same payload works across all three commands; the command code selects the
+ * code path (see docs/adr/0021-alarm-solo-trigger.md).
+ */
+export function encodeAlarmPayload(config: AlarmConfig): string {
+  const payload = {
+    pl: config.vibrationIntensity,
+    du: Math.max(10, config.duration),
+    pi: config.vibrationPattern,
+    tt: Math.floor(Date.now() / 1000),
+  }
+  return Buffer.from(encoder.encode(payload)).toString('hex')
+}

--- a/src/hardware/client.ts
+++ b/src/hardware/client.ts
@@ -1,5 +1,6 @@
 import { connectToSocket, type SocketClient } from './socketClient'
 import { parseDeviceStatus, parseSimpleResponse } from './responseParser'
+import { encodeAlarmPayload } from './alarmPayload'
 import {
   type AlarmConfig,
   type DeviceStatus,
@@ -16,8 +17,9 @@ import {
  * Configuration for the hardware client connection.
  *
  * This is the CLIENT-mode connection (for dev/testing only).
- * In production, use FrankenHardwareClient from dacMonitor.instance.ts instead,
- * which uses the FrankenServer pattern (socket server that frankenfirmware connects to).
+ * In production, use `getSharedHardwareClient()` from `./sharedClient.ts` instead,
+ * which talks through the shared DacTransport connection so every writer in the
+ * app queues into the same FIFO.
  *
  * @property socketPath - Path to Unix socket to connect to
  * @property connectionTimeout - Max milliseconds to wait for connection (default: 30s)
@@ -75,8 +77,8 @@ export class HardwareClient {
   /**
    * Connects TO an existing Unix socket as a client.
    *
-   * This is for dev/testing only. In production, use FrankenHardwareClient
-   * from dacMonitor.instance.ts which uses the FrankenServer pattern.
+   * Dev/testing only. Production code uses `getSharedHardwareClient()` from
+   * `./sharedClient.ts`, which routes through the shared DacTransport.
    */
   async connect(): Promise<void> {
     if (this.client && !this.client.isClosed()) {
@@ -241,14 +243,12 @@ export class HardwareClient {
       throw new HardwareError('Alarm duration must be between 0 and 180 seconds')
     }
 
-    const command = side === 'left' ? HardwareCommand.ALARM_LEFT : HardwareCommand.ALARM_RIGHT
-
-    // Hardware protocol: "intensity,pattern,duration"
-    // Pattern encoding: 0 = double burst, 1 = rising intensity
-    const patternCode = config.vibrationPattern === 'double' ? '0' : '1'
-    const argument = `${config.vibrationIntensity},${patternCode},${config.duration}`
-
-    const response = await client.executeCommand(command, argument)
+    // Route per-side: ALARM_LEFT (5) or ALARM_RIGHT (6) with hex-CBOR.
+    // See sharedClient.ts for the live-verification details on Pod 5 J55
+    // firmware. ALARM_SOLO (cmd 2) is not registered on that firmware and
+    // silently drops.
+    const cmd = side === 'left' ? HardwareCommand.ALARM_LEFT : HardwareCommand.ALARM_RIGHT
+    const response = await client.executeCommand(cmd, encodeAlarmPayload(config))
     const parsed = parseSimpleResponse(response)
 
     if (!parsed.success) {

--- a/src/hardware/dacMonitor.instance.ts
+++ b/src/hardware/dacMonitor.instance.ts
@@ -1,64 +1,41 @@
 /**
- * Global hardware singleton — ONE franken connection, ONE client, ONE monitor.
+ * Read-side singleton for the DAC: owns the transport connection, the polling
+ * monitor, the gesture handler, and the device-state writer. **Does not** issue
+ * commands itself — every writer goes through `getSharedHardwareClient()` from
+ * `./sharedClient.ts`. Keeping the write surface out of this file makes it
+ * obvious what the monitor's job is (observe + broadcast) and prevents new
+ * accessors from accidentally landing here.
  *
- * Lifecycle (managed by instrumentation.ts):
- *   1. startDacServer()     — connectDac() on dac.sock
- *   2. getDacMonitor()      — create monitor + client, start polling when connected
- *   3. shutdownDacMonitor() — disconnectDac() + stop everything
+ * Lifecycle (driven by `instrumentation.ts`):
+ *   1. `startDacServer()`     — kicks off the DacTransport connection on dac.sock
+ *   2. `getDacMonitor()`      — creates the monitor, gesture handler, state sync;
+ *                               wires status / gesture events; starts polling
+ *   3. `shutdownDacMonitor()` — stops the monitor, cancels snoozes, clears the
+ *                               shared client, disconnects the transport
  *
- * All consumers (DacMonitor, device router, health router) share the same
- * DacTransport connection and HardwareClient. No competing listeners.
- *
- * The HardwareClient returned by getSharedHardwareClient() is a thin wrapper
- * around sendCommand() from ./dacTransport — it implements the same interface
- * as the old SocketClient-based HardwareClient.
+ * Backed by `globalThis` so Turbopack module duplication can't produce two
+ * monitors competing for the same socket.
  */
 
-import { connectDac, disconnectDac, sendCommand, isDacConnected } from './dacTransport'
+import { connectDac, disconnectDac } from './dacTransport'
 import { DacMonitor } from './dacMonitor'
-import type { HardwareClient } from './client'
 import { GestureActionHandler } from './gestureActionHandler'
 import { defaultGestureActionDeps } from './gestureActionHandler.deps'
 import { DeviceStateSync, getAlarmState } from './deviceStateSync'
 import { trackPrimingState, resetPrimingState, getPrimeCompletedAt } from './primeNotification'
 import { cancelSnooze, getSnoozeStatus } from './snoozeManager'
-import { parseDeviceStatus, parseSimpleResponse } from './responseParser'
-import {
-  type AlarmConfig,
-  type DeviceStatus,
-  type Side,
-  DEFAULT_HEATING_DURATION,
-  HardwareCommand,
-  HardwareError,
-  fahrenheitToLevel,
-  MAX_TEMP,
-  MIN_TEMP,
-} from './types'
+import { clearSharedHardwareClient, getSharedHardwareClient } from './sharedClient'
 
 const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
 
-/**
- * Last-resort target when a caller asks to power a side ON without supplying
- * a temperature. Real callers (HomeKit, gestures, scheduler) all pass an
- * explicit target sourced from cache/state; this fallback only fires for
- * legacy paths (e.g. mqttBridge passthrough with no temperature in payload)
- * so the pod doesn't sit at level 0 after a power-on.
- */
-const POWER_ON_FALLBACK_F = 75
-
-// ── Singleton storage on globalThis (survives Turbopack module duplication) ──
-
 const KEYS = {
   server: '__sp_dac_server__',
-  client: '__sp_hw_client__',
   monitor: '__sp_dac_monitor__',
   gesture: '__sp_gesture_handler__',
   unsubFlow: '__sp_unsub_flow__',
 } as const
 
 const g = globalThis as Record<string, unknown>
-
-// ── DacTransport connection (replaces DacSocketServer) ──
 
 export async function startDacServer(): Promise<void> {
   if (g[KEYS.server]) return
@@ -75,127 +52,9 @@ export function getDacServer(): unknown {
   return g[KEYS.server] ?? null
 }
 
-// ── DacHardwareClient — same interface as HardwareClient, backed by sendCommand() ──
-
-/**
- * Thin wrapper around sendCommand() that presents the same interface as
- * the original HardwareClient. All consumers (DacMonitor, tRPC routers,
- * gesture handler, job manager) use this without knowing the backend changed.
- */
-class DacHardwareClient {
-  async connect(): Promise<void> {
-    // connectDac is called in startDacServer().
-    // If not yet connected, connect now.
-    if (!isDacConnected()) {
-      await connectDac(DAC_SOCK_PATH)
-    }
-  }
-
-  async getDeviceStatus(): Promise<DeviceStatus> {
-    const response = await sendCommand(HardwareCommand.DEVICE_STATUS)
-    return parseDeviceStatus(response)
-  }
-
-  async setTemperature(side: Side, temperature: number, duration?: number): Promise<void> {
-    if (temperature < MIN_TEMP || temperature > MAX_TEMP) {
-      throw new HardwareError(`Temperature must be between ${MIN_TEMP}°F and ${MAX_TEMP}°F`)
-    }
-
-    const level = fahrenheitToLevel(temperature)
-
-    const levelCommand = side === 'left'
-      ? HardwareCommand.TEMP_LEVEL_LEFT
-      : HardwareCommand.TEMP_LEVEL_RIGHT
-
-    await sendCommand(levelCommand, level.toString())
-
-    // Always send duration — default to 8 hours if not specified so the pod actually heats
-    const durationCommand = side === 'left'
-      ? HardwareCommand.LEFT_TEMP_DURATION
-      : HardwareCommand.RIGHT_TEMP_DURATION
-
-    await sendCommand(durationCommand, (duration ?? DEFAULT_HEATING_DURATION).toString())
-  }
-
-  async setAlarm(side: Side, config: AlarmConfig): Promise<void> {
-    if (config.vibrationIntensity < 1 || config.vibrationIntensity > 100) {
-      throw new HardwareError('Vibration intensity must be between 1 and 100')
-    }
-    if (config.duration < 0 || config.duration > 180) {
-      throw new HardwareError('Alarm duration must be between 0 and 180 seconds')
-    }
-
-    const command = side === 'left' ? HardwareCommand.ALARM_LEFT : HardwareCommand.ALARM_RIGHT
-    const patternCode = config.vibrationPattern === 'double' ? '0' : '1'
-    const argument = `${config.vibrationIntensity},${patternCode},${config.duration}`
-
-    const response = await sendCommand(command, argument)
-    const parsed = parseSimpleResponse(response)
-
-    if (!parsed.success) {
-      throw new HardwareError(`Failed to set alarm: ${parsed.message}`)
-    }
-  }
-
-  async clearAlarm(side: Side): Promise<void> {
-    await sendCommand(HardwareCommand.ALARM_CLEAR, side === 'left' ? '0' : '1')
-  }
-
-  async startPriming(): Promise<void> {
-    const response = await sendCommand(HardwareCommand.PRIME)
-    const parsed = parseSimpleResponse(response)
-
-    if (!parsed.success) {
-      throw new HardwareError(`Failed to start priming: ${parsed.message}`)
-    }
-  }
-
-  async setPower(side: Side, powered: boolean, temperature?: number): Promise<void> {
-    if (powered) {
-      const temp = temperature ?? POWER_ON_FALLBACK_F
-      await this.setTemperature(side, temp)
-    }
-    else {
-      const command = side === 'left'
-        ? HardwareCommand.TEMP_LEVEL_LEFT
-        : HardwareCommand.TEMP_LEVEL_RIGHT
-
-      const response = await sendCommand(command, '0')
-      const parsed = parseSimpleResponse(response)
-
-      if (!parsed.success) {
-        throw new HardwareError(`Failed to power off: ${parsed.message}`)
-      }
-    }
-  }
-
-  isConnected(): boolean {
-    return isDacConnected()
-  }
-
-  disconnect(): void {
-    // No-op for shared client — disconnectDac() is called at shutdown.
-    // Individual consumers should not tear down the shared connection.
-  }
-
-  getRawClient(): null {
-    return null
-  }
-}
-
-// ── Shared HardwareClient ──
-
-export function getSharedHardwareClient(): HardwareClient {
-  if (g[KEYS.client]) return g[KEYS.client] as HardwareClient
-
-  // Return a DacHardwareClient cast as HardwareClient.
-  // It implements the same interface (duck typing).
-  const client = new DacHardwareClient() as unknown as HardwareClient
-  g[KEYS.client] = client
-  return client
-}
-
-// ── DacMonitor ──
+// Re-export for callers that historically imported from this module. The
+// implementation lives in `./sharedClient.ts` — new code should import there.
+export { getSharedHardwareClient }
 
 let monitorInitPromise: Promise<DacMonitor> | null = null
 
@@ -306,9 +165,9 @@ export const shutdownDacMonitor = async (): Promise<void> => {
 
   g[KEYS.monitor] = null
   g[KEYS.gesture] = null
-  g[KEYS.client] = null
   g[KEYS.server] = null
   g[KEYS.unsubFlow] = null
+  clearSharedHardwareClient()
   monitorInitPromise = null
 
   gestureHandler?.cleanup()

--- a/src/hardware/sharedClient.ts
+++ b/src/hardware/sharedClient.ts
@@ -1,0 +1,175 @@
+/**
+ * Production HardwareClient used by every writer in the app — tRPC routers,
+ * scheduler jobs, gesture actions, HomeKit accessories, services. All callers
+ * share one instance backed by the singleton DacTransport connection so the
+ * pod sees a single FIFO of commands instead of competing writers.
+ *
+ * This is the **only** path that should issue commands to the hardware in
+ * production. The `HardwareClient` class in `./client.ts` is the dev/test
+ * variant that opens its own socket — do not use it from app code.
+ *
+ * Lifecycle: started by `startDacServer()` in `./dacMonitor.instance.ts`,
+ * cleared by `clearSharedHardwareClient()` during shutdown.
+ */
+
+import { connectDac, isDacConnected, sendCommand } from './dacTransport'
+import { encodeAlarmPayload } from './alarmPayload'
+import { parseDeviceStatus, parseSimpleResponse } from './responseParser'
+import type { HardwareClient } from './client'
+import {
+  type AlarmConfig,
+  type DeviceStatus,
+  type Side,
+  DEFAULT_HEATING_DURATION,
+  HardwareCommand,
+  HardwareError,
+  fahrenheitToLevel,
+  MAX_TEMP,
+  MIN_TEMP,
+} from './types'
+
+const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
+const CLIENT_KEY = '__sp_hw_client__'
+
+/**
+ * Last-resort target when a caller asks to power a side ON without supplying
+ * a temperature. Real callers (HomeKit, gestures, scheduler) all pass an
+ * explicit target sourced from cache/state; this fallback only fires for
+ * legacy paths (e.g. mqttBridge passthrough with no temperature in payload)
+ * so the pod doesn't sit at level 0 after a power-on.
+ */
+const POWER_ON_FALLBACK_F = 75
+const g = globalThis as Record<string, unknown>
+
+/**
+ * Thin wrapper around sendCommand() that presents the same interface as the
+ * dev `HardwareClient`. Duck-typed, not nominally — callers depend on the
+ * shape, not the class identity.
+ */
+class DacHardwareClient {
+  async connect(): Promise<void> {
+    if (!isDacConnected()) {
+      await connectDac(DAC_SOCK_PATH)
+    }
+  }
+
+  async getDeviceStatus(): Promise<DeviceStatus> {
+    const response = await sendCommand(HardwareCommand.DEVICE_STATUS)
+    return parseDeviceStatus(response)
+  }
+
+  async setTemperature(side: Side, temperature: number, duration?: number): Promise<void> {
+    if (temperature < MIN_TEMP || temperature > MAX_TEMP) {
+      throw new HardwareError(`Temperature must be between ${MIN_TEMP}°F and ${MAX_TEMP}°F`)
+    }
+
+    const level = fahrenheitToLevel(temperature)
+
+    const levelCommand = side === 'left'
+      ? HardwareCommand.TEMP_LEVEL_LEFT
+      : HardwareCommand.TEMP_LEVEL_RIGHT
+
+    await sendCommand(levelCommand, level.toString())
+
+    const durationCommand = side === 'left'
+      ? HardwareCommand.LEFT_TEMP_DURATION
+      : HardwareCommand.RIGHT_TEMP_DURATION
+
+    await sendCommand(durationCommand, (duration ?? DEFAULT_HEATING_DURATION).toString())
+  }
+
+  async setAlarm(side: Side, config: AlarmConfig): Promise<void> {
+    if (config.vibrationIntensity < 1 || config.vibrationIntensity > 100) {
+      throw new HardwareError('Vibration intensity must be between 1 and 100')
+    }
+    if (config.duration < 0 || config.duration > 180) {
+      throw new HardwareError('Alarm duration must be between 0 and 180 seconds')
+    }
+
+    // Route per-side: ALARM_LEFT (cmd 5) or ALARM_RIGHT (cmd 6) with hex-CBOR.
+    // Verified live on Pod 5 (J55) cover on 2026-05-11 against journalctl -u frank:
+    // cmd 5/6 + CBOR → `sparkAlarmL/R` fires → `triggerVibrationAlarm side X` →
+    // `[alarm io] side N power P pattern X for D` writes to the cover MCU and
+    // the motor engages. The `Pillow.cpp:383 ... label uninitialized` log that
+    // appears alongside is the SEPARATE pillow-accessory code path and does NOT
+    // gate the cover motor. ALARM_SOLO (cmd 2) appears in the wire protocol but
+    // frank has no registered spark function at that opcode on this firmware —
+    // commands are silently dropped (no `sparkAlarmS` log, no motor write).
+    const cmd = side === 'left' ? HardwareCommand.ALARM_LEFT : HardwareCommand.ALARM_RIGHT
+    const response = await sendCommand(cmd, encodeAlarmPayload(config))
+    const parsed = parseSimpleResponse(response)
+
+    if (!parsed.success) {
+      throw new HardwareError(`Failed to set alarm: ${parsed.message}`)
+    }
+  }
+
+  async clearAlarm(side: Side): Promise<void> {
+    await sendCommand(HardwareCommand.ALARM_CLEAR, side === 'left' ? '0' : '1')
+  }
+
+  async startPriming(): Promise<void> {
+    const response = await sendCommand(HardwareCommand.PRIME)
+    const parsed = parseSimpleResponse(response)
+
+    if (!parsed.success) {
+      throw new HardwareError(`Failed to start priming: ${parsed.message}`)
+    }
+  }
+
+  async setPower(side: Side, powered: boolean, temperature?: number): Promise<void> {
+    if (powered) {
+      const temp = temperature ?? POWER_ON_FALLBACK_F
+      await this.setTemperature(side, temp)
+    }
+    else {
+      const command = side === 'left'
+        ? HardwareCommand.TEMP_LEVEL_LEFT
+        : HardwareCommand.TEMP_LEVEL_RIGHT
+
+      const response = await sendCommand(command, '0')
+      const parsed = parseSimpleResponse(response)
+
+      if (!parsed.success) {
+        throw new HardwareError(`Failed to power off: ${parsed.message}`)
+      }
+    }
+  }
+
+  isConnected(): boolean {
+    return isDacConnected()
+  }
+
+  // DEBUG passthrough for device.execute. Lives on the client (not as a
+  // free function) so the call binds to the same `dacTransport` module
+  // instance that owns the live `transport` singleton — importing
+  // sendCommand directly into a route handler can resolve to a separate
+  // Next.js bundle whose `transport` is undefined.
+  async sendRaw(command: string, args?: string): Promise<string> {
+    if (!isDacConnected()) {
+      await connectDac(DAC_SOCK_PATH)
+    }
+    return sendCommand(command, args)
+  }
+
+  disconnect(): void {
+    // No-op for the shared client — disconnectDac() runs at app shutdown.
+    // Per-caller teardown would kill the shared connection for every other consumer.
+  }
+
+  getRawClient(): null {
+    return null
+  }
+}
+
+export function getSharedHardwareClient(): HardwareClient {
+  if (g[CLIENT_KEY]) return g[CLIENT_KEY] as HardwareClient
+  const client = new DacHardwareClient() as unknown as HardwareClient
+  g[CLIENT_KEY] = client
+  return client
+}
+
+/** Used by the DAC monitor's shutdown path. Not for general use. */
+export function clearSharedHardwareClient(): void {
+  g[CLIENT_KEY] = null
+}

--- a/src/hardware/tests/dacMonitor.instance.test.ts
+++ b/src/hardware/tests/dacMonitor.instance.test.ts
@@ -364,18 +364,26 @@ describe('hardware/dacMonitor.instance', () => {
           .rejects.toThrow(/duration/)
       })
 
-      it('setAlarm(left, rise) sends ALARM_LEFT with pattern code 1', async () => {
+      it('setAlarm(left, rise) sends ALARM_LEFT (cmd 5) with hex-CBOR payload', async () => {
         const mod = await freshModule()
         await mod.getSharedHardwareClient()
           .setAlarm('left', { vibrationIntensity: 50, vibrationPattern: 'rise', duration: 60 })
-        expect(sendCommandMock).toHaveBeenCalledWith('5', '50,1,60')
+        const [cmd, arg] = sendCommandMock.mock.calls[0]
+        expect(cmd).toBe('5')
+        expect(arg).toMatch(/^[0-9a-f]+$/)
+        // CBOR text(4) "rise" encodes as 0x64 0x72 0x69 0x73 0x65
+        expect(arg).toContain('6472697365')
       })
 
-      it('setAlarm(right, double) sends ALARM_RIGHT with pattern code 0', async () => {
+      it('setAlarm(right, double) sends ALARM_RIGHT (cmd 6) with hex-CBOR payload', async () => {
         const mod = await freshModule()
         await mod.getSharedHardwareClient()
           .setAlarm('right', { vibrationIntensity: 100, vibrationPattern: 'double', duration: 0 })
-        expect(sendCommandMock).toHaveBeenCalledWith('6', '100,0,0')
+        const [cmd, arg] = sendCommandMock.mock.calls[0]
+        expect(cmd).toBe('6')
+        expect(arg).toMatch(/^[0-9a-f]+$/)
+        // CBOR text(6) "double" encodes as 0x66 0x64 0x6f 0x75 0x62 0x6c 0x65
+        expect(arg).toContain('66646f75626c65')
       })
 
       it('setAlarm throws when parseSimpleResponse reports failure', async () => {

--- a/src/hardware/tests/mockServer.ts
+++ b/src/hardware/tests/mockServer.ts
@@ -54,6 +54,7 @@ export class MockHardwareServer {
     this.commandResponses.set(HardwareCommand.TEMP_LEVEL_RIGHT, OK_RESPONSE)
     this.commandResponses.set(HardwareCommand.LEFT_TEMP_DURATION, OK_RESPONSE)
     this.commandResponses.set(HardwareCommand.RIGHT_TEMP_DURATION, OK_RESPONSE)
+    this.commandResponses.set(HardwareCommand.ALARM_SOLO, OK_RESPONSE)
     this.commandResponses.set(HardwareCommand.ALARM_LEFT, OK_RESPONSE)
     this.commandResponses.set(HardwareCommand.ALARM_RIGHT, OK_RESPONSE)
     this.commandResponses.set(HardwareCommand.ALARM_CLEAR, OK_RESPONSE)

--- a/src/hardware/tests/sharedClient.test.ts
+++ b/src/hardware/tests/sharedClient.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for src/hardware/sharedClient.ts.
+ *
+ * Focuses on the `sendRaw` debug path used by device.execute — it must
+ * auto-connect when the transport is idle and forward verbatim to
+ * sendCommand. The wider client surface is exercised through dacMonitor /
+ * device router tests; this file just patches the coverage gap.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const connectDacMock = vi.fn<(path: string) => Promise<void>>(async () => {})
+const sendCommandMock = vi.fn<(cmd: string, arg?: string) => Promise<string>>(async () => 'OK\n\n')
+const isDacConnectedMock = vi.fn(() => true)
+
+vi.mock('../dacTransport', () => ({
+  connectDac: (path: string) => connectDacMock(path),
+  sendCommand: (cmd: string, arg?: string) => sendCommandMock(cmd, arg),
+  isDacConnected: () => isDacConnectedMock(),
+}))
+
+import type * as SharedClientModule from '../sharedClient'
+type Module = typeof SharedClientModule
+
+async function freshModule(): Promise<Module> {
+  vi.resetModules()
+  const g = globalThis as Record<string, unknown>
+  delete g['__sp_hw_client__']
+  return await import('../sharedClient')
+}
+
+beforeEach(() => {
+  connectDacMock.mockClear()
+  sendCommandMock.mockClear()
+  isDacConnectedMock.mockReset()
+  isDacConnectedMock.mockReturnValue(true)
+})
+
+afterEach(() => {
+  const g = globalThis as Record<string, unknown>
+  delete g['__sp_hw_client__']
+})
+
+describe('sharedClient singleton', () => {
+  it('returns the same instance across calls', async () => {
+    const mod = await freshModule()
+    const a = mod.getSharedHardwareClient()
+    const b = mod.getSharedHardwareClient()
+    expect(a).toBe(b)
+  })
+
+  it('clearSharedHardwareClient drops the cached instance', async () => {
+    const mod = await freshModule()
+    const a = mod.getSharedHardwareClient()
+    mod.clearSharedHardwareClient()
+    const b = mod.getSharedHardwareClient()
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('sharedClient.sendRaw', () => {
+  it('forwards command + args verbatim to sendCommand when already connected', async () => {
+    const mod = await freshModule()
+    const client = mod.getSharedHardwareClient() as unknown as {
+      sendRaw: (cmd: string, args?: string) => Promise<string>
+    }
+    sendCommandMock.mockResolvedValueOnce('raw-response')
+
+    const result = await client.sendRaw('5', 'deadbeef')
+
+    expect(connectDacMock).not.toHaveBeenCalled()
+    expect(sendCommandMock).toHaveBeenCalledWith('5', 'deadbeef')
+    expect(result).toBe('raw-response')
+  })
+
+  it('auto-connects when DAC is idle, then forwards to sendCommand', async () => {
+    const mod = await freshModule()
+    isDacConnectedMock.mockReturnValue(false)
+    const client = mod.getSharedHardwareClient() as unknown as {
+      sendRaw: (cmd: string, args?: string) => Promise<string>
+    }
+
+    await client.sendRaw('14')
+
+    expect(connectDacMock).toHaveBeenCalledTimes(1)
+    expect(sendCommandMock).toHaveBeenCalledWith('14', undefined)
+  })
+})

--- a/src/hardware/tests/types.test.ts
+++ b/src/hardware/tests/types.test.ts
@@ -117,6 +117,7 @@ describe('Enums', () => {
       expect(HardwareCommand.PRIME).toBe('13')
       expect(HardwareCommand.DEVICE_STATUS).toBe('14')
       expect(HardwareCommand.ALARM_CLEAR).toBe('16')
+      expect(HardwareCommand.ALARM_SOLO).toBe('17')
     })
   })
 

--- a/src/hardware/types.ts
+++ b/src/hardware/types.ts
@@ -7,6 +7,8 @@ export enum HardwareCommand {
   HELLO = '0',
   SET_TEMP = '1',
   SET_ALARM = '2',
+  // Per-side alarms — `sparkAlarmL` / `sparkAlarmR`. Gated on the Pillow
+  // subsystem reporting a valid label; rejects with err:-1 on cover-only pods.
   ALARM_LEFT = '5',
   ALARM_RIGHT = '6',
   SET_SETTINGS = '8',
@@ -17,6 +19,13 @@ export enum HardwareCommand {
   PRIME = '13',
   DEVICE_STATUS = '14',
   ALARM_CLEAR = '16',
+  // Solo alarm — `sparkAlarmS` in frankenfirmware. Drives both LP5009 motor
+  // controllers on the cover directly via setHighCurrentVibration, bypassing
+  // the per-side `Pillow.cpp::triggerVibrationAlarm` label gate. Should be
+  // the path that buzzes on a cover-only Pod 5. Identified from free-sleep
+  // (throwaway31265/free-sleep) deviceApi.ts where `ALARM_SOLO: "17"` was
+  // commented out.
+  ALARM_SOLO = '17',
 }
 
 /**

--- a/src/lib/tests/vibrationPatterns.test.ts
+++ b/src/lib/tests/vibrationPatterns.test.ts
@@ -1,26 +1,33 @@
 import { describe, expect, test } from 'vitest'
-import { VIBRATION_PRESETS } from '../vibrationPatterns'
+import { FIXED_INTENSITY, FIXED_PATTERN, VIBRATION_PRESETS } from '../vibrationPatterns'
 
 describe('VIBRATION_PRESETS', () => {
   test('exposes a non-empty preset list', () => {
     expect(VIBRATION_PRESETS.length).toBeGreaterThan(0)
   })
 
-  test('every preset has the required shape and uses a known pattern', () => {
+  test('every preset has the required shape and a sane duration', () => {
     for (const preset of VIBRATION_PRESETS) {
       expect(typeof preset.name).toBe('string')
       expect(preset.name.length).toBeGreaterThan(0)
       expect(typeof preset.description).toBe('string')
-      expect(['rise', 'double']).toContain(preset.pattern)
-      expect(Number.isFinite(preset.intensity)).toBe(true)
-      expect(preset.intensity).toBeGreaterThanOrEqual(1)
-      expect(preset.intensity).toBeLessThanOrEqual(100)
-      expect(preset.duration).toBeGreaterThan(0)
+      expect(preset.duration).toBeGreaterThanOrEqual(10)
     }
   })
 
   test('preset names are unique — they double as React keys in selectors', () => {
     const names = VIBRATION_PRESETS.map(p => p.name)
     expect(new Set(names).size).toBe(names.length)
+  })
+})
+
+describe('Fixed cosmetic fields', () => {
+  test('intensity is a valid uint in firmware range', () => {
+    expect(FIXED_INTENSITY).toBeGreaterThanOrEqual(1)
+    expect(FIXED_INTENSITY).toBeLessThanOrEqual(100)
+  })
+
+  test('pattern is a firmware-accepted string', () => {
+    expect(['rise', 'double']).toContain(FIXED_PATTERN)
   })
 })

--- a/src/lib/vibrationPatterns.ts
+++ b/src/lib/vibrationPatterns.ts
@@ -1,23 +1,29 @@
 /**
- * Shared vibration pattern presets.
- * Used by: AlarmEditor (quick-pick), HapticsTestCard (test patterns).
- * Single source of truth — no duplication.
+ * Shared vibration presets — duration-only.
+ *
+ * On Pod 5 J55 firmware the cover MCU clamps `pl` (intensity) and `pi`
+ * (pattern) — both are cosmetic. Only `du` (duration) has a user-perceptible
+ * effect. The API still accepts intensity/pattern for forward compatibility,
+ * but the UI no longer exposes them.
+ *
+ * See docs/hardware/alarms.md#empirical-behavior-pl-and-pi.
  */
 
-export interface VibrationPattern {
+export interface VibrationPreset {
   name: string
-  intensity: number // 1-100
-  pattern: 'rise' | 'double'
   duration: number // seconds
   description: string
 }
 
-export const VIBRATION_PRESETS: VibrationPattern[] = [
-  { name: 'Gentle Wake', intensity: 30, pattern: 'rise', duration: 10, description: 'Soft rising vibration' },
-  { name: 'Standard Alarm', intensity: 50, pattern: 'rise', duration: 30, description: 'Default alarm pattern' },
-  { name: 'Urgent Wake', intensity: 80, pattern: 'double', duration: 15, description: 'Strong double-burst' },
-  { name: 'Nudge', intensity: 20, pattern: 'double', duration: 3, description: 'Quick gentle tap' },
-  { name: 'Pulse Train', intensity: 60, pattern: 'double', duration: 20, description: 'Repeated double bursts' },
-  { name: 'Deep Sleeper', intensity: 100, pattern: 'rise', duration: 60, description: 'Maximum intensity ramp' },
-  { name: 'Meditation End', intensity: 15, pattern: 'rise', duration: 5, description: 'Barely noticeable fade-in' },
+export const VIBRATION_PRESETS: VibrationPreset[] = [
+  { name: 'Quick', duration: 10, description: 'Brief buzz' },
+  { name: 'Standard', duration: 30, description: 'Default alarm' },
+  { name: 'Long', duration: 60, description: 'Extended ramp' },
 ]
+
+/**
+ * Hardcoded values sent for the cosmetic fields. Kept in one place so the API
+ * surface stays unchanged.
+ */
+export const FIXED_INTENSITY = 100
+export const FIXED_PATTERN = 'rise' as const

--- a/src/lib/vibrationPatterns.ts
+++ b/src/lib/vibrationPatterns.ts
@@ -1,6 +1,6 @@
 /**
  * Shared vibration pattern presets.
- * Used by: AlarmScheduleSection (quick-select), HapticsTestCard (test patterns).
+ * Used by: AlarmEditor (quick-pick), HapticsTestCard (test patterns).
  * Single source of truth — no duplication.
  */
 

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -227,6 +227,20 @@ describe('JobManager public surface (stub DB)', () => {
     manager.stopHeartbeat() // double-stop is safe
   })
 
+  it('startHeartbeat does not create a second interval on re-entry (kills L258 guard mutant)', () => {
+    // Kills `if (this.heartbeatTimer) return` → `if (false) return`. Without
+    // the guard, every call would leak a new setInterval and the cleanup in
+    // stopHeartbeat would only clear the latest, leaving prior intervals to
+    // fire forever.
+    const setIntervalSpy = vi.spyOn(global, 'setInterval')
+    manager.startHeartbeat()
+    const callsAfterFirst = setIntervalSpy.mock.calls.length
+    manager.startHeartbeat()
+    manager.startHeartbeat()
+    expect(setIntervalSpy.mock.calls.length).toBe(callsAfterFirst)
+    setIntervalSpy.mockRestore()
+  })
+
   it('checkLiveness returns empty when no jobs are registered', async () => {
     const stale = await manager.checkLiveness()
     expect(stale).toEqual([])

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -9,7 +9,7 @@ import { getPrimeCompletedAt, dismissPrimeNotification } from '@/src/hardware/pr
 import { snoozeAlarm, cancelSnooze, getSnoozeStatus } from '@/src/hardware/snoozeManager'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { HardwareCommand, fahrenheitToLevel } from '@/src/hardware/types'
-import { sendCommand } from '@/src/hardware/dacTransport'
+import { getSharedHardwareClient } from '@/src/hardware/sharedClient'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import {
   sideSchema,
@@ -25,14 +25,19 @@ import { toC } from '@/src/lib/tempUtils'
 // ---------------------------------------------------------------------------
 
 const COMMAND_MAP: Record<string, HardwareCommand> = {
+  HELLO: HardwareCommand.HELLO,
   SET_TEMP: HardwareCommand.SET_TEMP,
-  SET_ALARM: HardwareCommand.SET_ALARM,
   ALARM_LEFT: HardwareCommand.ALARM_LEFT,
   ALARM_RIGHT: HardwareCommand.ALARM_RIGHT,
   SET_SETTINGS: HardwareCommand.SET_SETTINGS,
+  LEFT_TEMP_DURATION: HardwareCommand.LEFT_TEMP_DURATION,
+  RIGHT_TEMP_DURATION: HardwareCommand.RIGHT_TEMP_DURATION,
+  TEMP_LEVEL_LEFT: HardwareCommand.TEMP_LEVEL_LEFT,
+  TEMP_LEVEL_RIGHT: HardwareCommand.TEMP_LEVEL_RIGHT,
   PRIME: HardwareCommand.PRIME,
   DEVICE_STATUS: HardwareCommand.DEVICE_STATUS,
   ALARM_CLEAR: HardwareCommand.ALARM_CLEAR,
+  ALARM_SOLO: HardwareCommand.ALARM_SOLO,
 }
 
 // ---------------------------------------------------------------------------
@@ -622,23 +627,37 @@ export const deviceRouter = router({
   execute: publicProcedure
     .meta({ openapi: { method: 'POST', path: '/device/execute', protect: false, tags: ['Device'] } })
     .input(z.object({
-      command: z.enum(['SET_TEMP', 'SET_ALARM', 'ALARM_LEFT', 'ALARM_RIGHT', 'SET_SETTINGS', 'PRIME', 'DEVICE_STATUS', 'ALARM_CLEAR']),
+      // Either an allowlisted name (mapped via COMMAND_MAP) or a raw numeric
+      // opcode string passed through verbatim. Raw opcodes let us probe for
+      // commands not yet in HardwareCommand (e.g. cover-only Pod 5 codes).
+      command: z.string().refine(
+        v => v in COMMAND_MAP || /^\d+$/.test(v),
+        { message: 'command must be an allowlisted name or a numeric opcode string' },
+      ),
       args: z.string().optional(),
     }).strict())
     .output(z.object({
       command: z.string(),
+      opcode: z.string(),
       args: z.string().nullable(),
       response: z.unknown(),
       disclaimer: z.string(),
     }))
     .mutation(async ({ input }) => {
-      const hwCommand = COMMAND_MAP[input.command]
+      const opcode = COMMAND_MAP[input.command] ?? input.command
 
       try {
-        const response = await sendCommand(hwCommand, input.args)
+        // Route through the singleton client so the call binds to the same
+        // `dacTransport` module instance that owns the live transport.
+        // Importing sendCommand directly into the route handler can hit a
+        // separate Next.js bundle whose `transport` is undefined — that
+        // path stomps on dac.sock by spinning up a second listener.
+        const client = getSharedHardwareClient() as unknown as { sendRaw(command: string, args?: string): Promise<string> }
+        const response = await client.sendRaw(opcode, input.args)
 
         return {
           command: input.command,
+          opcode,
           args: input.args ?? null,
           response,
           disclaimer: 'WARNING: Raw command execution. No validation, no safety checks. Misuse can damage hardware or cause unexpected behavior. Use at your own risk. This feature is unsupported.',

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -631,7 +631,7 @@ export const deviceRouter = router({
       // opcode string passed through verbatim. Raw opcodes let us probe for
       // commands not yet in HardwareCommand (e.g. cover-only Pod 5 codes).
       command: z.string().refine(
-        v => v in COMMAND_MAP || /^\d+$/.test(v),
+        v => Object.hasOwn(COMMAND_MAP, v) || /^\d+$/.test(v),
         { message: 'command must be an allowlisted name or a numeric opcode string' },
       ),
       args: z.string().optional(),
@@ -644,7 +644,9 @@ export const deviceRouter = router({
       disclaimer: z.string(),
     }))
     .mutation(async ({ input }) => {
-      const opcode = COMMAND_MAP[input.command] ?? input.command
+      const opcode = Object.hasOwn(COMMAND_MAP, input.command)
+        ? COMMAND_MAP[input.command]
+        : input.command
 
       try {
         // Route through the singleton client so the call binds to the same

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -38,7 +38,17 @@ const broadcastMock = vi.hoisted(() => ({
 
 const transportMock = vi.hoisted(() => ({
   sendCommand: vi.fn(),
+  isDacConnected: vi.fn(() => true),
+  connectDac: vi.fn(),
 }))
+
+const sharedClientMock = vi.hoisted(() => {
+  const sendRaw = vi.fn()
+  return {
+    sendRaw,
+    getSharedHardwareClient: vi.fn(() => ({ sendRaw })),
+  }
+})
 
 const stateSyncMock = vi.hoisted(() => ({
   markSideMutated: vi.fn(),
@@ -74,6 +84,7 @@ vi.mock('@/src/hardware/primeNotification', () => primeMock)
 vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
 vi.mock('@/src/hardware/dacTransport', () => transportMock)
+vi.mock('@/src/hardware/sharedClient', () => ({ getSharedHardwareClient: sharedClientMock.getSharedHardwareClient }))
 vi.mock('@/src/hardware/deviceStateSync', () => stateSyncMock)
 vi.mock('@/src/db', () => ({
   db: dbMock,
@@ -107,6 +118,7 @@ beforeEach(() => {
   snoozeMock.getSnoozeStatus.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
   broadcastMock.broadcastMutationStatus.mockReset()
   transportMock.sendCommand.mockReset()
+  sharedClientMock.sendRaw.mockReset()
   stateSyncMock.markSideMutated.mockReset()
   dbState.rowsQueue.length = 0
   dbMock.select.mockClear()
@@ -252,22 +264,34 @@ describe('device.startPriming / dismissPrimeNotification', () => {
 })
 
 describe('device.execute (raw command)', () => {
-  it('passes the command name through and returns disclaimer', async () => {
-    transportMock.sendCommand.mockResolvedValue('{ "ok": true }')
+  it('maps an allowlisted name to its opcode and returns disclaimer', async () => {
+    sharedClientMock.sendRaw.mockResolvedValue('{ "ok": true }')
 
     const result = await caller.execute({ command: 'DEVICE_STATUS' })
+    expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('14', undefined)
     expect(result.command).toBe('DEVICE_STATUS')
+    expect(result.opcode).toBe('14')
     expect(result.args).toBeNull()
     expect(result.response).toBe('{ "ok": true }')
     expect(result.disclaimer).toContain('Raw command execution')
   })
 
-  it('rejects unknown command via Zod enum', async () => {
-    await expect(caller.execute({ command: 'BOGUS' as never })).rejects.toThrow()
+  it('passes a raw numeric opcode through verbatim', async () => {
+    sharedClientMock.sendRaw.mockResolvedValue('ok')
+
+    const result = await caller.execute({ command: '99', args: 'foo' })
+    expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('99', 'foo')
+    expect(result.command).toBe('99')
+    expect(result.opcode).toBe('99')
+    expect(result.args).toBe('foo')
+  })
+
+  it('rejects non-numeric, non-allowlisted commands', async () => {
+    await expect(caller.execute({ command: 'BOGUS' })).rejects.toThrow()
   })
 
   it('wraps transport errors as INTERNAL_SERVER_ERROR', async () => {
-    transportMock.sendCommand.mockRejectedValue(new Error('socket dead'))
+    sharedClientMock.sendRaw.mockRejectedValue(new Error('socket dead'))
     await expect(caller.execute({ command: 'DEVICE_STATUS' })).rejects.toThrow(/Failed to execute raw command: socket dead/)
   })
 })

--- a/src/services/tests/autoOffWatcher.test.ts
+++ b/src/services/tests/autoOffWatcher.test.ts
@@ -764,3 +764,154 @@ describe('watcher lifecycle', () => {
     await expect(stopAutoOffWatcher()).resolves.toBeUndefined()
   })
 })
+
+// ── Mutation-killing boundary tests ──────────────────────────────────────
+//
+// These pin equality boundaries that survive coarse "well past the cap" tests:
+// strict `>` vs `>=`, `< 0` vs `<= 0`, `> 0` vs `>= 0`. Each uses fake-timer
+// freezing so msSinceX can hit the cap exactly to one millisecond.
+
+describe('boundary equality (kills `>`/`>=`, `< 0`/`<= 0`, `> 0`/`>= 0` mutants)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
+    vi.setSystemTime(new Date('2026-05-10T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('isUserInBed returns false when enteredBedAt equals leftBedAt — strict `>` boundary', async () => {
+    // Kills L205 `enteredMs > leftMs` → `>=`. Equal timestamps must NOT count
+    // as "in bed", otherwise auto-off is suppressed forever the moment a
+    // session row is written with simultaneous in/out (sensor noise edge case).
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 3 * 3600_000)
+    insertSleepRecord('left', now - 31 * 60_000, now - 31 * 60_000) // entered == left
+
+    await pollAndFlush()
+    await Promise.resolve()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('global cap of 0 is disabled (kills `> 0` → `>= 0` mutant on L298)', async () => {
+    // With `>= 0`, a cap of 0 would treat any positive msSincePowerOn as
+    // "exceeded" and power off any newly-on side. The strict `> 0` guard
+    // keeps 0 meaning "feature disabled".
+    const now = Date.now()
+    setGlobalCap(0)
+    setSideOn('left', now - 90 * 60_000) // 90min on — would fire if 0 were enabled
+
+    await pollAndFlush()
+    await Promise.resolve()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('global cap does not fire when msSincePowerOn equals capMs exactly (kills `>` → `>=` on L307)', async () => {
+    // With `>=`, a side powered for exactly the cap would be cut at the tick.
+    // The strict `>` means the cap is a *ceiling* — fires only after exceeding.
+    const now = Date.now()
+    setGlobalCap(1) // 1h = 3_600_000ms
+    setSideOn('left', now - 3_600_000) // exactly 1h ago
+
+    await pollAndFlush()
+    await Promise.resolve()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('clock-sanity 7-day window is strict `>` — fires at exactly 7 days (kills `> 7d` → `>= 7d` on L306)', async () => {
+    // With `>=`, a side powered exactly 7 days ago would be flagged
+    // "suspicious" and the cap path would skip — a real 1-week heater would
+    // never auto-off. The strict `>` flags only stranger-than-7-day values.
+    const now = Date.now()
+    setGlobalCap(1) // 1h cap, clearly exceeded by 7d
+    setSideOn('left', now - 7 * 86_400_000) // exactly 7 days ago
+
+    await pollAndFlush()
+    await Promise.resolve()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('per-side timeout does not fire-immediate at exact boundary (kills `>` → `>=` on L353)', async () => {
+    // With `>=`, a bed-exit exactly at the timeout would skip the timer-arming
+    // path and fire immediately on the same poll. The strict `>` means at the
+    // boundary we arm a 0ms timer instead (subtle but matters: the firePowerOff
+    // path skips the bed-presence re-check inside the timer callback).
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 60 * 60_000)
+    insertSleepRecord('left', now - 90 * 60_000, now - 30 * 60_000) // exit exactly 30min ago == timeoutMs
+
+    startAutoOffWatcher()
+    // Synchronous poll on start: original arms a 0ms timer (not yet fired);
+    // mutated `>=` would fire firePowerOff synchronously. Without advancing
+    // timers, setPower must not be observed.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+})
+
+// ── More mutation-killing tests (lifecycle + DB writes) ──────────────────
+
+describe('restartAutoOffTimers is gated by pollHandle (kills L471 mutant)', () => {
+  it('does not invoke poll() when watcher is not running, even when conditions would fire', async () => {
+    // Kills `if (!pollHandle) return` → removing the guard. With the guard
+    // gone, restartAutoOffTimers would fall through to poll() and the global
+    // cap path would fire on a side that is past-cap. The contract is that
+    // the watcher must be explicitly started before any power-off can fire.
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 5 * 3600_000) // 5h past cap
+
+    // Watcher never started.
+    restartAutoOffTimers()
+    // Flush any fire-and-forget promise.
+    await new Promise(resolve => setImmediate(resolve))
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(setPower).not.toHaveBeenCalled()
+  })
+})
+
+describe('powerOffSide DB write (kills L226 `isPowered: false` → `true`)', () => {
+  it('clears device_state.isPowered to 0 after firing', async () => {
+    // Pins the value written into device_state. A mutation flipping the
+    // literal to `true` would leave isPowered=1 in the DB and the next status
+    // poll would see "still on" until the DAC reconciles.
+    const now = Date.now()
+    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
+    setSideOn('left', now - 3 * 3600_000)
+    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
+
+    await pollAndFlush()
+
+    const row = (sqlite as any)
+      .prepare('SELECT is_powered FROM device_state WHERE side=?')
+      .get('left')
+    expect(row.is_powered).toBe(0)
+  })
+})
+
+describe('getAutoOffConfig defaults (kills L110 boolean mutants)', () => {
+  it('alwaysOn defaults to false when side_settings read throws — cap still fires', async () => {
+    // Kills `alwaysOn: false` → `true` in the catch-path defaults. Without
+    // side_settings the cap path must still treat alwaysOn as false (i.e.,
+    // not exempt the side); with the mutation, alwaysOn=true would silently
+    // suppress every cap-driven power-off after a DB read failure.
+    const now = Date.now()
+    setGlobalCap(1)
+    setSideOn('left', now - 5 * 3600_000) // 5h past cap
+    ;(sqlite as any).exec('DROP TABLE side_settings;')
+
+    await pollAndFlush()
+
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the missing UI for the alarm-schedule pipeline. Backend (DB, tRPC CRUD, cron job manager) was already complete, but no user-facing path existed to create rows — the cron had nothing to fire.

- `AlarmSection` — lists alarms below the temperature curves on the schedule page. Groups rows that share every field except day-of-week (so "wake at 7am Mon–Fri" renders as one card backed by five row ids).
- `AlarmCard` — time, day label ("Weekdays", "Mon–Fri"), intensity bar, pattern/duration/temp; per-card Test/Edit/Delete buttons.
- `AlarmEditor` — full-screen create/edit: time picker, multi-day selector, preset chips from `VIBRATION_PRESETS`, intensity slider, pattern toggle (rise/double), duration slider, bed-temperature slider, inline Test (fires `device.setAlarm` immediately) + Stop, Delete (edit mode).
- Save goes through `schedules.batchUpdate` (delete existing group ids → create one row per selected day in one transaction → scheduler reloads automatically).
- Fixed stale `AlarmScheduleSection` doc reference in `src/lib/vibrationPatterns.ts`.

Hardware constraint: firmware protocol is `intensity,pattern,duration` with pattern ∈ {`rise`, `double`}; "custom" means intensity 1–100 + envelope + duration. Arbitrary multi-step patterns would need firmware changes.

## Test plan

- [ ] Schedule page renders alarms section under curves
- [ ] "Add alarm" opens editor; pick days, set time, preset chip applies all 3 fields
- [ ] Test button buzzes the selected side; Stop halts immediately
- [ ] Save creates one row per day; cron fires at scheduled time (left side, near-future time)
- [ ] Edit existing alarm preserves group, replaces rows on save
- [ ] Delete confirmation removes all rows for the group
- [ ] Multi-day "Wake at 7am Mon–Fri" renders as a single card after save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added alarm scheduling with customizable repeat days, wake time, vibration intensity/pattern, duration, and temperature control
  * Enabled test, edit, and delete actions for alarms
  * Added visual intensity indicator and pattern display for alarm cards

* **Documentation**
  * Comprehensive alarm system documentation with hardware details and troubleshooting guides
  * Architectural decision records on alarm triggering behavior

* **Tests**
  * Expanded test coverage for alarm operations and device communication

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/556)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->