### PR TITLE
install: fetch CI artifacts via nightly.link; auto-inject install commands into PR body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
                gets overwritten on the next CI run. Want to change what's
                here? Edit .github/workflows/build.yml instead. 💤 -->
           <details open>
-          <summary>🛏️ <strong>Beam this PR onto a Pod</strong> ✨</summary>
+          <summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>
 
           🚀 **Latest build of \`$HEAD_REF\`** — rebuilds every push, zero auth:
           \`\`\`bash
@@ -105,13 +105,16 @@ jobs:
           gh pr view "$PR_NUMBER" --json body --jq '.body // ""' > /tmp/body.md
 
           # Replace the marked section if it exists; otherwise append.
+          # Markers must sit at column 0 — anchoring with ^ stops the regex
+          # from matching when someone references the marker tokens inside
+          # backticks or prose in their PR description.
           python3 - <<'PY'
           import pathlib, re
           body = pathlib.Path('/tmp/body.md').read_text()
           section = pathlib.Path('/tmp/section.md').read_text().rstrip() + '\n'
           pattern = re.compile(
-              r'<!-- sleepypod:install-start -->.*?<!-- sleepypod:install-end -->\n?',
-              re.DOTALL,
+              r'^<!-- sleepypod:install-start -->.*?^<!-- sleepypod:install-end -->\n?',
+              re.DOTALL | re.MULTILINE,
           )
           if pattern.search(body):
               new_body = pattern.sub(section, body)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   build:
@@ -48,9 +49,83 @@ jobs:
           mv /tmp/sleepypod-core.tar.gz .
 
       - name: Upload artifact
+        id: upload
         uses: actions/upload-artifact@v7
         with:
           name: sleepypod-core
           path: sleepypod-core.tar.gz
           retention-days: 30
+
+      - name: Inject install commands into PR description
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SERVER: ${{ github.server_url }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${HEAD_SHA:0:7}"
+
+          cat > /tmp/section.md <<EOF
+          <!-- sleepypod:install-start -->
+          <!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
+               Hello fellow agent / curious human! Anything between the
+               sleepypod:install-start and sleepypod:install-end markers
+               gets overwritten on the next CI run. Want to change what's
+               here? Edit .github/workflows/build.yml instead. 💤 -->
+          <details open>
+          <summary>🛏️ <strong>Beam this PR onto a Pod</strong> ✨</summary>
+
+          🚀 **Latest build of \`$HEAD_REF\`** — rebuilds every push, zero auth:
+          \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/$REPO/$HEAD_REF/scripts/install \\
+            | sudo bash -s -- --branch $HEAD_REF
+          \`\`\`
+
+          🎯 **Pin to this exact build** ([run $RUN_ID]($SERVER/$REPO/actions/runs/$RUN_ID) · \`$SHORT_SHA\`):
+          \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/$REPO/$HEAD_SHA/scripts/install \\
+            | sudo bash -s -- \\
+                --branch $HEAD_REF \\
+                --artifact-url 'https://nightly.link/$REPO/actions/runs/$RUN_ID/sleepypod-core.zip'
+          \`\`\`
+
+          🧊 Artifact: [\`sleepypod-core\`]($ARTIFACT_URL) · self-destructs in 30 days 💥
+          </details>
+
+          <!-- sleepypod:install-end -->
+          EOF
+
+          # Fetch current body (jq's // "" handles null bodies).
+          gh pr view "$PR_NUMBER" --json body --jq '.body // ""' > /tmp/body.md
+
+          # Replace the marked section if it exists; otherwise append.
+          python3 - <<'PY'
+          import pathlib, re
+          body = pathlib.Path('/tmp/body.md').read_text()
+          section = pathlib.Path('/tmp/section.md').read_text().rstrip() + '\n'
+          pattern = re.compile(
+              r'<!-- sleepypod:install-start -->.*?<!-- sleepypod:install-end -->\n?',
+              re.DOTALL,
+          )
+          if pattern.search(body):
+              new_body = pattern.sub(section, body)
+          else:
+              sep = '\n\n' if body.strip() else ''
+              new_body = body.rstrip() + sep + section
+          pathlib.Path('/tmp/new-body.md').write_text(new_body)
+          PY
+
+          # Only push an edit when the body actually changed.
+          if ! cmp -s /tmp/body.md /tmp/new-body.md; then
+            gh pr edit "$PR_NUMBER" --body-file /tmp/new-body.md
+            echo "PR description updated."
+          else
+            echo "PR description already current — no edit needed."
+          fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -22,17 +22,24 @@ echo ""
 
 # --------------------------------------------------------------------------------
 # Mode flags
-#   --local    Skip download (code already on disk, e.g. via scp/deploy)
-#   --no-ssh   Skip interactive SSH setup prompt
-#   --branch X Install a specific branch (default: main)
+#   --local            Skip download (code already on disk, e.g. via scp/deploy)
+#   --no-ssh           Skip interactive SSH setup prompt
+#   --branch X         Install a specific branch (default: main). For branches
+#                      outside main/dev/latest, the latest successful build
+#                      artifact is fetched via nightly.link.
+#   --artifact-url URL Pin to an exact CI build artifact (zip from GH Actions).
+#                      Posted on every PR comment so reviewers can install the
+#                      exact SHA the run built, not whatever's latest.
 INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
+ARTIFACT_URL_OVERRIDE=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --local)  INSTALL_LOCAL=true ;;
-    --no-ssh) SKIP_SSH=true ;;
-    --branch) shift; INSTALL_BRANCH="${1:-}" ;;
+    --local)        INSTALL_LOCAL=true ;;
+    --no-ssh)       SKIP_SSH=true ;;
+    --branch)       shift; INSTALL_BRANCH="${1:-}" ;;
+    --artifact-url) shift; ARTIFACT_URL_OVERRIDE="${1:-}" ;;
   esac
   shift
 done
@@ -645,6 +652,52 @@ else
       else
         # Clean partial download before fallback
         find "$DOWNLOAD_DIR" -mindepth 1 -delete 2>/dev/null || true
+      fi
+    fi
+  fi
+
+  # Try a CI workflow artifact via nightly.link. Two paths in:
+  #   1. --artifact-url <url>  — pinned to an exact run (PR comments use this).
+  #   2. --branch <name>       — resolved to the latest successful build on
+  #                              that branch, for any branch outside main/dev.
+  # nightly.link proxies private GH artifact downloads as anonymous zips so
+  # the installer needs no auth. Artifact retention (build.yml) gates how
+  # long these stay reachable.
+  if [ "$HAS_BUILD" = false ]; then
+    ARTIFACT_URL="$ARTIFACT_URL_OVERRIDE"
+    if [ -z "$ARTIFACT_URL" ] && [ -n "$INSTALL_BRANCH" ] \
+        && [ "$INSTALL_BRANCH" != "main" ] \
+        && [ "$INSTALL_BRANCH" != "dev" ] \
+        && [ "$INSTALL_BRANCH" != "latest" ]; then
+      ARTIFACT_URL="https://nightly.link/${GITHUB_REPO}/workflows/build/${INSTALL_BRANCH}/sleepypod-core.zip"
+    fi
+
+    if [ -n "$ARTIFACT_URL" ]; then
+      echo "Downloading CI artifact from $ARTIFACT_URL..."
+      if curl -fSL "$ARTIFACT_URL" -o "$DOWNLOAD_DIR/artifact.zip"; then
+        # GH wraps every uploaded artifact in a zip; the tar.gz we want
+        # lives inside. Try unzip first; fall back to python3's zipfile
+        # since Pods reliably ship Python but not always unzip.
+        UNZIPPED=false
+        if command -v unzip &>/dev/null; then
+          unzip -q "$DOWNLOAD_DIR/artifact.zip" -d "$DOWNLOAD_DIR" && UNZIPPED=true
+        elif command -v python3 &>/dev/null; then
+          python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+            "$DOWNLOAD_DIR/artifact.zip" "$DOWNLOAD_DIR" && UNZIPPED=true
+        fi
+        rm -f "$DOWNLOAD_DIR/artifact.zip"
+
+        if [ "$UNZIPPED" = true ] && [ -f "$DOWNLOAD_DIR/sleepypod-core.tar.gz" ]; then
+          tar xzf "$DOWNLOAD_DIR/sleepypod-core.tar.gz" -C "$DOWNLOAD_DIR"
+          rm -f "$DOWNLOAD_DIR/sleepypod-core.tar.gz"
+          HAS_BUILD=true
+          echo "CI artifact downloaded (pre-built)."
+        else
+          echo "  Artifact extraction failed — falling back to source tarball"
+          find "$DOWNLOAD_DIR" -mindepth 1 -delete 2>/dev/null || true
+        fi
+      else
+        echo "  No artifact at $ARTIFACT_URL — falling back to source tarball"
       fi
     fi
   fi


### PR DESCRIPTION
## Summary

- **Installer**: adds `--artifact-url <url>` (pin to an exact CI run) and teaches `--branch <name>` to fetch the latest successful build artifact via [nightly.link](https://nightly.link) for any branch outside main/dev/latest. No GitHub token required, no per-branch tag, no git-history pollution.
- **CI**: the build workflow now edits a marked section of the PR description after each run, so the install commands appear at the top of the PR (above the bot-comment flood). Renders as a whimsical `<details open>` block with a hidden DO-NOT-EDIT marker for fellow agents.

This PR is itself the first test — once CI runs, its own description picks up the install block.

## Test plan

- [ ] CI build job passes
- [ ] After the build completes, the PR description gains a "Beam this PR onto a sleepypod" section bounded by the sleepypod-bot HTML markers
- [ ] Pushing another commit updates the run-id / SHA in the pinned block but does not duplicate the section
- [ ] (Manual) on a real sleepypod: the "Latest build" command resolves the nightly.link artifact and installs without falling back to the source tarball
- [ ] (Manual) the `--artifact-url` flag installs the pinned zip directly when supplied

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

🚀 **Latest build of `worktree-update-installer-w-build-arts`** — rebuilds every push, zero auth:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-update-installer-w-build-arts/scripts/install \
  | sudo bash -s -- --branch worktree-update-installer-w-build-arts
```

🎯 **Pin to this exact build** ([run 25838211299](https://github.com/sleepypod/core/actions/runs/25838211299) · `a8ccda8`):
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a8ccda8f6b52c5a506ae41f7e5b1d9e9b8859596/scripts/install \
  | sudo bash -s -- \
      --branch worktree-update-installer-w-build-arts \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25838211299/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25838211299/artifacts/6985965150) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
