### PR TITLE
test(server): cover system router gaps

### DIFF
--- a/src/server/routers/tests/system.test.ts
+++ b/src/server/routers/tests/system.test.ts
@@ -29,7 +29,9 @@ const fsPromisesMock = vi.hoisted(() => ({
 }))
 
 const fsSyncMock = vi.hoisted(() => ({
-  accessSync: vi.fn(),
+  // Default: throw so resolveExec falls back to bare names (matches dev/macOS).
+  // The fallback `return name` branch in resolveExec is exercised at module load.
+  accessSync: vi.fn(() => { throw new Error('ENOENT') }),
   constants: { X_OK: 1 },
 }))
 
@@ -97,12 +99,58 @@ describe('system.setInternetAccess', () => {
     expect(result.blocked).toBe(false)
   })
 
+  it('blocks WAN by applying LAN-only rules and persists iptables-save output', async () => {
+    // Final isWanBlocked check should see DROP after blockWan applies its rules.
+    let callCount = 0
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      // promisify(execFile)(file) → (file, callback); with args → (file, args, callback)
+      const second = args[1]
+      const argList: string[] = Array.isArray(second) ? (second as string[]) : []
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      callCount++
+      // iptables-save (no args) → return a sentinel payload for persistence
+      if (argList.length === 0) {
+        cb(null, { stdout: 'saved-rules\n' })
+        return
+      }
+      // The final isWanBlocked call uses -L OUTPUT → fake a DROP rule
+      if (argList.includes('-L') && argList.includes('OUTPUT')) {
+        cb(null, { stdout: 'DROP all -- 0.0.0.0/0\n' })
+        return
+      }
+      cb(null, { stdout: '' })
+    })
+    const result = await caller.setInternetAccess({ blocked: true })
+    expect(result.blocked).toBe(true)
+    // mkdir + writeFile invoked when persistence runs
+    expect(fsPromisesMock.mkdir).toHaveBeenCalledWith('/etc/iptables', { recursive: true })
+    expect(fsPromisesMock.writeFile).toHaveBeenCalledWith('/etc/iptables/iptables.rules', 'saved-rules\n')
+    // Sanity: many iptables invocations happened (flush, allow rules, drops)
+    expect(callCount).toBeGreaterThan(10)
+  })
+
+  it('swallows persistence errors during blockWan as best-effort', async () => {
+    fsPromisesMock.mkdir.mockRejectedValueOnce(new Error('readonly fs'))
+    // Default execFile mock returns empty stdout — isWanBlocked sees no DROP → false
+    const result = await caller.setInternetAccess({ blocked: true })
+    expect(result.blocked).toBe(false)
+  })
+
   it('wraps execFile failures as INTERNAL_SERVER_ERROR', async () => {
     execMock.execFile.mockImplementation((...args: unknown[]) => {
       const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
       cb(new Error('iptables boom'), { stdout: '' })
     })
     await expect(caller.setInternetAccess({ blocked: false })).rejects.toThrow(/Failed to update iptables/)
+  })
+
+  it('wraps non-Error throws with an "Unknown error" message', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      // Reject with a non-Error value to hit the `'Unknown error'` branch
+      cb('weird string failure', { stdout: '' })
+    })
+    await expect(caller.setInternetAccess({ blocked: false })).rejects.toThrow(/Unknown error/)
   })
 })
 
@@ -136,6 +184,26 @@ describe('system.wifiStatus', () => {
     expect(result.ssid).toBe('My:Net')
     expect(result.signal).toBe(75)
   })
+
+  it('returns connected=false when no active WiFi line is present', async () => {
+    queueExec(
+      file => file === 'nmcli',
+      { stdout: 'no:OtherNet:50\nno:Cafe:30\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result).toEqual({ connected: false, ssid: null, signal: null })
+  })
+
+  it('returns null signal when nmcli signal field is non-numeric', async () => {
+    queueExec(
+      file => file === 'nmcli',
+      { stdout: 'yes:Home:NaN\n' },
+    )
+    const result = await caller.wifiStatus({})
+    expect(result.connected).toBe(true)
+    expect(result.ssid).toBe('Home')
+    expect(result.signal).toBeNull()
+  })
 })
 
 describe('system.triggerUpdate', () => {
@@ -160,6 +228,35 @@ describe('system.triggerUpdate', () => {
 
   it('rejects branch names with invalid characters', async () => {
     await expect(caller.triggerUpdate({ branch: 'evil; rm -rf /' })).rejects.toThrow(/Invalid branch name/)
+  })
+
+  it('registers an error listener on the child to swallow spawn failures', async () => {
+    const onSpy = vi.fn()
+    const unrefSpy = vi.fn()
+    execMock.spawn.mockReturnValueOnce({ on: onSpy, unref: unrefSpy } as never)
+    await caller.triggerUpdate({})
+    expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(unrefSpy).toHaveBeenCalled()
+    // Invoke the registered error handler — must not throw (only logs).
+    const handler = onSpy.mock.calls.find(c => c[0] === 'error')?.[1] as (e: Error) => void
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => handler(new Error('ENOENT'))).not.toThrow()
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+
+  it('wraps synchronous spawn failures as INTERNAL_SERVER_ERROR', async () => {
+    execMock.spawn.mockImplementationOnce(() => {
+      throw new Error('spawn EACCES')
+    })
+    await expect(caller.triggerUpdate({})).rejects.toThrow(/Failed to trigger update/)
+  })
+
+  it('wraps non-Error spawn throws with "Unknown error"', async () => {
+    execMock.spawn.mockImplementationOnce(() => {
+      throw 'string failure'
+    })
+    await expect(caller.triggerUpdate({})).rejects.toThrow(/Unknown error/)
   })
 })
 
@@ -207,6 +304,63 @@ describe('system.getLogs', () => {
   it('rejects unit names that do not match the sleepypod*.service pattern', async () => {
     await expect(caller.getLogs({ unit: 'evil.service', lines: 10 })).rejects.toThrow(/Invalid unit name/)
   })
+
+  it('passes --until-cursor, --since, and -p when those inputs are set', async () => {
+    let capturedArgs: string[] = []
+    execMock.execFile.mockImplementationOnce((...args: unknown[]) => {
+      capturedArgs = (args[1] as string[]) ?? []
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(null, { stdout: 'l1\n-- cursor: s=xyz\n' })
+    })
+    const result = await caller.getLogs({
+      unit: 'sleepypod.service',
+      lines: 5,
+      cursor: 's=prev',
+      since: '1 hour ago',
+      priority: 'err',
+    })
+    expect(capturedArgs).toContain('--until-cursor')
+    expect(capturedArgs).toContain('s=prev')
+    expect(capturedArgs).toContain('--since')
+    expect(capturedArgs).toContain('1 hour ago')
+    expect(capturedArgs).toContain('-p')
+    expect(capturedArgs).toContain('err')
+    // With only one log line and lines=5 → hasMore=false, nextCursor=null
+    expect(result.nextCursor).toBeNull()
+    expect(result.lines).toEqual(['l1'])
+  })
+
+  it('returns a truncation message when journalctl exceeds maxBuffer', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      const err = Object.assign(new Error('maxBuffer exceeded'), { code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' })
+      cb(err, { stdout: '' })
+    })
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 10 })
+    expect(result.lines[0]).toMatch(/too large/i)
+    expect(result.nextCursor).toBeNull()
+  })
+
+  it('wraps unexpected journalctl failures as INTERNAL_SERVER_ERROR', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      cb(new Error('permission denied'), { stdout: '' })
+    })
+    await expect(
+      caller.getLogs({ unit: 'sleepypod.service', lines: 10 }),
+    ).rejects.toThrow(/Failed to read logs/)
+  })
+
+  it('returns nextCursor=null when journalctl omits the cursor line but more entries exist', async () => {
+    queueExec(
+      file => file === 'journalctl',
+      // 3 lines + no cursor line, with lines=2 → hasMore=true but parsing failed
+      { stdout: 'line1\nline2\nline3\n' },
+    )
+    const result = await caller.getLogs({ unit: 'sleepypod.service', lines: 2 })
+    expect(result.lines).toHaveLength(2)
+    expect(result.nextCursor).toBeNull()
+  })
 })
 
 describe('system.getDiskUsage', () => {
@@ -244,6 +398,42 @@ describe('system.getStorageBreakdown', () => {
     expect(result.emmc.totalBytes).toBe(0)
     expect(result.biometricsArchive).toEqual({ usedBytes: 0, fileCount: 0 })
   })
+
+  it('parses df + du output for each mount and counts archive files', async () => {
+    execMock.execFile.mockImplementation((...args: unknown[]) => {
+      const file = args[0] as string
+      const argList = (args[1] as string[]) ?? []
+      const cb = args[args.length - 1] as (e: unknown, o: { stdout: string }) => void
+      if (file === 'df' && argList.includes('/persistent') && !argList.includes('/persistent/biometrics')) {
+        cb(null, { stdout: 'fs 1B-blocks Used Available Use% Mounted\n/dev/mmcblk0 2000 500 1500 25% /persistent\n' })
+        return
+      }
+      if (file === 'df' && argList.includes('/persistent/biometrics')) {
+        cb(null, { stdout: 'fs 1B-blocks Used Available Use% Mounted\ntmpfs 100 40 60 40% /persistent/biometrics\n' })
+        return
+      }
+      if (file === 'du') {
+        cb(null, { stdout: '1234\t/persistent/biometrics-archive\n' })
+        return
+      }
+      cb(null, { stdout: '' })
+    })
+    // 3 entries: 2 files + 1 dir → fileCount=2
+    fsPromisesMock.readdir.mockResolvedValueOnce([
+      { isFile: () => true } as never,
+      { isFile: () => true } as never,
+      { isFile: () => false } as never,
+    ])
+
+    const result = await caller.getStorageBreakdown({})
+    expect(result.emmc).toEqual({
+      totalBytes: 2000, usedBytes: 500, availableBytes: 1500, usedPercent: 25,
+    })
+    expect(result.biometricsTmpfs).toEqual({
+      totalBytes: 100, usedBytes: 40, availableBytes: 60, usedPercent: 40,
+    })
+    expect(result.biometricsArchive).toEqual({ usedBytes: 1234, fileCount: 2 })
+  })
 })
 
 describe('system.getVersion', () => {
@@ -265,6 +455,21 @@ describe('system.getVersion', () => {
 
   it('returns "unknown" placeholders when .git-info is missing', async () => {
     fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'))
+    const result = await caller.getVersion({})
+    expect(result).toEqual({
+      branch: 'unknown', commitHash: 'unknown',
+      commitTitle: 'unknown', buildDate: 'unknown',
+    })
+  })
+
+  it('substitutes "unknown" for individual non-string fields in .git-info', async () => {
+    // Each field of the parsed JSON is non-string → each branch falls back
+    fsPromisesMock.readFile.mockResolvedValue(JSON.stringify({
+      branch: 42,
+      commitHash: null,
+      commitTitle: { not: 'a string' },
+      buildDate: ['array'],
+    }))
     const result = await caller.getVersion({})
     expect(result).toEqual({
       branch: 'unknown', commitHash: 'unknown',


### PR DESCRIPTION
## Summary
system.ts was at 62% with 63 uncovered lines on dev — mostly shell-out and fs branches.

## Tests added
- `setInternetAccess`: full `blockWan` happy path (iptables-save persistence with mkdir + writeFile), best-effort persistence error swallowing, non-Error throw → `Unknown error` wrap.
- `wifiStatus`: no-active-line branch, non-numeric signal → null.
- `triggerUpdate`: child `error` listener registration + handler (console.error only, no throw), synchronous spawn failure → INTERNAL_SERVER_ERROR, non-Error throw → `Unknown error` wrap.
- `getLogs`: `cursor`/`since`/`priority` arg passthrough, `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` truncation message, generic failure → INTERNAL_SERVER_ERROR, hasMore-without-cursor path.
- `getStorageBreakdown`: parsed df + du happy path with mixed file/dir readdir entries.
- `getVersion`: non-string field substitution branch.
- `resolveExec`: default mock now throws so the bare-name fallback executes at module load.

## Coverage delta
- system.ts lines: 62.0% → 100.0%
- system.ts statements: 76.54% → 100.0%
- system.ts branches: 53.75% → 83.75%
- system.ts functions: 84.61% → 100.0%

## Test plan
- [x] `pnpm vitest run src/server/routers/tests/system.test.ts` passes (34/34)
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm tsc` clean