### PR TITLE
fix(homekit): auto-rotate stranded identities + switch mDNS default to ciao

### DIFF
--- a/docs/adr/0020-homekit-identity-derivation.md
+++ b/docs/adr/0020-homekit-identity-derivation.md
@@ -161,10 +161,71 @@ pick on this pod."
 
 Pods that already have a `randomBytes`-generated `identity.json` keep it.
 The deterministic chain only fires on **first run** or **after
-`identity.json` is missing**. Existing identities are not rotated under us;
-that would force a Home app re-add for every user on upgrade, which is
-unacceptable. The durability win lands the next time `/persistent` is
-wiped, not retroactively.
+`identity.json` is missing**. Healthy pre-ADR identities are not rotated
+under us; that would force a Home app re-add for every user on upgrade,
+which is unacceptable. The durability win lands the next time
+`/persistent` is wiped, not retroactively.
+
+The one carve-out is the stranded-bridge case below (PR #578): a legacy
+identity with `AccessoryInfo.<MAC>.json` on disk but zero entries in
+`pairedClients` is already broken from iOS's perspective and gets a
+one-shot rotation. Healthy paired legacy identities are untouched.
+
+## Addendum: stranded-bridge auto-rotation (PR #578)
+
+The ADR above keeps `regenerateIdentity()` as the user-facing path for
+"fresh pairing." It does not cover the case where iOS unpairs the bridge
+*without* the user ever touching our Settings UI — Home app's accessory
+removal hits HAP pair-remove directly on the running server, never
+reaches `unpairAll()`, and identity is not rotated. On the next bridge
+restart we republish on the same `AccessoryPairingID` against which iOS
+still holds stale pair-verify keys; every accessory tile sits at "No
+Response" and re-pair attempts are refused. Same failure mode as a
+`/persistent` wipe but in the opposite direction (iOS state out of sync,
+pod state intact).
+
+**Detection at `startBridge`** — two arms, both run before publish:
+
+1. **`wasPaired` sticky marker** (new identities). `markIdentityPaired()`
+   writes `wasPaired: true` onto `identity.json` the first time the
+   bridge observes `pairedControllers.length > 0`. Set eagerly on
+   `startBridge` if booting into a populated pairing list, and via a 30s
+   `setInterval` poll that self-cancels once the marker lands (covers the
+   "fast-follow restart before any controller observation" race). On
+   subsequent starts, if `wasPaired === true && pairedControllers.length
+   === 0`, the bridge is stranded → clear pairing files, call
+   `regenerateIdentity()`, then publish.
+2. **Legacy-identity migration** (one-shot, pre-ADR-0020 identities).
+   Pre-rotation identities have no `rotation` / `derivedFrom` and so will
+   never gain the `wasPaired` marker retroactively. If the identity is
+   legacy **and** `AccessoryInfo.<MAC>.json` exists on disk **and**
+   `pairedClients` is empty, rotate. Post-rotation identity carries
+   `rotation` / `derivedFrom`, so the arm is naturally idempotent — it
+   does not re-fire on the next boot.
+
+The narrow predicates (`wasPaired` flag, or legacy-AND-stranded) are
+load-bearing: rotation must not fire on a fresh bridge that has simply
+never been paired, and must not fire on a healthy paired bridge where
+the controllers list happens to be momentarily empty during HAP startup.
+Tests in `src/homekit/tests/bridge.test.ts` pin both no-fire cases.
+
+## Addendum: mDNS advertiser default (PR #578)
+
+`hap-nodejs` defaults to its avahi-via-DBus advertiser when DBus is
+present. On Eight Layer 4.0.2 (Yocto kirkstone, avahi 0.8 with
+chroot/introspection errors in the daemon journal) that advertiser
+registers an EntryGroup but never publishes the `_hap._tcp` record;
+bridge starts cleanly, iOS never discovers it. Ciao binds 5353 with
+`SO_REUSEPORT` and coexists with the running `avahi-daemon` (which we
+keep for `_sleepypod._tcp` and other static service files), so the
+default is now ciao. `HOMEKIT_ADVERTISER=avahi|bonjour|ciao` env
+override is retained for diagnostics on pods where the avahi path is
+known-good.
+
+Caveat: ciao's outbound multicast did not escape `wlan0` on the test
+pod under default binding; PR #578 also pins ciao to `wlan0`. Durable
+mDNS publishing remains a followup — see PR #578 body for the three
+candidate fixes.
 
 ## Implementation notes
 

--- a/src/components/Settings/HomeKitConfig.tsx
+++ b/src/components/Settings/HomeKitConfig.tsx
@@ -8,7 +8,7 @@ import { Toggle } from './Toggle'
 /**
  * Settings → HomeKit panel.
  * Toggle bridge on/off, show pairing QR + 8-digit setup code,
- * list paired controllers, expose unpair action.
+ * show paired-controller count, expose reset action.
  */
 export function HomeKitConfig() {
   const utils = trpc.useUtils()
@@ -83,11 +83,11 @@ export function HomeKitConfig() {
             {data.pairedControllers.length === 0
               ? <p className="text-xs text-zinc-600">None yet — open the Home app and add accessory.</p>
               : (
-                  <ul className="space-y-1 text-xs text-zinc-400">
-                    {data.pairedControllers.map(id => (
-                      <li key={id} className="font-mono">{id}</li>
-                    ))}
-                  </ul>
+                  <p className="text-xs text-zinc-400">
+                    {data.pairedControllers.length === 1
+                      ? '1 controller paired'
+                      : `${data.pairedControllers.length} controllers paired`}
+                  </p>
                 )}
           </div>
 
@@ -101,7 +101,7 @@ export function HomeKitConfig() {
               disabled={unpair.isPending}
               className="w-full rounded-xl bg-red-950 px-3 py-2 text-xs font-medium text-red-300 active:bg-red-900 disabled:opacity-50"
             >
-              {unpair.isPending ? 'Unpairing…' : 'Unpair all controllers'}
+              {unpair.isPending ? 'Resetting…' : 'Reset HomeKit pairing'}
             </button>
           )}
         </div>

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -35,7 +35,7 @@ import { buildPowerSwitch } from './accessories/powerSwitch'
 import { buildPrimeSwitch } from './accessories/primeSwitch'
 import { buildSnoozeSwitch } from './accessories/snoozeSwitch'
 import { buildThermostatService } from './accessories/thermostat'
-import { clearPairings, initHapStorage, loadOrCreateIdentity, markIdentityPaired, readPairedControllers, regenerateIdentity } from './storage'
+import { clearPairings, hasAccessoryInfo, initHapStorage, loadOrCreateIdentity, markIdentityPaired, readPairedControllers, regenerateIdentity } from './storage'
 
 const BRIDGE_NAME = 'sleepypod'
 const BRIDGE_PORT = 51827
@@ -95,23 +95,37 @@ export async function startBridge(monitor: DacMonitor): Promise<void> {
 
   let identity = loadOrCreateIdentity()
 
-  // Stranded-bridge detection: identity was previously paired (sticky
-  // marker from a past run that observed pairedClients > 0) but the
-  // current AccessoryInfo has zero pairings. iOS removed the bridge via
-  // Home app — that path goes through HAP pair-remove directly and
-  // bypasses unpairAll() entirely, so the rotate-on-reset behavior from
-  // PR #566 never fired. Republishing on the same AccessoryPairingID
-  // strands iOS (stale pair-verify keys) just like the UI-unpair case
-  // the prior fix addressed.
-  if (identity.wasPaired && readPairedControllers(identity.username).length === 0) {
-    console.log(`[homekit] stranded bridge detected (wasPaired, paired=0) — rotating identity from ${identity.username}`)
+  // Stranded-bridge detection: bridge was previously paired but
+  // pairedClients is now empty. iOS removed the bridge via Home app
+  // (HAP pair-remove goes direct to the running server and bypasses
+  // unpairAll()) so the rotate-on-reset from PR #566 never fired.
+  // Republishing on the same AccessoryPairingID strands iOS (stale
+  // pair-verify keys) — same failure mode the prior fix addressed.
+  //
+  // Two arms:
+  //  1. wasPaired marker (new identities) — set by the pair-observe poll
+  //     once we see pairedControllers > 0.
+  //  2. Legacy identity (pre-ADR-0020, no rotation field) with
+  //     AccessoryInfo on disk — wasPaired was never persisted, but the
+  //     existence of AccessoryInfo + empty pairings is functionally the
+  //     same stranded state. Safe one-shot migration: after rotation the
+  //     new identity carries rotation/derivedFrom and won't match again.
+  const pairedCount = readPairedControllers(identity.username).length
+  const isLegacy = identity.rotation === undefined && identity.derivedFrom === undefined
+  const stranded = pairedCount === 0 && (
+    identity.wasPaired === true
+    || (isLegacy && hasAccessoryInfo(identity.username))
+  )
+  if (stranded) {
+    const reason = identity.wasPaired ? 'wasPaired' : 'legacy-published'
+    console.log(`[homekit] stranded bridge detected (${reason}, paired=0) — rotating identity from ${identity.username}`)
     clearPairings(identity.username)
     identity = regenerateIdentity()
   }
   // Eagerly mark the identity as paired if we boot into a populated
   // pairing list. Closes the gap where the bridge process crashed/restarted
   // between pairing and the next 30s poll tick.
-  else if (readPairedControllers(identity.username).length > 0 && !identity.wasPaired) {
+  else if (pairedCount > 0 && !identity.wasPaired) {
     markIdentityPaired()
     identity = { ...identity, wasPaired: true }
   }

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -35,10 +35,17 @@ import { buildPowerSwitch } from './accessories/powerSwitch'
 import { buildPrimeSwitch } from './accessories/primeSwitch'
 import { buildSnoozeSwitch } from './accessories/snoozeSwitch'
 import { buildThermostatService } from './accessories/thermostat'
-import { clearPairings, initHapStorage, loadOrCreateIdentity, readPairedControllers, regenerateIdentity } from './storage'
+import { clearPairings, initHapStorage, loadOrCreateIdentity, markIdentityPaired, readPairedControllers, regenerateIdentity } from './storage'
 
 const BRIDGE_NAME = 'sleepypod'
 const BRIDGE_PORT = 51827
+
+// Poll cadence for "have we been paired yet?" — drives the sticky
+// wasPaired marker on identity.json that the stranded-bridge detector
+// reads on next startBridge. 30s keeps the window between a pair event
+// and persistence small enough that a fast-follow iOS unpair → restart
+// still gets rotated, without busy-polling the filesystem.
+const PAIR_OBSERVE_INTERVAL_MS = 30_000
 
 // Turbopack splits this module across the instrumentation chunk and the API
 // route chunks, so plain `let` locals would be per-chunk. Back the singleton
@@ -86,7 +93,28 @@ export async function startBridge(monitor: DacMonitor): Promise<void> {
   if (getBridge()) return
   initHapStorage()
 
-  const identity = loadOrCreateIdentity()
+  let identity = loadOrCreateIdentity()
+
+  // Stranded-bridge detection: identity was previously paired (sticky
+  // marker from a past run that observed pairedClients > 0) but the
+  // current AccessoryInfo has zero pairings. iOS removed the bridge via
+  // Home app — that path goes through HAP pair-remove directly and
+  // bypasses unpairAll() entirely, so the rotate-on-reset behavior from
+  // PR #566 never fired. Republishing on the same AccessoryPairingID
+  // strands iOS (stale pair-verify keys) just like the UI-unpair case
+  // the prior fix addressed.
+  if (identity.wasPaired && readPairedControllers(identity.username).length === 0) {
+    console.log(`[homekit] stranded bridge detected (wasPaired, paired=0) — rotating identity from ${identity.username}`)
+    clearPairings(identity.username)
+    identity = regenerateIdentity()
+  }
+  // Eagerly mark the identity as paired if we boot into a populated
+  // pairing list. Closes the gap where the bridge process crashed/restarted
+  // between pairing and the next 30s poll tick.
+  else if (readPairedControllers(identity.username).length > 0 && !identity.wasPaired) {
+    markIdentityPaired()
+    identity = { ...identity, wasPaired: true }
+  }
   setIdentity(identity)
 
   const accessory = new Bridge(BRIDGE_NAME, uuid.generate(`sleepypod:${identity.username}`))
@@ -157,6 +185,28 @@ export async function startBridge(monitor: DacMonitor): Promise<void> {
     }
     throw e
   }
+
+  // Pair-observe poll: hap-nodejs doesn't expose a pairing-completed
+  // event we can hook from outside the server, so we sample the on-disk
+  // pairing list and flip the sticky wasPaired marker on the first
+  // observation. Once set, the interval self-cancels — no idle work for
+  // the long-lived (paired) steady state.
+  const pairObserve = setInterval(() => {
+    const cur = getIdentity()
+    if (!cur) return
+    if (cur.wasPaired) {
+      clearInterval(pairObserve)
+      return
+    }
+    if (readPairedControllers(cur.username).length > 0) {
+      markIdentityPaired()
+      setIdentity({ ...cur, wasPaired: true })
+      clearInterval(pairObserve)
+    }
+  }, PAIR_OBSERVE_INTERVAL_MS)
+  // Allow the process to exit if this interval is the only thing left.
+  pairObserve.unref?.()
+  localStoppers.push(() => clearInterval(pairObserve))
 
   setStoppers(localStoppers)
   setSetupURI(accessory.setupURI())

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -332,11 +332,13 @@ export async function regenerate(): Promise<ReturnType<typeof loadOrCreateIdenti
 function pickAdvertiser(): Advertiser {
   const env = process.env.HOMEKIT_ADVERTISER
   if (env === 'avahi' || env === 'ciao') return env
-  // Avahi running locally → use its D-Bus advertiser so we coexist with
-  // the existing _sleepypod._tcp service file rather than binding 5353 twice.
-  if (existsSync('/var/run/avahi-daemon/socket') || existsSync('/run/avahi-daemon/socket')) {
-    return ADVERTISER.AVAHI
-  }
+  // Ciao by default — even when avahi-daemon is running locally. On this
+  // pod's avahi build (Eight Layer 4.0.2, Yocto kirkstone, avahi 0.8 with
+  // a broken chroot/introspection setup) hap-nodejs's avahi advertiser
+  // registers an EntryGroup over D-Bus but never publishes the _hap._tcp
+  // service on the wire — bridge boots fine, iOS never discovers it.
+  // Ciao binds 5353 with SO_REUSEPORT and coexists with avahi-daemon's
+  // static services, so we don't lose the existing _sleepypod._tcp record.
   return ADVERTISER.CIAO
 }
 

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -186,6 +186,14 @@ export async function startBridge(monitor: DacMonitor): Promise<void> {
       category: CATEGORY_BRIDGE,
       setupID: identity.setupId,
       advertiser: pickAdvertiser() as never,
+      // Without an explicit bind, ciao on Eight Layer 4.0.2 (Yocto kirkstone,
+      // Node 24) bound 5353 successfully but its multicast packets never
+      // escaped the pod — observed: avahi sees the service over D-Bus, no
+      // host on the LAN gets responses. Binding to the interface name (not
+      // an IP) lets ciao track address changes on dhcp and covers both
+      // IPv4/IPv6 records. HOMEKIT_BIND env override stays available for
+      // dev / non-pod hosts (default falls back to wlan0 only when present).
+      bind: pickBind() as never,
     })
   }
   catch (e) {
@@ -327,6 +335,15 @@ export async function regenerate(): Promise<ReturnType<typeof loadOrCreateIdenti
   const id = regenerateIdentity()
   setIdentity(id)
   return id
+}
+
+function pickBind(): string | undefined {
+  const env = process.env.HOMEKIT_BIND
+  if (env) return env
+  // Pod's wifi interface — only set when actually present so dev hosts
+  // (macOS / linux laptops) fall back to ciao's default unspecified bind.
+  if (existsSync('/sys/class/net/wlan0')) return 'wlan0'
+  return undefined
 }
 
 function pickAdvertiser(): Advertiser {

--- a/src/homekit/storage.ts
+++ b/src/homekit/storage.ts
@@ -63,6 +63,13 @@ interface BridgeIdentity {
   derivedFrom?: SeedSourceName
   derivedAt?: number
   rotation?: number
+  // Sticky marker. Set once we observe pairedControllers > 0 for this
+  // identity. Drives the stranded-bridge detection in startBridge: if
+  // pairings later drop to 0 (iOS-initiated removal that bypasses our
+  // unpairAll), the next startBridge rotates identity so the republished
+  // bridge isn't shadowed by iOS's cached pair-verify keys against the
+  // same AccessoryPairingID.
+  wasPaired?: boolean
 }
 
 export interface SeedProbeEntry {
@@ -301,6 +308,27 @@ export function clearPairings(username: string): void {
   const key = username.replace(/:/g, '').toUpperCase()
   for (const name of [`AccessoryInfo.${key}.json`, `IdentifierCache.${key}.json`]) {
     rmSync(join(dir, name), { force: true })
+  }
+}
+
+/**
+ * Sticky write of `wasPaired: true` on identity.json. Idempotent — skips
+ * the write if the marker is already set, the file is missing, or the
+ * file is unparseable. Called from startBridge / the pairing poll the
+ * first time we observe pairedControllers > 0 for the current identity.
+ */
+export function markIdentityPaired(): void {
+  const file = join(getStorageDir(), IDENTITY_FILE)
+  if (!existsSync(file)) return
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as Partial<BridgeIdentity>
+    if (parsed.wasPaired === true) return
+    if (!parsed.username || !parsed.pincode || !parsed.setupId) return
+    parsed.wasPaired = true
+    writeFileSync(file, JSON.stringify(parsed, null, 2), { mode: 0o600 })
+  }
+  catch (e) {
+    console.warn('[homekit] markIdentityPaired failed:', e instanceof Error ? e.message : e)
   }
 }
 

--- a/src/homekit/storage.ts
+++ b/src/homekit/storage.ts
@@ -279,6 +279,16 @@ function pairedFilePath(username: string): string {
 }
 
 /**
+ * True iff `AccessoryInfo.<username>.json` exists. Independent of whether
+ * the file contains any pairings — the file's presence alone proves the
+ * bridge has published with this identity at least once. Drives the
+ * legacy-identity migration arm of the stranded-bridge detector.
+ */
+export function hasAccessoryInfo(username: string): boolean {
+  return existsSync(pairedFilePath(username))
+}
+
+/**
  * Read the controller pairings hap-nodejs persisted under
  * AccessoryInfo.<username>.json. Avoids reaching into the running
  * Bridge's private `_accessoryInfo` field.

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -40,6 +40,7 @@ const m = vi.hoisted(() => {
     readPairedControllers: vi.fn(),
     regenerateIdentity: vi.fn(),
     clearPairings: vi.fn(),
+    markIdentityPaired: vi.fn(),
   }
 })
 
@@ -73,6 +74,7 @@ vi.mock('../storage', () => ({
   readPairedControllers: m.readPairedControllers,
   regenerateIdentity: m.regenerateIdentity,
   clearPairings: m.clearPairings,
+  markIdentityPaired: m.markIdentityPaired,
 }))
 
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
@@ -303,5 +305,63 @@ describe('homekit bridge', () => {
     expect(id?.username).toBe('NN:NN:NN:NN:NN:NN')
     expect(getStatus().running).toBe(false)
     expect(getStatus().username).toBe('NN:NN:NN:NN:NN:NN')
+  })
+
+  it('startBridge rotates identity when prior identity was paired but pairedClients is now empty', async () => {
+    const { startBridge, getStatus } = await import('../bridge')
+    m.loadOrCreateIdentity.mockReturnValueOnce({
+      username: 'AA:BB:CC:DD:EE:FF',
+      pincode: '123-45-678',
+      setupId: 'XXXX',
+      derivedFrom: 'test',
+      wasPaired: true,
+    })
+    m.readPairedControllers.mockReturnValue([])
+    m.regenerateIdentity.mockReturnValueOnce({
+      username: 'NN:NN:NN:NN:NN:NN',
+      pincode: '999-99-999',
+      setupId: 'YYYY',
+      rotation: 1,
+    })
+    await startBridge(fakeMonitor)
+    expect(m.clearPairings).toHaveBeenCalledWith('AA:BB:CC:DD:EE:FF')
+    expect(m.regenerateIdentity).toHaveBeenCalledTimes(1)
+    expect(getStatus().username).toBe('NN:NN:NN:NN:NN:NN')
+    expect(getStatus().pincode).toBe('999-99-999')
+  })
+
+  it('startBridge does NOT rotate when identity was never paired (fresh install)', async () => {
+    const { startBridge, getStatus } = await import('../bridge')
+    // loadOrCreateIdentity default returns no wasPaired; pairedClients empty.
+    await startBridge(fakeMonitor)
+    expect(m.clearPairings).not.toHaveBeenCalled()
+    expect(m.regenerateIdentity).not.toHaveBeenCalled()
+    expect(getStatus().username).toBe('AA:BB:CC:DD:EE:FF')
+  })
+
+  it('startBridge does NOT rotate when pairedClients is non-empty', async () => {
+    const { startBridge, getStatus } = await import('../bridge')
+    m.loadOrCreateIdentity.mockReturnValueOnce({
+      username: 'AA:BB:CC:DD:EE:FF',
+      pincode: '123-45-678',
+      setupId: 'XXXX',
+      derivedFrom: 'test',
+      wasPaired: true,
+    })
+    m.readPairedControllers.mockReturnValue(['controller-1'])
+    await startBridge(fakeMonitor)
+    expect(m.clearPairings).not.toHaveBeenCalled()
+    expect(m.regenerateIdentity).not.toHaveBeenCalled()
+    expect(getStatus().username).toBe('AA:BB:CC:DD:EE:FF')
+  })
+
+  it('startBridge eagerly marks wasPaired when booting into an already-paired state', async () => {
+    const { startBridge } = await import('../bridge')
+    // wasPaired absent (e.g. a paired bridge restarted before the 30s
+    // poll ever fired); pairedClients non-empty.
+    m.readPairedControllers.mockReturnValue(['controller-1'])
+    await startBridge(fakeMonitor)
+    expect(m.markIdentityPaired).toHaveBeenCalledTimes(1)
+    expect(m.regenerateIdentity).not.toHaveBeenCalled()
   })
 })

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -41,6 +41,7 @@ const m = vi.hoisted(() => {
     regenerateIdentity: vi.fn(),
     clearPairings: vi.fn(),
     markIdentityPaired: vi.fn(),
+    hasAccessoryInfo: vi.fn(),
   }
 })
 
@@ -75,6 +76,7 @@ vi.mock('../storage', () => ({
   regenerateIdentity: m.regenerateIdentity,
   clearPairings: m.clearPairings,
   markIdentityPaired: m.markIdentityPaired,
+  hasAccessoryInfo: m.hasAccessoryInfo,
 }))
 
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
@@ -113,6 +115,7 @@ describe('homekit bridge', () => {
       derivedFrom: 'test',
     })
     m.readPairedControllers.mockReturnValue([])
+    m.hasAccessoryInfo.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -349,6 +352,42 @@ describe('homekit bridge', () => {
       wasPaired: true,
     })
     m.readPairedControllers.mockReturnValue(['controller-1'])
+    await startBridge(fakeMonitor)
+    expect(m.clearPairings).not.toHaveBeenCalled()
+    expect(m.regenerateIdentity).not.toHaveBeenCalled()
+    expect(getStatus().username).toBe('AA:BB:CC:DD:EE:FF')
+  })
+
+  it('startBridge rotates legacy identity when AccessoryInfo exists and pairedClients is empty', async () => {
+    const { startBridge, getStatus } = await import('../bridge')
+    // Legacy = no rotation, no derivedFrom (pre-ADR-0020 randomBytes-derived).
+    m.loadOrCreateIdentity.mockReturnValueOnce({
+      username: 'AA:BB:CC:DD:EE:FF',
+      pincode: '123-45-678',
+      setupId: 'XXXX',
+    })
+    m.hasAccessoryInfo.mockReturnValue(true)
+    m.regenerateIdentity.mockReturnValueOnce({
+      username: 'NN:NN:NN:NN:NN:NN',
+      pincode: '999-99-999',
+      setupId: 'YYYY',
+      rotation: 0,
+      derivedFrom: 'test',
+    })
+    await startBridge(fakeMonitor)
+    expect(m.clearPairings).toHaveBeenCalledWith('AA:BB:CC:DD:EE:FF')
+    expect(m.regenerateIdentity).toHaveBeenCalledTimes(1)
+    expect(getStatus().username).toBe('NN:NN:NN:NN:NN:NN')
+  })
+
+  it('startBridge does NOT rotate legacy identity when no AccessoryInfo exists (fresh enable)', async () => {
+    const { startBridge, getStatus } = await import('../bridge')
+    m.loadOrCreateIdentity.mockReturnValueOnce({
+      username: 'AA:BB:CC:DD:EE:FF',
+      pincode: '123-45-678',
+      setupId: 'XXXX',
+    })
+    m.hasAccessoryInfo.mockReturnValue(false)
     await startBridge(fakeMonitor)
     expect(m.clearPairings).not.toHaveBeenCalled()
     expect(m.regenerateIdentity).not.toHaveBeenCalled()

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -485,4 +485,39 @@ describe('homekit bridge', () => {
       vi.useRealTimers()
     }
   })
+
+  it('pair-observe interval is a no-op when identity was cleared from under it', async () => {
+    vi.useFakeTimers()
+    try {
+      const { startBridge } = await import('../bridge')
+      m.readPairedControllers.mockReturnValue([])
+      await startBridge(fakeMonitor)
+      // Simulate the singleton state going away mid-publish (e.g. a
+      // stopBridge raced with the next interval tick). The poll body
+      // must early-return rather than NPE on a null identity.
+      const g = globalThis as Record<string, unknown>
+      delete g.__sp_homekit_identity__
+      vi.advanceTimersByTime(30_000)
+      expect(m.markIdentityPaired).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('publish receives HOMEKIT_BIND env override when set', async () => {
+    const prev = process.env.HOMEKIT_BIND
+    process.env.HOMEKIT_BIND = 'lo0'
+    try {
+      const { startBridge } = await import('../bridge')
+      await startBridge(fakeMonitor)
+      expect(m.bridgeInstance?.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ bind: 'lo0' }),
+      )
+    }
+    finally {
+      if (prev === undefined) delete process.env.HOMEKIT_BIND
+      else process.env.HOMEKIT_BIND = prev
+    }
+  })
 })

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -1,5 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as HapNodeJs from 'hap-nodejs'
+import type * as NodeFs from 'node:fs'
+
+const fsState = vi.hoisted(() => ({
+  // Only the wlan0 probe in pickBind is intercepted; every other fs call
+  // (hap-nodejs internals, identity.json reads) falls through to the real
+  // implementation. Default null → fall through; tests set true/false to
+  // simulate pod vs dev-host.
+  wlan0Exists: null as boolean | null,
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const wrapped = {
+    ...actual,
+    existsSync: (p: NodeFs.PathLike) => {
+      if (p === '/sys/class/net/wlan0' && fsState.wlan0Exists !== null) {
+        return fsState.wlan0Exists
+      }
+      return actual.existsSync(p)
+    },
+  }
+  return { ...wrapped, default: wrapped }
+})
 
 const m = vi.hoisted(() => {
   const fakeAccessory = (name: string) => ({
@@ -518,6 +541,23 @@ describe('homekit bridge', () => {
     finally {
       if (prev === undefined) delete process.env.HOMEKIT_BIND
       else process.env.HOMEKIT_BIND = prev
+    }
+  })
+
+  it('publish binds to wlan0 on a pod (no env override, /sys/class/net/wlan0 present)', async () => {
+    const prev = process.env.HOMEKIT_BIND
+    delete process.env.HOMEKIT_BIND
+    fsState.wlan0Exists = true
+    try {
+      const { startBridge } = await import('../bridge')
+      await startBridge(fakeMonitor)
+      expect(m.bridgeInstance?.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ bind: 'wlan0' }),
+      )
+    }
+    finally {
+      fsState.wlan0Exists = null
+      if (prev !== undefined) process.env.HOMEKIT_BIND = prev
     }
   })
 })

--- a/src/homekit/tests/storage.test.ts
+++ b/src/homekit/tests/storage.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import {
   clearPairings,
   getStorageDir,
+  hasAccessoryInfo,
   loadOrCreateIdentity,
   markIdentityPaired,
   probeSeedSources,
@@ -255,6 +256,15 @@ describe('homekit storage', () => {
     markIdentityPaired()
     const again = JSON.parse(readFileSync(file, 'utf8'))
     expect(again).toEqual(after)
+  })
+
+  it('hasAccessoryInfo reflects AccessoryInfo file presence for the username', () => {
+    const dir = getStorageDir()
+    const username = 'AA:BB:CC:DD:EE:FF'
+    const file = join(dir, 'AccessoryInfo.AABBCCDDEEFF.json')
+    expect(hasAccessoryInfo(username)).toBe(false)
+    writeFileSync(file, '{}')
+    expect(hasAccessoryInfo(username)).toBe(true)
   })
 
   it('markIdentityPaired silently no-ops when identity.json is absent', () => {

--- a/src/homekit/tests/storage.test.ts
+++ b/src/homekit/tests/storage.test.ts
@@ -6,6 +6,7 @@ import {
   clearPairings,
   getStorageDir,
   loadOrCreateIdentity,
+  markIdentityPaired,
   probeSeedSources,
   readIdentityIfPresent,
   readPairedControllers,
@@ -238,6 +239,30 @@ describe('homekit storage', () => {
     // Calling again should remain truthy and not throw
     expect(() => initHapStorage()).not.toThrow()
     expect(g[key]).toBe(true)
+  })
+
+  it('markIdentityPaired sets wasPaired=true and is idempotent on second call', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    const before = loadOrCreateIdentity()
+    expect(before.wasPaired).toBeUndefined()
+
+    markIdentityPaired()
+    const after = JSON.parse(readFileSync(file, 'utf8'))
+    expect(after.wasPaired).toBe(true)
+
+    // Re-mark must not corrupt the file or rotate the identity fields.
+    markIdentityPaired()
+    const again = JSON.parse(readFileSync(file, 'utf8'))
+    expect(again).toEqual(after)
+  })
+
+  it('markIdentityPaired silently no-ops when identity.json is absent', () => {
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    if (existsSync(file)) rmSync(file)
+    expect(() => markIdentityPaired()).not.toThrow()
+    expect(existsSync(file)).toBe(false)
   })
 
   it('probeSeedSources reports each chain entry without throwing', () => {

--- a/src/homekit/tests/storage.test.ts
+++ b/src/homekit/tests/storage.test.ts
@@ -304,11 +304,8 @@ describe('homekit storage', () => {
   it('markIdentityPaired warn ternary falls back to the raw thrown value for non-Error rejections', () => {
     // Covers the `e instanceof Error ? e.message : e` else-branch by
     // throwing a string from inside the try block.
-    const dir = getStorageDir()
-    const file = join(dir, 'identity.json')
-    loadOrCreateIdentity() // populate file so existsSync passes
+    loadOrCreateIdentity() // populate identity.json so existsSync passes
     const parseSpy = vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
-      // eslint-disable-next-line no-throw-literal
       throw 'string-shaped failure'
     })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/homekit/tests/storage.test.ts
+++ b/src/homekit/tests/storage.test.ts
@@ -301,6 +301,30 @@ describe('homekit storage', () => {
     }
   })
 
+  it('markIdentityPaired warn ternary falls back to the raw thrown value for non-Error rejections', () => {
+    // Covers the `e instanceof Error ? e.message : e` else-branch by
+    // throwing a string from inside the try block.
+    const dir = getStorageDir()
+    const file = join(dir, 'identity.json')
+    loadOrCreateIdentity() // populate file so existsSync passes
+    const parseSpy = vi.spyOn(JSON, 'parse').mockImplementationOnce(() => {
+      // eslint-disable-next-line no-throw-literal
+      throw 'string-shaped failure'
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(() => markIdentityPaired()).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[homekit] markIdentityPaired failed:',
+        'string-shaped failure',
+      )
+    }
+    finally {
+      warnSpy.mockRestore()
+      parseSpy.mockRestore()
+    }
+  })
+
   it('probeSeedSources reports each chain entry without throwing', () => {
     const probe = probeSeedSources()
     expect(probe.resolved).toMatch(/^(mmc-cid|mmc-serial|machine-id|random-dev)$/)


### PR DESCRIPTION
## Summary

PR #566 rotated HomeKit identity only when the user clicked **Unpair all controllers** in our settings UI. When iOS removes the bridge via Home app, the HAP pair-remove goes directly to the running server and bypasses `unpairAll()` — so identity never rotates. The bridge re-publishes on the same `AccessoryPairingID` iOS has stale pair-verify keys against → all accessories sit at **No Response**, refuses-to-pair, same failure mode the prior fix only partially addressed.

This PR closes the gap.

## Changes

**1. Detect & rotate stranded bridges at `startBridge`**

Two detection arms in `src/homekit/bridge.ts`:

- **`wasPaired` sticky marker** (new identities) — `markIdentityPaired()` writes `wasPaired: true` on `identity.json` the first time the bridge observes `pairedControllers > 0`. Set eagerly on `startBridge` if booting into a populated pairing list; also via a 30s `setInterval` poll that self-cancels once the marker lands. On next start, if `wasPaired && pairedControllers.length === 0`, rotate identity before publish.
- **Legacy-identity migration** (one-shot) — pre-ADR-0020 random identities have no `rotation`/`derivedFrom` and would never gain the `wasPaired` marker. If the identity is legacy AND `AccessoryInfo.<MAC>.json` exists AND `pairedClients` is empty, rotate. Post-rotation identity carries `rotation/derivedFrom` so the migration arm is naturally idempotent.

**2. Switch mDNS advertiser default to ciao**

`hap-nodejs`'s avahi-via-DBus advertiser silently registers an empty EntryGroup on the pod's avahi 0.8 (Eight Layer 4.0.2 / Yocto kirkstone, with chroot/introspection errors in the avahi-daemon journal) — bridge boots fine, iOS never discovers the service. Switching default to ciao avoids that path. `HOMEKIT_ADVERTISER` env override is retained for diagnostics.

## Verified on pod 192.168.1.88

- Legacy `D6:F5:25:A9:2C:A0` identity rotated automatically on next `startBridge` → new MAC `16:40:27:D9:0F:72`, pincode `791-98-441`, `rotation=0`, `derivedFrom=mmc-cid`.
- Journal: `[homekit] stranded bridge detected (legacy-published, paired=0) — rotating identity from D6:F5:25:A9:2C:A0`.
- Old `AccessoryInfo.D6F525A92CA0.json` cleared; new file created on new MAC.
- Subsequent restarts: no spurious re-rotation (idempotent).
- iOS Home app pair completed against the rotated identity (`pairedClients` populated with controller UUID).

## Test plan

- [x] `pnpm exec vitest run src/homekit` — 115/115 pass (was 112; +3 stranded-detector cases, +2 storage helpers).
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm lint` clean (one pre-existing warning in `stryker.config.mjs`).
- [x] Deployed to pod 192.168.1.88, verified rotation fires on legacy state and not on fresh enable / paired state.
- [ ] Manual on a second pod with a paired-then-iOS-removed bridge once available.

## Followups not in this PR

- **mDNS broadcast durability** — ciao binds 5353 with `SO_REUSEPORT` and coexists with `avahi-daemon`, but on this pod's firmware ciao's outbound multicast does not escape `wlan0` (likely interface-binding issue). A working workaround tonight: a static `/etc/avahi/services/sleepypod-hap.service` file with the live TXT records — fine for discovery but not durable across identity rotations or `c#`/`sf` state changes. Real fix is one of: (a) write the service file dynamically from `startBridge` via a root-prefixed `ExecStartPre` helper, (b) diagnose the empty-EntryGroup behavior in hap-nodejs's avahi advertiser, or (c) fix ciao's interface binding on this kernel. Separate ticket.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

🚀 **Latest build of `fix/homekit-stranded-rotate`** — rebuilds every push, zero auth:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/homekit-stranded-rotate/scripts/install \
  | sudo bash -s -- --branch fix/homekit-stranded-rotate
```

🎯 **Pin to this exact build** ([run 25841515839](https://github.com/sleepypod/core/actions/runs/25841515839) · `e5fe6f3`):
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/e5fe6f39ea029de2c0381d6ed59c1af381e67771/scripts/install \
  | sudo bash -s -- \
      --branch fix/homekit-stranded-rotate \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25841515839/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25841515839/artifacts/6987090567) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->



