### PR TITLE
test: lift coverage to 95%/87%/93%/96% across the JS suite

### DIFF
--- a/src/hardware/tests/gestureActionHandler.deps.test.ts
+++ b/src/hardware/tests/gestureActionHandler.deps.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The deps module is a thin wiring layer between the GestureActionHandler
+ * and the DB / shared-client singletons. The behaviour under test is "the
+ * deps actually call the wired-up dependencies", so the test layer mocks
+ * the imports it shouldn't pull in (DB + dacMonitor.instance) and exercises
+ * each dep function.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+const dbMock = vi.hoisted(() => {
+  const limit = vi.fn(async () => [])
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+  return { db: { select }, select, from, where, limit }
+})
+
+const sharedClient = { connect: vi.fn() }
+const sharedMock = vi.hoisted(() => ({
+  getSharedHardwareClient: vi.fn(() => sharedClient),
+}))
+
+vi.mock('@/src/db', () => ({ db: dbMock.db }))
+vi.mock('@/src/db/schema', () => ({
+  tapGestures: { side: 'side', tapType: 'tapType' },
+  deviceState: { side: 'side' },
+}))
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (col: unknown, val: unknown) => ({ eq: [col, val] }),
+}))
+vi.mock('@/src/hardware/dacMonitor.instance', () => sharedMock)
+
+const { defaultGestureActionDeps } = await import('@/src/hardware/gestureActionHandler.deps')
+
+describe('defaultGestureActionDeps', () => {
+  it('findGestureConfig returns the first row or null', async () => {
+    dbMock.limit.mockResolvedValueOnce([{ actionType: 'alarm' }] as never)
+    expect(await defaultGestureActionDeps.findGestureConfig('left', 'doubleTap'))
+      .toEqual({ actionType: 'alarm' })
+
+    dbMock.limit.mockResolvedValueOnce([] as never)
+    expect(await defaultGestureActionDeps.findGestureConfig('right', 'tripleTap'))
+      .toBeNull()
+  })
+
+  it('findDeviceState returns the first row or null', async () => {
+    dbMock.limit.mockResolvedValueOnce([{ isPowered: true }] as never)
+    expect(await defaultGestureActionDeps.findDeviceState('left'))
+      .toEqual({ isPowered: true })
+
+    dbMock.limit.mockResolvedValueOnce([] as never)
+    expect(await defaultGestureActionDeps.findDeviceState('right')).toBeNull()
+  })
+
+  it('newHardwareClient ignores the socketPath and returns the shared client', () => {
+    const client = defaultGestureActionDeps.newHardwareClient('/tmp/whatever.sock')
+    expect(client).toBe(sharedClient)
+    expect(sharedMock.getSharedHardwareClient).toHaveBeenCalled()
+  })
+})

--- a/src/hardware/tests/gestureActionHandler.test.ts
+++ b/src/hardware/tests/gestureActionHandler.test.ts
@@ -201,6 +201,53 @@ describe('GestureActionHandler', () => {
     })
   })
 
+  test('cleanup() cancels pending snooze restart timers so process can exit', async () => {
+    vi.useFakeTimers()
+    const snoozeClient = makeMockClient()
+    const gesture = { actionType: 'alarm', alarmBehavior: 'snooze', alarmSnoozeDuration: 300 }
+    const state = { isAlarmVibrating: true }
+    const newHardwareClient = vi.fn()
+      .mockReturnValueOnce(makeMockClient())
+      .mockReturnValueOnce(snoozeClient)
+    const deps: GestureActionDeps = {
+      findGestureConfig: vi.fn().mockResolvedValue(gesture),
+      findDeviceState: vi.fn().mockResolvedValue(state),
+      newHardwareClient,
+    }
+
+    const handler = new GestureActionHandler(SOCKET_PATH, deps)
+    await handler.handle(makeEvent('left', 'tripleTap'))
+
+    handler.cleanup()
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(snoozeClient.setAlarm).not.toHaveBeenCalled()
+  })
+
+  test('snooze restart logs without throwing when restart connect fails', async () => {
+    vi.useFakeTimers()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const failingClient = makeMockClient({
+      connect: vi.fn().mockRejectedValue(new Error('connect refused')),
+    })
+    const gesture = { actionType: 'alarm', alarmBehavior: 'snooze', alarmSnoozeDuration: 1 }
+    const state = { isAlarmVibrating: true }
+    const newHardwareClient = vi.fn()
+      .mockReturnValueOnce(makeMockClient())
+      .mockReturnValueOnce(failingClient)
+    const deps: GestureActionDeps = {
+      findGestureConfig: vi.fn().mockResolvedValue(gesture),
+      findDeviceState: vi.fn().mockResolvedValue(state),
+      newHardwareClient,
+    }
+
+    await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('left', 'tripleTap'))
+    await vi.advanceTimersByTimeAsync(1000)
+    // Allow promise chain to resolve
+    await vi.advanceTimersByTimeAsync(100)
+    expect(errSpy).toHaveBeenCalledWith('GestureActionHandler: snooze restart failed:', expect.any(Error))
+    errSpy.mockRestore()
+  })
+
   test('errors in execution do not throw', async () => {
     const gesture = { actionType: 'temperature', temperatureChange: 'increment', temperatureAmount: 5 }
     const client = makeMockClient({

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -249,6 +249,48 @@ describe('homekit bridge', () => {
     expect(getStatus().username).toBe('AA:BB:CC:DD:EE:FF')
   })
 
+  it('stopBridge swallows stopper exceptions with a warning', async () => {
+    const { startBridge, stopBridge, getStatus } = await import('../bridge')
+    // Make one stopper explode; stopBridge must keep going and still tear down the bridge.
+    m.thermostatStop.mockImplementationOnce((): never => {
+      throw new Error('stopper kaboom')
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await startBridge(fakeMonitor)
+    await stopBridge()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[homekit] stopper failed:',
+      expect.stringMatching(/stopper kaboom/),
+    )
+    expect(getStatus().running).toBe(false)
+    warnSpy.mockRestore()
+  })
+
+  it('stopBridge warns when unpublish() throws but destroy() still completes', async () => {
+    const { startBridge, stopBridge, getStatus } = await import('../bridge')
+    await startBridge(fakeMonitor)
+    if (m.bridgeInstance) {
+      m.bridgeInstance.unpublish = vi.fn().mockRejectedValue(new Error('unpub boom'))
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await stopBridge()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[homekit] unpublish failed:',
+      expect.stringMatching(/unpub boom/),
+    )
+    expect(getStatus().running).toBe(false)
+    warnSpy.mockRestore()
+  })
+
+  it('stopBridge clears setupURI even when no bridge was ever published', async () => {
+    const { stopBridge, getStatus } = await import('../bridge')
+    await stopBridge()
+    expect(getStatus().setupURI).toBeNull()
+    expect(getStatus().running).toBe(false)
+  })
+
   it('regenerate stops the bridge and replaces identity', async () => {
     const { startBridge, regenerate, getStatus } = await import('../bridge')
     await startBridge(fakeMonitor)

--- a/src/homekit/tests/storage.test.ts
+++ b/src/homekit/tests/storage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -7,6 +7,7 @@ import {
   getStorageDir,
   loadOrCreateIdentity,
   probeSeedSources,
+  readIdentityIfPresent,
   readPairedControllers,
   regenerateIdentity,
 } from '../storage'
@@ -167,6 +168,76 @@ describe('homekit storage', () => {
       seen.add(r.username)
     }
     expect(seen.size).toBe(10)
+  })
+
+  it('readIdentityIfPresent returns null when identity.json is absent', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    if (existsSync(file)) rmSync(file)
+    expect(readIdentityIfPresent()).toBeNull()
+  })
+
+  it('readIdentityIfPresent returns the parsed identity when present', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    const payload = {
+      username: 'AA:BB:CC:DD:EE:FF',
+      pincode: '321-54-987',
+      setupId: 'ABCD',
+      derivedFrom: 'mmc-cid' as const,
+      rotation: 4,
+    }
+    writeFileSync(file, JSON.stringify(payload))
+    expect(readIdentityIfPresent()).toEqual(payload)
+  })
+
+  it('readIdentityIfPresent returns null when JSON is unparseable', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    writeFileSync(file, '{ broken')
+    expect(readIdentityIfPresent()).toBeNull()
+  })
+
+  it('readIdentityIfPresent returns null when shape is incomplete', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    writeFileSync(file, JSON.stringify({ username: 'AA:BB:CC:DD:EE:FF' }))
+    expect(readIdentityIfPresent()).toBeNull()
+  })
+
+  it('loadOrCreateIdentity backs up the corrupt file before regenerating', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    writeFileSync(file, '{ corrupt')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const id = loadOrCreateIdentity()
+      expect(id.username).toMatch(/^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/)
+      const backups = readdirSync(dir).filter(n => n.startsWith('identity.json.corrupt.'))
+      expect(backups.length).toBeGreaterThan(0)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/backed up to/),
+        expect.anything(),
+      )
+    }
+    finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('initHapStorage is idempotent across repeated calls', async () => {
+    // First call triggers the hap-nodejs setCustomStoragePath; second is a no-op
+    // because the module caches the init flag on globalThis.
+    const { initHapStorage } = await import('../storage')
+    const g = globalThis as Record<string, unknown>
+    const key = '__sp_homekit_hapInit__'
+    g[key] = undefined
+    initHapStorage()
+    expect(g[key]).toBe(true)
+    // Calling again should remain truthy and not throw
+    expect(() => initHapStorage()).not.toThrow()
+    expect(g[key]).toBe(true)
   })
 
   it('probeSeedSources reports each chain entry without throwing', () => {

--- a/src/lib/tests/sleep-stages.test.ts
+++ b/src/lib/tests/sleep-stages.test.ts
@@ -233,6 +233,38 @@ describe('calculateQualityScore', () => {
     const score = calculateQualityScore({ deep: 20, light: 45, rem: 25, wake: 3 }, 0.2)
     expect(score).toBeLessThanOrEqual(50)
   })
+
+  it('penalizes excessive deep sleep (>30%)', () => {
+    const ideal = calculateQualityScore({ deep: 20, light: 45, rem: 25, wake: 3 })
+    const tooMuchDeep = calculateQualityScore({ deep: 50, light: 18, rem: 25, wake: 3 })
+    expect(tooMuchDeep).toBeLessThan(ideal)
+  })
+
+  it('penalizes low REM (<20%)', () => {
+    const ideal = calculateQualityScore({ deep: 20, light: 45, rem: 25, wake: 3 })
+    const lowRem = calculateQualityScore({ deep: 20, light: 65, rem: 5, wake: 3 })
+    expect(lowRem).toBeLessThan(ideal)
+  })
+
+  it('penalizes excessive REM (>35%)', () => {
+    const ideal = calculateQualityScore({ deep: 20, light: 45, rem: 25, wake: 3 })
+    const tooMuchRem = calculateQualityScore({ deep: 20, light: 25, rem: 45, wake: 3 })
+    expect(tooMuchRem).toBeLessThan(ideal)
+  })
+})
+
+describe('calculateDistribution edge cases', () => {
+  it('returns zeros for an empty epoch list', () => {
+    expect(calculateDistribution([])).toEqual({ wake: 0, light: 0, deep: 0, rem: 0 })
+  })
+
+  it('returns zeros when every epoch has zero duration', () => {
+    const zeros = { heartRate: null, hrv: null, breathingRate: null, movement: null }
+    expect(calculateDistribution([
+      { stage: 'wake', duration: 0, start: 0, ...zeros },
+      { stage: 'deep', duration: 0, start: 0, ...zeros },
+    ])).toEqual({ wake: 0, light: 0, deep: 0, rem: 0 })
+  })
 })
 
 describe('formatDurationHM', () => {

--- a/src/scheduler/tests/scheduler.test.ts
+++ b/src/scheduler/tests/scheduler.test.ts
@@ -289,6 +289,56 @@ describe('Scheduler', () => {
     }, 10000)
   })
 
+  describe('schedule failure surfaces', () => {
+    it('scheduleJob throws when node-schedule returns null (invalid cron)', () => {
+      const handler = vi.fn(async () => {})
+      expect(() =>
+        scheduler.scheduleJob('bad', JobType.TEMPERATURE, 'this is not a cron', handler),
+      ).toThrow(/Failed to schedule job: bad/)
+    })
+
+    it('scheduleOneTimeJob throws when the fire date is in the past', () => {
+      const handler = vi.fn(async () => {})
+      expect(() =>
+        scheduler.scheduleOneTimeJob(
+          'past-one',
+          JobType.TEMPERATURE,
+          new Date(Date.now() - 60_000),
+          handler,
+        ),
+      ).toThrow(/Failed to schedule one-time job: past-one/)
+    })
+  })
+
+  describe('waitForInFlightJobs', () => {
+    it('returns immediately when no jobs are in flight', async () => {
+      // No in-flight jobs — should resolve without delay
+      const start = Date.now()
+      await scheduler.waitForInFlightJobs(1000)
+      expect(Date.now() - start).toBeLessThan(100)
+    })
+
+    it('warns when in-flight jobs exceed timeout (force-shutdown path)', async () => {
+      let release: () => void = () => {}
+      const stuck = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      // Schedule a one-time job that hangs until we release it
+      const future = new Date(Date.now() + 50)
+      scheduler.scheduleOneTimeJob('hang', JobType.AWAY_MODE, future, async () => stuck)
+
+      // Wait for the job to actually start (in-flight)
+      await new Promise(resolve => setTimeout(resolve, 100))
+      await scheduler.waitForInFlightJobs(150)
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/Force shutdown with/))
+      release()
+      warnSpy.mockRestore()
+    })
+  })
+
   describe('getNextInvocation', () => {
     it('returns next invocation time for job', () => {
       const handler = vi.fn(async () => {})

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -271,3 +271,50 @@ describe('device.execute (raw command)', () => {
     await expect(caller.execute({ command: 'DEVICE_STATUS' })).rejects.toThrow(/Failed to execute raw command: socket dead/)
   })
 })
+
+describe('device best-effort DB sync swallows errors', () => {
+  beforeEach(() => {
+    // Make `db.update(...)...` chain reject so the catch path fires.
+    const failingChain = () => {
+      const chain: Record<string, unknown> = {}
+      chain.then = (_resolve: unknown, reject: (reason: unknown) => unknown) =>
+        Promise.reject(new Error('db dead')).catch(reject)
+      chain.where = vi.fn(() => chain)
+      chain.set = vi.fn(() => chain)
+      return chain
+    }
+    dbMock.update.mockImplementation(failingChain)
+  })
+
+  it('setAlarm logs but still broadcasts when the DB sync fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await caller.setAlarm({
+      side: 'left', vibrationIntensity: 50, vibrationPattern: 'rise', duration: 120,
+    })
+    expect(result).toEqual({ success: true })
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { isAlarmVibrating: true })
+    expect(errSpy).toHaveBeenCalledWith('Failed to sync alarm state to DB:', expect.any(Error))
+    errSpy.mockRestore()
+  })
+
+  it('clearAlarm logs but still broadcasts when the DB sync fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await caller.clearAlarm({ side: 'right' })
+    expect(result).toEqual({ success: true })
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('right', { isAlarmVibrating: false })
+    expect(errSpy).toHaveBeenCalledWith('Failed to sync alarm clear state to DB:', expect.any(Error))
+    errSpy.mockRestore()
+  })
+
+  it('snoozeAlarm logs but still broadcasts when the DB sync fails', async () => {
+    snoozeMock.snoozeAlarm.mockReturnValue(new Date(1700000000000))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = await caller.snoozeAlarm({
+      side: 'left', duration: 300, vibrationIntensity: 50, vibrationPattern: 'rise', alarmDuration: 120,
+    })
+    expect(result.success).toBe(true)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { isAlarmVibrating: false })
+    expect(errSpy).toHaveBeenCalledWith('Failed to sync snooze state to DB:', expect.any(Error))
+    errSpy.mockRestore()
+  })
+})

--- a/src/server/routers/tests/environment.test.ts
+++ b/src/server/routers/tests/environment.test.ts
@@ -240,3 +240,45 @@ describe('environment.getAmbientLightSummary', () => {
     })).rejects.toThrow(/startDate/)
   })
 })
+
+describe('environment error wrappers', () => {
+  it('wraps each query DB failure as INTERNAL_SERVER_ERROR', async () => {
+    const boom = (): never => {
+      throw new Error('db dead')
+    }
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getBedTemp({
+      startDate: new Date('2025-01-01'), endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to fetch bed temp/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getFreezerTemp({
+      startDate: new Date('2025-01-01'), endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to fetch freezer temp/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getLatestBedTemp({})).rejects.toThrow(/Failed to fetch latest bed temp/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getLatestFreezerTemp({})).rejects.toThrow(/Failed to fetch latest freezer temp/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getSummary({
+      startDate: new Date('2025-01-01'), endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to calculate environment summary/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getAmbientLight({
+      startDate: new Date('2025-01-01'), endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to fetch ambient light/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getLatestAmbientLight({})).rejects.toThrow(/Failed to fetch latest ambient light/)
+
+    dbMock.select.mockImplementationOnce(boom)
+    await expect(caller.getAmbientLightSummary({
+      startDate: new Date('2025-01-01'), endDate: new Date('2025-01-02'),
+    })).rejects.toThrow(/Failed to calculate ambient light summary/)
+  })
+})

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -189,6 +189,60 @@ describe('health.system', () => {
     expect(result.database.error).toBe('db locked')
     expect(result.status).toBe('degraded')
   })
+
+  it('excludes PRIME / REBOOT system jobs from drift comparison', async () => {
+    dbMock.allSchedules.temp.push({ id: 1 })
+    schedulerMock.scheduler.getJobs.mockReturnValue([
+      { id: 't-1', type: 'temperature' },
+      { id: 'prime', type: 'prime' },
+      { id: 'reboot', type: 'reboot' },
+    ])
+    const result = await caller.system({})
+    expect(result.scheduler.drift?.drifted).toBe(false)
+    expect(result.scheduler.drift?.schedulerJobCount).toBe(1)
+  })
+
+  it('auto-reloads scheduler when drift detected and clears drifted flag on success', async () => {
+    dbMock.allSchedules.temp.push({ id: 1 })
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+
+    const result = await caller.system({})
+    expect(schedulerMock.jobManager.reloadSchedules).toHaveBeenCalled()
+    expect(result.scheduler.drift?.drifted).toBe(false)
+    expect(result.status).toBe('ok')
+  })
+
+  it('marks system degraded when drift auto-reload throws', async () => {
+    dbMock.allSchedules.temp.push({ id: 1 })
+    schedulerMock.scheduler.getJobs.mockReturnValue([])
+    schedulerMock.jobManager.reloadSchedules.mockRejectedValueOnce(new Error('reload failed'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = await caller.system({})
+    expect(result.status).toBe('degraded')
+    errSpy.mockRestore()
+  })
+
+  it('marks system degraded when iptables critical rules are missing', async () => {
+    iptablesMock.checkIptables.mockReturnValueOnce({
+      ok: false,
+      rules: [
+        { name: 'critical-rule', present: false, critical: true },
+        { name: 'optional-rule', present: false, critical: false },
+        { name: 'present-rule', present: true, critical: true },
+      ],
+    } as unknown as ReturnType<typeof iptablesMock.checkIptables>)
+    const result = await caller.system({})
+    expect(result.iptables.ok).toBe(false)
+    expect(result.iptables.missing).toEqual(['critical-rule'])
+    expect(result.status).toBe('degraded')
+  })
+
+  it('marks system degraded when scheduler getJobManager rejects', async () => {
+    schedulerMock.getJobManager.mockRejectedValueOnce(new Error('scheduler down'))
+    const result = await caller.system({})
+    expect(result.status).toBe('degraded')
+  })
 })
 
 describe('health.dacMonitor', () => {

--- a/src/server/routers/tests/raw.test.ts
+++ b/src/server/routers/tests/raw.test.ts
@@ -178,4 +178,27 @@ describe('raw.diskUsage', () => {
     expect(result.totalBytes).toBe(0)
     expect(result.rawFileCount).toBe(0)
   })
+
+  it('wraps unexpected listRawFiles failure as INTERNAL_SERVER_ERROR', async () => {
+    fsMock.readdir.mockRejectedValue(new Error('disk on fire'))
+    await expect(caller.diskUsage({})).rejects.toThrow(/Failed to get disk usage/)
+  })
+})
+
+describe('raw.deleteFile error wrappers', () => {
+  it('wraps non-ENOENT unlink failure as INTERNAL_SERVER_ERROR', async () => {
+    fsMock.lstat.mockResolvedValue({ isSymbolicLink: () => false } as never)
+    fsMock.realpath.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith('b.RAW')) return '/persistent/b.RAW'
+      return '/persistent'
+    })
+    fsMock.readdir.mockResolvedValue(['a.RAW', 'b.RAW'] as never)
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const name = String(p).split('/').pop()
+      return { size: 1, mtime: name === 'a.RAW' ? new Date('2025-02-01') : new Date('2025-01-01') } as never
+    })
+    fsMock.unlink.mockRejectedValue(new Error('EBUSY: locked'))
+
+    await expect(caller.deleteFile({ filename: 'b.RAW' })).rejects.toThrow(/Failed to delete file/)
+  })
 })

--- a/src/server/routers/tests/schedules.test.ts
+++ b/src/server/routers/tests/schedules.test.ts
@@ -756,5 +756,100 @@ describe('schedules query error paths', () => {
     vi.doUnmock('@/src/scheduler')
     vi.resetModules()
   })
+
+  it('create handlers throw INTERNAL_SERVER_ERROR when insert returns no row', async () => {
+    // Build a chain whose tx.insert(...).values(...).returning().all() yields [].
+    const emptyAll = vi.fn(() => [])
+    const txReturning = { returning: vi.fn(() => ({ all: emptyAll })) }
+    const txValues = { values: vi.fn(() => txReturning) }
+    const txInsert = { insert: vi.fn(() => txValues) }
+
+    const failing = { db: {
+      transaction: (cb: (tx: typeof txInsert) => unknown) => cb(txInsert),
+    } }
+
+    vi.resetModules()
+    vi.doMock('@/src/scheduler', () => ({
+      getJobManager: vi.fn(async () => ({ reloadSchedules: vi.fn() })),
+    }))
+    vi.doMock('@/src/db', () => failing)
+
+    const { schedulesRouter: failingRouter } = await import('@/src/server/routers/schedules')
+    const failingCaller = failingRouter.createCaller({})
+
+    await expect(failingCaller.createTemperatureSchedule({
+      side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68,
+    })).rejects.toThrow(/no record returned/)
+
+    await expect(failingCaller.createPowerSchedule({
+      side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 75,
+    })).rejects.toThrow(/no record returned/)
+
+    await expect(failingCaller.createAlarmSchedule({
+      side: 'left', dayOfWeek: 'monday', time: '07:00',
+      vibrationIntensity: 50, duration: 120, alarmTemperature: 80,
+    } as any)).rejects.toThrow(/no record returned/)
+
+    vi.doUnmock('@/src/db')
+    vi.doUnmock('@/src/scheduler')
+    vi.resetModules()
+  })
+
+  it('mutation handlers wrap non-TRPC DB errors as INTERNAL_SERVER_ERROR', async () => {
+    const failing = { db: {
+      transaction: () => { throw new Error('tx exploded') },
+    } }
+
+    vi.resetModules()
+    vi.doMock('@/src/scheduler', () => ({
+      getJobManager: vi.fn(async () => ({ reloadSchedules: vi.fn() })),
+    }))
+    vi.doMock('@/src/db', () => failing)
+
+    const { schedulesRouter: failingRouter } = await import('@/src/server/routers/schedules')
+    const failingCaller = failingRouter.createCaller({})
+
+    await expect(failingCaller.createTemperatureSchedule({
+      side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68,
+    })).rejects.toThrow(/Failed to create temperature schedule/)
+
+    await expect(failingCaller.updateTemperatureSchedule({
+      id: 1, temperature: 70,
+    })).rejects.toThrow(/Failed to update temperature schedule/)
+
+    await expect(failingCaller.deleteTemperatureSchedule({ id: 1 }))
+      .rejects.toThrow(/Failed to delete temperature schedule/)
+
+    await expect(failingCaller.createPowerSchedule({
+      side: 'left', dayOfWeek: 'monday', onTime: '22:00', offTime: '07:00', onTemperature: 75,
+    })).rejects.toThrow(/Failed to create power schedule/)
+
+    await expect(failingCaller.updatePowerSchedule({
+      id: 1, enabled: false,
+    })).rejects.toThrow(/Failed to update power schedule/)
+
+    await expect(failingCaller.deletePowerSchedule({ id: 1 }))
+      .rejects.toThrow(/Failed to delete power schedule/)
+
+    await expect(failingCaller.createAlarmSchedule({
+      side: 'left', dayOfWeek: 'monday', time: '07:00',
+      vibrationIntensity: 50, duration: 120, alarmTemperature: 80,
+    } as any)).rejects.toThrow(/Failed to create alarm schedule/)
+
+    await expect(failingCaller.updateAlarmSchedule({
+      id: 1, duration: 60,
+    })).rejects.toThrow(/Failed to update alarm schedule/)
+
+    await expect(failingCaller.deleteAlarmSchedule({ id: 1 }))
+      .rejects.toThrow(/Failed to delete alarm schedule/)
+
+    await expect(failingCaller.batchUpdate({
+      creates: { temperature: [{ side: 'left', dayOfWeek: 'monday', time: '22:00', temperature: 68 }] },
+    })).rejects.toThrow(/Failed to batch update schedules/)
+
+    vi.doUnmock('@/src/db')
+    vi.doUnmock('@/src/scheduler')
+    vi.resetModules()
+  })
 })
 

--- a/src/server/routers/tests/waterLevel.test.ts
+++ b/src/server/routers/tests/waterLevel.test.ts
@@ -185,3 +185,62 @@ describe('waterLevel.getFlowReadings / getLatestFlowReading', () => {
     expect(result?.id).toBe(9)
   })
 })
+
+describe('waterLevel error wrappers', () => {
+  it('wraps every read query DB failure as INTERNAL_SERVER_ERROR', async () => {
+    const boom = new Error('db dead')
+    const throwBoom = (): never => {
+      throw boom
+    }
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getHistory({ limit: 1 })).rejects.toThrow(/Failed to fetch water level history/)
+
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getLatest({})).rejects.toThrow(/Failed to fetch latest water level/)
+
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getTrend({ hours: 24 })).rejects.toThrow(/Failed to calculate water level trend/)
+
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getAlerts({})).rejects.toThrow(/Failed to fetch water level alerts/)
+
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getFlowReadings({ hours: 24 })).rejects.toThrow(/Failed to fetch flow readings/)
+
+    dbMock.select.mockImplementationOnce(throwBoom)
+    await expect(caller.getLatestFlowReading({})).rejects.toThrow(/Failed to fetch latest flow reading/)
+  })
+
+  it('wraps dismissAlert DB failure as INTERNAL_SERVER_ERROR', async () => {
+    dbMock.update.mockImplementationOnce((): never => {
+      throw new Error('update failed')
+    })
+    await expect(caller.dismissAlert({ id: 1 })).rejects.toThrow(/Failed to dismiss alert/)
+  })
+
+  it('getTrend returns stable trend when totals are between thresholds', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 60 },
+      { level: 'low', cnt: 40 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 20 }]) // recentLow
+    dbState.rowsQueue.push([{ cnt: 20 }]) // olderLow
+    dbState.rowsQueue.push([{ cnt: 50 }]) // recentTotal
+    dbState.rowsQueue.push([{ cnt: 50 }]) // olderTotal
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('stable')
+  })
+
+  it('getTrend keeps stable when one half has zero readings', async () => {
+    dbState.rowsQueue.push([
+      { level: 'ok', cnt: 5 },
+      { level: 'low', cnt: 5 },
+    ])
+    dbState.rowsQueue.push([{ cnt: 0 }])
+    dbState.rowsQueue.push([{ cnt: 0 }])
+    dbState.rowsQueue.push([{ cnt: 0 }]) // recentTotal=0 — branch
+    dbState.rowsQueue.push([{ cnt: 10 }])
+    const result = await caller.getTrend({ hours: 24 })
+    expect(result.trend).toBe('stable')
+  })
+})

--- a/tests/instrumentation.initialize.test.ts
+++ b/tests/instrumentation.initialize.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Behavioural tests for the Next.js instrumentation hook body —
+ * `initializeScheduler()` orchestrates a long chain of (non-)blocking
+ * startup steps and must swallow per-step failures without crashing.
+ * `register()` is the entry; the gate is covered in instrumentation.test.ts.
+ *
+ * Every external module is mocked. Each test resets module state so the
+ * `isInitialized` flag doesn't leak between cases.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getJobManager: vi.fn(),
+  shutdownJobManager: vi.fn(async () => undefined),
+  closeDatabase: vi.fn(),
+  closeBiometricsDatabase: vi.fn(),
+  startBiometricsRetention: vi.fn(),
+  stopBiometricsRetention: vi.fn(),
+  getDacMonitor: vi.fn(async () => ({ getStatus: () => 'running' })),
+  shutdownDacMonitor: vi.fn(async () => undefined),
+  startDacServer: vi.fn(async () => undefined),
+  startPiezoStreamServer: vi.fn(),
+  shutdownPiezoStreamServer: vi.fn(async () => undefined),
+  startBonjourAnnouncement: vi.fn(),
+  stopBonjourAnnouncement: vi.fn(),
+  startMqttBridge: vi.fn(async () => undefined),
+  shutdownMqttBridge: vi.fn(async () => undefined),
+  initializeKeepalives: vi.fn(),
+  shutdownKeepalives: vi.fn(),
+  startAutoOffWatcher: vi.fn(),
+  stopAutoOffWatcher: vi.fn(async () => undefined),
+  shutdownHomeKit: vi.fn(async () => undefined),
+  startHomeKitIfEnabled: vi.fn(async () => undefined),
+  runMigrations: vi.fn(async () => undefined),
+  seedDefaultData: vi.fn(async () => undefined),
+  checkAndRepairIptables: vi.fn(() => ({ ok: true, repaired: [] })),
+}))
+
+vi.mock('@/src/scheduler', () => ({
+  getJobManager: mocks.getJobManager,
+  shutdownJobManager: mocks.shutdownJobManager,
+}))
+vi.mock('@/src/db', () => ({
+  closeDatabase: mocks.closeDatabase,
+  closeBiometricsDatabase: mocks.closeBiometricsDatabase,
+}))
+vi.mock('@/src/db/retention', () => ({
+  startBiometricsRetention: mocks.startBiometricsRetention,
+  stopBiometricsRetention: mocks.stopBiometricsRetention,
+}))
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getDacMonitor: mocks.getDacMonitor,
+  shutdownDacMonitor: mocks.shutdownDacMonitor,
+  startDacServer: mocks.startDacServer,
+}))
+vi.mock('@/src/streaming/piezoStream', () => ({
+  startPiezoStreamServer: mocks.startPiezoStreamServer,
+  shutdownPiezoStreamServer: mocks.shutdownPiezoStreamServer,
+}))
+vi.mock('@/src/streaming/bonjourAnnounce', () => ({
+  startBonjourAnnouncement: mocks.startBonjourAnnouncement,
+  stopBonjourAnnouncement: mocks.stopBonjourAnnouncement,
+}))
+vi.mock('@/src/streaming/mqttBridge', () => ({
+  startMqttBridge: mocks.startMqttBridge,
+  shutdownMqttBridge: mocks.shutdownMqttBridge,
+}))
+vi.mock('@/src/services/temperatureKeepalive', () => ({
+  initializeKeepalives: mocks.initializeKeepalives,
+  shutdownKeepalives: mocks.shutdownKeepalives,
+}))
+vi.mock('@/src/services/autoOffWatcher', () => ({
+  startAutoOffWatcher: mocks.startAutoOffWatcher,
+  stopAutoOffWatcher: mocks.stopAutoOffWatcher,
+}))
+vi.mock('@/src/homekit', () => ({
+  shutdownHomeKit: mocks.shutdownHomeKit,
+  startHomeKitIfEnabled: mocks.startHomeKitIfEnabled,
+}))
+vi.mock('@/src/db/migrate', () => ({
+  runMigrations: mocks.runMigrations,
+  seedDefaultData: mocks.seedDefaultData,
+}))
+vi.mock('@/src/hardware/iptablesCheck', () => ({
+  checkAndRepairIptables: mocks.checkAndRepairIptables,
+}))
+
+const scheduler = {
+  getJobs: vi.fn(() => [] as { id: string, type: string }[]),
+  getNextInvocation: vi.fn<(id: string) => Date | null>(() => null),
+}
+const jobManager = { getScheduler: () => scheduler }
+
+beforeEach(() => {
+  vi.resetModules()
+  for (const key of Object.keys(mocks) as Array<keyof typeof mocks>) {
+    const m = mocks[key] as ReturnType<typeof vi.fn>
+    if (typeof m.mockReset === 'function') m.mockReset()
+  }
+  mocks.shutdownJobManager.mockResolvedValue(undefined)
+  mocks.shutdownPiezoStreamServer.mockResolvedValue(undefined)
+  mocks.shutdownMqttBridge.mockResolvedValue(undefined)
+  mocks.shutdownHomeKit.mockResolvedValue(undefined)
+  mocks.stopAutoOffWatcher.mockResolvedValue(undefined)
+  mocks.shutdownDacMonitor.mockResolvedValue(undefined)
+  mocks.getDacMonitor.mockResolvedValue({ getStatus: () => 'running' } as never)
+  mocks.startDacServer.mockResolvedValue(undefined)
+  mocks.startMqttBridge.mockResolvedValue(undefined)
+  mocks.startHomeKitIfEnabled.mockResolvedValue(undefined)
+  mocks.runMigrations.mockResolvedValue(undefined)
+  mocks.seedDefaultData.mockResolvedValue(undefined)
+  mocks.checkAndRepairIptables.mockReturnValue({ ok: true, repaired: [] })
+  mocks.getJobManager.mockResolvedValue(jobManager)
+  scheduler.getJobs.mockReturnValue([])
+  scheduler.getNextInvocation.mockReturnValue(null)
+})
+
+afterEach(() => {
+  delete process.env.CI
+  delete process.env.NEXT_RUNTIME
+})
+
+async function fresh() {
+  return await import('../instrumentation')
+}
+
+describe('initializeScheduler — happy path', () => {
+  it('boots every startup service in order', async () => {
+    scheduler.getJobs.mockReturnValue([
+      { id: 'j1', type: 'temperature' },
+      { id: 'j2', type: 'power_on' },
+    ])
+    scheduler.getNextInvocation.mockImplementation((id: string) =>
+      id === 'j1' ? new Date(Date.now() + 1000) : new Date(Date.now() + 500),
+    )
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+
+    expect(mocks.getJobManager).toHaveBeenCalled()
+    expect(mocks.startDacServer).toHaveBeenCalled()
+    expect(mocks.getDacMonitor).toHaveBeenCalled()
+    expect(mocks.initializeKeepalives).toHaveBeenCalled()
+    expect(mocks.startPiezoStreamServer).toHaveBeenCalled()
+    expect(mocks.startMqttBridge).toHaveBeenCalled()
+    expect(mocks.startAutoOffWatcher).toHaveBeenCalled()
+    expect(mocks.startBonjourAnnouncement).toHaveBeenCalled()
+    expect(mocks.startHomeKitIfEnabled).toHaveBeenCalled()
+    expect(mocks.startBiometricsRetention).toHaveBeenCalled()
+  })
+
+  it('is idempotent — second call is a no-op', async () => {
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    mocks.getJobManager.mockClear()
+    await initializeScheduler()
+    expect(mocks.getJobManager).not.toHaveBeenCalled()
+  })
+
+  it('skips upcoming-jobs log block when no jobs have a nextRun', async () => {
+    scheduler.getJobs.mockReturnValue([{ id: 'never', type: 'temperature' }])
+    scheduler.getNextInvocation.mockReturnValue(null)
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(logSpy).not.toHaveBeenCalledWith('Next scheduled jobs:')
+    logSpy.mockRestore()
+  })
+})
+
+describe('initializeScheduler — error swallowing', () => {
+  it('logs and swallows when DAC socket server fails to start', async () => {
+    mocks.startDacServer.mockRejectedValueOnce(new Error('dac sock busy'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/DAC.*Socket server failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs and swallows when DacMonitor throws', async () => {
+    mocks.getDacMonitor.mockRejectedValueOnce(new Error('no socket'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    // Wait a microtask — initializeDacMonitor() is fire-and-forget
+    await new Promise(resolve => setImmediate(resolve))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/DacMonitor failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs and swallows when piezo stream server throws', async () => {
+    mocks.startPiezoStreamServer.mockImplementationOnce((): never => {
+      throw new Error('addr in use')
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/Piezo stream server failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs and swallows when MQTT bridge rejects', async () => {
+    mocks.startMqttBridge.mockRejectedValueOnce(new Error('mqtt down'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/MQTT bridge failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs HomeKit startup failures via the .catch chain', async () => {
+    mocks.startHomeKitIfEnabled.mockRejectedValueOnce(new Error('home boom'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    await new Promise(resolve => setImmediate(resolve))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/\[homekit] startup failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs and swallows when getJobManager rejects all retries', async () => {
+    mocks.getJobManager.mockRejectedValue(new Error('manager down'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Speed up exponential backoff in withRetry
+    const origSetTimeout = global.setTimeout
+    const fakeTimeout = ((cb: () => void) => origSetTimeout(cb, 0)) as unknown as typeof global.setTimeout
+    Object.assign(fakeTimeout, origSetTimeout)
+    vi.stubGlobal('setTimeout', fakeTimeout)
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(errSpy).toHaveBeenCalledWith('Failed to initialize job scheduler:', expect.any(Error))
+    errSpy.mockRestore()
+    warnSpy.mockRestore()
+    vi.unstubAllGlobals()
+  }, 15000)
+})
+
+describe('register()', () => {
+  it('skips body entirely when NEXT_RUNTIME=edge', async () => {
+    process.env.NEXT_RUNTIME = 'edge'
+    const { register } = await fresh()
+    await register()
+    expect(mocks.runMigrations).not.toHaveBeenCalled()
+  })
+
+  it('runs migrations + seed, then short-circuits before hardware on CI', async () => {
+    process.env.CI = '1'
+    const { register } = await fresh()
+    await register()
+    expect(mocks.runMigrations).toHaveBeenCalled()
+    expect(mocks.seedDefaultData).toHaveBeenCalled()
+    expect(mocks.checkAndRepairIptables).not.toHaveBeenCalled()
+    expect(mocks.getJobManager).not.toHaveBeenCalled()
+  })
+
+  it('runs migrations and full init when not in CI', async () => {
+    const { register } = await fresh()
+    await register()
+    expect(mocks.runMigrations).toHaveBeenCalled()
+    expect(mocks.checkAndRepairIptables).toHaveBeenCalled()
+    expect(mocks.getJobManager).toHaveBeenCalled()
+  })
+
+  it('warns when iptables auto-repaired rules', async () => {
+    mocks.checkAndRepairIptables.mockReturnValueOnce({ ok: false, repaired: ['mdns', 'ntp'] } as any)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { register } = await fresh()
+    await register()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/Repaired 2 missing iptables rules/),
+      'mdns, ntp',
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('logs ok when iptables already verified', async () => {
+    mocks.checkAndRepairIptables.mockReturnValueOnce({ ok: true, repaired: [] } as any)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const { register } = await fresh()
+    await register()
+    expect(logSpy).toHaveBeenCalledWith('[startup] iptables rules verified')
+    logSpy.mockRestore()
+  })
+
+  it('swallows iptables check failures with a warning', async () => {
+    mocks.checkAndRepairIptables.mockImplementationOnce((): never => {
+      throw new Error('no perms')
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { register } = await fresh()
+    await register()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[startup] iptables check skipped:',
+      expect.stringMatching(/no perms/),
+    )
+    warnSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Pushed overall JS coverage from 92.3% stmts / 83.1% branches to 95.2% / 86.7% (and lines from 93.4% to 96.2%).
- New tests target startup, schedules/device/health/water-level/environment error wrappers, homekit corrupt-identity recovery, and gesture handler cleanup.

## What changed
- `tests/instrumentation.initialize.test.ts` (new): exercises `register()` + `initializeScheduler()`, including per-step error swallowing and CI/edge gates.
- `src/hardware/tests/gestureActionHandler.deps.test.ts` (new): covers the prod wiring layer.
- `src/scheduler/tests/scheduler.test.ts`: invalid-cron / past one-time job throw paths + `waitForInFlightJobs` force-shutdown warning.
- `src/homekit/tests/storage.test.ts`: `readIdentityIfPresent`, corrupt-file backup, `initHapStorage` idempotency.
- `src/homekit/tests/bridge.test.ts`: stopper/unpublish failures swallow + setupURI clearing on bare stopBridge.
- `src/server/routers/tests/*`: schedules (insert-no-row + non-TRPC errors), waterLevel (read/dismiss wrappers + trend stable branches), environment (per-query DB failures), raw (non-ENOENT unlink + diskUsage failure), device (best-effort DB sync swallows), health (drift auto-reload, iptables critical missing).
- `src/lib/tests/sleep-stages.test.ts`: high-deep, low/high-REM penalty branches; zero-duration distribution.
- `src/hardware/tests/gestureActionHandler.test.ts`: `cleanup()` cancels snooze restart; restart-connect failure logs.

## Test plan
- [x] `pnpm vitest run` — 1532 passed
- [x] `pnpm lint` — clean (1 pre-existing warning)
- [x] `pnpm tsc` — clean
- [ ] Codecov uploads on CI and the coverage delta is visible in the PR check.