### PR TITLE
test(server): cover archivePush + settings router gaps

### DIFF
--- a/src/server/routers/tests/archivePush.test.ts
+++ b/src/server/routers/tests/archivePush.test.ts
@@ -1,13 +1,48 @@
 /**
  * Unit tests for the archive-push router. Covers conf parsing/rendering,
  * getConfig/setConfig roundtrip on a temp dir, and behaviour when the conf
- * is absent. Excludes ssh-keygen / ssh — those shell out to binaries we'd
- * have to mock and provide little signal in a unit run.
+ * is absent. ssh-keygen / ssh are mocked via vi.mock('node:child_process')
+ * so generateKey + testConnection happy/error branches are exercised
+ * without invoking real binaries.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+
+// Hoisted control surface for the execFile mock. Each test sets `impl` to
+// the (cmd, args) -> { stdout, stderr } | throw it wants.
+const execMock = vi.hoisted(() => {
+  type Impl = (cmd: string, args: readonly string[]) => { stdout?: string, stderr?: string } | Promise<{ stdout?: string, stderr?: string }>
+  const state: { impl: Impl } = { impl: () => ({ stdout: '', stderr: '' }) }
+  return state
+})
+
+vi.mock('node:child_process', () => {
+  // Callback-style execFile so promisify wraps it correctly. The router
+  // ignores stdout/stderr — only the resolve/reject matters here.
+  function execFile(
+    cmd: string,
+    args: readonly string[],
+    _opts: unknown,
+    cb: (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+  ): void {
+    Promise.resolve()
+      .then(() => execMock.impl(cmd, args))
+      .then(
+        out => cb(null, out?.stdout ?? '', out?.stderr ?? ''),
+        (err: Error & { stderr?: string }) => {
+          // Match Node's execFile error shape (carries .stderr) so the router's
+          // `(err as { stderr?: string }).stderr` branch is exercised.
+          cb(err as NodeJS.ErrnoException, '', err?.stderr ?? '')
+        },
+      )
+  }
+  return {
+    execFile,
+    default: { execFile },
+  }
+})
 
 let configDir: string
 
@@ -27,7 +62,10 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await rm(path.join(configDir, 'archive-push.conf'), { force: true })
+  await rm(path.join(configDir, 'archive-push.id_ed25519'), { force: true })
   await rm(path.join(configDir, 'archive-push.id_ed25519.pub'), { force: true })
+  // Reset execFile behaviour to a benign success — tests opt into failures.
+  execMock.impl = () => ({ stdout: '', stderr: '' })
 })
 
 const { archivePushRouter, parseConf, renderConf } = await import('@/src/server/routers/archivePush')
@@ -55,6 +93,11 @@ describe('parseConf', () => {
   it('skips lines without =', () => {
     const result = parseConf('ENABLED=true\nbogus line\nHOST=h')
     expect(result).toEqual({ ENABLED: 'true', HOST: 'h' })
+  })
+
+  it('drops blank keys (line starting with =)', () => {
+    const result = parseConf('=novalue\nHOST=h')
+    expect(result).toEqual({ HOST: 'h' })
   })
 })
 
@@ -137,6 +180,32 @@ describe('archivePush.getConfig', () => {
     const result = await caller.getConfig({})
     expect(result.publicKey).toBe('ssh-ed25519 AAAA test')
   })
+
+  it('falls back to defaults when PORT is non-numeric', async () => {
+    await writeFile(
+      path.join(configDir, 'archive-push.conf'),
+      'PORT=notanumber\nINCLUDE=',
+    )
+    const result = await caller.getConfig({})
+    // Number('notanumber') -> NaN -> guarded fallback to 22
+    expect(result.config.port).toBe(22)
+    // INCLUDE= with empty value -> fall back to default ['raw','db']
+    expect(result.config.include).toEqual(['raw', 'db'])
+  })
+
+  it('propagates non-ENOENT errors from readFile', async () => {
+    // Replace the conf path with a directory — readFile then rejects EISDIR
+    // which the router rethrows (only ENOENT is swallowed).
+    await mkdir(path.join(configDir, 'archive-push.conf'), { recursive: true })
+    await expect(caller.getConfig({})).rejects.toThrow()
+    await rm(path.join(configDir, 'archive-push.conf'), { recursive: true, force: true })
+  })
+
+  it('propagates non-ENOENT errors from readPublicKey', async () => {
+    await mkdir(path.join(configDir, 'archive-push.id_ed25519.pub'), { recursive: true })
+    await expect(caller.getConfig({})).rejects.toThrow()
+    await rm(path.join(configDir, 'archive-push.id_ed25519.pub'), { recursive: true, force: true })
+  })
 })
 
 describe('archivePush.setConfig', () => {
@@ -163,6 +232,66 @@ describe('archivePush.setConfig', () => {
   })
 })
 
+describe('archivePush.generateKey', () => {
+  it('shells out to ssh-keygen, writes pubkey, returns generated=true', async () => {
+    const pubPath = path.join(configDir, 'archive-push.id_ed25519.pub')
+    execMock.impl = async (cmd, args) => {
+      expect(cmd).toBe('ssh-keygen')
+      // Identity path is passed via -f
+      const idIdx = args.indexOf('-f')
+      expect(idIdx).toBeGreaterThan(-1)
+      const identity = args[idIdx + 1]
+      // Real ssh-keygen would write both the private + .pub — fake only the
+      // .pub here (chmod on the missing private file is .catch()'d).
+      await writeFile(pubPath, 'ssh-ed25519 AAAAfaked sleepypod-archive-push\n')
+      // Also create the private file so the post-keygen chmod doesn't ENOENT
+      await writeFile(identity, 'PRIVATE')
+      return { stdout: '', stderr: '' }
+    }
+
+    const result = await caller.generateKey({})
+    expect(result.generated).toBe(true)
+    expect(result.publicKey).toContain('ssh-ed25519')
+  })
+
+  it('returns generated=false when identity already exists', async () => {
+    const identity = path.join(configDir, 'archive-push.id_ed25519')
+    const pubPath = `${identity}.pub`
+    await writeFile(identity, 'PRIVATE')
+    await writeFile(pubPath, 'ssh-ed25519 AAAApreexisting sleepypod\n')
+
+    let calls = 0
+    execMock.impl = () => {
+      calls += 1
+      return { stdout: '', stderr: '' }
+    }
+
+    const result = await caller.generateKey({})
+    expect(result.generated).toBe(false)
+    expect(result.publicKey).toContain('AAAApreexisting')
+    expect(calls).toBe(0) // ssh-keygen was NOT invoked
+  })
+
+  it('throws INTERNAL_SERVER_ERROR when ssh-keygen fails', async () => {
+    execMock.impl = () => {
+      throw new Error('keygen boom')
+    }
+    await expect(caller.generateKey({})).rejects.toThrow(/ssh-keygen failed: keygen boom/)
+  })
+
+  it('throws when ssh-keygen succeeded but no pubkey landed on disk', async () => {
+    // Pretend ssh-keygen ran fine but produced nothing — guards against a
+    // silent partial-success leaving the user with no key to copy.
+    const identity = path.join(configDir, 'archive-push.id_ed25519')
+    execMock.impl = async () => {
+      await writeFile(identity, 'PRIVATE')
+      // Deliberately do NOT write the .pub
+      return { stdout: '', stderr: '' }
+    }
+    await expect(caller.generateKey({})).rejects.toThrow(/Public key missing/)
+  })
+})
+
 describe('archivePush.testConnection', () => {
   it('rejects when host is unset', async () => {
     const result = await caller.testConnection({})
@@ -183,5 +312,87 @@ describe('archivePush.testConnection', () => {
     const result = await caller.testConnection({})
     expect(result.ok).toBe(false)
     expect(result.message).toMatch(/identity .* missing/)
+  })
+
+  it('returns ok=true when ssh succeeds', async () => {
+    const identity = path.join(configDir, 'archive-push.id_ed25519')
+    await writeFile(identity, 'PRIVATE')
+    await caller.setConfig({
+      enabled: true,
+      host: 'nas.local',
+      remoteUser: 'sp',
+      remotePath: '/x',
+      port: 2222,
+      identity,
+      include: ['raw'],
+    })
+
+    let observed: { cmd: string, args: readonly string[] } | null = null
+    execMock.impl = (cmd, args) => {
+      observed = { cmd, args }
+      return { stdout: '', stderr: '' }
+    }
+
+    const result = await caller.testConnection({})
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe('connection ok')
+    if (!observed) throw new Error('execFile mock was not invoked')
+    const seen = observed as { cmd: string, args: readonly string[] }
+    expect(seen.cmd).toBe('ssh')
+    // Verify BatchMode + accept-new are set so a hung password prompt cannot
+    // happen on the daemon.
+    expect(seen.args).toContain('BatchMode=yes')
+    expect(seen.args).toContain('StrictHostKeyChecking=accept-new')
+    // user@host and port are passed through
+    expect(seen.args).toContain('sp@nas.local')
+    expect(seen.args).toContain('2222')
+  })
+
+  it('returns ok=false carrying ssh stderr on failure', async () => {
+    const identity = path.join(configDir, 'archive-push.id_ed25519')
+    await writeFile(identity, 'PRIVATE')
+    await caller.setConfig({
+      enabled: true,
+      host: 'nas.local',
+      remoteUser: 'sp',
+      remotePath: '/x',
+      port: 22,
+      identity,
+      include: ['raw'],
+    })
+
+    execMock.impl = () => {
+      const e = new Error('exit 255') as Error & { stderr?: string }
+      e.stderr = 'Permission denied (publickey)'
+      throw e
+    }
+
+    const result = await caller.testConnection({})
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('Permission denied (publickey)')
+  })
+
+  it('falls back to err.message when stderr is absent', async () => {
+    const identity = path.join(configDir, 'archive-push.id_ed25519')
+    await writeFile(identity, 'PRIVATE')
+    await caller.setConfig({
+      enabled: true,
+      host: 'nas.local',
+      remoteUser: 'sp',
+      remotePath: '/x',
+      port: 22,
+      identity,
+      include: ['raw'],
+    })
+
+    execMock.impl = () => {
+      throw new Error('connect timeout')
+    }
+
+    const result = await caller.testConnection({})
+    expect(result.ok).toBe(false)
+    // execFile's callback strips Error -> ErrnoException-shaped object; the
+    // router falls back to the err.message string when stderr is empty.
+    expect(result.message).toMatch(/connect timeout|exit/i)
   })
 })

--- a/src/server/routers/tests/settings.test.ts
+++ b/src/server/routers/tests/settings.test.ts
@@ -145,6 +145,41 @@ describe('settings.getAll', () => {
     expect(result.sides.left.side).toBe('left')
     expect(result.sides.right.side).toBe('right')
   })
+
+  it('partitions gestures by side', async () => {
+    const device = { ...baseDevice }
+    const sides = [
+      { side: 'left', name: 'L', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+      { side: 'right', name: 'R', awayMode: false, alwaysOn: false, autoOffEnabled: false, autoOffMinutes: 30, awayStart: null, awayReturn: null, createdAt: new Date(0), updatedAt: new Date(0) },
+    ]
+    const gestures = [
+      { id: 1, side: 'left', tapType: 'doubleTap', actionType: 'temperature', temperatureChange: 'increment', temperatureAmount: 1, createdAt: new Date(0), updatedAt: new Date(0) },
+      { id: 2, side: 'right', tapType: 'doubleTap', actionType: 'alarm', alarmBehavior: 'snooze', createdAt: new Date(0), updatedAt: new Date(0) },
+    ]
+    dbState.topRowsQueue.push([device], sides, gestures)
+    const result = await caller.getAll({})
+    expect(result.gestures.left).toHaveLength(1)
+    expect(result.gestures.right).toHaveLength(1)
+    expect(result.gestures.left[0].id).toBe(1)
+  })
+
+  it('wraps unexpected DB errors in TRPCError(INTERNAL_SERVER_ERROR)', async () => {
+    // Make the first db.select() throw synchronously — simulates a DB outage.
+    dbMock.select.mockImplementationOnce(() => {
+      throw new Error('db down')
+    })
+    await expect(caller.getAll({})).rejects.toThrow(/Failed to fetch settings: db down/)
+    // Restore default chain factory for subsequent tests.
+    dbMock.select.mockImplementation(() => {
+      const chain: Record<string, unknown> = {}
+      chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(dbState.popTop()).then(resolve)
+      chain.where = vi.fn(() => chain)
+      chain.limit = vi.fn(() => chain)
+      chain.from = vi.fn(() => chain)
+      chain.set = vi.fn(() => chain)
+      return chain
+    })
+  })
 })
 
 describe('settings.updateDevice', () => {
@@ -356,5 +391,205 @@ describe('settings.setGesture / deleteGesture', () => {
     dbState.txRowsQueue.push([{ id: 1 }])
     const out = await caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })
     expect(out).toEqual({ success: true })
+  })
+})
+
+// Shared device row fixture for branches that don't care about specific values.
+const baseDevice = {
+  id: 1, timezone: 'UTC', temperatureUnit: 'F' as const,
+  rebootDaily: false, rebootTime: '03:00',
+  primePodDaily: false, primePodTime: '14:00',
+  ledNightModeEnabled: false, ledDayBrightness: 100, ledNightBrightness: 0,
+  ledNightStartTime: '22:00', ledNightEndTime: '07:00',
+  globalMaxOnHours: null, homekitEnabled: false,
+  createdAt: new Date(0), updatedAt: new Date(0),
+}
+
+const baseSide = {
+  side: 'left' as const, name: 'L', awayMode: false, alwaysOn: false,
+  autoOffEnabled: false, autoOffMinutes: 30,
+  awayStart: null, awayReturn: null,
+  createdAt: new Date(0), updatedAt: new Date(0),
+}
+
+describe('settings.updateDevice — extra branches', () => {
+  it('throws NOT_FOUND when current device row is missing inside the tx', async () => {
+    dbState.txRowsQueue.push([]) // tx select(current) → empty
+    await expect(caller.updateDevice({ timezone: 'UTC' })).rejects.toThrow(/Device settings not found/)
+  })
+
+  it('rejects primePodDaily=true without a primePodTime', async () => {
+    const current = { ...baseDevice, primePodTime: null }
+    dbState.txRowsQueue.push([current])
+    await expect(caller.updateDevice({ primePodDaily: true })).rejects.toThrow(/primePodTime is required/)
+  })
+
+  it('throws NOT_FOUND when the update returning() is empty', async () => {
+    dbState.txRowsQueue.push([baseDevice], []) // current present, update result empty
+    await expect(caller.updateDevice({ timezone: 'UTC' })).rejects.toThrow(/Device settings not found/)
+  })
+
+  it('swallows scheduler reload failures without failing the mutation', async () => {
+    const current = { ...baseDevice }
+    const updated = { ...current, timezone: 'America/New_York' }
+    dbState.txRowsQueue.push([current], [updated])
+    schedulerMock.jm.updateTimezone.mockRejectedValueOnce(new Error('scheduler down'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await caller.updateDevice({ timezone: 'America/New_York' })
+    expect(result.timezone).toBe('America/New_York')
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('restarts auto-off timers when globalMaxOnHours changes', async () => {
+    const current = { ...baseDevice }
+    const updated = { ...current, globalMaxOnHours: 8 }
+    dbState.txRowsQueue.push([current], [updated])
+    await caller.updateDevice({ globalMaxOnHours: 8 })
+    expect(autoOffMock.restartAutoOffTimers).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs but does not fail when autoOff restart throws', async () => {
+    const current = { ...baseDevice }
+    const updated = { ...current, globalMaxOnHours: 12 }
+    dbState.txRowsQueue.push([current], [updated])
+    autoOffMock.restartAutoOffTimers.mockImplementationOnce(() => {
+      throw new Error('autoOff bust')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await caller.updateDevice({ globalMaxOnHours: 12 })
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('invokes homekit.disable() when homekitEnabled flips to false', async () => {
+    dbState.topRowsQueue.push([{ homekitEnabled: true }])
+    const current = { ...baseDevice, homekitEnabled: true }
+    const updated = { ...current, homekitEnabled: false }
+    dbState.txRowsQueue.push([current], [updated])
+    await caller.updateDevice({ homekitEnabled: false })
+    expect(homekitMock.disable).toHaveBeenCalledTimes(1)
+    expect(homekitMock.enable).not.toHaveBeenCalled()
+  })
+
+  it('wraps non-TRPC errors thrown by the transaction in INTERNAL_SERVER_ERROR', async () => {
+    // First call to db.transaction throws a raw Error — the catch block at
+    // the bottom of updateDevice should wrap it.
+    dbMock.transaction.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    await expect(caller.updateDevice({ timezone: 'UTC' })).rejects.toThrow(/Failed to update device settings: boom/)
+  })
+})
+
+describe('settings.updateSide — extra branches', () => {
+  it('throws NOT_FOUND when update returning() is empty (race vs delete)', async () => {
+    const current = { ...baseSide }
+    dbState.txRowsQueue.push([current], [])
+    await expect(caller.updateSide({ side: 'left', name: 'Renamed' })).rejects.toThrow(/Side settings for left not found/)
+  })
+
+  it('reloads scheduler when away window changes', async () => {
+    const current = { ...baseSide }
+    const updated = { ...current, awayStart: '2025-01-01T00:00:00Z' }
+    dbState.txRowsQueue.push([current], [updated])
+    await caller.updateSide({ side: 'left', awayStart: '2025-01-01T00:00:00Z' })
+    expect(schedulerMock.jm.reloadSchedules).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs but does not fail when away-window scheduler reload throws', async () => {
+    const current = { ...baseSide }
+    const updated = { ...current, awayReturn: '2025-01-02T00:00:00Z' }
+    dbState.txRowsQueue.push([current], [updated])
+    schedulerMock.jm.reloadSchedules.mockRejectedValueOnce(new Error('reload boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await caller.updateSide({ side: 'left', awayReturn: '2025-01-02T00:00:00Z' })
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('restarts auto-off timers when autoOffMinutes changes', async () => {
+    const current = { ...baseSide }
+    const updated = { ...current, autoOffMinutes: 45 }
+    dbState.txRowsQueue.push([current], [updated])
+    await caller.updateSide({ side: 'left', autoOffMinutes: 45 })
+    expect(autoOffMock.restartAutoOffTimers).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs but does not fail when auto-off restart throws in updateSide', async () => {
+    const current = { ...baseSide }
+    const updated = { ...current, autoOffEnabled: true }
+    dbState.txRowsQueue.push([current], [updated])
+    autoOffMock.restartAutoOffTimers.mockImplementationOnce(() => {
+      throw new Error('autoOff fail')
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await caller.updateSide({ side: 'left', autoOffEnabled: true })
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('wraps non-TRPC errors from the transaction in INTERNAL_SERVER_ERROR', async () => {
+    dbMock.transaction.mockImplementationOnce(() => {
+      throw new Error('side boom')
+    })
+    await expect(caller.updateSide({ side: 'left', name: 'X' })).rejects.toThrow(/Failed to update side settings: side boom/)
+  })
+})
+
+describe('settings.setAlwaysOn — error wrap', () => {
+  it('wraps non-TRPC errors from the transaction in INTERNAL_SERVER_ERROR', async () => {
+    dbMock.transaction.mockImplementationOnce(() => {
+      throw new Error('toggle boom')
+    })
+    await expect(caller.setAlwaysOn({ side: 'left', alwaysOn: true })).rejects.toThrow(/Failed to set alwaysOn: toggle boom/)
+  })
+})
+
+describe('settings.setGesture — extra branches', () => {
+  it('throws INTERNAL_SERVER_ERROR when update returning() yields no row', async () => {
+    // Existing gesture found, but the update inside the same tx returns no
+    // row (theoretically impossible with a returning() chain — guarded anyway).
+    dbState.txRowsQueue.push([{ id: 9, side: 'left', tapType: 'doubleTap' }], [])
+    await expect(caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'temperature',
+      temperatureChange: 'increment',
+      temperatureAmount: 1,
+    })).rejects.toThrow(/Failed to update gesture/)
+  })
+
+  it('throws INTERNAL_SERVER_ERROR when insert returning() yields no row', async () => {
+    dbState.txRowsQueue.push([], []) // no existing, insert returned nothing
+    await expect(caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'temperature',
+      temperatureChange: 'increment',
+      temperatureAmount: 1,
+    })).rejects.toThrow(/Failed to create gesture/)
+  })
+
+  it('wraps non-TRPC errors thrown by the transaction in INTERNAL_SERVER_ERROR', async () => {
+    dbMock.transaction.mockImplementationOnce(() => {
+      throw new Error('gesture boom')
+    })
+    await expect(caller.setGesture({
+      side: 'left',
+      tapType: 'doubleTap',
+      actionType: 'temperature',
+      temperatureChange: 'increment',
+      temperatureAmount: 1,
+    })).rejects.toThrow(/Failed to set gesture: gesture boom/)
+  })
+})
+
+describe('settings.deleteGesture — extra branches', () => {
+  it('wraps non-TRPC errors thrown by the transaction in INTERNAL_SERVER_ERROR', async () => {
+    dbMock.transaction.mockImplementationOnce(() => {
+      throw new Error('delete boom')
+    })
+    await expect(caller.deleteGesture({ side: 'left', tapType: 'doubleTap' })).rejects.toThrow(/Failed to delete gesture: delete boom/)
   })
 })


### PR DESCRIPTION
## Summary
archivePush (55%) and settings (65%) routers had ~85 uncovered lines combined on dev. This adds 32 new unit tests bringing both routers to ~100% line coverage.

## Tests added

### archivePush.test.ts (+11 tests)
- `parseConf` drops blank keys (line starting with `=`)
- `getConfig` falls back to defaults when `PORT` is non-numeric
- `getConfig` propagates non-`ENOENT` errors from `readFile` (conf path is a directory)
- `getConfig` propagates non-`ENOENT` errors from `readPublicKey`
- `generateKey` shells out to `ssh-keygen`, writes pubkey, returns `generated: true` (`node:child_process` mocked)
- `generateKey` returns `generated: false` and skips `ssh-keygen` when identity already exists
- `generateKey` throws `INTERNAL_SERVER_ERROR` when `ssh-keygen` fails
- `generateKey` throws when `ssh-keygen` succeeded but no pubkey landed on disk
- `testConnection` returns `ok: true` on ssh success (asserts `BatchMode=yes`, `accept-new`, `user@host`, port flags)
- `testConnection` returns `ok: false` carrying ssh `stderr` on failure
- `testConnection` falls back to `err.message` when stderr is absent

### settings.test.ts (+21 tests)
- `getAll` partitions gestures by side (covers filter arrow bodies)
- `getAll` wraps unexpected DB errors in `TRPCError(INTERNAL_SERVER_ERROR)`
- `updateDevice` throws `NOT_FOUND` when current device row is missing inside the tx
- `updateDevice` rejects `primePodDaily=true` without a `primePodTime`
- `updateDevice` throws `NOT_FOUND` when the `update().returning()` is empty
- `updateDevice` swallows scheduler reload failures without failing the mutation
- `updateDevice` restarts auto-off timers when `globalMaxOnHours` changes
- `updateDevice` logs but does not fail when autoOff restart throws
- `updateDevice` invokes `homekit.disable()` when `homekitEnabled` flips to false
- `updateDevice` wraps non-TRPC errors thrown by the transaction
- `updateSide` throws `NOT_FOUND` when `update().returning()` is empty
- `updateSide` reloads scheduler when away window changes
- `updateSide` logs but does not fail when away-window scheduler reload throws
- `updateSide` restarts auto-off timers when `autoOffMinutes` changes
- `updateSide` logs but does not fail when auto-off restart throws
- `updateSide` wraps non-TRPC errors from the transaction
- `setAlwaysOn` wraps non-TRPC errors from the transaction
- `setGesture` throws `INTERNAL_SERVER_ERROR` when update `returning()` yields no row
- `setGesture` throws `INTERNAL_SERVER_ERROR` when insert `returning()` yields no row
- `setGesture` wraps non-TRPC errors from the transaction
- `deleteGesture` wraps non-TRPC errors from the transaction

## Coverage delta
- `archivePush.ts`: 55% → **100%** lines (87% branches, 93% functions)
- `settings.ts`: 65% → **100%** lines (95% branches, 100% functions)

Combined, the two files went from 76% → 99% line coverage on the targeted set.

## Test plan
- [x] `pnpm vitest run src/server/routers/tests/archivePush.test.ts src/server/routers/tests/settings.test.ts` passes (61 tests, 0 failures)
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean