### PR TITLE
fix(sp-update): run biometrics-archiver install on OTA upgrades (#576)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,13 @@ model, and what's deferred until `protectedProcedure` lands.
 graph LR
     subgraph HW ["Pod Hardware"]
         DAC["dac.sock"]
-        RAW["/persistent/*.RAW"]
+        FRANK["frankenfirmware<br/>(cwd: /persistent/biometrics)"]
+    end
+
+    subgraph RAWFS ["RAW frames — ADR 0018"]
+        TMPFS["/persistent/biometrics/*.RAW<br/>tmpfs · 500 MB · hot"]
+        ARCH["/persistent/biometrics-archive/<br/>eMMC · gzip cold"]
+        TMPFS -. "archiver timer 15m" .-> ARCH
     end
 
     subgraph TRANSPORT ["Hardware Transport"]
@@ -279,13 +285,16 @@ graph LR
     SCHED -->|on success| BMS
     BMS --> BF
 
+    %% RAW pipeline — firmware writes hot tmpfs, archiver rolls cold to eMMC
+    FRANK -->|writes CBOR| TMPFS
+
     %% WebSocket delivery
     BF --> WS
-    RAW -->|tail CBOR| WS
+    TMPFS -->|tail CBOR| WS
     WS -->|push frames| UI
 
     %% Biometrics pipeline
-    RAW --> PP & SD
+    TMPFS --> PP & SD
     PP & SD --> BIODB
     BIODB -->|query| API
 
@@ -296,27 +305,33 @@ graph LR
 
 ### Biometrics data flow
 
-The Pod hardware daemon continuously writes raw sensor data to `/persistent/*.RAW` as CBOR-encoded binary records. Independent Python sidecar processes tail these files, extract signals, and write results to `biometrics.db`. The core app never touches raw data — it reads clean rows via tRPC.
+The Pod hardware daemon (frankenfirmware) writes raw sensor data continuously as CBOR-encoded binary records into `/persistent/biometrics/*.RAW`, which is a **500 MB tmpfs** to keep ~1 GB/day of writes off the eMMC. An archiver timer gzips files older than 15 minutes into `/persistent/biometrics-archive/` on eMMC (cold storage with a pruner cap of 80% disk usage). See **[ADR 0018](docs/adr/0018-tmpfs-raw-frames.md)** for the firmware-integration rationale, including how `SEQNO.RAW` and state directories are symlinked through so the firmware sees its persistent state unchanged.
+
+Independent Python sidecar processes tail the hot tmpfs files, extract signals, and write results to `biometrics.db` (durable on eMMC). The core app never touches raw data — it reads clean rows via tRPC.
 
 ```mermaid
 sequenceDiagram
-    participant HW as Pod Hardware
-    participant RAW as RAW Files
+    participant HW as Pod Hardware<br/>(frankenfirmware)
+    participant TMPFS as /persistent/biometrics<br/>(tmpfs, 500 MB)
+    participant ARCH as /persistent/biometrics-archive<br/>(eMMC, gzip cold)
     participant PP as piezo-processor
     participant SD as sleep-detector
     participant BDB as biometrics.db
     participant UI as Web UI
 
-    HW->>RAW: writes CBOR records (500Hz piezo, capSense)
+    HW->>TMPFS: writes CBOR records (500Hz piezo, capSense)
     loop every ~60s
-        PP->>RAW: tail + decode piezo-dual records
+        PP->>TMPFS: tail + decode piezo-dual records
         PP->>PP: bandpass filter, HR/HRV/breathing rate
         PP->>BDB: INSERT vitals row
     end
     loop continuously
-        SD->>RAW: tail + decode capSense records
+        SD->>TMPFS: tail + decode capSense records
         SD->>SD: capacitance threshold, presence/absence
         SD->>BDB: INSERT sleep_record on session end
+    end
+    loop every 15 min
+        TMPFS->>ARCH: gzip files older than 15 min
     end
     UI->>BDB: tRPC getVitals / getSleepRecords
 ```
@@ -572,7 +587,7 @@ Key decisions are documented in [`docs/adr/`](docs/adr/):
 | [0014](docs/adr/0014-sensor-calibration.md) | Per-sensor calibration profiles |
 | [0015](docs/adr/0015-event-bus-mutation-broadcast.md) | Event bus: broadcast device state after mutations |
 | [0017](docs/adr/0017-uv-python-package-management.md) | uv for Python module package management |
-| [0018](docs/adr/0018-tmpfs-raw-frames.md) | Tmpfs for `/persistent/*.RAW` to spare eMMC writes |
+| [0018](docs/adr/0018-tmpfs-raw-frames.md) | Tmpfs at `/persistent/biometrics/` for live RAW frames + gzip cold archive on eMMC |
 | [0019](docs/adr/0019-mqtt-bridge.md) | MQTT bridge for Home Assistant integration |
 | [0020](docs/adr/0020-homekit-identity-derivation.md) | Deterministic HomeKit identity from hardware-rooted seed |
 
@@ -588,7 +603,7 @@ Config/state and time-series biometrics have fundamentally different access patt
 Heart rate extraction from 500 Hz piezoelectric data requires FFT, bandpass filtering, and peak detection. Python's scipy/numpy ecosystem handles this naturally. A crash in a Python module has zero impact on the core app.
 
 **How does real-time data reach clients?**
-A WebSocket server on port 3001 (`piezoStream`) acts as a read-only pub/sub channel. It streams raw sensor data (piezo, bed temp, capacitance) by tailing `/persistent/*.RAW`, and pushes `deviceStatus` frames via two buses:
+A WebSocket server on port 3001 (`piezoStream`) acts as a read-only pub/sub channel. It streams raw sensor data (piezo, bed temp, capacitance) by tailing `/persistent/biometrics/*.RAW` (tmpfs, per ADR 0018), and pushes `deviceStatus` frames via two buses:
 - **Read bus** — DacMonitor polls hardware every 2s and broadcasts the authoritative `deviceStatus` frame. This is the consistency backstop.
 - **Write bus** — After any hardware mutation succeeds (user-initiated via tRPC or automated via Scheduler), `broadcastMutationStatus()` overlays the changed fields onto the last polled status and broadcasts immediately. All connected clients see the change within ~200ms.
 

--- a/docs/adr/0012-biometrics-module-system.md
+++ b/docs/adr/0012-biometrics-module-system.md
@@ -10,7 +10,7 @@ sleepypod needs to process raw biometric sensor data from the Pod hardware and d
 The key constraints are:
 
 - **Signal processing is compute-heavy**: Heart rate extraction from 500 Hz piezoelectric data requires FFT, bandpass filtering, and peak detection. Node.js is not suited for this; Python (scipy/numpy) or Rust handle it naturally.
-- **Raw data is filesystem-based**: The hardware daemon writes binary CBOR files to `/persistent/*.RAW` continuously. There is no streaming API through `dac.sock` — that socket is command/response only.
+- **Raw data is filesystem-based**: The hardware daemon writes binary CBOR files to `/persistent/biometrics/*.RAW` continuously (tmpfs since ADR 0018; previously `/persistent/*.RAW` on eMMC). There is no streaming API through `dac.sock` — that socket is command/response only.
 - **Embedded hardware**: The Pod runs constrained Linux (ARM). Heavy dependencies (InfluxDB, message queues, etc.) are ruled out.
 - **Community extensibility**: We want people to be able to swap in better algorithms (e.g., a Rust implementation, an ML-based sleep scorer) without touching the core app.
 - **Time-series vs config data have different access patterns**: Config/state data is small and randomly accessed. Biometrics data is append-only, queried by time range, and may grow to tens of thousands of rows.
@@ -22,14 +22,17 @@ We will use a **plugin/sidecar module system** with a **separate `biometrics.db`
 The architecture:
 
 ```text
-/persistent/*.RAW   ←  hardware daemon writes CBOR sensor data continuously
-       ↓
-[module process]    reads + tails RAW files, processes signals (any language)
-       ↓
-[biometrics.db]     module writes to agreed schema tables
-       ↑
-[sleepypod-core]    reads biometrics.db via tRPC API → UI
+/persistent/biometrics/*.RAW   ←  hardware daemon writes CBOR sensor data
+                                  continuously into tmpfs (ADR 0018)
+                ↓
+        [module process]       reads + tails RAW files, processes signals (any language)
+                ↓
+        [biometrics.db]        module writes to agreed schema tables (eMMC, durable)
+                ↑
+        [sleepypod-core]       reads biometrics.db via tRPC API → UI
 ```
+
+The path above is the **hot** RAW dir on tmpfs. Files older than 15 minutes are gzipped into `/persistent/biometrics-archive/` on eMMC by a separate archiver/pruner pair — modules read from the hot path only and need not be aware of the cold archive.
 
 The **database schema is the public contract**. Modules do not call into the core app. The core app does not call into modules. They share only a file.
 
@@ -151,7 +154,7 @@ modules/
 ```
 
 Each module:
-1. Tails `/persistent/*.RAW` for new CBOR sensor data
+1. Tails `/persistent/biometrics/*.RAW` for new CBOR sensor data
 2. Processes its relevant signal type
 3. Writes results to `biometrics.db` using transactions
 4. Writes its health status to `system_health` table in `sleepypod.db`

--- a/docs/hardware/calibration-architecture.md
+++ b/docs/hardware/calibration-architecture.md
@@ -22,7 +22,7 @@ graph TB
     end
 
     G[/tmp/sleepypod-calibrate<br/>trigger file/]
-    H[/persistent/*.RAW<br/>sensor data/]
+    H[/persistent/biometrics/*.RAW<br/>sensor data · tmpfs · ADR 0018/]
 
     A -->|"calibration.trigger()"| B
     B -->|"write trigger file"| G
@@ -43,9 +43,9 @@ graph TB
 | Component | Reads | Writes |
 |---|---|---|
 | tRPC calibration router | `calibration_profiles`, `calibration_runs`, `vitals_quality` | trigger file only |
-| Calibrator module | `/persistent/*.RAW`, trigger file | `calibration_profiles`, `calibration_runs` |
-| Piezo processor | `calibration_profiles`, `/persistent/*.RAW` | `vitals`, `vitals_quality` |
-| Sleep detector | `calibration_profiles`, `/persistent/*.RAW` | `sleep_records`, `movement` |
+| Calibrator module | `/persistent/biometrics/*.RAW`, trigger file | `calibration_profiles`, `calibration_runs` |
+| Piezo processor | `calibration_profiles`, `/persistent/biometrics/*.RAW` | `vitals`, `vitals_quality` |
+| Sleep detector | `calibration_profiles`, `/persistent/biometrics/*.RAW` | `sleep_records`, `movement` |
 
 ## Database Schema
 
@@ -130,7 +130,7 @@ sequenceDiagram
 
     Cal->>FS: detect trigger file, read + delete
     Cal->>DB: INSERT calibration_runs (trigger='on_demand', status='running')
-    Cal->>FS: read latest /persistent/*.RAW (last 5 minutes of data)
+    Cal->>FS: read latest /persistent/biometrics/*.RAW (last 5 minutes of data)
 
     Note over Cal: For each side + sensor_type:<br/>1. Extract relevant signal band<br/>2. Compute RMS, P95, mean, std<br/>3. Derive adaptive thresholds
 
@@ -156,7 +156,7 @@ sequenceDiagram
 sequenceDiagram
     participant Timer as systemd timer (03:00)
     participant Cal as Calibrator Module
-    participant FS as /persistent/*.RAW
+    participant FS as /persistent/biometrics/*.RAW
     participant DB as biometrics.db
     participant Piezo as Piezo Processor
     participant Sleep as Sleep Detector

--- a/docs/hardware/calibration-architecture.md
+++ b/docs/hardware/calibration-architecture.md
@@ -6,36 +6,49 @@ Technical architecture for the sleepypod-core sensor calibration system. Covers 
 
 ```mermaid
 graph TB
-    subgraph iOS["iOS App"]
-        A[Calibration UI]
+    subgraph Triggers["Triggers"]
+        A[Calibration UI<br/>iOS App]
+        T[systemd timer<br/>OnCalendar=*-*-* 03:00:00]
     end
 
     subgraph Core["sleepypod-core (Node.js)"]
         B[tRPC calibration router]
-        C[biometrics.db]
+        C[(biometrics.db)]
+    end
+
+    subgraph FS["Filesystem (Pod)"]
+        G[/tmp/sleepypod-calibrate<br/>trigger file/]
+        H[/persistent/biometrics/*.RAW<br/>sensor data · tmpfs · ADR 0018/]
     end
 
     subgraph Modules["Python Modules"]
-        D[calibrator]
+        D[calibrator<br/>single writer]
         E[piezo-processor]
         F[sleep-detector]
     end
 
-    G[/tmp/sleepypod-calibrate<br/>trigger file/]
-    H[/persistent/biometrics/*.RAW<br/>sensor data · tmpfs · ADR 0018/]
-
+    %% On-demand path
     A -->|"calibration.trigger()"| B
     B -->|"write trigger file"| G
-    B -->|"read profiles"| C
-    D -->|"poll trigger file<br/>every 10s"| G
-    D -->|"read raw sensor data"| H
-    D -->|"write profiles<br/>(single writer)"| C
+    B -->|"read profiles + vitals_quality"| C
+
+    %% Daily path
+    T -.->|"start"| D
+
+    %% Calibrator inputs/outputs
+    D -->|"poll every 10s<br/>read + delete"| G
+    D -->|"read latest ~5 min"| H
+    D -->|"write profiles<br/>+ calibration_runs"| C
+
+    %% Consumer modules: profiles refresh + raw signal
     E -->|"read profiles<br/>(60s poll)"| C
     F -->|"read profiles<br/>(60s poll)"| C
     E -->|"read raw sensor data"| H
     F -->|"read raw sensor data"| H
-    E -->|"write vitals"| C
-    F -->|"write sleep_records"| C
+
+    %% Consumer module outputs
+    E -->|"write vitals<br/>+ vitals_quality"| C
+    F -->|"write sleep_records<br/>+ movement"| C
 ```
 
 ### Data Ownership

--- a/docs/piezo-processor.md
+++ b/docs/piezo-processor.md
@@ -17,7 +17,7 @@ The piezo-processor module extracts heart rate (HR), HR variability index, and b
 
 ```mermaid
 flowchart TD
-    RAW["RAW file (CBOR-encoded)<br/>RawFileFollower tails /persistent/*.RAW"]
+    RAW["RAW file (CBOR-encoded)<br/>RawFileFollower tails /persistent/biometrics/*.RAW (tmpfs · ADR 0018)"]
     DECODE["Decode piezo-dual record<br/>left1 + right1 channels (int32, 500 Hz)"]
     PUMP{"PumpGate<br/>Dual-channel energy<br/>spike detection"}
     DROP["Drop record<br/>(pump or guard active)"]

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -320,6 +320,16 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   done
 fi
 
+# Biometrics archiver — tmpfs RAW writes + frank.sh cd patch. Module
+# unit files set RAW_DATA_DIR=/persistent/biometrics, so without this the
+# modules tail a directory that doesn't exist and biometrics silently
+# stop populating. Pre-#576, this only ran from scripts/install, so any
+# pod that upgraded via sp-update past v2.0.0 hit the regression.
+if [ -f "$INSTALL_DIR/scripts/lib/biometrics-archiver-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/biometrics-archiver-helpers"
+  install_biometrics_archiver
+fi
+
 # Install CLI tools from new source.
 #
 # Use `install` (atomic mkstemp + rename) instead of `cp` — sp-update is

--- a/scripts/install
+++ b/scripts/install
@@ -1099,94 +1099,13 @@ fi
 # ============================================================================
 # Biometrics archiver — tmpfs RAW writes + gzip cold archive on eMMC.
 # ============================================================================
-# Frankenfirmware writes ~1 GB/day of *.RAW frames. Move them to a 500 MB
-# tmpfs at /persistent/biometrics so wear stays off eMMC; archiver gzips
-# files older than 15 min into /persistent/biometrics-archive/, pruner
-# keeps /persistent < 80% full. SEQNO.RAW + persistent state subdirs are
-# symlinked from tmpfs back to /persistent so the firmware sees its
-# state without code changes. See modules/biometrics-archiver/README.
-ARCHIVER_SRC="$INSTALL_DIR/modules/biometrics-archiver"
-if [ -d "$ARCHIVER_SRC" ]; then
-  echo "Installing biometrics-archiver (tmpfs + cold archive)..."
-
-  # Scripts
-  for s in sleepypod-tmpfs-prep sleepypod-biometrics-archiver sleepypod-biometrics-pruner; do
-    install -m 0755 "$ARCHIVER_SRC/$s" "/usr/local/bin/$s"
-  done
-
-  # Systemd units
-  install -m 0644 "$ARCHIVER_SRC/persistent-biometrics.mount"      /etc/systemd/system/
-  install -m 0644 "$ARCHIVER_SRC/sleepypod-tmpfs-prep.service"     /etc/systemd/system/
-  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-archiver.service" /etc/systemd/system/
-  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-archiver.timer"   /etc/systemd/system/
-  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-pruner.service"   /etc/systemd/system/
-  install -m 0644 "$ARCHIVER_SRC/sleepypod-biometrics-pruner.timer"     /etc/systemd/system/
-
-  # frank.service drop-in: pull in mount + prep before frankenfirmware execs
-  mkdir -p /etc/systemd/system/frank.service.d
-  install -m 0644 "$ARCHIVER_SRC/frank.service.d/sleepypod-biometrics-tmpfs.conf" \
-    /etc/systemd/system/frank.service.d/sleepypod-biometrics-tmpfs.conf
-
-  systemctl daemon-reload
-
-  # Bring up the mount + symlinks BEFORE patching frank.sh so the cd
-  # target exists when frank restarts.
-  systemctl enable --now persistent-biometrics.mount
-  systemctl enable --now sleepypod-tmpfs-prep.service
-
-  # Patch /opt/eight/bin/frank.sh idempotently. The original is a 12-line
-  # firmware shim that does `cd /persistent && exec frankenfirmware`. We
-  # need cwd=/persistent/biometrics so RAW frames land in tmpfs.
-  if [ -f /opt/eight/bin/frank.sh ]; then
-    if ! grep -q 'cd /persistent/biometrics' /opt/eight/bin/frank.sh; then
-      backup="/opt/eight/bin/frank.sh.bak-pre-tmpfs-$(date -u +%Y%m%dT%H%M%SZ)"
-      cp -p /opt/eight/bin/frank.sh "$backup"
-      echo "Backed up frank.sh to $backup"
-      sed -i 's|cd /persistent &&|cd /persistent/biometrics \&\&|' /opt/eight/bin/frank.sh
-      echo "Patched frank.sh: cwd -> /persistent/biometrics"
-      systemctl restart frank.service
-    else
-      echo "frank.sh already patched — skipping"
-    fi
-  else
-    echo "Warning: /opt/eight/bin/frank.sh not found — skipping patch (not a Pod?)"
-  fi
-
-  # Restart sleepypod modules so they pick up RAW_DATA_DIR=/persistent/biometrics
-  for u in sleepypod-piezo-processor sleepypod-sleep-detector \
-           sleepypod-environment-monitor sleepypod-cover-buttons; do
-    systemctl restart "$u.service" 2>/dev/null || true
-  done
-
-  systemctl enable --now sleepypod-biometrics-archiver.timer
-  systemctl enable --now sleepypod-biometrics-pruner.timer
-
-  # One-time migration: gzip + relocate any pre-tmpfs RAW files at
-  # /persistent root (firmware now writes to /persistent/biometrics, so
-  # files at the old location are stranded). Idempotent — runs only if
-  # there are .RAW files at root, skips SEQNO.RAW.
-  shopt -s nullglob
-  stranded=( /persistent/*.RAW )
-  shopt -u nullglob
-  archived=0
-  for src in "${stranded[@]}"; do
-    base=$(basename "$src")
-    [ "$base" = "SEQNO.RAW" ] && continue
-    dst="/persistent/biometrics-archive/$base.gz"
-    if [ -f "$dst" ]; then
-      rm -f "$src"
-      archived=$((archived + 1))
-      continue
-    fi
-    if gzip -c "$src" > "$dst.tmp.$$"; then
-      mv -f "$dst.tmp.$$" "$dst"
-      rm -f "$src"
-      archived=$((archived + 1))
-    else
-      rm -f "$dst.tmp.$$"
-    fi
-  done
-  [ "$archived" -gt 0 ] && echo "Archived $archived stranded pre-tmpfs RAW files"
+# Shared helper, also called from sp-update so OTA upgrades land in the
+# same state as fresh installs (issue #576). Guarded with -f to match the
+# pattern used for every other lib source above — without the guard,
+# --local mode against a pre-#576 working tree would abort under set -e.
+if [ -f "$INSTALL_DIR/scripts/lib/biometrics-archiver-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/biometrics-archiver-helpers"
+  install_biometrics_archiver
 fi
 
 # ============================================================================

--- a/scripts/lib/biometrics-archiver-helpers
+++ b/scripts/lib/biometrics-archiver-helpers
@@ -1,0 +1,132 @@
+# shellcheck shell=bash
+# Biometrics-archiver install — tmpfs RAW writes + gzip cold archive.
+#
+# Frankenfirmware writes ~1 GB/day of *.RAW frames. We move them to a
+# 500 MB tmpfs at /persistent/biometrics so wear stays off eMMC; an
+# archiver gzips files older than 15 min into /persistent/biometrics-archive/,
+# a pruner keeps /persistent < 80% full. SEQNO.RAW + persistent state
+# subdirs are symlinked from tmpfs back to /persistent so the firmware
+# sees its state without code changes. See modules/biometrics-archiver/README.
+#
+# Sourced by:
+#   - scripts/install     (fresh install path)
+#   - scripts/bin/sp-update (in-place upgrade path — issue #576)
+#
+# Idempotent: subsequent runs detect existing mount + patched frank.sh
+# and no-op. Safe to call on every install/upgrade.
+#
+# Requires INSTALL_DIR to be set by the caller.
+
+install_biometrics_archiver() {
+  local archiver_src="${INSTALL_DIR:-/home/dac/sleepypod-core}/modules/biometrics-archiver"
+
+  if [ ! -d "$archiver_src" ]; then
+    return 0
+  fi
+
+  echo "Installing biometrics-archiver (tmpfs + cold archive)..."
+
+  # Remember whether the tmpfs was already up. If it was, every caller
+  # (install + sp-update) already restarted the RAW modules against a
+  # correct cwd in their own module-sync loop — skipping the helper's
+  # restart below avoids a redundant ~1s biometrics gap on every upgrade.
+  local was_mounted=false
+  mountpoint -q /persistent/biometrics && was_mounted=true
+
+  # Scripts
+  local s
+  for s in sleepypod-tmpfs-prep sleepypod-biometrics-archiver sleepypod-biometrics-pruner; do
+    install -m 0755 "$archiver_src/$s" "/usr/local/bin/$s"
+  done
+
+  # Systemd units
+  install -m 0644 "$archiver_src/persistent-biometrics.mount"      /etc/systemd/system/
+  install -m 0644 "$archiver_src/sleepypod-tmpfs-prep.service"     /etc/systemd/system/
+  install -m 0644 "$archiver_src/sleepypod-biometrics-archiver.service" /etc/systemd/system/
+  install -m 0644 "$archiver_src/sleepypod-biometrics-archiver.timer"   /etc/systemd/system/
+  install -m 0644 "$archiver_src/sleepypod-biometrics-pruner.service"   /etc/systemd/system/
+  install -m 0644 "$archiver_src/sleepypod-biometrics-pruner.timer"     /etc/systemd/system/
+
+  # frank.service drop-in: pull in mount + prep before frankenfirmware execs
+  mkdir -p /etc/systemd/system/frank.service.d
+  install -m 0644 "$archiver_src/frank.service.d/sleepypod-biometrics-tmpfs.conf" \
+    /etc/systemd/system/frank.service.d/sleepypod-biometrics-tmpfs.conf
+
+  systemctl daemon-reload
+
+  # Bring up the mount + symlinks BEFORE patching frank.sh so the cd
+  # target exists when frank restarts.
+  systemctl enable --now persistent-biometrics.mount
+  systemctl enable --now sleepypod-tmpfs-prep.service
+
+  # Patch /opt/eight/bin/frank.sh idempotently. The original is a 12-line
+  # firmware shim that does `cd /persistent && exec frankenfirmware`. We
+  # need cwd=/persistent/biometrics so RAW frames land in tmpfs.
+  if [ -f /opt/eight/bin/frank.sh ]; then
+    if ! grep -q 'cd /persistent/biometrics' /opt/eight/bin/frank.sh; then
+      local backup
+      backup="/opt/eight/bin/frank.sh.bak-pre-tmpfs-$(date -u +%Y%m%dT%H%M%SZ)"
+      cp -p /opt/eight/bin/frank.sh "$backup"
+      echo "Backed up frank.sh to $backup"
+      sed -i 's|cd /persistent &&|cd /persistent/biometrics \&\&|' /opt/eight/bin/frank.sh
+      echo "Patched frank.sh: cwd -> /persistent/biometrics"
+      # Guarded — sp-update's rollback trap fires on uncaught failures here
+      # and would leave orphaned systemd units behind while rolling back
+      # only the codebase. Module restarts below use the same guard.
+      systemctl restart frank.service 2>/dev/null || true
+    else
+      echo "frank.sh already patched — skipping"
+    fi
+  else
+    echo "Warning: /opt/eight/bin/frank.sh not found — skipping patch (not a Pod?)"
+  fi
+
+  # Restart sleepypod modules so they pick up RAW_DATA_DIR=/persistent/biometrics.
+  # Skip if the mount was already established at entry — the caller's own
+  # module-sync loop has already restarted them against a correct cwd.
+  if [ "$was_mounted" = false ]; then
+    local u
+    for u in sleepypod-piezo-processor sleepypod-sleep-detector \
+             sleepypod-environment-monitor sleepypod-cover-buttons; do
+      systemctl restart "$u.service" 2>/dev/null || true
+    done
+  fi
+
+  systemctl enable --now sleepypod-biometrics-archiver.timer
+  systemctl enable --now sleepypod-biometrics-pruner.timer
+
+  # One-time migration: gzip + relocate any pre-tmpfs RAW files at
+  # /persistent root (firmware now writes to /persistent/biometrics, so
+  # files at the old location are stranded). Idempotent — runs only if
+  # there are .RAW files at root, skips SEQNO.RAW.
+  #
+  # The archiver service mkdirs the archive dir on its first timer fire
+  # (~15 min after enable below), but the migration loop runs first and
+  # needs the dir up front — otherwise gzip's redirect into a missing
+  # dir fails inside the `if`-cond, the else branch runs, and stranded
+  # files are silently left behind on eMMC.
+  mkdir -p /persistent/biometrics-archive
+  shopt -s nullglob
+  local stranded=( /persistent/*.RAW )
+  shopt -u nullglob
+  local archived=0
+  local src base dst
+  for src in "${stranded[@]}"; do
+    base=$(basename "$src")
+    [ "$base" = "SEQNO.RAW" ] && continue
+    dst="/persistent/biometrics-archive/$base.gz"
+    if [ -f "$dst" ]; then
+      rm -f "$src"
+      archived=$((archived + 1))
+      continue
+    fi
+    if gzip -c "$src" > "$dst.tmp.$$"; then
+      mv -f "$dst.tmp.$$" "$dst"
+      rm -f "$src"
+      archived=$((archived + 1))
+    else
+      rm -f "$dst.tmp.$$"
+    fi
+  done
+  [ "$archived" -gt 0 ] && echo "Archived $archived stranded pre-tmpfs RAW files"
+}


### PR DESCRIPTION
Closes #576.

## Summary

The tmpfs RAW migration (PR #499) updated the module unit files to read RAW frames from `/persistent/biometrics`, but the block that creates the tmpfs mount, patches `/opt/eight/bin/frank.sh` to `cd /persistent/biometrics`, and installs the archiver/pruner timers lived only in `scripts/install`. Anyone who upgraded via `sp-update` past v2.0.0 ended up with modules tailing a directory that didn't exist while firmware kept writing `/persistent/*.RAW`. Symptoms in #576: no HR/HRV in `/en/data`, no bed temp / humidity in `/en/sensors`, calibration stuck at "Insufficient temp data: 0 rows".

oliver's pod confirmed the failure mode exactly: `frank.sh` unpatched (`cd /persistent && DAC_SOCKET=...`), `/persistent/biometrics/` missing, fresh 3 MB `00A992C5.RAW` at `/persistent/`.

## Fix

Extracted the install block into `scripts/lib/biometrics-archiver-helpers` and call it from both `scripts/install` and `scripts/bin/sp-update`. Idempotent — safe on every upgrade.

## Adversarial-review catches rolled into this PR

- `systemctl restart frank.service` now guarded with `|| true`. In the original inline location no rollback trap existed; inside sp-update's rollback window an unguarded failure would roll back code while leaving newly-written systemd unit files at `/etc/systemd/system/`.
- The new `source` call in `scripts/install` is wrapped in `[ -f ... ]`, matching every other lib source in the file. Without the guard, `--local` mode against a pre-#576 tree would abort under `set -euo pipefail`.
- `mkdir -p /persistent/biometrics-archive` before the stranded-RAW migration loop. The archiver service mkdirs it on first timer fire, but that's ~15 min after the migration loop, so without this fix gzip's redirect into a missing dir would silently leave stranded files behind.
- Snapshot `was_mounted` at function entry; skip the helper's module-restart loop when the mount was already established. Caller's own module-sync loop already restarted them against a correct cwd — eliminates the redundant restart + ~1s biometrics gap on idempotent re-runs.

## Test plan

- [x] `bash -n` clean on all three files
- [x] `shellcheck -x scripts/lib/biometrics-archiver-helpers` clean
- [x] Workaround (`/etc/sleepypod/modules/*.env` overriding `RAW_DATA_DIR=/persistent`) confirmed by oliver to restore data flow on his Pod 3
- [ ] On a pre-#576 pod via `sp-update`: `/persistent/biometrics/` is created, `frank.sh` becomes `cd /persistent/biometrics && ...`, modules tail the new dir, biometrics start populating within minutes
- [ ] Second `sp-update` on the same pod: no double-restart of RAW modules (was_mounted=true path), helper is otherwise a no-op
- [ ] Fresh `scripts/install` on a Pod 5 still works (regression check on the install path)
- [ ] Stranded `/persistent/*.RAW` files at install time are gzipped into `/persistent/biometrics-archive/`

## Refs

- Discord thread with oliver / trinity / Drizzy / LoL_XD reporting the same symptom across multiple pods (2026-05-12 to 2026-05-13)
- Review summary: `.reviews/worktree-issue-576/summary.md`

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

🚀 **Latest build of `worktree-issue-576`** — rebuilds every push, zero auth:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-issue-576/scripts/install \
  | sudo bash -s -- --branch worktree-issue-576
```

🎯 **Pin to this exact build** ([run 25839866490](https://github.com/sleepypod/core/actions/runs/25839866490) · `1e30d1e`):
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/1e30d1e33ae7f17e65d0ebb2d64f50033e28c679/scripts/install \
  | sudo bash -s -- \
      --branch worktree-issue-576 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25839866490/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25839866490/artifacts/6986537265) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated biometrics data storage architecture documentation to reflect reorganized storage pipeline with real-time data retention and archival system.

* **Chores**
  * Enhanced installation and update scripts to configure biometrics archiver for managing sensor data retention and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/579)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
