### PR TITLE
test(server): cover biometrics router gaps

### DIFF
--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -392,4 +392,360 @@ describe('biometrics.getSleepStages', () => {
       endDate: new Date('2025-01-01'),
     })).rejects.toThrow(/startDate/)
   })
+
+  it('uses current time as windowEnd for active sleep sessions (leftBedAt=null)', async () => {
+    const record = {
+      id: 7, side: 'left',
+      enteredBedAt: new Date('2025-01-01T22:00:00Z'),
+      leftBedAt: null, // active session
+    }
+    dbState.rowsQueue.push([record])
+    dbState.rowsQueue.push([]) // vitals empty
+    dbState.rowsQueue.push([]) // movement empty
+    const out = await caller.getSleepStages({ side: 'left', sleepRecordId: 7 })
+    expect(out.sleepRecordId).toBe(7)
+    expect(out.leftBedAt).toBeNull()
+    expect(out.enteredBedAt).toBe(record.enteredBedAt.getTime())
+  })
+
+  it('classifies stages from a custom date-range window', async () => {
+    // No record lookup: vitals + movement queries only
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), heartRate: 60, hrv: 50, breathingRate: 14 }])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), totalMovement: 50 }])
+
+    sleepStagesMock.classifySleepStages.mockReturnValue([
+      { start: 0, duration: 600_000, stage: 'deep', heartRate: 55, hrv: 60, breathingRate: 12, movement: 10 },
+    ])
+    sleepStagesMock.mergeIntoBlocks.mockReturnValue([{ start: 0, end: 600_000, stage: 'deep' }])
+    sleepStagesMock.calculateDistribution.mockReturnValue({ wake: 0, light: 0, deep: 1, rem: 0 })
+    sleepStagesMock.calculateQualityScore.mockReturnValue(90)
+
+    const out = await caller.getSleepStages({
+      side: 'left',
+      startDate: new Date('2025-01-01T22:00:00Z'),
+      endDate: new Date('2025-01-02T06:00:00Z'),
+    })
+    expect(out.sleepRecordId).toBeNull()
+    expect(out.enteredBedAt).toBeNull()
+    expect(out.leftBedAt).toBeNull()
+    expect(out.epochs).toHaveLength(1)
+    expect(out.qualityScore).toBe(90)
+  })
+
+  it('returns empty stages result when classifier yields no epochs (default path)', async () => {
+    // Default branch with a record found: hits localHour + overnight finder, then empty-epoch return
+    const enteredAt = new Date()
+    enteredAt.setHours(22, 0, 0, 0) // 10pm local — qualifies as overnight (>=20)
+    const record = {
+      id: 9, side: 'left',
+      enteredBedAt: enteredAt,
+      leftBedAt: new Date(enteredAt.getTime() + 8 * 60 * 60 * 1000),
+      sleepDurationSeconds: 8 * 60 * 60,
+    }
+    dbState.rowsQueue.push([record]) // recent records
+    dbState.rowsQueue.push([]) // vitals empty
+    dbState.rowsQueue.push([]) // movement empty
+    sleepStagesMock.classifySleepStages.mockReturnValue([])
+
+    const out = await caller.getSleepStages({ side: 'left' })
+    expect(out.epochs).toEqual([])
+    expect(out.sleepRecordId).toBe(9)
+    expect(out.qualityScore).toBe(0)
+  })
+
+  it('falls back to longest record in last 24h when no overnight session matches', async () => {
+    // Two daytime naps within 24h — neither qualifies as "overnight" (8pm-4am local)
+    // and one is shorter than 3h. So overnightRecord = undefined, last24h reduce picks longest.
+    const noon = new Date()
+    noon.setHours(12, 0, 0, 0)
+    const shortNap = {
+      id: 11, side: 'left',
+      enteredBedAt: noon,
+      leftBedAt: new Date(noon.getTime() + 30 * 60 * 1000),
+      sleepDurationSeconds: 30 * 60,
+    }
+    const longerNap = {
+      id: 12, side: 'left',
+      enteredBedAt: new Date(noon.getTime() + 2 * 60 * 60 * 1000),
+      leftBedAt: new Date(noon.getTime() + 4 * 60 * 60 * 1000),
+      sleepDurationSeconds: 2 * 60 * 60,
+    }
+    dbState.rowsQueue.push([shortNap, longerNap])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), heartRate: 60, hrv: 50, breathingRate: 14 }])
+    dbState.rowsQueue.push([{ id: 1, timestamp: new Date(), totalMovement: 50 }])
+
+    sleepStagesMock.classifySleepStages.mockReturnValue([
+      { start: 0, duration: 1000, stage: 'light', heartRate: 60, hrv: 50, breathingRate: 14, movement: 10 },
+    ])
+
+    const out = await caller.getSleepStages({ side: 'left' })
+    // longerNap (2h) > shortNap (30min), so longerNap wins via reduce
+    expect(out.sleepRecordId).toBe(12)
+  })
+
+  it('falls back to most recent record (>24h old) when no overnight or 24h record qualifies', async () => {
+    // Record older than 24h ago — fails both overnight check (daytime) and 24h filter.
+    // Falls through to recentRecords[0].
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    twoDaysAgo.setHours(12, 0, 0, 0) // noon local — not overnight
+    const oldNap = {
+      id: 13, side: 'left',
+      enteredBedAt: twoDaysAgo,
+      leftBedAt: new Date(twoDaysAgo.getTime() + 30 * 60 * 1000),
+      sleepDurationSeconds: 30 * 60,
+    }
+    dbState.rowsQueue.push([oldNap])
+    dbState.rowsQueue.push([])
+    dbState.rowsQueue.push([])
+    sleepStagesMock.classifySleepStages.mockReturnValue([])
+
+    const out = await caller.getSleepStages({ side: 'left' })
+    expect(out.sleepRecordId).toBe(13)
+  })
+
+  it('wraps unexpected errors as INTERNAL_SERVER_ERROR', async () => {
+    // Cause classifySleepStages to throw — must be wrapped, not bubbled raw.
+    const record = {
+      id: 1, side: 'left',
+      enteredBedAt: new Date('2025-01-01T22:00:00Z'),
+      leftBedAt: new Date('2025-01-02T07:00:00Z'),
+    }
+    dbState.rowsQueue.push([record])
+    dbState.rowsQueue.push([])
+    dbState.rowsQueue.push([])
+    sleepStagesMock.classifySleepStages.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    await expect(caller.getSleepStages({ side: 'left', sleepRecordId: 1 }))
+      .rejects.toThrow(/Failed to classify sleep stages.*boom/)
+  })
+})
+
+describe('biometrics filter combinations (side + startDate + endDate)', () => {
+  // These cover the per-filter conditions.push(...) branches that single-filter
+  // cases miss.
+  it('getSleepRecords applies all three filters', async () => {
+    dbState.rowsQueue.push([])
+    await caller.getSleepRecords({
+      side: 'right',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-31'),
+      limit: 5,
+    })
+    expect(dbMock.select).toHaveBeenCalled()
+  })
+
+  it('getVitals applies all three filters', async () => {
+    dbState.rowsQueue.push([])
+    await caller.getVitals({
+      side: 'right',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+      limit: 5,
+    })
+    expect(dbMock.select).toHaveBeenCalled()
+  })
+
+  it('getMovement applies all three filters', async () => {
+    dbState.rowsQueue.push([])
+    await caller.getMovement({
+      side: 'right',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+      limit: 5,
+    })
+    expect(dbMock.select).toHaveBeenCalled()
+  })
+
+  it('getMovementBuckets applies startDate and endDate', async () => {
+    dbState.rowsQueue.push([])
+    const out = await caller.getMovementBuckets({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+      bucketSeconds: 300,
+      limit: 100,
+    })
+    expect(out).toEqual([])
+  })
+
+  it('getMovementBuckets coerces null SQL aggregates to zero', async () => {
+    dbState.rowsQueue.push([
+      { bucketStart: 1700000, totalMovement: null, eventCount: null, sampleCount: null },
+    ])
+    const out = await caller.getMovementBuckets({ side: 'left', bucketSeconds: 60, limit: 10 })
+    expect(out[0].totalMovement).toBe(0)
+    expect(out[0].eventCount).toBe(0)
+    expect(out[0].sampleCount).toBe(0)
+  })
+
+  it('getMovementSummary applies startDate and endDate', async () => {
+    dbState.rowsQueue.push([{ positionChanges: 1, restlessMinutes: 2, sampleCount: 3 }])
+    const out = await caller.getMovementSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out.positionChanges).toBe(1)
+  })
+
+  it('getMovementSummary rejects inverted date range', async () => {
+    await expect(caller.getMovementSummary({
+      side: 'left',
+      startDate: new Date('2025-02-01'),
+      endDate: new Date('2025-01-01'),
+    })).rejects.toThrow(/startDate/)
+  })
+})
+
+describe('biometrics getVitalsSummary edge cases', () => {
+  it('returns null-typed aggregates when SQL avgs are null but recordCount > 0', async () => {
+    // Edge case: COUNT(*) > 0 but all heart-rate columns are NULL.
+    dbState.rowsQueue.push([{
+      avgHeartRate: null, minHeartRate: null, maxHeartRate: null,
+      avgHRV: null, avgBreathingRate: null, recordCount: 3,
+    }])
+    const out = await caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })
+    expect(out).toEqual({
+      avgHeartRate: null, minHeartRate: null, maxHeartRate: null,
+      avgHRV: null, avgBreathingRate: null, recordCount: 3,
+    })
+  })
+
+  it('uses default 7-day window when startDate/endDate not provided', async () => {
+    dbState.rowsQueue.push([{
+      avgHeartRate: '60', minHeartRate: 50, maxHeartRate: 80,
+      avgHRV: '40', avgBreathingRate: '14', recordCount: 5,
+    }])
+    const out = await caller.getVitalsSummary({ side: 'left' })
+    expect(out?.recordCount).toBe(5)
+  })
+
+  it('rejects when endDate-only is older than the default 7-day window start', async () => {
+    // No startDate → defaults to now-7d. endDate set to 30 days ago →
+    // effectiveStart > effectiveEnd, triggering the computed-inverted guard.
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    await expect(caller.getVitalsSummary({
+      side: 'left',
+      endDate: thirtyDaysAgo,
+    })).rejects.toThrow(/Computed date range is inverted/)
+  })
+})
+
+describe('biometrics updateSleepRecord happy paths', () => {
+  it('recalculates duration when both timestamps are supplied', async () => {
+    const entered = new Date('2025-01-01T22:00:00Z')
+    const left = new Date('2025-01-02T06:00:00Z')
+    // tx.select returns existing record (so the inner branch fires)
+    dbState.txRowsQueue.push([
+      { id: 1, side: 'left', enteredBedAt: entered, leftBedAt: left },
+    ])
+    // tx.update returns updated row
+    dbState.txRowsQueue.push([
+      {
+        id: 1, side: 'left',
+        enteredBedAt: entered, leftBedAt: left,
+        sleepDurationSeconds: 8 * 3600, timesExitedBed: 0,
+        presentIntervals: null, notPresentIntervals: null, createdAt: new Date(0),
+      },
+    ])
+    const out = await caller.updateSleepRecord({
+      id: 1,
+      enteredBedAt: entered,
+      leftBedAt: left,
+    })
+    expect(out.sleepDurationSeconds).toBe(8 * 3600)
+  })
+
+  it('throws NOT_FOUND when update returns no row (timesExitedBed-only path)', async () => {
+    // Skips the recompute branch (no enteredBedAt/leftBedAt). tx.update returns [].
+    dbState.txRowsQueue.push([])
+    await expect(caller.updateSleepRecord({ id: 99, timesExitedBed: 3 }))
+      .rejects.toThrow(/Sleep record 99 not found/)
+  })
+})
+
+describe('biometrics error wrapping (INTERNAL_SERVER_ERROR catches)', () => {
+  // Cover the catch(error) branches in each procedure. We force the DB chain
+  // to throw by making `.where()` (or another late chain method) reject.
+  function forceDbError(method: 'select' | 'insert' | 'update' | 'delete') {
+    const failingChain = {
+      then: (resolve: unknown, reject: (err: Error) => unknown) =>
+        Promise.reject(new Error('db down')).catch(reject),
+      where: vi.fn(() => failingChain),
+      orderBy: vi.fn(() => failingChain),
+      limit: vi.fn(() => failingChain),
+      from: vi.fn(() => failingChain),
+      values: vi.fn(() => failingChain),
+      set: vi.fn(() => failingChain),
+      onConflictDoNothing: vi.fn(() => failingChain),
+      returning: vi.fn(() => failingChain),
+      groupBy: vi.fn(() => failingChain),
+    }
+    dbMock[method].mockImplementationOnce(() => failingChain)
+  }
+
+  it('getSleepRecords wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getSleepRecords({ limit: 5 }))
+      .rejects.toThrow(/Failed to fetch sleep records.*db down/)
+  })
+
+  it('getVitals wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getVitals({ limit: 5 }))
+      .rejects.toThrow(/Failed to fetch vitals.*db down/)
+  })
+
+  it('getMovement wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getMovement({ limit: 5 }))
+      .rejects.toThrow(/Failed to fetch movement data.*db down/)
+  })
+
+  it('getMovementBuckets wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getMovementBuckets({ side: 'left', bucketSeconds: 60, limit: 10 }))
+      .rejects.toThrow(/Failed to fetch movement buckets.*db down/)
+  })
+
+  it('getMovementSummary wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getMovementSummary({ side: 'left' }))
+      .rejects.toThrow(/Failed to fetch movement summary.*db down/)
+  })
+
+  it('getLatestSleep wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getLatestSleep({ side: 'left' }))
+      .rejects.toThrow(/Failed to fetch latest sleep record.*db down/)
+  })
+
+  it('getVitalsSummary wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('select')
+    await expect(caller.getVitalsSummary({
+      side: 'left',
+      startDate: new Date('2025-01-01'),
+      endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to calculate vitals summary.*db down/)
+  })
+
+  it('reportVitals wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('insert')
+    await expect(caller.reportVitals({
+      side: 'left', timestamp: 1700000000,
+      heartRate: 60, hrv: 50, breathingRate: 14,
+    })).rejects.toThrow(/Failed to report vitals.*db down/)
+  })
+
+  it('reportVitalsBatch wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    forceDbError('insert')
+    await expect(caller.reportVitalsBatch({
+      vitals: [{ side: 'left', timestamp: 1700000000, heartRate: 60, hrv: 50, breathingRate: 14 }],
+    })).rejects.toThrow(/Failed to report vitals batch.*db down/)
+  })
 })


### PR DESCRIPTION
## Summary
biometrics.ts was the biggest absolute coverage miss on dev (57%, 90 uncovered lines).

## Tests added
- getSleepStages: active session (leftBedAt=null), custom date-range path, default-branch with record found, last-24h-longest fallback, recentRecords[0] final fallback, error-wrapping
- Filter-combination tests for getSleepRecords / getVitals / getMovement / getMovementBuckets / getMovementSummary that exercise all three of (side, startDate, endDate) together
- getMovementBuckets: null SQL aggregate coercion to zero
- getMovementSummary: startDate+endDate path, inverted-range rejection
- getVitalsSummary: null SQL avgs with recordCount > 0, default 7-day window, computed-inverted-range guard (endDate older than now-7d)
- updateSleepRecord: full happy-path with duration recompute when both timestamps supplied, NOT_FOUND on timesExitedBed-only path
- INTERNAL_SERVER_ERROR wrapping for getSleepRecords, getVitals, getMovement, getMovementBuckets, getMovementSummary, getLatestSleep, getVitalsSummary, reportVitals, reportVitalsBatch

## Coverage delta
- biometrics.ts: 56.7% (dev codecov baseline) -> 100% lines / 100% statements / 100% funcs / 91.8% branches (local v8)
- The remaining branch gaps are short-circuit halves inside compound `||` / `??` expressions and the `instanceof TRPCError` re-throw arms

## Test plan
- [x] `pnpm vitest run src/server/routers/tests/biometrics.test.ts` passes (56 tests)
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean