### PR TITLE
test(hardware,scheduler): cover instance singletons

### DIFF
--- a/src/hardware/tests/dacMonitor.instance.test.ts
+++ b/src/hardware/tests/dacMonitor.instance.test.ts
@@ -1,0 +1,662 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests for src/hardware/dacMonitor.instance.ts — the global hardware
+ * singleton wrapper (DAC server connect, shared HardwareClient, DacMonitor).
+ *
+ * The class boundaries (DacMonitor, GestureActionHandler, DeviceStateSync,
+ * dacTransport) are mocked so we exercise only the wrapper's wiring.
+ *
+ * `globalThis` carries the singleton state, so each test calls
+ * `freshModule()` which resets module state AND clears the relevant global
+ * keys to avoid cross-test bleed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import type { DeviceStatus } from '../types'
+
+// ── Module-scoped mock targets ───────────────────────────────────────────────
+
+const connectDacMock = vi.fn<(path: string) => Promise<void>>(async () => {})
+const disconnectDacMock = vi.fn(async () => {})
+const sendCommandMock = vi.fn<(cmd: string, arg?: string) => Promise<string>>(async () => 'OK\n\n')
+const isDacConnectedMock = vi.fn(() => true)
+
+const parseDeviceStatusMock = vi.fn<(resp: string) => DeviceStatus>(() => ({
+  leftSide: { currentTemperature: 75, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+  rightSide: { currentTemperature: 75, targetTemperature: 75, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
+  waterLevel: 'ok',
+  isPriming: false,
+  podVersion: 'I00' as any,
+  sensorLabel: 'I00-test',
+}))
+const parseSimpleResponseMock = vi.fn<(resp: string) => { success: boolean, message: string }>(
+  () => ({ success: true, message: 'ok' }),
+)
+
+// DacMonitor mock — captures registered listeners so tests can fire them.
+// `nextStartImpl` lets a test queue a one-shot start() body for the next
+// constructed monitor (e.g. to make it throw and exercise the catch path).
+type ListenerMap = Record<string, Array<(...args: unknown[]) => void>>
+const monitorInstances: any[] = []
+let nextStartImpl: (() => Promise<void>) | null = null
+class FakeDacMonitor {
+  config: any
+  listeners: ListenerMap = {}
+  start: Mock
+  stop = vi.fn()
+  removeAllListeners = vi.fn((event?: string) => {
+    if (event) this.listeners[event] = []
+    else this.listeners = {}
+  })
+
+  constructor(config: any) {
+    this.config = config
+    const impl = nextStartImpl ?? (async () => {})
+    nextStartImpl = null
+    this.start = vi.fn(impl)
+    monitorInstances.push(this)
+  }
+
+  on(event: string, cb: (...args: unknown[]) => void) {
+    ;(this.listeners[event] ||= []).push(cb)
+    return this
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const cb of this.listeners[event] || []) cb(...args)
+  }
+}
+
+const gestureCleanupMock = vi.fn()
+const gestureHandleMock = vi.fn()
+class FakeGestureActionHandler {
+  socketPath: string
+  deps: unknown
+  cleanup = gestureCleanupMock
+  handle = gestureHandleMock
+  constructor(socketPath: string, deps: unknown) {
+    this.socketPath = socketPath
+    this.deps = deps
+  }
+}
+
+const stateSyncSyncMock = vi.fn(async () => {})
+const stateSyncRecordFlowMock = vi.fn()
+class FakeDeviceStateSync {
+  sync = stateSyncSyncMock
+  recordFlowData = stateSyncRecordFlowMock
+}
+
+const cancelSnoozeMock = vi.fn<(side: 'left' | 'right') => void>()
+const resetPrimingStateMock = vi.fn()
+const trackPrimingStateMock = vi.fn<(priming: boolean) => void>()
+const getPrimeCompletedAtMock = vi.fn(() => null as number | null)
+const getAlarmStateMock = vi.fn(() => ({ left: false, right: false }))
+const getSnoozeStatusMock = vi.fn<(side: 'left' | 'right') => { active: boolean, snoozeUntil: number | null }>(
+  () => ({ active: false, snoozeUntil: null }),
+)
+
+const broadcastFrameMock = vi.fn()
+const onServerFrameMock = vi.fn<(cb: (frame: unknown) => void) => () => void>(() => () => {})
+
+// ── vi.mock declarations ─────────────────────────────────────────────────────
+
+vi.mock('../dacTransport', () => ({
+  connectDac: (...a: unknown[]) => connectDacMock(...a as [string]),
+  disconnectDac: () => disconnectDacMock(),
+  sendCommand: (...a: unknown[]) => sendCommandMock(...a as [string, string?]),
+  isDacConnected: () => isDacConnectedMock(),
+}))
+
+vi.mock('../dacMonitor', () => ({
+  DacMonitor: FakeDacMonitor,
+}))
+
+vi.mock('../gestureActionHandler', () => ({
+  GestureActionHandler: FakeGestureActionHandler,
+}))
+
+vi.mock('../gestureActionHandler.deps', () => ({
+  defaultGestureActionDeps: { _stub: true },
+}))
+
+vi.mock('../deviceStateSync', () => ({
+  DeviceStateSync: FakeDeviceStateSync,
+  getAlarmState: () => getAlarmStateMock(),
+}))
+
+vi.mock('../primeNotification', () => ({
+  trackPrimingState: (priming: boolean) => trackPrimingStateMock(priming),
+  resetPrimingState: () => resetPrimingStateMock(),
+  getPrimeCompletedAt: () => getPrimeCompletedAtMock(),
+}))
+
+vi.mock('../snoozeManager', () => ({
+  cancelSnooze: (side: 'left' | 'right') => cancelSnoozeMock(side),
+  getSnoozeStatus: (side: 'left' | 'right') => getSnoozeStatusMock(side),
+}))
+
+vi.mock('../responseParser', () => ({
+  parseDeviceStatus: (...a: unknown[]) => parseDeviceStatusMock(...a as [string]),
+  parseSimpleResponse: (...a: unknown[]) => parseSimpleResponseMock(...a as [string]),
+}))
+
+vi.mock('@/src/streaming/piezoStream', () => ({
+  broadcastFrame: (...a: unknown[]) => broadcastFrameMock(...a),
+  onServerFrame: (cb: (frame: unknown) => void) => onServerFrameMock(cb),
+}))
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+import type * as InstanceModuleTypes from '../dacMonitor.instance'
+type InstanceModule = typeof InstanceModuleTypes
+
+const GLOBAL_KEYS = [
+  '__sp_dac_server__',
+  '__sp_hw_client__',
+  '__sp_dac_monitor__',
+  '__sp_gesture_handler__',
+  '__sp_unsub_flow__',
+] as const
+
+function clearGlobals() {
+  const g = globalThis as Record<string, unknown>
+  // The keys come from a const tuple; dynamic-access on a known shape is safe.
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  for (const k of GLOBAL_KEYS) delete g[k]
+}
+
+async function freshModule(): Promise<InstanceModule> {
+  vi.resetModules()
+  clearGlobals()
+  return await import('../dacMonitor.instance')
+}
+
+async function flushMicrotasks(): Promise<void> {
+  // Dynamic imports return a Promise; the wrapper chains .then(broadcastFrame).
+  // Several macrotask ticks ensure the chain settles before assertions.
+  for (let i = 0; i < 5; i++) {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('hardware/dacMonitor.instance', () => {
+  beforeEach(() => {
+    connectDacMock.mockReset().mockResolvedValue(undefined)
+    disconnectDacMock.mockReset().mockResolvedValue(undefined)
+    sendCommandMock.mockReset().mockResolvedValue('OK\n\n')
+    isDacConnectedMock.mockReset().mockReturnValue(true)
+    parseDeviceStatusMock.mockClear()
+    parseSimpleResponseMock.mockReset().mockReturnValue({ success: true, message: 'ok' })
+    gestureCleanupMock.mockClear()
+    gestureHandleMock.mockClear()
+    stateSyncSyncMock.mockReset().mockResolvedValue(undefined)
+    stateSyncRecordFlowMock.mockClear()
+    cancelSnoozeMock.mockClear()
+    resetPrimingStateMock.mockClear()
+    trackPrimingStateMock.mockClear()
+    getPrimeCompletedAtMock.mockReset().mockReturnValue(null)
+    getAlarmStateMock.mockReset().mockReturnValue({ left: false, right: false })
+    getSnoozeStatusMock.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
+    broadcastFrameMock.mockClear()
+    onServerFrameMock.mockReset().mockImplementation(() => () => {})
+    monitorInstances.length = 0
+    nextStartImpl = null
+  })
+
+  afterEach(async () => {
+    // Drain any in-flight shutdown so the singleton globals are clean before
+    // the next test re-imports the module.
+    try {
+      const mod = await import('../dacMonitor.instance')
+      await mod.shutdownDacMonitor().catch(() => {})
+    }
+    catch { /* ignore */ }
+    // Give pending dynamic-import .then() chains a chance to settle before
+    // the next test resets module + mock state, so leftover side effects
+    // (e.g. onServerFrame registration) can't bleed across tests.
+    await flushMicrotasks()
+    clearGlobals()
+  })
+
+  // ── startDacServer / getDacServer ──
+
+  describe('startDacServer / getDacServer', () => {
+    it('returns null before startDacServer is called', async () => {
+      const mod = await freshModule()
+      expect(mod.getDacServer()).toBeNull()
+    })
+
+    it('invokes connectDac on first call and marks the server flag', async () => {
+      const mod = await freshModule()
+      await mod.startDacServer()
+      await flushMicrotasks()
+
+      expect(connectDacMock).toHaveBeenCalledTimes(1)
+      expect(mod.getDacServer()).toBe(true)
+    })
+
+    it('is idempotent — second call does NOT re-invoke connectDac', async () => {
+      const mod = await freshModule()
+      await mod.startDacServer()
+      await mod.startDacServer()
+      await flushMicrotasks()
+      expect(connectDacMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('swallows connectDac rejection (degraded mode) with a console warning', async () => {
+      const mod = await freshModule()
+      connectDacMock.mockRejectedValueOnce(new Error('no socket'))
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await mod.startDacServer()
+      await flushMicrotasks()
+
+      expect(warnSpy).toHaveBeenCalled()
+      expect(mod.getDacServer()).toBe(true) // server flag still set
+      warnSpy.mockRestore()
+    })
+
+    it('handles non-Error rejection values without crashing', async () => {
+      const mod = await freshModule()
+      connectDacMock.mockRejectedValueOnce('string failure')
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await mod.startDacServer()
+      await flushMicrotasks()
+
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('honours DAC_SOCK_PATH from the environment', async () => {
+      const prev = process.env.DAC_SOCK_PATH
+      process.env.DAC_SOCK_PATH = '/tmp/custom-dac.sock'
+      try {
+        const mod = await freshModule()
+        await mod.startDacServer()
+        await flushMicrotasks()
+        expect(connectDacMock).toHaveBeenCalledWith('/tmp/custom-dac.sock')
+      }
+      finally {
+        if (prev === undefined) delete process.env.DAC_SOCK_PATH
+        else process.env.DAC_SOCK_PATH = prev
+      }
+    })
+  })
+
+  // ── getSharedHardwareClient ──
+
+  describe('getSharedHardwareClient', () => {
+    it('returns the same client instance across calls', async () => {
+      const mod = await freshModule()
+      const a = mod.getSharedHardwareClient()
+      const b = mod.getSharedHardwareClient()
+      expect(a).toBe(b)
+    })
+
+    describe('DacHardwareClient methods', () => {
+      it('connect() short-circuits when already connected', async () => {
+        const mod = await freshModule()
+        isDacConnectedMock.mockReturnValue(true)
+        await mod.getSharedHardwareClient().connect()
+        expect(connectDacMock).not.toHaveBeenCalled()
+      })
+
+      it('connect() calls connectDac when disconnected', async () => {
+        const mod = await freshModule()
+        isDacConnectedMock.mockReturnValue(false)
+        await mod.getSharedHardwareClient().connect()
+        expect(connectDacMock).toHaveBeenCalledTimes(1)
+      })
+
+      it('getDeviceStatus delegates to sendCommand + parseDeviceStatus', async () => {
+        const mod = await freshModule()
+        sendCommandMock.mockResolvedValue('raw-response')
+        const client = mod.getSharedHardwareClient()
+        await client.getDeviceStatus()
+        expect(sendCommandMock).toHaveBeenCalledWith('14') // DEVICE_STATUS
+        expect(parseDeviceStatusMock).toHaveBeenCalledWith('raw-response')
+      })
+
+      it('setTemperature throws below MIN_TEMP', async () => {
+        const mod = await freshModule()
+        await expect(mod.getSharedHardwareClient().setTemperature('left', 40))
+          .rejects.toThrow(/between/)
+      })
+
+      it('setTemperature throws above MAX_TEMP', async () => {
+        const mod = await freshModule()
+        await expect(mod.getSharedHardwareClient().setTemperature('right', 200))
+          .rejects.toThrow(/between/)
+      })
+
+      it('setTemperature(left) sends level + duration commands', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().setTemperature('left', 75)
+        // Level + duration → 2 calls; the first is TEMP_LEVEL_LEFT ('11')
+        expect(sendCommandMock).toHaveBeenCalledTimes(2)
+        expect(sendCommandMock).toHaveBeenNthCalledWith(1, '11', expect.any(String))
+        expect(sendCommandMock).toHaveBeenNthCalledWith(2, '9', expect.any(String))
+      })
+
+      it('setTemperature(right) routes to the right-side commands', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().setTemperature('right', 75, 600)
+        expect(sendCommandMock).toHaveBeenNthCalledWith(1, '12', expect.any(String))
+        expect(sendCommandMock).toHaveBeenNthCalledWith(2, '10', '600')
+      })
+
+      it('setAlarm rejects vibrationIntensity outside 1..100', async () => {
+        const mod = await freshModule()
+        const c = mod.getSharedHardwareClient()
+        await expect(c.setAlarm('left', { vibrationIntensity: 0, vibrationPattern: 'rise', duration: 60 }))
+          .rejects.toThrow(/intensity/)
+        await expect(c.setAlarm('left', { vibrationIntensity: 200, vibrationPattern: 'rise', duration: 60 }))
+          .rejects.toThrow(/intensity/)
+      })
+
+      it('setAlarm rejects duration outside 0..180', async () => {
+        const mod = await freshModule()
+        await expect(mod.getSharedHardwareClient()
+          .setAlarm('left', { vibrationIntensity: 50, vibrationPattern: 'rise', duration: 999 }))
+          .rejects.toThrow(/duration/)
+      })
+
+      it('setAlarm(left, rise) sends ALARM_LEFT with pattern code 1', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient()
+          .setAlarm('left', { vibrationIntensity: 50, vibrationPattern: 'rise', duration: 60 })
+        expect(sendCommandMock).toHaveBeenCalledWith('5', '50,1,60')
+      })
+
+      it('setAlarm(right, double) sends ALARM_RIGHT with pattern code 0', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient()
+          .setAlarm('right', { vibrationIntensity: 100, vibrationPattern: 'double', duration: 0 })
+        expect(sendCommandMock).toHaveBeenCalledWith('6', '100,0,0')
+      })
+
+      it('setAlarm throws when parseSimpleResponse reports failure', async () => {
+        const mod = await freshModule()
+        parseSimpleResponseMock.mockReturnValue({ success: false, message: 'nope' })
+        await expect(mod.getSharedHardwareClient()
+          .setAlarm('left', { vibrationIntensity: 50, vibrationPattern: 'rise', duration: 60 }))
+          .rejects.toThrow(/nope/)
+      })
+
+      it('clearAlarm(left) sends ALARM_CLEAR with arg "0"', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().clearAlarm('left')
+        expect(sendCommandMock).toHaveBeenCalledWith('16', '0')
+      })
+
+      it('clearAlarm(right) sends ALARM_CLEAR with arg "1"', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().clearAlarm('right')
+        expect(sendCommandMock).toHaveBeenCalledWith('16', '1')
+      })
+
+      it('startPriming throws when the firmware response indicates failure', async () => {
+        const mod = await freshModule()
+        parseSimpleResponseMock.mockReturnValue({ success: false, message: 'busy' })
+        await expect(mod.getSharedHardwareClient().startPriming())
+          .rejects.toThrow(/busy/)
+      })
+
+      it('startPriming resolves silently on success', async () => {
+        const mod = await freshModule()
+        await expect(mod.getSharedHardwareClient().startPriming()).resolves.toBeUndefined()
+        expect(sendCommandMock).toHaveBeenCalledWith('13') // PRIME
+      })
+
+      it('setPower(true) without temperature uses the POWER_ON_FALLBACK', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().setPower('left', true)
+        // Routed through setTemperature → 2 sendCommand calls
+        expect(sendCommandMock).toHaveBeenCalledTimes(2)
+      })
+
+      it('setPower(true) with explicit temperature routes through setTemperature', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().setPower('right', true, 80)
+        expect(sendCommandMock).toHaveBeenNthCalledWith(1, '12', expect.any(String))
+      })
+
+      it('setPower(false, left) sends TEMP_LEVEL_LEFT "0"', async () => {
+        const mod = await freshModule()
+        await mod.getSharedHardwareClient().setPower('left', false)
+        expect(sendCommandMock).toHaveBeenCalledWith('11', '0')
+      })
+
+      it('setPower(false, right) throws when the firmware reports failure', async () => {
+        const mod = await freshModule()
+        parseSimpleResponseMock.mockReturnValue({ success: false, message: 'fail' })
+        await expect(mod.getSharedHardwareClient().setPower('right', false))
+          .rejects.toThrow(/power off/i)
+      })
+
+      it('isConnected delegates to isDacConnected', async () => {
+        const mod = await freshModule()
+        isDacConnectedMock.mockReturnValue(true)
+        expect(mod.getSharedHardwareClient().isConnected()).toBe(true)
+        isDacConnectedMock.mockReturnValue(false)
+        expect(mod.getSharedHardwareClient().isConnected()).toBe(false)
+      })
+
+      it('disconnect is a no-op on the shared client', async () => {
+        const mod = await freshModule()
+        mod.getSharedHardwareClient().disconnect()
+        expect(disconnectDacMock).not.toHaveBeenCalled()
+      })
+
+      it('getRawClient returns null on the shared client', async () => {
+        const mod = await freshModule()
+        const client = mod.getSharedHardwareClient() as any
+        expect(client.getRawClient()).toBeNull()
+      })
+    })
+  })
+
+  // ── getDacMonitor / getDacMonitorIfRunning / shutdownDacMonitor ──
+
+  describe('getDacMonitor', () => {
+    it('returns null from getDacMonitorIfRunning before init', async () => {
+      const mod = await freshModule()
+      expect(mod.getDacMonitorIfRunning()).toBeNull()
+    })
+
+    it('lazy-constructs a DacMonitor on first call and starts it', async () => {
+      const mod = await freshModule()
+      const monitor = await mod.getDacMonitor()
+      expect(monitorInstances).toHaveLength(1)
+      expect(monitor).toBe(monitorInstances[0])
+      expect(monitorInstances[0].start).toHaveBeenCalledTimes(1)
+    })
+
+    it('is idempotent — second call returns the same monitor without re-starting', async () => {
+      const mod = await freshModule()
+      const a = await mod.getDacMonitor()
+      const b = await mod.getDacMonitor()
+      expect(a).toBe(b)
+      expect(monitorInstances).toHaveLength(1)
+      expect(monitorInstances[0].start).toHaveBeenCalledTimes(1)
+    })
+
+    it('coalesces concurrent callers into a single init (single-flight)', async () => {
+      const mod = await freshModule()
+      const [a, b, c] = await Promise.all([
+        mod.getDacMonitor(),
+        mod.getDacMonitor(),
+        mod.getDacMonitor(),
+      ])
+      expect(a).toBe(b)
+      expect(b).toBe(c)
+      expect(monitorInstances).toHaveLength(1)
+    })
+
+    it('clears the monitor slot when start() rejects so the next call can retry', async () => {
+      const mod = await freshModule()
+      nextStartImpl = async () => {
+        throw new Error('start-fail')
+      }
+
+      await expect(mod.getDacMonitor()).rejects.toThrow('start-fail')
+      expect(mod.getDacMonitorIfRunning()).toBeNull()
+
+      // Second attempt: next monitor uses the default success impl
+      const m2 = await mod.getDacMonitor()
+      expect(m2).toBeDefined()
+      expect(monitorInstances.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('wires status:updated listener — fires trackPrimingState + DeviceStateSync.sync', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw') // shape from default mock
+      const beforeCalls = broadcastFrameMock.mock.calls.length
+      monitor.emit('status:updated', status)
+      await flushMicrotasks()
+
+      expect(trackPrimingStateMock).toHaveBeenCalledWith(status.isPriming)
+      expect(stateSyncSyncMock).toHaveBeenCalledWith(status)
+      // Allow for frames already emitted during init wiring; require at least
+      // one additional broadcast triggered by the emit above.
+      expect(broadcastFrameMock.mock.calls.length).toBeGreaterThan(beforeCalls)
+    })
+
+    it('status:updated includes primeCompletedNotification when getPrimeCompletedAt returns a value', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+      getPrimeCompletedAtMock.mockReturnValue(123_456)
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw')
+      monitor.emit('status:updated', status)
+      await flushMicrotasks()
+
+      const lastFrame = broadcastFrameMock.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+      expect(lastFrame).toBeDefined()
+      expect(lastFrame?.primeCompletedNotification).toEqual({ timestamp: 123_456 })
+    })
+
+    it('status:updated does NOT crash when trackPrimingState throws', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      const monitor = monitorInstances[0]
+      trackPrimingStateMock.mockImplementationOnce(() => {
+        throw new Error('prime-bad')
+      })
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw')
+      expect(() => monitor.emit('status:updated', status)).not.toThrow()
+      await flushMicrotasks()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+
+    it('wires gesture:detected listener — fires gesture handler + broadcasts frame', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+
+      const gestureEvent = { side: 'left', tapType: 'doubleTap', timestamp: new Date() }
+      monitor.emit('gesture:detected', gestureEvent)
+      await flushMicrotasks()
+
+      expect(gestureHandleMock).toHaveBeenCalledWith(gestureEvent)
+      expect(broadcastFrameMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'gesture', side: 'left', tapType: 'doubleTap' }),
+      )
+    })
+
+    it('subscribes to piezoStream server frames and records flow data', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+
+      expect(onServerFrameMock).toHaveBeenCalledTimes(1)
+      const cb = (onServerFrameMock.mock.calls[0]?.[0]) as ((frame: unknown) => void) | undefined
+      cb?.({ type: 'frzHealth', flow: 42 })
+      expect(stateSyncRecordFlowMock).toHaveBeenCalledWith({ type: 'frzHealth', flow: 42 })
+    })
+
+    it('isolates DeviceStateSync.sync rejections (logged, not thrown)', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      const monitor = monitorInstances[0]
+      stateSyncSyncMock.mockRejectedValueOnce(new Error('sync-bad'))
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      monitor.emit('status:updated', parseDeviceStatusMock('raw'))
+      await flushMicrotasks()
+      await flushMicrotasks()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+  })
+
+  // ── shutdownDacMonitor ──
+
+  describe('shutdownDacMonitor', () => {
+    it('cleans up monitor, gesture handler, and clears all global keys', async () => {
+      const mod = await freshModule()
+      await mod.startDacServer()
+      mod.getSharedHardwareClient()
+      const monitor = await mod.getDacMonitor()
+      await flushMicrotasks()
+
+      expect(mod.getDacServer()).toBe(true)
+      expect(mod.getDacMonitorIfRunning()).toBe(monitor)
+
+      await mod.shutdownDacMonitor()
+
+      expect(monitor.stop).toHaveBeenCalled()
+      expect(monitor.removeAllListeners).toHaveBeenCalledWith('gesture:detected')
+      expect(monitor.removeAllListeners).toHaveBeenCalledWith('status:updated')
+      expect(gestureCleanupMock).toHaveBeenCalled()
+      expect(disconnectDacMock).toHaveBeenCalled()
+      expect(cancelSnoozeMock).toHaveBeenCalledWith('left')
+      expect(cancelSnoozeMock).toHaveBeenCalledWith('right')
+      expect(resetPrimingStateMock).toHaveBeenCalled()
+      expect(mod.getDacServer()).toBeNull()
+      expect(mod.getDacMonitorIfRunning()).toBeNull()
+    })
+
+    it('is safe to call before any init (no-op path)', async () => {
+      const mod = await freshModule()
+      await expect(mod.shutdownDacMonitor()).resolves.toBeUndefined()
+      expect(disconnectDacMock).toHaveBeenCalled() // still drains transport
+    })
+
+    it('awaits an in-flight monitorInitPromise without throwing', async () => {
+      const mod = await freshModule()
+      nextStartImpl = async () => {
+        throw new Error('start-fail')
+      }
+
+      const initP = mod.getDacMonitor().catch(() => { /* swallow */ })
+      await mod.shutdownDacMonitor()
+      await initP
+    })
+
+    it('invokes the flow-data unsubscribe handle stored on globalThis', async () => {
+      const mod = await freshModule()
+      const unsub = vi.fn()
+      onServerFrameMock.mockImplementation(() => unsub)
+
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      await mod.shutdownDacMonitor()
+
+      expect(unsub).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/scheduler/tests/instance.test.ts
+++ b/src/scheduler/tests/instance.test.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests for src/scheduler/instance.ts — the JobManager singleton wrapper.
+ *
+ * Covers: lazy init, single-flight, timezone-from-db, default fallback on
+ * db error, timezone caching across calls, shutdown teardown.
+ *
+ * The JobManager class is mocked at the import boundary so we exercise only
+ * the wrapper's wiring — class behaviour is covered separately in
+ * jobManager.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Module-scoped state we manipulate per test. Each test resets these via
+// resetMocks() and then re-imports the instance module so its module-level
+// `let` state (cachedTimezone, jobManagerInstance, jobManagerInitPromise) is
+// fresh.
+const loadSchedulesMock = vi.fn(async () => {})
+const shutdownMock = vi.fn(async () => {})
+const ctorMock = vi.fn()
+
+vi.mock('../jobManager', () => {
+  class JobManager {
+    public timezone: string
+    constructor(timezone: string) {
+      this.timezone = timezone
+      ctorMock(timezone)
+    }
+
+    loadSchedules = loadSchedulesMock
+    shutdown = shutdownMock
+  }
+  return { JobManager }
+})
+
+// db.select().from(deviceSettings).limit(1) — drizzle-shaped thenable stub.
+// `setDbBehavior` swaps in the next promise/rows the test wants returned.
+let dbBehavior: () => Promise<any[]> = async () => []
+
+vi.mock('@/src/db', () => {
+  const makeQuery = (): any => {
+    const promise: any = {
+      async then(resolve: (v: any) => void, reject?: (e: unknown) => void) {
+        try {
+          const rows = await dbBehavior()
+          resolve(rows)
+        }
+        catch (err) {
+          if (reject) reject(err)
+          else throw err
+        }
+      },
+      where() { return promise },
+      limit() { return promise },
+    }
+    return promise
+  }
+  return {
+    db: {
+      select() {
+        return { from: () => makeQuery() }
+      },
+    },
+  }
+})
+
+vi.mock('@/src/db/schema', () => ({
+  deviceSettings: { _: { name: 'deviceSettings' } },
+}))
+
+import type * as InstanceModuleTypes from '../instance'
+type InstanceModule = typeof InstanceModuleTypes
+
+async function freshModule(): Promise<InstanceModule> {
+  vi.resetModules()
+  return await import('../instance')
+}
+
+describe('scheduler/instance', () => {
+  beforeEach(() => {
+    loadSchedulesMock.mockClear()
+    shutdownMock.mockClear()
+    ctorMock.mockClear()
+    dbBehavior = async () => []
+  })
+
+  afterEach(async () => {
+    // Best-effort cleanup so a leaked instance from one test can't bleed into
+    // the next module-load. vi.resetModules() in freshModule() handles the
+    // rest.
+    const mod = await import('../instance')
+    await mod.shutdownJobManager().catch(() => {})
+  })
+
+  it('falls back to America/Los_Angeles when device_settings row is missing', async () => {
+    const mod = await freshModule()
+    dbBehavior = async () => [] // no rows
+
+    const m = await mod.getJobManager()
+
+    expect(ctorMock).toHaveBeenCalledTimes(1)
+    expect(ctorMock).toHaveBeenCalledWith('America/Los_Angeles')
+    expect((m as any).timezone).toBe('America/Los_Angeles')
+    expect(loadSchedulesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the timezone stored in device_settings when present', async () => {
+    const mod = await freshModule()
+    dbBehavior = async () => [{ timezone: 'Europe/Berlin' }]
+
+    await mod.getJobManager()
+
+    expect(ctorMock).toHaveBeenCalledWith('Europe/Berlin')
+  })
+
+  it('falls back to default when the row has an empty timezone string', async () => {
+    const mod = await freshModule()
+    dbBehavior = async () => [{ timezone: '' }] // falsy
+
+    await mod.getJobManager()
+
+    expect(ctorMock).toHaveBeenCalledWith('America/Los_Angeles')
+  })
+
+  it('falls back to default and logs a warning when the db throws', async () => {
+    const mod = await freshModule()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    dbBehavior = async () => {
+      throw new Error('db down')
+    }
+
+    await mod.getJobManager()
+
+    expect(ctorMock).toHaveBeenCalledWith('America/Los_Angeles')
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('returns the same instance on the second call (idempotent)', async () => {
+    const mod = await freshModule()
+    dbBehavior = async () => [{ timezone: 'UTC' }]
+
+    const a = await mod.getJobManager()
+    const b = await mod.getJobManager()
+
+    expect(a).toBe(b)
+    expect(ctorMock).toHaveBeenCalledTimes(1)
+    expect(loadSchedulesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent callers into a single initialization (single-flight)', async () => {
+    const mod = await freshModule()
+    let resolveLoad: () => void = () => {}
+    const loadStarted = new Promise<void>((startResolve) => {
+      loadSchedulesMock.mockImplementationOnce(
+        () => new Promise<void>((resolve) => {
+          resolveLoad = () => resolve()
+          startResolve()
+        }),
+      )
+    })
+    dbBehavior = async () => [{ timezone: 'UTC' }]
+
+    const p1 = mod.getJobManager()
+    const p2 = mod.getJobManager()
+    const p3 = mod.getJobManager()
+
+    // Wait until loadSchedules has actually been entered before unblocking it,
+    // so the second and third callers latch onto jobManagerInitPromise rather
+    // than racing past it.
+    await loadStarted
+    resolveLoad()
+
+    const [a, b, c] = await Promise.all([p1, p2, p3])
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    expect(ctorMock).toHaveBeenCalledTimes(1)
+    expect(loadSchedulesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries timezone load after a failed first attempt (no instance cached)', async () => {
+    const mod = await freshModule()
+    // First load throws AFTER timezone is read — so jobManagerInstance is
+    // never assigned, but cachedTimezone may have been set. We simulate this
+    // path by having loadSchedules() reject the first time.
+    dbBehavior = async () => [{ timezone: 'UTC' }]
+    loadSchedulesMock.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(mod.getJobManager()).rejects.toThrow('boom')
+
+    // After failure, the init promise is cleared (the finally block) and the
+    // next call starts a fresh attempt. Both attempts hit the ctor since the
+    // instance never settled.
+    loadSchedulesMock.mockResolvedValueOnce(undefined)
+    const m = await mod.getJobManager()
+    expect(m).toBeTruthy()
+    expect(ctorMock).toHaveBeenCalledTimes(2)
+    expect(loadSchedulesMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches the resolved timezone across retries (single db read)', async () => {
+    const mod = await freshModule()
+    let dbCalls = 0
+    dbBehavior = async () => {
+      dbCalls++
+      return [{ timezone: 'Asia/Tokyo' }]
+    }
+    loadSchedulesMock.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(mod.getJobManager()).rejects.toThrow('boom')
+
+    loadSchedulesMock.mockResolvedValueOnce(undefined)
+    await mod.getJobManager()
+
+    expect(dbCalls).toBe(1) // cachedTimezone short-circuits the second read
+    expect(ctorMock).toHaveBeenNthCalledWith(2, 'Asia/Tokyo')
+  })
+
+  it('shutdownJobManager tears down the instance and clears state', async () => {
+    const mod = await freshModule()
+    dbBehavior = async () => [{ timezone: 'UTC' }]
+
+    const before = await mod.getJobManager()
+    await mod.shutdownJobManager()
+
+    expect(shutdownMock).toHaveBeenCalledTimes(1)
+
+    // After shutdown, a fresh getJobManager() constructs a new instance and
+    // reloads timezone from db (cachedTimezone reset).
+    let dbReads = 0
+    dbBehavior = async () => {
+      dbReads++
+      return [{ timezone: 'Europe/Paris' }]
+    }
+    const after = await mod.getJobManager()
+
+    expect(after).not.toBe(before)
+    expect(ctorMock).toHaveBeenCalledTimes(2)
+    expect(dbReads).toBe(1)
+    expect(ctorMock).toHaveBeenNthCalledWith(2, 'Europe/Paris')
+  })
+
+  it('shutdownJobManager is a no-op when no instance exists', async () => {
+    const mod = await freshModule()
+    await mod.shutdownJobManager()
+    expect(shutdownMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
Cover the two singleton wrappers that surfaced as the worst-covered files on dev (codecov: dacMonitor.instance 7%, scheduler/instance 12%).

Both files are thin wiring around heavier classes that already have their own tests, so the new tests mock the underlying classes at the import boundary and exercise only the wrapper logic: lazy init, idempotency, single-flight coalescing, env-var / db-driven config, shutdown teardown, and the error-handling / re-baselining paths.

## Tests added

`src/scheduler/tests/instance.test.ts` (10 cases):
- Default timezone fallback when `device_settings` row is missing
- Reads timezone from `device_settings.timezone` when present
- Falls back to default when stored timezone is an empty string
- Falls back to default + logs a warning when the db throws
- Idempotent: second `getJobManager()` returns the same instance
- Single-flight: concurrent callers coalesce into one init
- Retries cleanly after a failed first `loadSchedules()`
- Caches resolved timezone across retries (single db read)
- `shutdownJobManager()` tears down and resets cache + instance state
- `shutdownJobManager()` is a no-op when no instance exists

`src/hardware/tests/dacMonitor.instance.test.ts` (45 cases) across:
- `startDacServer` / `getDacServer`: lazy + idempotent, swallows `connectDac` rejection (Error and non-Error), honours `DAC_SOCK_PATH`
- `getSharedHardwareClient`: returns same instance; covers every method on the wrapping `DacHardwareClient` — connect short-circuit / lazy connect, getDeviceStatus, setTemperature bounds + routing (left/right), setAlarm bounds + pattern code + parseSimpleResponse failure, clearAlarm L/R, startPriming success + failure, setPower with/without fallback temperature + power-off failure, isConnected, disconnect no-op, getRawClient null
- `getDacMonitor`: lazy + idempotent, single-flight, clears slot on `start()` rejection so retries work, wires `status:updated` / `gesture:detected` listeners (incl. broadcastFrame side effects + `primeCompletedNotification` enrichment + isolated error handling on `trackPrimingState` / `DeviceStateSync.sync`), subscribes to piezoStream server frames for flow data
- `shutdownDacMonitor`: cleans up monitor + gesture handler + globals + transport disconnect, no-op before init, drains in-flight init promise, calls the flow-data unsubscribe handle

Measured coverage on the target files after these tests:
- `src/hardware/dacMonitor.instance.ts`: **100% lines** (was 7.0%)
- `src/scheduler/instance.ts`: **100% lines** (was 11.8%)

## Test plan
- [x] `pnpm vitest run src/hardware/tests/dacMonitor.instance.test.ts src/scheduler/tests/instance.test.ts` passes (55/55)
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean