### PR TITLE
test(streaming): cover normalizeFrame edge cases

### DIFF
--- a/src/streaming/tests/normalizeFrame.test.ts
+++ b/src/streaming/tests/normalizeFrame.test.ts
@@ -361,5 +361,315 @@ describe('normalizeFrame', () => {
       expect((result.left as (number | null)[])).toEqual([null, null, 241, 241, 339, 339])
       expect((result.right as (number | null)[])).toEqual([372, 372, 498, 498, 526, 526])
     })
+
+    it('defaults left/right to empty objects when both sides are missing', () => {
+      // Exercises the `rec.left ?? {}` and `rec.right ?? {}` fallbacks.
+      const empty = { type: 'capSense', ts: 1776463227 }
+      const result = normalizeFrame(empty as Record<string, unknown>)
+      expect((result.left as (number | null)[])).toEqual([null, null, null, null, null, null])
+      expect((result.right as (number | null)[])).toEqual([null, null, null, null, null, null])
+      expect(result.status).toBeUndefined()
+    })
+
+    it('falls back to right.status when left.status is missing', () => {
+      const partial = {
+        type: 'capSense', ts: 1776463227,
+        left: { out: 290, cen: 241, in: 339 },
+        right: { out: 372, cen: 498, in: 526, status: 'good' },
+      }
+      const result = normalizeFrame(partial as Record<string, unknown>)
+      expect(result.status).toBe('good')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Branch coverage — edge cases for each variant
+  // -------------------------------------------------------------------------
+
+  describe('default (unknown type)', () => {
+    it('passes through unknown frame types unchanged', () => {
+      const unknown = { type: 'somethingNew', ts: 42, payload: 'opaque' }
+      const result = normalizeFrame(unknown as Record<string, unknown>)
+      expect(result).toEqual(unknown)
+    })
+
+    it('passes through records with no type field', () => {
+      const noType = { ts: 42, foo: 'bar' }
+      const result = normalizeFrame(noType as Record<string, unknown>)
+      expect(result).toEqual(noType)
+    })
+  })
+
+  describe('frzTemp edge cases', () => {
+    it('returns null when fields are missing', () => {
+      const partial = { type: 'frzTemp', ts: 1 }
+      const result = normalizeFrame(partial as Record<string, unknown>)
+      expect(result.left).toBeNull()
+      expect(result.right).toBeNull()
+      expect(result.amb).toBeNull()
+      expect(result.hs).toBeNull()
+    })
+
+    it('treats float near -32768 sentinel as null (within 1 unit)', () => {
+      // Exercises the `Math.abs(v - -32768) < 1` branch in cdToC.
+      const nearSentinel = { type: 'frzTemp', ts: 1, left: -32767.5, right: 2225, amb: 2237, hs: 2531 }
+      const result = normalizeFrame(nearSentinel as Record<string, unknown>)
+      expect(result.left).toBeNull()
+      expect(result.right).toBeCloseTo(22.25)
+    })
+
+    it('treats non-numeric values as null', () => {
+      // Exercises the `typeof v !== 'number'` branch in cdToC.
+      const garbage = { type: 'frzTemp', ts: 1, left: 'oops', right: null, amb: undefined, hs: 2531 }
+      const result = normalizeFrame(garbage as Record<string, unknown>)
+      expect(result.left).toBeNull()
+      expect(result.right).toBeNull()
+      expect(result.amb).toBeNull()
+      expect(result.hs).toBeCloseTo(25.31)
+    })
+  })
+
+  describe('frzHealth edge cases', () => {
+    it('coerces null/undefined RPM, duty, and current to 0', () => {
+      // Exercises every `?? 0` fallback in frzHealth.
+      const sparse = {
+        type: 'frzHealth', ts: 100,
+        left: {
+          tec: { current: null },
+          pump: { mode: 'pwm', rpm: null, water: false, duty: null },
+        },
+        right: {
+          tec: { current: null },
+          pump: { mode: 'pwm', rpm: null, water: false, duty: null },
+        },
+        fan: { top: { rpm: null, duty: null } },
+      }
+      const result = normalizeFrame(sparse as Record<string, unknown>)
+      const left = result.left as Record<string, unknown>
+      const right = result.right as Record<string, unknown>
+      const fan = result.fan as Record<string, unknown>
+      expect(left.pumpRpm).toBe(0)
+      expect(left.pumpDuty).toBe(0)
+      expect(left.tecCurrent).toBe(0)
+      expect(left.flowrate).toBeNull()
+      expect(right.pumpRpm).toBe(0)
+      expect(right.pumpDuty).toBe(0)
+      expect(right.tecCurrent).toBe(0)
+      expect(right.flowrate).toBeNull()
+      expect(fan.rpm).toBe(0)
+      expect(fan.duty).toBe(0)
+      expect(fan.bottomRpm).toBeNull()
+    })
+
+    it('extracts pump duty when present', () => {
+      const withDuty = {
+        type: 'frzHealth', ts: 100,
+        left: {
+          tec: { current: 2 },
+          pump: { mode: 'pwm', rpm: 1800, water: true, duty: 65 },
+          temps: { flowrate: 25.5 },
+        },
+        right: {
+          tec: { current: 2 },
+          pump: { mode: 'pwm', rpm: 1800, water: true, duty: 70 },
+          temps: { flowrate: 25.5 },
+        },
+        fan: { top: { rpm: 500, duty: 50 }, bottom: { rpm: 300 } },
+      }
+      const result = normalizeFrame(withDuty as Record<string, unknown>)
+      const left = result.left as Record<string, unknown>
+      const right = result.right as Record<string, unknown>
+      const fan = result.fan as Record<string, unknown>
+      expect(left.pumpDuty).toBe(65)
+      expect(right.pumpDuty).toBe(70)
+      expect(fan.duty).toBe(50)
+      expect(fan.bottomRpm).toBe(300)
+    })
+
+    it('returns null bottomRpm when fan.bottom is missing entirely', () => {
+      const noBottom = {
+        type: 'frzHealth', ts: 100,
+        left: { tec: { current: 0 }, pump: { mode: 'pwm', rpm: 0, water: true } },
+        right: { tec: { current: 0 }, pump: { mode: 'pwm', rpm: 0, water: true } },
+        fan: { top: { rpm: 234 } },
+      }
+      const result = normalizeFrame(noBottom as Record<string, unknown>)
+      const fan = result.fan as Record<string, unknown>
+      expect(fan.bottomRpm).toBeNull()
+    })
+  })
+
+  describe('frzTherm edge cases', () => {
+    it('accepts plain numeric left/right (legacy firmware)', () => {
+      // Exercises the `typeof wire.left === 'number'` true branch.
+      const numeric = { type: 'frzTherm', ts: 1, left: -0.5, right: 0.25 }
+      const result = normalizeFrame(numeric as Record<string, unknown>)
+      expect(result.left).toBe(-0.5)
+      expect(result.right).toBe(0.25)
+    })
+
+    it('coerces null power to 0', () => {
+      // Exercises the `?? 0` fallback when the .power field is null.
+      const nullPower = {
+        type: 'frzTherm', ts: 1,
+        left: { target: 23, power: null, valid: true, enabled: true },
+        right: { target: 27, power: null, valid: true, enabled: false },
+      }
+      const result = normalizeFrame(nullPower as Record<string, unknown>)
+      expect(result.left).toBe(0)
+      expect(result.right).toBe(0)
+    })
+
+    it('mixes numeric left with object right', () => {
+      const mixed = {
+        type: 'frzTherm', ts: 1,
+        left: -0.75,
+        right: { target: 27, power: 0.5, valid: true, enabled: true },
+      }
+      const result = normalizeFrame(mixed as Record<string, unknown>)
+      expect(result.left).toBe(-0.75)
+      expect(result.right).toBe(0.5)
+    })
+  })
+
+  describe('bedTemp2 edge cases', () => {
+    it('defaults left/right to empty objects when both sides are missing', () => {
+      // Exercises `rec.left ?? {}`, `rec.right ?? {}`, and `temps ?? []` fallbacks.
+      const empty = { type: 'bedTemp2', ts: 1 }
+      const result = normalizeFrame(empty as Record<string, unknown>)
+      expect(result.ambientTemp).toBeNull()
+      expect(result.humidity).toBeNull()
+      expect(result.mcuTemp).toBeNull()
+      expect(result.leftOuterTemp).toBeNull()
+      expect(result.leftCenterTemp).toBeNull()
+      expect(result.leftInnerTemp).toBeNull()
+      expect(result.rightOuterTemp).toBeNull()
+      expect(result.rightCenterTemp).toBeNull()
+      expect(result.rightInnerTemp).toBeNull()
+    })
+
+    it('falls back to right.amb/hu when left side is sentinel', () => {
+      // Exercises the `?? safeNum(right.amb)` and `?? safeNum(right.hu)` branches.
+      const leftSentinel = {
+        type: 'bedTemp2', ts: 1,
+        left: { amb: -327.68, hu: -327.68, temps: [] },
+        right: { amb: 22.5, hu: 48, temps: [] },
+      }
+      const result = normalizeFrame(leftSentinel as Record<string, unknown>)
+      expect(result.ambientTemp).toBeCloseTo(22.5)
+      expect(result.humidity).toBeCloseTo(48)
+    })
+
+    it('treats non-numeric temps array entries as null', () => {
+      // Exercises the `typeof v === 'number'` false branch inside safeNum.
+      const oddTemps = {
+        type: 'bedTemp2', ts: 1,
+        left: { temps: ['nope', null, undefined] },
+        right: { temps: [22, 'bad', 24] },
+      }
+      const result = normalizeFrame(oddTemps as Record<string, unknown>)
+      expect(result.leftOuterTemp).toBeNull()
+      expect(result.leftCenterTemp).toBeNull()
+      expect(result.leftInnerTemp).toBeNull()
+      expect(result.rightOuterTemp).toBeCloseTo(22)
+      expect(result.rightCenterTemp).toBeNull()
+      expect(result.rightInnerTemp).toBeCloseTo(24)
+    })
+
+    it('treats the -327.68 sentinel as null with float tolerance', () => {
+      // Exercises the `Math.abs(v - NO_SENSOR) < 0.01` close-match branch.
+      const near = {
+        type: 'bedTemp2', ts: 1,
+        left: { temps: [-327.679, -327.681, 26] },
+        right: { temps: [] },
+      }
+      const result = normalizeFrame(near as Record<string, unknown>)
+      expect(result.leftOuterTemp).toBeNull()
+      expect(result.leftCenterTemp).toBeNull()
+      expect(result.leftInnerTemp).toBeCloseTo(26)
+    })
+  })
+
+  describe('bedTemp v1 edge cases', () => {
+    it('defaults left/right to empty objects when both sides are missing', () => {
+      // Exercises `rec.left ?? {}` / `rec.right ?? {}` when the side is absent.
+      const empty = { type: 'bedTemp', ts: 1 }
+      const result = normalizeFrame(empty as Record<string, unknown>)
+      expect(result.ambientTemp).toBeNull()
+      expect(result.mcuTemp).toBeNull()
+      expect(result.humidity).toBeNull()
+      expect(result.leftOuterTemp).toBeNull()
+      expect(result.rightInnerTemp).toBeNull()
+    })
+
+    it('treats -32768 sentinel as null in centidegree fields', () => {
+      const sentinel = {
+        type: 'bedTemp', ts: 1,
+        amb: -32768, mcu: 3428, hu: -32768,
+        left: { out: -32768, cen: 2301, in: 2359 },
+        right: { out: 2351, cen: -32768, in: 2396 },
+      }
+      const result = normalizeFrame(sentinel as Record<string, unknown>)
+      expect(result.ambientTemp).toBeNull()
+      expect(result.humidity).toBeNull()
+      expect(result.leftOuterTemp).toBeNull()
+      expect(result.rightCenterTemp).toBeNull()
+      expect(result.mcuTemp).toBeCloseTo(34.28)
+    })
+  })
+
+  describe('capSense2 edge cases', () => {
+    it('defaults left/right to empty objects when both sides are missing', () => {
+      // Falls through every `?? {}` / `?? left` / Array.isArray fallback.
+      const empty = { type: 'capSense2', ts: 1 }
+      const result = normalizeFrame(empty as Record<string, unknown>)
+      expect(result.left).toEqual([])
+      expect(result.right).toEqual([])
+      expect(result.status).toBeUndefined()
+    })
+
+    it('accepts numeric sides (legacy single-value frame)', () => {
+      // Exercises the `typeof rec.left === 'number'` branch.
+      const numeric = { type: 'capSense2', ts: 1, left: 12.5, right: 14.25 }
+      const result = normalizeFrame(numeric as Record<string, unknown>)
+      expect(result.left).toEqual([12.5])
+      expect(result.right).toEqual([14.25])
+    })
+
+    it('falls back to right.status when neither rec.status nor left.status is set', () => {
+      // Exercises the right.status branch of the `?? ... ??` fallback chain.
+      const onlyRight = {
+        type: 'capSense2', ts: 1,
+        left: { values: [1, 2, 3] },
+        right: { values: [4, 5, 6], status: 'good' },
+      }
+      const result = normalizeFrame(onlyRight as Record<string, unknown>)
+      expect(result.status).toBe('good')
+    })
+
+    it('prefers rec.status when set at the top level', () => {
+      // Exercises the leading `rec.status ??` branch.
+      const topStatus = {
+        type: 'capSense2', ts: 1, status: 'warn',
+        left: { values: [1], status: 'good' },
+        right: { values: [2], status: 'good' },
+      }
+      const result = normalizeFrame(topStatus as Record<string, unknown>)
+      expect(result.status).toBe('warn')
+    })
+
+    it('returns empty arrays when sides are objects without values keys', () => {
+      // Exercises the `left.values ?? left` fallback. When the side is a plain
+      // object with no `values` key (and no numeric coercion path), the result
+      // is an empty array — never a stale non-array reference.
+      const noValues = {
+        type: 'capSense2', ts: 1,
+        left: { status: 'good' },
+        right: { status: 'good' },
+      }
+      const result = normalizeFrame(noValues as Record<string, unknown>)
+      expect(result.left).toEqual([])
+      expect(result.right).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
## Summary
normalizeFrame.ts was at 49% with 29 uncovered lines (codecov dev). It's a pure function — every branch is reachable. Closing the gaps.

## Tests added
- `default` passthrough for unknown frame types and records without a `type` field
- `frzTemp` missing/non-numeric/near-sentinel inputs (covers `cdToC` type guard and `Math.abs(v - -32768) < 1` branch)
- `frzHealth` null RPM/duty/current coercion to 0, explicit duty values, and missing `fan.bottom` returning null bottomRpm
- `frzTherm` numeric-side legacy form, null `.power` coercion to 0, and mixed numeric/object sides
- `bedTemp2` missing sides defaulting to empty objects, fallback from sentinel `left.amb/hu` to `right.amb/hu`, non-numeric temps array entries returning null, and float-tolerance sentinel match (`|v - -327.68| < 0.01`)
- `bedTemp` v1 missing sides defaulting to empty objects and centidegree `-32768` sentinel handling
- `capSense` v1 missing sides and `left.status ?? right.status` fallback
- `capSense2` missing sides, numeric-side legacy form, `rec.status ?? left.status ?? right.status` fallback chain (both extremes), and objects without a `values` key

## Coverage delta
- normalizeFrame.ts: 49.1% (branch) -> 100% (statements 100%, branches 100%, lines 100%, functions 100%)

## Test plan
- [x] `pnpm vitest run src/streaming/tests/normalizeFrame.test.ts` passes (54 tests)
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended test coverage with comprehensive edge-case scenarios for frame normalization across multiple data types, improving robustness verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/557)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->