### PR TITLE
fix(homekit): post-PR-566 follow-ups — orphan cleanup, wipe-stability docs, transitioning flag

### DIFF
--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -259,10 +259,13 @@ export async function unpairAll(): Promise<void> {
 }
 
 export async function regenerate(): Promise<ReturnType<typeof loadOrCreateIdentity> | null> {
-  await stopBridge()
-  const id = regenerateIdentity()
-  setIdentity(id)
-  return id
+  // Aligned with unpairAll(): both rotate identity AND clear hap-nodejs
+  // pairing state. The split was historical (pre-rotation, regenerate
+  // skipped clearPairings); now that unpair rotates the MAC the orphan
+  // AccessoryInfo.<old-MAC>.json was unreachable anyway, so we sweep it.
+  // tRPC routes remain separate — same effect, different return shape.
+  await unpairAll()
+  return getIdentity()
 }
 
 function pickAdvertiser(): Advertiser {

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -50,6 +50,7 @@ const KEYS = {
   stoppers: '__sp_homekit_stoppers__',
   identity: '__sp_homekit_identity__',
   setupURI: '__sp_homekit_setupURI__',
+  transitioning: '__sp_homekit_transitioning__',
 } as const
 
 const getBridge = (): Bridge | null => (G[KEYS.bridge] as Bridge | null) ?? null
@@ -73,8 +74,19 @@ const setSetupURI = (u: string | null): void => {
   G[KEYS.setupURI] = u
 }
 
+// Lifecycle ops (enable/disable/unpair/regenerate) flip this while in flight.
+// getStatus surfaces it so a 5s poll racing a sub-second teardown can render
+// "rotating…" instead of treating the transient running=false as a final
+// state. Lives here (not in index.ts) so bridge.getStatus stays a single
+// globalThis read; index.ts owns the flip via setTransitioning.
+const isTransitioning = (): boolean => Boolean(G[KEYS.transitioning])
+export const setTransitioning = (v: boolean): void => {
+  G[KEYS.transitioning] = v
+}
+
 export interface BridgeStatus {
   running: boolean
+  transitioning: boolean
   pincode: string | null
   setupId: string | null
   setupURI: string | null
@@ -223,6 +235,7 @@ export function getStatus(): BridgeStatus {
   const id = getIdentity()
   return {
     running: getBridge() !== null,
+    transitioning: isTransitioning(),
     pincode: id?.pincode ?? null,
     setupId: id?.setupId ?? null,
     setupURI: getSetupURI(),

--- a/src/homekit/index.ts
+++ b/src/homekit/index.ts
@@ -7,7 +7,7 @@ import { db } from '@/src/db'
 import { deviceSettings } from '@/src/db/schema'
 import { eq } from 'drizzle-orm'
 import { getDacMonitor } from '@/src/hardware/dacMonitor.instance'
-import { getStatus, regenerate, startBridge, stopBridge, unpairAll } from './bridge'
+import { getStatus, regenerate, setTransitioning, startBridge, stopBridge, unpairAll } from './bridge'
 import type { BridgeStatus } from './bridge'
 
 // Turbopack splits this module across instrumentation + every API route
@@ -36,6 +36,19 @@ function serialize<T>(fn: () => Promise<T>): Promise<T> {
   return next
 }
 
+// Flag transitioning=true around the body so a getStatus() poll that lands
+// mid-rotation sees the transient running=false as in-flight, not a final
+// state. Always pairs the set with a finally to release even on throw.
+async function withTransition<T>(fn: () => Promise<T>): Promise<T> {
+  setTransitioning(true)
+  try {
+    return await fn()
+  }
+  finally {
+    setTransitioning(false)
+  }
+}
+
 export async function startHomeKitIfEnabled(): Promise<void> {
   const enabled = await readEnabled()
   if (!enabled) return
@@ -43,20 +56,20 @@ export async function startHomeKitIfEnabled(): Promise<void> {
 }
 
 export function enable(): Promise<void> {
-  return serialize(async () => {
+  return serialize(() => withTransition(async () => {
     if (isStarted()) return
     const monitor = await getDacMonitor()
     await startBridge(monitor)
     setStarted(true)
-  })
+  }))
 }
 
 export function disable(): Promise<void> {
-  return serialize(async () => {
+  return serialize(() => withTransition(async () => {
     if (!isStarted()) return
     await stopBridge()
     setStarted(false)
-  })
+  }))
 }
 
 export async function shutdownHomeKit(): Promise<void> {
@@ -68,7 +81,7 @@ export function status(): BridgeStatus {
 }
 
 export function unpair(): Promise<void> {
-  return serialize(async () => {
+  return serialize(() => withTransition(async () => {
     await unpairAll()
     setStarted(false)
     if (await readEnabled()) {
@@ -76,18 +89,23 @@ export function unpair(): Promise<void> {
       await startBridge(monitor)
       setStarted(true)
     }
-  })
+  }))
 }
 
 export function regeneratePairing(): Promise<BridgeStatus> {
   return serialize(async () => {
-    await regenerate()
-    setStarted(false)
-    if (await readEnabled()) {
-      const monitor = await getDacMonitor()
-      await startBridge(monitor)
-      setStarted(true)
-    }
+    // Run rotation/republish under withTransition so concurrent pollers see
+    // transitioning=true, then snapshot status AFTER the flag flips back so
+    // the mutation response reflects the settled state.
+    await withTransition(async () => {
+      await regenerate()
+      setStarted(false)
+      if (await readEnabled()) {
+        const monitor = await getDacMonitor()
+        await startBridge(monitor)
+        setStarted(true)
+      }
+    })
     return getStatus()
   })
 }

--- a/src/homekit/storage.ts
+++ b/src/homekit/storage.ts
@@ -327,6 +327,8 @@ export function regenerateIdentity(): BridgeIdentity {
     catch { /* treat as no prior rotation */ }
   }
 
+  // Legacy (no rotation field): prevRotation=-1 → newIdentity(0), same as
+  // post-wipe derivation — wipe-stable per ADR-0020.
   const identity = newIdentity(prevRotation + 1)
   writeIdentity(identity)
   return identity

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -88,6 +88,7 @@ describe('homekit bridge', () => {
     delete g.__sp_homekit_stoppers__
     delete g.__sp_homekit_identity__
     delete g.__sp_homekit_setupURI__
+    delete g.__sp_homekit_transitioning__
 
     m.bridgeInstance = null
     m.BridgeCtor.mockClear()
@@ -306,6 +307,17 @@ describe('homekit bridge', () => {
     expect(id?.username).toBe('NN:NN:NN:NN:NN:NN')
     expect(getStatus().running).toBe(false)
     expect(getStatus().username).toBe('NN:NN:NN:NN:NN:NN')
+  })
+
+  it('getStatus surfaces the transitioning flag flipped by setTransitioning', async () => {
+    const { startBridge, getStatus, setTransitioning } = await import('../bridge')
+    await startBridge(fakeMonitor)
+    expect(getStatus().transitioning).toBe(false)
+    setTransitioning(true)
+    expect(getStatus().transitioning).toBe(true)
+    expect(getStatus().running).toBe(true)
+    setTransitioning(false)
+    expect(getStatus().transitioning).toBe(false)
   })
 
   it('regenerate aborts when stopBridge fails to clear the singleton', async () => {

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -291,7 +291,7 @@ describe('homekit bridge', () => {
     expect(getStatus().running).toBe(false)
   })
 
-  it('regenerate stops the bridge and replaces identity', async () => {
+  it('regenerate stops the bridge, clears pairings, and replaces identity', async () => {
     const { startBridge, regenerate, getStatus } = await import('../bridge')
     await startBridge(fakeMonitor)
     m.regenerateIdentity.mockReturnValueOnce({
@@ -300,8 +300,25 @@ describe('homekit bridge', () => {
       setupId: 'YYYY',
     })
     const id = await regenerate()
+    // regenerate now aligns with unpairAll — orphan AccessoryInfo.<old-MAC>.json
+    // is swept on rotation rather than left on disk.
+    expect(m.clearPairings).toHaveBeenCalledWith('AA:BB:CC:DD:EE:FF')
     expect(id?.username).toBe('NN:NN:NN:NN:NN:NN')
     expect(getStatus().running).toBe(false)
     expect(getStatus().username).toBe('NN:NN:NN:NN:NN:NN')
+  })
+
+  it('regenerate aborts when stopBridge fails to clear the singleton', async () => {
+    const { startBridge, regenerate, getStatus } = await import('../bridge')
+    await startBridge(fakeMonitor)
+    if (m.bridgeInstance) {
+      m.bridgeInstance.destroy = vi.fn().mockRejectedValue(new Error('destroy failed'))
+    }
+    // Same invariant as unpairAll: rotating identity while a live bridge
+    // still answers on the old MAC desyncs getStatus from the HAP server.
+    await expect(regenerate()).rejects.toThrow(/bridge teardown incomplete/)
+    expect(m.clearPairings).not.toHaveBeenCalled()
+    expect(m.regenerateIdentity).not.toHaveBeenCalled()
+    expect(getStatus().username).toBe('AA:BB:CC:DD:EE:FF')
   })
 })

--- a/src/homekit/tests/index.test.ts
+++ b/src/homekit/tests/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const m = vi.hoisted(() => {
   const status = {
     running: false,
+    transitioning: false,
     pincode: null as string | null,
     setupId: null,
     setupURI: null,
@@ -18,6 +19,7 @@ const m = vi.hoisted(() => {
     unpairAll: vi.fn(async () => { /* no-op */ }),
     regenerate: vi.fn(async () => ({ username: 'aa', pincode: 'bb', setupId: 'cc' })),
     getStatus: vi.fn(() => status),
+    setTransitioning: vi.fn((v: boolean) => { status.transitioning = v }),
     getDacMonitor: vi.fn(async () => ({ id: 'monitor' })),
     enabled: { value: true },
     dbThrows: { value: false },
@@ -31,6 +33,7 @@ vi.mock('../bridge', () => ({
   unpairAll: m.unpairAll,
   regenerate: m.regenerate,
   getStatus: m.getStatus,
+  setTransitioning: m.setTransitioning,
 }))
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
@@ -68,10 +71,12 @@ describe('homekit lifecycle', () => {
     m.stopBridge.mockClear()
     m.unpairAll.mockClear()
     m.regenerate.mockClear()
+    m.setTransitioning.mockClear()
     m.getDacMonitor.mockClear()
     m.enabled.value = true
     m.dbThrows.value = false
     m.status.running = false
+    m.status.transitioning = false
   })
   afterEach(() => {
     // Drain serializer between cases by re-importing fresh module.
@@ -176,5 +181,49 @@ describe('homekit lifecycle', () => {
     await Promise.all([mod.disable(), mod.enable()])
     expect(m.stopBridge).toHaveBeenCalledTimes(1)
     expect(m.startBridge).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes transitioning=true to concurrent getStatus during unpair, then clears it', async () => {
+    const mod = await import('../index')
+    await mod.enable()
+
+    // Hold unpairAll on a deferred so a status poll can land mid-flight.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    m.unpairAll.mockImplementationOnce(() => gate)
+
+    const inflight = mod.unpair()
+    // Microtask flush: serializer schedules the body, setTransitioning(true)
+    // runs, then unpairAll awaits the gate.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(m.setTransitioning).toHaveBeenCalledWith(true)
+    expect(m.status.transitioning).toBe(true)
+
+    release()
+    await inflight
+    expect(m.setTransitioning).toHaveBeenLastCalledWith(false)
+    expect(m.status.transitioning).toBe(false)
+  })
+
+  it('clears transitioning even when unpair throws', async () => {
+    const mod = await import('../index')
+    await mod.enable()
+    m.unpairAll.mockRejectedValueOnce(new Error('teardown failed'))
+    await expect(mod.unpair()).rejects.toThrow('teardown failed')
+    expect(m.setTransitioning).toHaveBeenLastCalledWith(false)
+    expect(m.status.transitioning).toBe(false)
+  })
+
+  it('regeneratePairing flips transitioning around the rotation and returns settled status', async () => {
+    const mod = await import('../index')
+    await mod.enable()
+    const out = await mod.regeneratePairing()
+    // First flip true, last flip false — settled state in the returned status.
+    expect(m.setTransitioning).toHaveBeenNthCalledWith(1, true)
+    expect(m.setTransitioning).toHaveBeenLastCalledWith(false)
+    expect(out.transitioning).toBe(false)
   })
 })

--- a/src/server/routers/homekit.ts
+++ b/src/server/routers/homekit.ts
@@ -17,6 +17,7 @@ import { probeSeedSources, readIdentityIfPresent } from '@/src/homekit/storage'
 const statusSchema = z.object({
   enabled: z.boolean(),
   running: z.boolean(),
+  transitioning: z.boolean(),
   pincode: z.string().nullable(),
   setupId: z.string().nullable(),
   setupURI: z.string().nullable(),
@@ -39,6 +40,7 @@ async function buildStatus(): Promise<z.infer<typeof statusSchema>> {
   return {
     enabled: Boolean(row?.homekitEnabled),
     running: s.running,
+    transitioning: s.transitioning,
     pincode: s.pincode,
     setupId: s.setupId,
     setupURI: s.setupURI,

--- a/src/server/routers/tests/homekit.test.ts
+++ b/src/server/routers/tests/homekit.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
   homekitMock.unpair.mockReset().mockResolvedValue(undefined)
   homekitMock.status.mockReset().mockReturnValue({
     running: false,
+    transitioning: false,
     pincode: null,
     setupId: null,
     setupURI: null,
@@ -80,6 +81,7 @@ describe('homekit.getStatus', () => {
     dbMock.selectRow.homekitEnabled = false
     homekitMock.status.mockReturnValue({
       running: false,
+      transitioning: false,
       pincode: null,
       setupId: null,
       setupURI: null,
@@ -91,6 +93,7 @@ describe('homekit.getStatus', () => {
     expect(result).toEqual({
       enabled: false,
       running: false,
+      transitioning: false,
       pincode: null,
       setupId: null,
       setupURI: null,
@@ -104,6 +107,7 @@ describe('homekit.getStatus', () => {
     dbMock.selectRow.homekitEnabled = true
     homekitMock.status.mockReturnValue({
       running: true,
+      transitioning: false,
       pincode: '111-22-333',
       setupId: 'XYZ1',
       setupURI: 'X-HM://0024K0R3F',
@@ -114,6 +118,7 @@ describe('homekit.getStatus', () => {
 
     expect(result.enabled).toBe(true)
     expect(result.running).toBe(true)
+    expect(result.transitioning).toBe(false)
     expect(result.pincode).toBe('111-22-333')
     expect(result.qrDataUrl).toBe('data:image/png;base64,FAKE')
     expect(qrcodeMock.toDataURL).toHaveBeenCalledWith(
@@ -121,6 +126,23 @@ describe('homekit.getStatus', () => {
       { errorCorrectionLevel: 'Q', margin: 1 },
     )
     expect(result.pairedControllers).toEqual(['controllerA'])
+  })
+
+  it('surfaces transitioning=true when a lifecycle op is in flight', async () => {
+    dbMock.selectRow.homekitEnabled = true
+    homekitMock.status.mockReturnValue({
+      running: false,
+      transitioning: true,
+      pincode: null,
+      setupId: null,
+      setupURI: null,
+      pairedControllers: [],
+    })
+
+    const result = await caller.getStatus({})
+
+    expect(result.transitioning).toBe(true)
+    expect(result.running).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Three adversarial-review follow-ups from PR #566. Each is independently small; bundled because they touch the same files.

- **Sweep orphan AccessoryInfo on regenerate** (`sleepypod-core-46`) — `regenerate()` now delegates to `unpairAll()` so the old \`AccessoryInfo.<MAC>.json\` is cleared on rotation instead of left behind. Post-MAC-rotation the file was already unreachable; sweeping it removes the semantic split between the two rotation paths and brings regenerate under the same "abort if stopBridge left a live singleton" guard.
- **Document legacy wipe-stability** (\`sleepypod-core-47\`) — One-line comment in \`storage.ts:317\` explaining that a legacy identity (no rotation field) regenerates to \`newIdentity(0)\` — same value as a fresh \`/persistent\` wipe — so the first unpair on a legacy pod is wipe-stable per ADR-0020.
- **Surface transitioning flag** (\`sleepypod-core-45\`) — A getStatus() poll racing an unpair/regenerate sees \`running=false\` during the sub-second teardown. Snapshots were already self-consistent, but the UI had no way to tell "bridge rotating" from "bridge off." Added \`transitioning: boolean\` to \`BridgeStatus\`, flipped by a \`withTransition\` wrapper around enable/disable/unpair/regenerate (try/finally so throws don't strand it), exposed through the tRPC status schema.

## Test plan

- [x] \`pnpm exec vitest run\` — 1483 passed / 1 skipped across 80 files
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec eslint\` clean (changed files)
- [x] New bridge test: \`getStatus surfaces the transitioning flag flipped by setTransitioning\`
- [x] New bridge test: \`regenerate aborts when stopBridge fails to clear the singleton\`
- [x] Updated bridge test: \`regenerate stops the bridge, clears pairings, and replaces identity\` now asserts \`clearPairings\` is called
- [x] New index tests: in-flight \`transitioning=true\` visible to concurrent pollers, cleared on throw, settled in the regeneratePairing return value
- [x] New router test: status schema includes \`transitioning\` and surfaces \`true\` when set
- [ ] Manual: toggle HomeKit + unpair on a paired pod, confirm new pincode shown and old controller files no longer accumulate

Closes sleepypod-core-45, sleepypod-core-46, sleepypod-core-47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System status now reports a transitioning indicator to show when the bridge is performing lifecycle operations such as enabling, disabling, pairing, and regeneration.

* **Bug Fixes**
  * Added validation to detect incomplete bridge teardown during lifecycle transitions.

* **Tests**
  * Added test coverage for operation state tracking during transitions and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/571)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

🚀 **Latest build of `worktree-homekit-disocnnect`** — rebuilds every push, zero auth:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-homekit-disocnnect/scripts/install \
  | sudo bash -s -- --branch worktree-homekit-disocnnect
```

🎯 **Pin to this exact build** ([run 25839050184](https://github.com/sleepypod/core/actions/runs/25839050184) · `1dc2d04`):
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/1dc2d04aab861f787d7fcff48764719e100c8a5e/scripts/install \
  | sudo bash -s -- \
      --branch worktree-homekit-disocnnect \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25839050184/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25839050184/artifacts/6986235346) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
