### PR TITLE
test(sleep-stages): kill ~95 surviving Stryker mutants

### DIFF
--- a/src/lib/tests/sleep-stages.test.ts
+++ b/src/lib/tests/sleep-stages.test.ts
@@ -243,3 +243,430 @@ describe('formatDurationHM', () => {
     expect(formatDurationHM(0)).toBe('0m')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutation-killing tests (issue #543)
+// Each block pins behaviour against a specific class of surviving mutants
+// surfaced by Stryker. Boundary values are chosen exactly to make
+// `<` vs `<=`, `>` vs `>=`, `+` vs `-`, and `||` vs `&&` observable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('filterOutliers — hard limits (heart rate)', () => {
+  // 5 uniform samples keep stdDev=0 so the windowed filter is skipped
+  // (`stdDev > 0` guard) and only the hard-limit branch is exercised.
+  const fiveOf = (hr: number) => [
+    vitalRow(0, hr), vitalRow(5, hr), vitalRow(10, hr), vitalRow(15, hr), vitalRow(20, hr),
+  ]
+
+  it('keeps heart rate at lower boundary 45', () => {
+    expect(classifySleepStages(fiveOf(45), [], 1.0)[0].heartRate).toBe(45)
+  })
+
+  it('nulls heart rate one below lower boundary (44)', () => {
+    expect(classifySleepStages(fiveOf(44), [], 1.0)[0].heartRate).toBeNull()
+  })
+
+  it('keeps heart rate at upper boundary 130', () => {
+    expect(classifySleepStages(fiveOf(130), [], 1.0)[0].heartRate).toBe(130)
+  })
+
+  it('nulls heart rate one above upper boundary (131)', () => {
+    expect(classifySleepStages(fiveOf(131), [], 1.0)[0].heartRate).toBeNull()
+  })
+
+  it('nulls a low-only outlier (kills || → && on the OR-range)', () => {
+    // HR=20 satisfies <45 but not >130. With `||`→`&&` the row would be kept.
+    expect(classifySleepStages([vitalRow(0, 20)], [], 1.0)[0].heartRate).toBeNull()
+  })
+
+  it('nulls a high-only outlier (kills || → && on the OR-range)', () => {
+    expect(classifySleepStages([vitalRow(0, 200)], [], 1.0)[0].heartRate).toBeNull()
+  })
+})
+
+describe('filterOutliers — hard limits (HRV)', () => {
+  it('keeps HRV at lower boundary 1', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 1)], [], 1.0)[0].hrv).toBe(1)
+  })
+
+  it('nulls HRV at 0 (just below lower boundary)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 0)], [], 1.0)[0].hrv).toBeNull()
+  })
+
+  it('keeps HRV at upper boundary 300', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 300)], [], 1.0)[0].hrv).toBe(300)
+  })
+
+  it('nulls HRV at 301 (just above upper boundary)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 301)], [], 1.0)[0].hrv).toBeNull()
+  })
+
+  it('nulls a low-only HRV (kills || → && on the OR-range)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 0.5)], [], 1.0)[0].hrv).toBeNull()
+  })
+
+  it('nulls a high-only HRV (kills || → && on the OR-range)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 400)], [], 1.0)[0].hrv).toBeNull()
+  })
+})
+
+describe('filterOutliers — hard limits (breathing rate)', () => {
+  it('keeps breathingRate at lower boundary 8', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 8)], [], 1.0)[0].breathingRate).toBe(8)
+  })
+
+  it('nulls breathingRate at 7 (just below lower boundary)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 7)], [], 1.0)[0].breathingRate).toBeNull()
+  })
+
+  it('keeps breathingRate at upper boundary 25', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 25)], [], 1.0)[0].breathingRate).toBe(25)
+  })
+
+  it('nulls breathingRate at 26 (just above upper boundary)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 26)], [], 1.0)[0].breathingRate).toBeNull()
+  })
+
+  it('nulls a low-only breathingRate (kills || → && on the OR-range)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 5)], [], 1.0)[0].breathingRate).toBeNull()
+  })
+
+  it('nulls a high-only breathingRate (kills || → && on the OR-range)', () => {
+    expect(classifySleepStages([vitalRow(0, 60, 40, 30)], [], 1.0)[0].breathingRate).toBeNull()
+  })
+})
+
+describe('filterOutliers — windowed median filter', () => {
+  it('nulls an HR spike that deviates >2× stdDev from the window median', () => {
+    // window=[60,60,100,60,60]: median=60, stdDev≈16, 2×stdDev≈32, |100-60|=40 → null.
+    // Kills BlockStatement{}, ConditionalExpression false on windowHRs.length>0
+    // and stdDev>0, ArrayDeclaration [], ArithmeticOperator on the reducers.
+    const v = [vitalRow(0, 60), vitalRow(5, 60), vitalRow(10, 100), vitalRow(15, 60), vitalRow(20, 60)]
+    expect(classifySleepStages(v, [], 1.0)[2].heartRate).toBeNull()
+  })
+
+  it('keeps surrounding HRs that match their own window median', () => {
+    const v = [vitalRow(0, 60), vitalRow(5, 60), vitalRow(10, 100), vitalRow(15, 60), vitalRow(20, 60)]
+    const r = classifySleepStages(v, [], 1.0)
+    expect(r[0].heartRate).toBe(60)
+    expect(r[1].heartRate).toBe(60)
+    expect(r[3].heartRate).toBe(60)
+    expect(r[4].heartRate).toBe(60)
+  })
+})
+
+describe('classifySleepStages — sort and duration', () => {
+  it('does not mutate the caller-supplied vitalsData order', () => {
+    // ArrayDeclaration `[...vitalsData]` → `vitalsData` would sort the input in place.
+    const v = [vitalRow(20, 60), vitalRow(0, 60), vitalRow(10, 60)]
+    const before = v.map(r => r.timestamp.getTime())
+    classifySleepStages(v, [], 1.0)
+    expect(v.map(r => r.timestamp.getTime())).toEqual(before)
+  })
+
+  it('sorts epochs in ascending timestamp order regardless of input order', () => {
+    // ArithmeticOperator on the sort comparator (a-b → a+b) would break ordering.
+    const v = [vitalRow(20, 60), vitalRow(0, 60), vitalRow(10, 60)]
+    const r = classifySleepStages(v, [], 1.0)
+    expect(r[0].start).toBeLessThan(r[1].start)
+    expect(r[1].start).toBeLessThan(r[2].start)
+  })
+
+  it('uses gap-to-next-sample as duration for non-last epochs', () => {
+    // 5-min gap → duration=300_000. Math.min vs Math.max diverge once the
+    // ternary picks `nextTs - ts` (300k) over the 600k cap.
+    expect(classifySleepStages([vitalRow(0, 60), vitalRow(5, 60)], [], 1.0)[0].duration).toBe(300_000)
+  })
+
+  it('caps non-last-epoch duration at 10 minutes for long gaps', () => {
+    // 30-min gap → Math.min(1_800_000, 600_000) = 600_000. ConditionalExpression
+    // `false` on the `i < length-1` ternary would substitute ts+5min → 300_000.
+    expect(classifySleepStages([vitalRow(0, 60), vitalRow(30, 60)], [], 1.0)[0].duration).toBe(600_000)
+  })
+
+  it('defaults last-epoch duration to exactly 5 minutes', () => {
+    // ArithmeticOperator `ts + 300_000` → `ts - 300_000` would yield -300_000.
+    expect(classifySleepStages([vitalRow(0, 60)], [], 1.0)[0].duration).toBe(300_000)
+  })
+})
+
+describe('classifySleepStages — phase 2 smoothing only fires when neighbors match', () => {
+  it('does NOT smooth a middle epoch when its neighbors disagree (A-B-C stays A-B-C)', () => {
+    // ConditionalExpression `true` on the smoothing check would rewrite
+    // epoch[1] to match epoch[0] unconditionally. Use uniform HR (so the
+    // windowed outlier filter is a no-op via stdDev=0) and drive the stage
+    // pattern through movement + HRV only.
+    // Phase 1: [light (mov=10), rem (hrv=20+mov=20), wake (mov=300)].
+    const v = [
+      vitalRow(0, 70),
+      vitalRow(5, 70, 20, 14),
+      vitalRow(10, 70),
+    ]
+    const m = [movRow(0, 10), movRow(5, 20), movRow(10, 300)]
+    expect(classifySleepStages(v, m, 1.0)[1].stage).toBe('rem')
+  })
+})
+
+describe('classifySleepStages — phase 3 transition constraints', () => {
+  it('inserts light between wake → deep', () => {
+    const v = [vitalRow(0, 70), vitalRow(5, 50)]
+    const m = [movRow(0, 300), movRow(5, 0)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('wake')
+    expect(r[1].stage).toBe('light')
+  })
+
+  it('inserts light between deep → wake', () => {
+    const v = [vitalRow(0, 50), vitalRow(5, 70)]
+    const m = [movRow(0, 0), movRow(5, 300)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('deep')
+    expect(r[1].stage).toBe('light')
+  })
+
+  it('inserts light between deep → rem', () => {
+    const v = [vitalRow(0, 50), vitalRow(5, 70, 20, 14)]
+    const m = [movRow(0, 0), movRow(5, 10)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('deep')
+    expect(r[1].stage).toBe('light')
+  })
+
+  it('inserts light between rem → deep', () => {
+    const v = [vitalRow(0, 70, 20, 14), vitalRow(5, 50)]
+    const m = [movRow(0, 10), movRow(5, 0)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('rem')
+    expect(r[1].stage).toBe('light')
+  })
+
+  it('does NOT rewrite a light → deep transition (no rule fires)', () => {
+    // ConditionalExpression `true` on lines 197/209 (`wake→deep` and `rem→deep`)
+    // would force epoch[1] to 'light' here. Original keeps it 'deep'.
+    // [0] HR=65 hrv=null mov=null → light (ratio≈1.08, no REM signals).
+    // [1] HR=55 hrv=null mov=null → deep (ratio≈0.92 → 0.917<0.92).
+    const v = [vitalRow(0, 65), vitalRow(5, 55)]
+    const r = classifySleepStages(v, [], 1.0)
+    expect(r[0].stage).toBe('light')
+    expect(r[1].stage).toBe('deep')
+  })
+
+  it('does NOT rewrite a light → wake transition (no rule fires)', () => {
+    // ConditionalExpression `true` on line 201 (`deep→wake`) would force [1] to 'light'.
+    const v = [vitalRow(0, 70), vitalRow(5, 70)]
+    const m = [movRow(0, 10), movRow(5, 300)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('light')
+    expect(r[1].stage).toBe('wake')
+  })
+
+  it('does NOT rewrite a light → rem transition (no rule fires)', () => {
+    // ConditionalExpression `true` on line 205 (`deep→rem`) would force [1] to 'light'.
+    const v = [vitalRow(0, 70), vitalRow(5, 70, 20, 14)]
+    const m = [movRow(0, 10), movRow(5, 10)]
+    const r = classifySleepStages(v, m, 1.0)
+    expect(r[0].stage).toBe('light')
+    expect(r[1].stage).toBe('rem')
+  })
+})
+
+describe('classifyEpoch — calibration threshold (strict <)', () => {
+  // window[0]=[50,50,55] for HR=50 at i=0: median=50, |50-50|=0 → kept.
+  // avgHR=59 → ratio=50/59≈0.847 < 0.92 → 'deep' on the high-cal path.
+  // Low-cal path with movement=null returns 'light' unconditionally.
+  const vitals = [
+    vitalRow(0, 50), vitalRow(5, 50), vitalRow(10, 55), vitalRow(15, 70), vitalRow(20, 70),
+  ]
+
+  it('uses high-cal classification at calibrationQuality === 0.3 (strict <)', () => {
+    expect(classifySleepStages(vitals, [], 0.3)[0].stage).toBe('deep')
+  })
+
+  it('uses low-cal classification just below 0.3', () => {
+    expect(classifySleepStages(vitals, [], 0.29)[0].stage).toBe('light')
+  })
+})
+
+describe('classifyEpoch — low-cal movement thresholds', () => {
+  // Use cal=0.1 to stay deep inside the low-cal branch.
+  // HR is uniform so the windowed outlier filter is a no-op.
+  const uniformHR = (mov: number) => ({
+    v: [vitalRow(0, 70)],
+    m: [movRow(0, mov)],
+  })
+
+  it('classifies movement > 200 as wake under low-cal (line 227)', () => {
+    const { v, m } = uniformHR(300)
+    expect(classifySleepStages(v, m, 0.1)[0].stage).toBe('wake')
+  })
+
+  it('does NOT classify movement === 200 as wake under low-cal (strict >)', () => {
+    // EqualityOperator `> 200` → `>= 200` on line 227 would yield 'wake' here.
+    // Line 228 catches movement>100 and returns 'light' instead.
+    const { v, m } = uniformHR(200)
+    expect(classifySleepStages(v, m, 0.1)[0].stage).toBe('light')
+  })
+
+  it('returns light when movement is null under low-cal (kills line-227 true)', () => {
+    // ConditionalExpression `true` on line 227 would return 'wake' here.
+    const r = classifySleepStages([vitalRow(0, 70)], [], 0.1)
+    expect(r[0].stage).toBe('light')
+  })
+})
+
+describe('classifyEpoch — high-cal REM fallback (line 248)', () => {
+  // Uniform HR=70 → ratio=1.0 across the board (no outlier filtering).
+  // The REM fallback fires when movement<50 AND hrv<40 (and the first
+  // REM check on line 244 misses).
+
+  it('classifies hrv=30, movement=10 as REM via the fallback branch', () => {
+    // Line 244 misses (hrv=30 is not <25). Line 248 must catch it.
+    // ConditionalExpression `false` on line 248 would default to 'light'.
+    const r = classifySleepStages([vitalRow(0, 70, 30, 14)], [movRow(0, 10)], 1.0)
+    expect(r[0].stage).toBe('rem')
+  })
+
+  it('does NOT classify hrv=40 as REM (strict <)', () => {
+    // EqualityOperator `hrv < 40` → `hrv <= 40` would yield 'rem'.
+    const r = classifySleepStages([vitalRow(0, 70, 40, 14)], [movRow(0, 10)], 1.0)
+    expect(r[0].stage).toBe('light')
+  })
+
+  it('classifies hrv=39 as REM (just below the 40 boundary)', () => {
+    // EqualityOperator `hrv < 40` → `hrv >= 40` would yield 'light'.
+    const r = classifySleepStages([vitalRow(0, 70, 39, 14)], [movRow(0, 10)], 1.0)
+    expect(r[0].stage).toBe('rem')
+  })
+
+  it('does NOT classify movement=50 as REM (strict <)', () => {
+    // EqualityOperator `movement < 50` → `movement <= 50` would yield 'rem'.
+    const r = classifySleepStages([vitalRow(0, 70, 39, 14)], [movRow(0, 50)], 1.0)
+    expect(r[0].stage).toBe('light')
+  })
+
+  it('classifies movement=49 as REM (just below the 50 boundary)', () => {
+    // EqualityOperator `movement < 50` → `movement >= 50` would yield 'light'.
+    const r = classifySleepStages([vitalRow(0, 70, 39, 14)], [movRow(0, 49)], 1.0)
+    expect(r[0].stage).toBe('rem')
+  })
+
+  it('falls through to light when REM signals are absent (kills line-248 true)', () => {
+    // ConditionalExpression `true` on line 248 would short-circuit to REM
+    // regardless of hrv/movement values.
+    const r = classifySleepStages([vitalRow(0, 70)], [], 1.0)
+    expect(r[0].stage).toBe('light')
+  })
+})
+
+describe('classifyEpoch — high-cal wake fallback at ratio≥0.95 (line 252)', () => {
+  // HR=70 uniform → ratio=1.0. HRV null so lines 244 and 248 don't fire.
+
+  it('classifies movement=150 as wake via the line-252 fallback', () => {
+    // ConditionalExpression `false` on line 252 would default to 'light'.
+    // movement=150 sits in (100, 200] so line 233 (`>200`) does not fire first.
+    const r = classifySleepStages([vitalRow(0, 70)], [movRow(0, 150)], 1.0)
+    expect(r[0].stage).toBe('wake')
+  })
+
+  it('does NOT classify movement=100 as wake (strict >)', () => {
+    // EqualityOperator `> 100` → `>= 100` on line 252 would yield 'wake'.
+    const r = classifySleepStages([vitalRow(0, 70)], [movRow(0, 100)], 1.0)
+    expect(r[0].stage).toBe('light')
+  })
+})
+
+describe('classifyEpoch — high-cal wake threshold at movement > 200', () => {
+  // Choose HR ratio in (0.92, 0.95) so the line-252 wake fallback (which only
+  // fires for ratio≥0.95) cannot mask the line-233 mutant.
+  const calmIshHR = [
+    vitalRow(0, 63), vitalRow(5, 65), vitalRow(10, 70), vitalRow(15, 70), vitalRow(20, 70),
+  ]
+
+  it('does NOT flag wake at movement === 200 (strict >)', () => {
+    const m = [movRow(0, 200)]
+    expect(classifySleepStages(calmIshHR, m, 1.0)[0].stage).not.toBe('wake')
+  })
+
+  it('flags wake at movement > 200 (line-233 path active)', () => {
+    const m = [movRow(0, 250)]
+    expect(classifySleepStages(calmIshHR, m, 1.0)[0].stage).toBe('wake')
+  })
+})
+
+describe('mergeIntoBlocks — boundary arithmetic', () => {
+  it('computes block end as start + duration on stage change', () => {
+    // ArithmeticOperator `+` → `-` at line 281: end would collapse to 0.
+    const epochs: SleepEpoch[] = [
+      { start: 0, duration: 300_000, stage: 'light', heartRate: 60, hrv: 30, breathingRate: 14, movement: null },
+      { start: 300_000, duration: 300_000, stage: 'deep', heartRate: 55, hrv: 40, breathingRate: 12, movement: null },
+    ]
+    const blocks = mergeIntoBlocks(epochs)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[1].start).toBe(300_000)
+    expect(blocks[1].end).toBe(600_000)
+  })
+})
+
+describe('calculateDistribution — divide-by-zero guard', () => {
+  it('returns zeros when all epoch durations sum to zero', () => {
+    // ConditionalExpression `totalDuration === 0` → `false` would divide by 0,
+    // producing NaN percentages.
+    const epochs: SleepEpoch[] = [
+      { start: 0, duration: 0, stage: 'deep', heartRate: null, hrv: null, breathingRate: null, movement: null },
+      { start: 0, duration: 0, stage: 'light', heartRate: null, hrv: null, breathingRate: null, movement: null },
+    ]
+    expect(calculateDistribution(epochs)).toEqual({ wake: 0, light: 0, deep: 0, rem: 0 })
+  })
+})
+
+describe('calculateQualityScore — exact penalty arithmetic', () => {
+  it('returns exactly 100 for an ideal distribution (no penalty triggered)', () => {
+    expect(calculateQualityScore({ deep: 20, light: 50, rem: 25, wake: 5 })).toBe(100)
+  })
+
+  it('subtracts 2 per percentage point below the 15% deep target', () => {
+    // deep=10 → penalty (15-10)*2 = 10 → score 90.
+    expect(calculateQualityScore({ deep: 10, light: 60, rem: 25, wake: 5 })).toBe(90)
+  })
+
+  it('subtracts 1.5 per percentage point above the 30% deep target', () => {
+    // deep=40 → penalty (40-30)*1.5 = 15 → score 85.
+    expect(calculateQualityScore({ deep: 40, light: 30, rem: 25, wake: 5 })).toBe(85)
+  })
+
+  it('subtracts 1.5 per percentage point below the 20% REM target', () => {
+    // rem=10 → penalty (20-10)*1.5 = 15 → score 85.
+    expect(calculateQualityScore({ deep: 20, light: 65, rem: 10, wake: 5 })).toBe(85)
+  })
+
+  it('subtracts 1 per percentage point above the 35% REM target', () => {
+    // rem=45 → penalty (45-35)*1 = 10 → score 90.
+    expect(calculateQualityScore({ deep: 20, light: 30, rem: 45, wake: 5 })).toBe(90)
+  })
+
+  it('subtracts 2 per percentage point above the 5% wake target', () => {
+    // wake=15 → penalty (15-5)*2 = 20 → score 80.
+    expect(calculateQualityScore({ deep: 20, light: 40, rem: 25, wake: 15 })).toBe(80)
+  })
+
+  it('still penalizes deep one below the 15% boundary', () => {
+    // deep=14 → penalty (15-14)*2 = 2 → score 98.
+    expect(calculateQualityScore({ deep: 14, light: 56, rem: 25, wake: 5 })).toBe(98)
+  })
+
+  it('does not penalize at the boundaries (deep=30, rem=20, rem=35, wake=5)', () => {
+    expect(calculateQualityScore({ deep: 30, light: 40, rem: 25, wake: 5 })).toBe(100)
+    expect(calculateQualityScore({ deep: 20, light: 55, rem: 20, wake: 5 })).toBe(100)
+    expect(calculateQualityScore({ deep: 20, light: 40, rem: 35, wake: 5 })).toBe(100)
+    expect(calculateQualityScore({ deep: 20, light: 50, rem: 25, wake: 5 })).toBe(100)
+  })
+
+  it('does NOT cap score at calibrationQuality === 0.3 (strict <)', () => {
+    // Mutant `<= 0.3` would force the cap-at-50 path here.
+    expect(calculateQualityScore({ deep: 20, light: 50, rem: 25, wake: 5 }, 0.3)).toBe(100)
+  })
+
+  it('caps score at 50 for calibrationQuality just below 0.3', () => {
+    expect(calculateQualityScore({ deep: 20, light: 50, rem: 25, wake: 5 }, 0.29)).toBe(50)
+  })
+})


### PR DESCRIPTION
## Summary

Addresses [#543](https://github.com/sleepypod/core/issues/543) — the weekly mutation-testing baseline. Targets `src/lib/sleep-stages.ts`, the single file with the most surviving mutants in the latest report (133 of 774 total).

Adds 60 focused tests pinning behaviour that was previously asserted only loosely:

- **Hard limits (lines 89–91):** HR/HRV/breathing-rate boundary values (44/45/130/131, 0/1/300/301, 7/8/25/26) plus the `||`→`&&` LogicalOperator kills (low-only and high-only outliers).
- **Windowed median filter (lines 94–115):** verifies that an HR spike `>2× stdDev` from the window median is nulled, and that neighbouring valid HRs are preserved.
- **Sort & duration (lines 139–170):** the caller's `vitalsData` is not mutated; epochs are sorted ascending; per-epoch duration uses gap-to-next, capped at 10 min, with a 5-min default on the last epoch.
- **Phase 2 smoothing (line 187):** the A-B-C case (non-matching neighbours) leaves the middle untouched.
- **Phase 3 transition constraints (lines 197/201/205/209):** each of the four physiological rules fires; light→{deep,wake,rem} cases verify that non-matching transitions don't fire.
- **`classifyEpoch` thresholds:** calibration-quality boundary (strict `<0.3`), high-cal wake threshold (strict `>200`), low-cal movement thresholds, REM fallback boundaries (`hrv<40`, `movement<50`), and the wake fallback (`movement>100`).
- **`mergeIntoBlocks`:** end = start + duration on stage change.
- **`calculateDistribution`:** zero-duration divide-by-zero guard.
- **`calculateQualityScore`:** exact penalty arithmetic (×2 / ×1.5 / ×1.5 / ×1 / ×2 per percentage-point), boundary no-op cases, and the calibration cap at strict `<0.3`.

### Result

Mutation score on `src/lib/sleep-stages.ts`: **60.1% → 84.6%** (259 killed / 47 surviving). Remaining survivors are largely equivalent mutants — the line-244 REM check is shadowed by line 248, A-B-A symmetric index mutants in the phase-2 smoother, and `EqualityOperator` mutants on boundaries where the resulting penalty is 0.

## Test plan

- [x] `pnpm exec vitest run src/lib/tests/sleep-stages.test.ts` — 79 passed
- [x] `pnpm exec vitest run` — full suite: 1553 passed, 1 skipped, 0 failed
- [x] `pnpm tsc` — clean
- [x] `pnpm exec stryker run --mutate 'src/lib/sleep-stages.ts'` — 84.64% (verified locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regression test coverage for sleep stage classification with comprehensive boundary and mutation-killing assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/570)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->