### PR TITLE
installer: free-sleep conflict preflight + install reliability fixes

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -218,6 +218,16 @@ block_wan() {
   iptables -t nat -F 2>/dev/null || true
   iptables -t nat -X 2>/dev/null || true
 
+  # Flush conntrack so stale entries from the prior ruleset don't
+  # confuse the new chain (mid-rebuild SYN/ACKs would otherwise hit
+  # the DROP at the bottom on the first packet under the new rules).
+  # Safe: LAN ACCEPT is stateless, so existing LAN connections
+  # recover on their next packet without needing the old conntrack
+  # entry. WAN connections die, which is the intended block_wan effect.
+  if command -v conntrack &>/dev/null; then
+    conntrack -F &>/dev/null || true
+  fi
+
   # Allow established connections
   iptables -I INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
   iptables -I OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT

--- a/scripts/install
+++ b/scripts/install
@@ -849,6 +849,14 @@ else
   # Clean old files if updating (preserve node_modules, .env, data)
   if [ -d "$INSTALL_DIR" ]; then
     echo "Updating existing installation..."
+    # Stop the running service first — it has WorkingDirectory=$INSTALL_DIR
+    # and writes into .next/standalone, racing the rm -rf below and
+    # producing ENOTEMPTY when the writer re-creates a file mid-recurse.
+    # Re-enable+restart happens later in the install flow.
+    if systemctl is-active --quiet sleepypod.service 2>/dev/null; then
+      echo "Stopping sleepypod.service before purge..."
+      systemctl stop sleepypod.service
+    fi
     find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
       ! -name 'node_modules' \
       ! -name '.env' \

--- a/scripts/install
+++ b/scripts/install
@@ -221,9 +221,11 @@ block_wan() {
   # Flush conntrack so stale entries from the prior ruleset don't
   # confuse the new chain (mid-rebuild SYN/ACKs would otherwise hit
   # the DROP at the bottom on the first packet under the new rules).
-  # Safe: LAN ACCEPT is stateless, so existing LAN connections
-  # recover on their next packet without needing the old conntrack
-  # entry. WAN connections die, which is the intended block_wan effect.
+  # Safe: the RFC1918 LAN ACCEPTs below are stateless (no -m conntrack),
+  # so existing LAN connections recover on their next packet by matching
+  # the CIDR allow. The ESTABLISHED,RELATED rule loses its entries but
+  # that's fine — LAN traffic falls through to the stateless allow.
+  # WAN connections die, which is the intended block_wan effect.
   if command -v conntrack &>/dev/null; then
     conntrack -F &>/dev/null || true
   fi
@@ -312,7 +314,9 @@ detect_free_sleep_conflict() {
   done
   [ -d /home/dac/free-sleep ]                && FREE_SLEEP_FINDINGS+=("directory:    /home/dac/free-sleep")
   [ -d /persistent/free-sleep-data ]         && FREE_SLEEP_FINDINGS+=("directory:    /persistent/free-sleep-data")
-  [ -f /etc/iptables/iptables.rules ]        && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/iptables.rules")
+  # Only the v6 rules file is a unique free-sleep indicator — sleepypod's
+  # own block_wan persists /etc/iptables/iptables.rules but never the v6
+  # file, so flagging the v4 file would false-positive on every reinstall.
   [ -f /etc/iptables/ip6tables.rules ]       && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/ip6tables.rules")
 }
 

--- a/scripts/install
+++ b/scripts/install
@@ -34,12 +34,14 @@ INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
+PURGE_FREE_SLEEP=false
 while [ $# -gt 0 ]; do
   case "$1" in
-    --local)        INSTALL_LOCAL=true ;;
-    --no-ssh)       SKIP_SSH=true ;;
-    --branch)       shift; INSTALL_BRANCH="${1:-}" ;;
-    --artifact-url) shift; ARTIFACT_URL_OVERRIDE="${1:-}" ;;
+    --local)              INSTALL_LOCAL=true ;;
+    --no-ssh)             SKIP_SSH=true ;;
+    --branch)             shift; INSTALL_BRANCH="${1:-}" ;;
+    --artifact-url)       shift; ARTIFACT_URL_OVERRIDE="${1:-}" ;;
+    --purge-free-sleep)   PURGE_FREE_SLEEP=true ;;
   esac
   shift
 done
@@ -277,11 +279,125 @@ block_wan() {
   echo "WAN blocked."
 }
 
+# --------------------------------------------------------------------------------
+# free-sleep conflict preflight
+# free-sleep (github.com/throwaway31265/free-sleep) ships three auto-start
+# services, persisted drop-all iptables rules, source/data dirs, and a
+# sudoers fragment. Its iptables rules auto-reload on boot and fight
+# sleepypod's own iptables permanently — even free-sleep's own
+# unblock_internet_access.sh only flushes runtime rules, not the persisted
+# files. Refuse to install on top by default; --purge-free-sleep opts into
+# the documented cleanup so support sessions don't need a separate manual
+# step.
+
+FREE_SLEEP_FINDINGS=()
+
+detect_free_sleep_conflict() {
+  FREE_SLEEP_FINDINGS=()
+  local svc
+  for svc in free-sleep free-sleep-stream free-sleep-update; do
+    if systemctl list-unit-files 2>/dev/null | grep -qE "^${svc}\.service"; then
+      FREE_SLEEP_FINDINGS+=("systemd unit: ${svc}.service")
+    fi
+  done
+  [ -d /home/dac/free-sleep ]                && FREE_SLEEP_FINDINGS+=("directory:    /home/dac/free-sleep")
+  [ -d /persistent/free-sleep-data ]         && FREE_SLEEP_FINDINGS+=("directory:    /persistent/free-sleep-data")
+  [ -f /etc/iptables/iptables.rules ]        && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/iptables.rules")
+  [ -f /etc/iptables/ip6tables.rules ]       && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/ip6tables.rules")
+}
+
+purge_free_sleep() {
+  echo ""
+  echo "========================================"
+  echo "  Purging free-sleep (--purge-free-sleep)"
+  echo "========================================"
+
+  systemctl stop free-sleep free-sleep-stream free-sleep-update 2>/dev/null || true
+  systemctl disable free-sleep free-sleep-stream free-sleep-update 2>/dev/null || true
+  rm -f /etc/systemd/system/free-sleep.service \
+        /etc/systemd/system/free-sleep-stream.service \
+        /etc/systemd/system/free-sleep-update.service
+  systemctl daemon-reload
+
+  iptables -F 2>/dev/null || true
+  iptables -X 2>/dev/null || true
+  iptables -t nat -F 2>/dev/null || true
+  iptables -t nat -X 2>/dev/null || true
+  if command -v ip6tables &>/dev/null; then
+    ip6tables -F 2>/dev/null || true
+    ip6tables -X 2>/dev/null || true
+  fi
+
+  rm -f /etc/iptables/iptables.rules /etc/iptables/ip6tables.rules
+  rm -rf /home/dac/free-sleep /persistent/free-sleep-data
+  rm -f /etc/sudoers.d/dac
+
+  echo "free-sleep services stopped+disabled, iptables flushed, persisted rules and dirs removed."
+  echo "Skipping reboot — install will continue and reconfigure iptables itself."
+}
+
+preflight_free_sleep_conflict() {
+  detect_free_sleep_conflict
+  if [ ${#FREE_SLEEP_FINDINGS[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$PURGE_FREE_SLEEP" = true ]; then
+    echo "Detected free-sleep artifacts:"
+    local item
+    for item in "${FREE_SLEEP_FINDINGS[@]}"; do
+      echo "  - $item"
+    done
+    purge_free_sleep
+    return 0
+  fi
+
+  echo "" >&2
+  echo "========================================" >&2
+  echo "  free-sleep detected — refusing to install" >&2
+  echo "========================================" >&2
+  echo "" >&2
+  echo "Found the following free-sleep artifacts on this Pod:" >&2
+  local item
+  for item in "${FREE_SLEEP_FINDINGS[@]}"; do
+    echo "  - $item" >&2
+  done
+  echo "" >&2
+  echo "free-sleep installs persistent drop-all iptables rules that auto-reload" >&2
+  echo "on boot and fight sleepypod's own iptables — cloud connectivity will" >&2
+  echo "fail until they are removed. Running free-sleep's unblock script only" >&2
+  echo "flushes the running rules, not the files on disk." >&2
+  echo "" >&2
+  echo "Run this on the Pod to clean up, then re-run the installer:" >&2
+  echo "" >&2
+  echo "----------------------------------------" >&2
+  echo "sudo systemctl stop free-sleep free-sleep-stream free-sleep-update 2>/dev/null" >&2
+  echo "sudo systemctl disable free-sleep free-sleep-stream free-sleep-update 2>/dev/null" >&2
+  echo "sudo rm -f /etc/systemd/system/free-sleep.service \\" >&2
+  echo "           /etc/systemd/system/free-sleep-stream.service \\" >&2
+  echo "           /etc/systemd/system/free-sleep-update.service" >&2
+  echo "sudo systemctl daemon-reload" >&2
+  echo "sudo iptables -F && sudo iptables -X && sudo iptables -t nat -F && sudo iptables -t nat -X" >&2
+  echo "sudo ip6tables -F && sudo ip6tables -X" >&2
+  echo "sudo rm -f /etc/iptables/iptables.rules /etc/iptables/ip6tables.rules" >&2
+  echo "sudo rm -rf /home/dac/free-sleep /persistent/free-sleep-data" >&2
+  echo "sudo rm -f /etc/sudoers.d/dac" >&2
+  echo "sudo reboot" >&2
+  echo "----------------------------------------" >&2
+  echo "" >&2
+  echo "Or re-run the installer with --purge-free-sleep to let it do the cleanup" >&2
+  echo "for you (skips the reboot step; install continues immediately)." >&2
+  echo "" >&2
+  exit 1
+}
+
 # Check if running as root
 if [ "$EUID" -ne 0 ]; then
   echo "Error: This script must be run as root (use sudo)" >&2
   exit 1
 fi
+
+preflight_free_sleep_conflict
 
 # Force /usr/local/bin to the front of PATH and strip Volta entries.
 # Pod 3 stock firmware (and free-sleep installs) ship Volta at

--- a/scripts/lib/iptables-helpers
+++ b/scripts/lib/iptables-helpers
@@ -52,6 +52,16 @@ block_wan() {
   iptables -t nat -F 2>/dev/null || true
   iptables -t nat -X 2>/dev/null || true
 
+  # Flush conntrack so stale entries from the prior ruleset don't
+  # confuse the new chain (mid-rebuild SYN/ACKs would otherwise hit
+  # the DROP at the bottom on the first packet under the new rules).
+  # Safe: LAN ACCEPT is stateless, so existing LAN connections
+  # recover on their next packet without needing the old conntrack
+  # entry. WAN connections die, which is the intended block_wan effect.
+  if command -v conntrack &>/dev/null; then
+    conntrack -F &>/dev/null || true
+  fi
+
   # Allow established connections
   iptables -I INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
   iptables -I OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT

--- a/scripts/lib/iptables-helpers
+++ b/scripts/lib/iptables-helpers
@@ -55,9 +55,11 @@ block_wan() {
   # Flush conntrack so stale entries from the prior ruleset don't
   # confuse the new chain (mid-rebuild SYN/ACKs would otherwise hit
   # the DROP at the bottom on the first packet under the new rules).
-  # Safe: LAN ACCEPT is stateless, so existing LAN connections
-  # recover on their next packet without needing the old conntrack
-  # entry. WAN connections die, which is the intended block_wan effect.
+  # Safe: the RFC1918 LAN ACCEPTs below are stateless (no -m conntrack),
+  # so existing LAN connections recover on their next packet by matching
+  # the CIDR allow. The ESTABLISHED,RELATED rule loses its entries but
+  # that's fine — LAN traffic falls through to the stateless allow.
+  # WAN connections die, which is the intended block_wan effect.
   if command -v conntrack &>/dev/null; then
     conntrack -F &>/dev/null || true
   fi


### PR DESCRIPTION
## Summary

Four installer/runtime fixes prompted by a real customer session (free-sleep coexistence breaking sleepypod, plus three follow-on bugs surfaced while debugging):

- **Free-sleep preflight** (`ddc7061`): refuse to install when free-sleep artifacts are detected, with paste-and-go cleanup instructions. New `--purge-free-sleep` flag opts into automatic cleanup. Detects all three free-sleep services, both source/data dirs, and the persisted iptables rule files (which auto-reload on boot and fight sleepypod's own iptables permanently).
- **Stop sleepypod.service before purge** (`09f0e43`): the existing `find ... rm -rf {} +` raced the running service writing into `.next/standalone`, producing ENOTEMPTY mid-recurse. Now guarded with `systemctl is-active --quiet ... && stop`, scoped to `sleepypod.service` only (the other module services have `WorkingDirectory` outside `$INSTALL_DIR`).
- **Fix biometrics-archiver exit-code leak** (`f8ac079`): the function's last line was `[ "$archived" -gt 0 ] && echo "..."` — when no stranded RAW files exist (the normal clean-install case), the test returns 1, `&&` short-circuits, and the function's exit code leaks to `set -e`. Install reported "Installation failed" even though every substantive step succeeded. Bug also affected `sp-update`.
- **Flush conntrack in `block_wan`** (`b29d20f`): customer hit a one-time "can't be reached" after applying the firewall — stale conntrack entries from before the iptables flush confused the new chain. LAN ACCEPTs are stateless (CIDR-matched, no `-m conntrack`), so flushing conntrack doesn't break active LAN connections; they recover on their next packet. Applied to both copies of `block_wan` (inline in `scripts/install` and the canonical `scripts/lib/iptables-helpers`).

Real customer (Discord, 2026-05-15) hit all four bugs in sequence during a single install attempt. With these fixes the same flow would have completed cleanly with one command.

## Test plan

- [ ] **Free-sleep refusal**: on a pod with any free-sleep service unit or source dir, `scripts/install` exits 1 with the cleanup banner listing exactly what was found.
- [ ] **Free-sleep purge**: `scripts/install --purge-free-sleep` removes the three services, deletes `/etc/iptables/*.rules`, removes `/home/dac/free-sleep` + `/persistent/free-sleep-data` + `/etc/sudoers.d/dac`, then proceeds with the install (no reboot).
- [ ] **No-op preflight**: on a clean pod (no free-sleep), the preflight is silent and the install proceeds normally.
- [ ] **Re-install over running service**: with `sleepypod.service` active, `scripts/install` stops it before the file purge and completes without ENOTEMPTY on `.next/standalone`.
- [ ] **Clean install completion**: install reaches the end and prints the success banner — no spurious "Installation failed" from the archiver helper.
- [ ] **block_wan idempotency**: running `block_wan` while a browser has an open HTTP keep-alive to port 3000 from a LAN client no longer produces "can't be reached" on the next request.
- [ ] **conntrack-absent guard**: on a firmware without the `conntrack` userspace tool, `block_wan` still completes cleanly (verified by `command -v conntrack` guard).
- [ ] `bash -n scripts/install` and `bash -n scripts/lib/iptables-helpers` clean.
- [ ] `shellcheck --severity=warning` adds zero new warnings (one pre-existing SC2034 in iptables-helpers:8 is unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic conflict detection during installation with step-by-step cleanup instructions.
  * Added `--purge-free-sleep` flag for automatic cleanup of existing conflicting services.

* **Bug Fixes**
  * Fixed filesystem race conditions during updates that could cause installation failures.
  * Improved reliability of WAN-blocking rules by removing stale connection tracking data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/installer-free-sleep-preflight
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/installer-free-sleep-preflight/scripts/install \
  | sudo bash -s -- --branch feat/installer-free-sleep-preflight
```

🎯 **Pin to this exact build** ([run 25976904907](https://github.com/sleepypod/core/actions/runs/25976904907) · `88bb1e0`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/88bb1e0be51219bab15715e1342cc2cc9a5c0be7/scripts/install \
  | sudo bash -s -- \
      --branch feat/installer-free-sleep-preflight \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25976904907/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25976904907/artifacts/7037894693) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


