### PR TITLE
fix(occupancy): repair calibrator RAW path; movement-based HomeKit sensor; density-gate chart

### DIFF
--- a/docs/sleep-detector.md
+++ b/docs/sleep-detector.md
@@ -139,6 +139,42 @@ Session records include:
 - Number of bed exits (mid-session absences)
 - Present/absent interval arrays
 
+## Chart Aggregation
+
+The Movement chart in the app (`src/components/MovementChart/MovementChart.tsx`) does **not** read individual 60-s epochs directly. It calls `biometrics.getMovementBuckets` (`src/server/routers/biometrics.ts`) which groups epochs into fixed-width buckets in SQL:
+
+| View | `bucketSeconds` (`src/lib/movement.ts`) | Bars per bucket |
+|------|-----------------------------------------|-----------------|
+| Day  | `MOVEMENT_BUCKET_DAY_SECONDS = 300` (5 min) | up to 5 epochs |
+| Week | `MOVEMENT_BUCKET_WEEK_SECONDS = 1800` (30 min) | up to 30 epochs |
+
+Per bucket the SQL returns:
+- `totalMovement` — `SUM(total_movement)` (raw PIM intensity).
+- `eventCount` — `COUNT(... >= POSITION_CHANGE_SCORE_MIN)`, rendered as **events/hour** on the y-axis.
+- `sampleCount` — total epochs in the bucket.
+
+### In-bed gate
+
+`inBedExists(side)` filters epochs to those whose timestamp falls inside a recorded `sleep_records` row for the same side. This drops empty-bed sensor noise that doesn't belong to a persisted session.
+
+### Density gate
+
+`inBedExists` is necessary but not sufficient — a noisy session of record (high `times_exited_bed`) can span hours yet contain many empty-bed sub-windows. A second filter, `pickMinBucketNonStillEpochs(bucketSeconds)`, requires each rendered bucket to contain at least that many epochs above `RESTLESS_SCORE_MIN`:
+
+```text
+minNonStillEpochs = max(MIN_BUCKET_NONSTILL_FLOOR, floor(bucketSeconds / 600))
+                  = max(2, floor(bucketSeconds / 600))
+```
+
+For the standard bucket widths:
+
+| Bucket | Epoch budget | Required non-still | Sleep-time expectation (per doc score table) |
+|--------|--------------|--------------------|----------------------------------------------|
+| 5 min  | 5  | 2 | ~1-2 non-still epochs even mid-sleep |
+| 30 min | 30 | 3 | ~6-10 non-still epochs in real sleep |
+
+This filters phantom-session flicker (1-3 scattered non-still epochs per bucket) without affecting real sessions. Tune `MIN_BUCKET_NONSTILL_FLOOR` if a quieter sleeper drops out of the chart.
+
 ## Configuration
 
 | Constant | Value | Rationale |
@@ -159,6 +195,7 @@ Session records include:
 | `BASELINE_COLD_START_EPOCHS` | 10 | 10-minute minimum before baseline subtraction activates |
 | `BASELINE_PERCENTILE` | 5 | 5th percentile; represents quietest epoch in trailing window |
 | `MEDIAN_FILTER_WINDOW` | 3 | 3-epoch median filter; suppresses isolated spikes |
+| `MIN_BUCKET_NONSTILL_FLOOR` | 2 | Chart density gate; minimum non-still epochs per rendered bucket |
 
 ## Literature References
 
@@ -186,3 +223,5 @@ Session records include:
 7. **Baseline subtraction cold start.** Movement scores during the first 10 minutes of a session are not baseline-subtracted, which may produce slightly elevated readings compared to later in the night. This is acceptable because the baseline requires sufficient history to be meaningful.
 
 8. **Median filter smoothing behavior.** The 3-epoch median filter is causal (trailing window), so it does not depend on future epochs. It may still soften abrupt transitions, which is acceptable since movement data is not used for real-time alerting.
+
+9. **Calibrator RAW path coupling (Pod 5).** The calibrator reads RAW files from `RAW_DATA_DIR`, which must match the tmpfs path created by `sleepypod-tmpfs-prep` (`/persistent/biometrics`, per ADR-0018). A mismatch causes every daily run to fail with "No capSense records available" and the detector silently falls back to `PRESENCE_THRESHOLD = 60.0`, producing severe presence chatter (`times_exited_bed` > 100 per session). The calibrator unit file declares `RequiresMountsFor=/persistent/biometrics` to surface this as a startup failure rather than a silent runtime degradation.

--- a/modules/calibrator/sleepypod-calibrator.service
+++ b/modules/calibrator/sleepypod-calibrator.service
@@ -3,6 +3,7 @@ Description=SleepyPod Calibrator (Sensor Baselines and Thresholds)
 Documentation=https://github.com/sleepypod/core/tree/main/modules/calibrator
 After=network.target sleepypod.service
 Wants=sleepypod.service
+RequiresMountsFor=/persistent/biometrics
 
 [Service]
 Type=simple
@@ -15,7 +16,7 @@ RestartSec=30
 
 # Environment — override via /etc/sleepypod/modules/calibrator.env
 EnvironmentFile=-/etc/sleepypod/modules/calibrator.env
-Environment="RAW_DATA_DIR=/persistent"
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
 Environment="CALIBRATION_HOUR=6"

--- a/src/components/Sensors/PresenceCard.tsx
+++ b/src/components/Sensors/PresenceCard.tsx
@@ -3,26 +3,28 @@
 import { useCallback, useState } from 'react'
 import { useSensorFrame, useOnSensorFrame } from '@/src/hooks/useSensorStream'
 import type { CapSenseFrame, CapSense2Frame, SensorFrame } from '@/src/hooks/useSensorStream'
+import { trpc } from '@/src/utils/trpc'
 import { Brain, PersonStanding, Footprints } from 'lucide-react'
 
 /**
- * Variance-based presence detection.
- * Maintains a sliding window of capSense readings per side and computes
- * per-channel standard deviation. Max variance > threshold = occupied.
- * Matches iOS SensorStreamService.isOccupied() logic.
+ * Bed presence card.
+ *
+ * The Occupied/Empty label is driven by the shared virtual sensor on the
+ * server (`trpc.biometrics.getOccupancy`) so HomeKit and the web app always
+ * agree on bed state. The zone activity bars below it are a live
+ * visualization of capSense channel variance — useful for seeing what the
+ * sensor is doing right now, but NOT the source of truth for occupancy.
  */
 
 const VARIANCE_WINDOW = 20
-const PRESENCE_THRESHOLD = 0.05 // variance threshold matching iOS
 const ACTIVITY_NORMALIZE = 0.5 // max variance for 100% bar fill
+const OCCUPANCY_POLL_MS = 3_000
 
 interface VarianceState {
-  leftHistory: number[][] // [frame][channel]
+  leftHistory: number[][]
   rightHistory: number[][]
   leftVariance: number[]
   rightVariance: number[]
-  leftOccupied: boolean
-  rightOccupied: boolean
 }
 
 function computeVariance(values: number[]): number {
@@ -100,27 +102,28 @@ function ZoneActivityRow({ zone, label, icon, leftVariance, rightVariance }: Zon
   )
 }
 
-/**
- * Shows real-time bed presence from capacitive sensors with zone activity bars.
- * Displays left/right side occupied status with head/torso/legs activity breakdown.
- * Matches iOS BedSensorScreen presenceCard layout.
- */
 export function PresenceCard() {
   const capSense = useSensorFrame('capSense')
   const capSense2 = useSensorFrame('capSense2')
   const frame: CapSenseFrame | CapSense2Frame | undefined = capSense2 ?? capSense
 
-  // Variance tracking state
+  const occupancyQuery = trpc.biometrics.getOccupancy.useQuery(undefined, {
+    refetchInterval: OCCUPANCY_POLL_MS,
+    refetchOnWindowFocus: false,
+  })
+  const leftOccupied = occupancyQuery.data?.left.occupied ?? false
+  const rightOccupied = occupancyQuery.data?.right.occupied ?? false
+
+  // Zone activity bars: track per-channel variance over a sliding window of
+  // live frames. This is purely a visualization — NOT used for the
+  // Occupied/Empty judgement.
   const [variance, setVariance] = useState<VarianceState>({
     leftHistory: [],
     rightHistory: [],
     leftVariance: [],
     rightVariance: [],
-    leftOccupied: false,
-    rightOccupied: false,
   })
 
-  // Track variance from incoming capSense frames
   useOnSensorFrame(useCallback((f: SensorFrame) => {
     if (f.type !== 'capSense' && f.type !== 'capSense2') return
 
@@ -131,11 +134,9 @@ export function PresenceCard() {
       const newLeftHistory = [...prev.leftHistory, leftChannels].slice(-VARIANCE_WINDOW)
       const newRightHistory = [...prev.rightHistory, rightChannels].slice(-VARIANCE_WINDOW)
 
-      // Compute per-channel variance (excluding REF channels 6,7)
       const numChannels = Math.max(leftChannels.length, 6)
       const leftVar: number[] = []
       const rightVar: number[] = []
-
       for (let ch = 0; ch < numChannels; ch++) {
         const leftVals = newLeftHistory.map(h => h[ch] ?? 0)
         const rightVals = newRightHistory.map(h => h[ch] ?? 0)
@@ -143,17 +144,11 @@ export function PresenceCard() {
         rightVar.push(computeVariance(rightVals))
       }
 
-      // Occupied = max variance > threshold
-      const maxLeft = Math.max(...leftVar.slice(0, 6))
-      const maxRight = Math.max(...rightVar.slice(0, 6))
-
       return {
         leftHistory: newLeftHistory,
         rightHistory: newRightHistory,
         leftVariance: leftVar,
         rightVariance: rightVar,
-        leftOccupied: maxLeft > PRESENCE_THRESHOLD,
-        rightOccupied: maxRight > PRESENCE_THRESHOLD,
       }
     })
   }, []))
@@ -174,11 +169,11 @@ export function PresenceCard() {
         )}
       </div>
 
-      {/* Status row — left and right occupied indicators */}
+      {/* Status row — left and right occupied indicators (server-derived) */}
       <div className="flex items-center">
         <PresenceStatus
           label="Left"
-          occupied={variance.leftOccupied}
+          occupied={leftOccupied}
           color="#4a9eff"
         />
         <div className="w-9" />
@@ -186,12 +181,12 @@ export function PresenceCard() {
         {/* spacer matching zone labels */}
         <PresenceStatus
           label="Right"
-          occupied={variance.rightOccupied}
+          occupied={rightOccupied}
           color="#40e0d0"
         />
       </div>
 
-      {/* Zone activity bars */}
+      {/* Zone activity bars (raw channel variance — visualization only) */}
       {variance.leftVariance.length > 0 && (
         <div className="space-y-1">
           <ZoneActivityRow

--- a/src/homekit/accessories/occupancySensor.ts
+++ b/src/homekit/accessories/occupancySensor.ts
@@ -1,27 +1,17 @@
 /**
  * HomeKit OccupancySensor accessory bound to one Pod side.
  *
- * Occupancy is derived from the `movement` table rather than `sleep_records`:
- * a `sleep_records` row is only inserted at session close (and `leftBedAt` is
- * NOT NULL by schema), so there is no queryable "session-open" signal. The
- * `movement` table is updated every 60s with a baseline-subtracted score
- * (~0 on an empty bed, >=50 when an occupant is moving — see docs/sleep-
- * detector.md PIM scoring).
- *
- * Rule: OCCUPIED iff any movement epoch in the last MOVEMENT_WINDOW_MS has
- * total_movement >= RESTLESS_SCORE_MIN. The 15-minute window tolerates the
- * 70-80% of deep-sleep epochs that score below the threshold.
+ * Reads from the shared virtual sensor (`src/lib/occupancy.ts`) so this
+ * accessory, the web-app PresenceCard, and any future consumer
+ * (MQTT/HA/iOS) all reflect the same state. See that module for the
+ * movement + level signal combination.
  */
 
 import { Service, Characteristic } from 'hap-nodejs'
-import { and, eq, gte, sql } from 'drizzle-orm'
-import { biometricsDb } from '@/src/db/biometrics'
-import { movement } from '@/src/db/biometrics-schema'
-import { RESTLESS_SCORE_MIN } from '@/src/lib/movement'
+import { getOccupancy } from '@/src/lib/occupancy'
 import type { Side } from '@/src/hardware/types'
 
 const POLL_MS = 5_000
-const MOVEMENT_WINDOW_MS = 15 * 60_000
 
 export interface OccupancyAccessory {
   service: Service
@@ -31,19 +21,17 @@ export interface OccupancyAccessory {
 export function buildOccupancySensor(side: Side): OccupancyAccessory {
   const service = new Service.OccupancySensor(`Bed ${side} occupancy`, side)
 
-  const update = (): void => {
-    const present = readPresence(side)
-    const value = present
+  const characteristicValue = (): number => (
+    getOccupancy(side).occupied
       ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED
       : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED
-    service.updateCharacteristic(Characteristic.OccupancyDetected, value)
+  )
+
+  const update = (): void => {
+    service.updateCharacteristic(Characteristic.OccupancyDetected, characteristicValue())
   }
 
-  service.getCharacteristic(Characteristic.OccupancyDetected)
-    .onGet(() => readPresence(side)
-      ? Characteristic.OccupancyDetected.OCCUPANCY_DETECTED
-      : Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED,
-    )
+  service.getCharacteristic(Characteristic.OccupancyDetected).onGet(characteristicValue)
 
   update()
   const handle = setInterval(update, POLL_MS)
@@ -52,22 +40,5 @@ export function buildOccupancySensor(side: Side): OccupancyAccessory {
   return {
     service,
     stop: () => clearInterval(handle),
-  }
-}
-
-function readPresence(side: Side): boolean {
-  try {
-    const since = new Date(Date.now() - MOVEMENT_WINDOW_MS)
-    const [row] = biometricsDb
-      .select({ peak: sql<number>`MAX(${movement.totalMovement})` })
-      .from(movement)
-      .where(and(eq(movement.side, side), gte(movement.timestamp, since)))
-      .limit(1)
-      .all()
-    const peak = row?.peak ?? 0
-    return peak >= RESTLESS_SCORE_MIN
-  }
-  catch {
-    return false
   }
 }

--- a/src/homekit/accessories/occupancySensor.ts
+++ b/src/homekit/accessories/occupancySensor.ts
@@ -1,15 +1,27 @@
 /**
  * HomeKit OccupancySensor accessory bound to one Pod side.
- * Sourced from biometrics: latest sleep_records row with leftBedAt IS NULL.
+ *
+ * Occupancy is derived from the `movement` table rather than `sleep_records`:
+ * a `sleep_records` row is only inserted at session close (and `leftBedAt` is
+ * NOT NULL by schema), so there is no queryable "session-open" signal. The
+ * `movement` table is updated every 60s with a baseline-subtracted score
+ * (~0 on an empty bed, >=50 when an occupant is moving — see docs/sleep-
+ * detector.md PIM scoring).
+ *
+ * Rule: OCCUPIED iff any movement epoch in the last MOVEMENT_WINDOW_MS has
+ * total_movement >= RESTLESS_SCORE_MIN. The 15-minute window tolerates the
+ * 70-80% of deep-sleep epochs that score below the threshold.
  */
 
 import { Service, Characteristic } from 'hap-nodejs'
-import { desc, eq } from 'drizzle-orm'
+import { and, eq, gte, sql } from 'drizzle-orm'
 import { biometricsDb } from '@/src/db/biometrics'
-import { sleepRecords } from '@/src/db/biometrics-schema'
+import { movement } from '@/src/db/biometrics-schema'
+import { RESTLESS_SCORE_MIN } from '@/src/lib/movement'
 import type { Side } from '@/src/hardware/types'
 
 const POLL_MS = 5_000
+const MOVEMENT_WINDOW_MS = 15 * 60_000
 
 export interface OccupancyAccessory {
   service: Service
@@ -45,15 +57,15 @@ export function buildOccupancySensor(side: Side): OccupancyAccessory {
 
 function readPresence(side: Side): boolean {
   try {
-    const [latest] = biometricsDb
-      .select({ leftBedAt: sleepRecords.leftBedAt })
-      .from(sleepRecords)
-      .where(eq(sleepRecords.side, side))
-      .orderBy(desc(sleepRecords.enteredBedAt))
+    const since = new Date(Date.now() - MOVEMENT_WINDOW_MS)
+    const [row] = biometricsDb
+      .select({ peak: sql<number>`MAX(${movement.totalMovement})` })
+      .from(movement)
+      .where(and(eq(movement.side, side), gte(movement.timestamp, since)))
       .limit(1)
       .all()
-    if (!latest) return false
-    return latest.leftBedAt == null
+    const peak = row?.peak ?? 0
+    return peak >= RESTLESS_SCORE_MIN
   }
   catch {
     return false

--- a/src/homekit/tests/occupancySensor.test.ts
+++ b/src/homekit/tests/occupancySensor.test.ts
@@ -1,93 +1,69 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Characteristic } from 'hap-nodejs'
+import type { OccupancyResult } from '@/src/lib/occupancy'
 
-let rows: Array<{ peak: number | null }> = []
-const all = vi.fn(() => rows)
+const occupancyMock = vi.fn<(side: 'left' | 'right') => OccupancyResult>()
 
-vi.mock('@/src/db/biometrics', () => ({
-  biometricsDb: {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => ({ all }),
-        }),
-      }),
-    }),
-  },
-}))
-
-vi.mock('@/src/db/biometrics-schema', () => ({
-  movement: { side: {}, timestamp: {}, totalMovement: {} },
+vi.mock('@/src/lib/occupancy', () => ({
+  getOccupancy: (side: 'left' | 'right') => occupancyMock(side),
 }))
 
 import { buildOccupancySensor } from '../accessories/occupancySensor'
 
+function result(occupied: boolean): OccupancyResult {
+  return {
+    occupied,
+    movement: { active: occupied, peakScore: occupied ? 660 : 12 },
+    level: { active: false, deviation: null, threshold: null, ageMs: null },
+  }
+}
+
 describe('occupancySensor accessory', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    rows = []
-    all.mockClear()
+    occupancyMock.mockReset()
+    occupancyMock.mockReturnValue(result(false))
   })
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('reports OCCUPANCY_NOT_DETECTED when no movement rows exist', async () => {
-    rows = [{ peak: null }]
+  it('reports OCCUPANCY_NOT_DETECTED when the virtual sensor returns occupied=false', async () => {
+    occupancyMock.mockReturnValue(result(false))
     const { service, stop } = buildOccupancySensor('left')
     const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
     expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
     stop()
   })
 
-  it('reports OCCUPANCY_NOT_DETECTED for empty-bed baseline noise', async () => {
-    rows = [{ peak: 30 }]
-    const { service, stop } = buildOccupancySensor('right')
-    const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
-    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
-    stop()
-  })
-
-  it('reports OCCUPANCY_DETECTED when peak movement crosses the threshold', async () => {
-    rows = [{ peak: 50 }]
+  it('reports OCCUPANCY_DETECTED when the virtual sensor returns occupied=true', async () => {
+    occupancyMock.mockReturnValue(result(true))
     const { service, stop } = buildOccupancySensor('right')
     const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
     expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)
     stop()
   })
 
-  it('reports OCCUPANCY_DETECTED for a clear movement spike', async () => {
-    rows = [{ peak: 662 }]
-    const { service, stop } = buildOccupancySensor('left')
-    const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
-    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)
+  it('passes through the requested side to the virtual sensor', async () => {
+    occupancyMock.mockReturnValue(result(false))
+    const { stop } = buildOccupancySensor('right')
+    expect(occupancyMock).toHaveBeenCalledWith('right')
     stop()
   })
 
-  it('tolerates db query errors and returns NOT_DETECTED', async () => {
-    all.mockImplementationOnce(() => {
-      throw new Error('db gone')
-    })
-    const { service, stop } = buildOccupancySensor('left')
-    const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
-    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
-    stop()
-  })
-
-  it('polls presence on interval', async () => {
-    rows = [{ peak: 0 }]
+  it('polls occupancy on interval', () => {
     const { stop } = buildOccupancySensor('left')
-    const before = all.mock.calls.length
+    const before = occupancyMock.mock.calls.length
     vi.advanceTimersByTime(15_000)
-    expect(all.mock.calls.length).toBeGreaterThan(before)
+    expect(occupancyMock.mock.calls.length).toBeGreaterThan(before)
     stop()
   })
 
   it('stop() clears the poll interval', () => {
     const { stop } = buildOccupancySensor('left')
     stop()
-    const after = all.mock.calls.length
+    const after = occupancyMock.mock.calls.length
     vi.advanceTimersByTime(60_000)
-    expect(all.mock.calls.length).toBe(after)
+    expect(occupancyMock.mock.calls.length).toBe(after)
   })
 })

--- a/src/homekit/tests/occupancySensor.test.ts
+++ b/src/homekit/tests/occupancySensor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Characteristic } from 'hap-nodejs'
 
-let rows: Array<{ leftBedAt: number | null }> = []
+let rows: Array<{ peak: number | null }> = []
 const all = vi.fn(() => rows)
 
 vi.mock('@/src/db/biometrics', () => ({
@@ -9,9 +9,7 @@ vi.mock('@/src/db/biometrics', () => ({
     select: () => ({
       from: () => ({
         where: () => ({
-          orderBy: () => ({
-            limit: () => ({ all }),
-          }),
+          limit: () => ({ all }),
         }),
       }),
     }),
@@ -19,7 +17,7 @@ vi.mock('@/src/db/biometrics', () => ({
 }))
 
 vi.mock('@/src/db/biometrics-schema', () => ({
-  sleepRecords: { side: {}, leftBedAt: {}, enteredBedAt: {} },
+  movement: { side: {}, timestamp: {}, totalMovement: {} },
 }))
 
 import { buildOccupancySensor } from '../accessories/occupancySensor'
@@ -34,27 +32,35 @@ describe('occupancySensor accessory', () => {
     vi.useRealTimers()
   })
 
-  it('reports OCCUPANCY_NOT_DETECTED when no sleep records exist', async () => {
-    rows = []
+  it('reports OCCUPANCY_NOT_DETECTED when no movement rows exist', async () => {
+    rows = [{ peak: null }]
     const { service, stop } = buildOccupancySensor('left')
     const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
     expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
     stop()
   })
 
-  it('reports OCCUPANCY_DETECTED when latest record has null leftBedAt', async () => {
-    rows = [{ leftBedAt: null }]
+  it('reports OCCUPANCY_NOT_DETECTED for empty-bed baseline noise', async () => {
+    rows = [{ peak: 30 }]
+    const { service, stop } = buildOccupancySensor('right')
+    const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
+    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
+    stop()
+  })
+
+  it('reports OCCUPANCY_DETECTED when peak movement crosses the threshold', async () => {
+    rows = [{ peak: 50 }]
     const { service, stop } = buildOccupancySensor('right')
     const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
     expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)
     stop()
   })
 
-  it('reports OCCUPANCY_NOT_DETECTED when latest record has leftBedAt set', async () => {
-    rows = [{ leftBedAt: 1000 }]
+  it('reports OCCUPANCY_DETECTED for a clear movement spike', async () => {
+    rows = [{ peak: 662 }]
     const { service, stop } = buildOccupancySensor('left')
     const value = await service.getCharacteristic(Characteristic.OccupancyDetected).handleGetRequest()
-    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED)
+    expect(value).toBe(Characteristic.OccupancyDetected.OCCUPANCY_DETECTED)
     stop()
   })
 
@@ -69,7 +75,7 @@ describe('occupancySensor accessory', () => {
   })
 
   it('polls presence on interval', async () => {
-    rows = []
+    rows = [{ peak: 0 }]
     const { stop } = buildOccupancySensor('left')
     const before = all.mock.calls.length
     vi.advanceTimersByTime(15_000)

--- a/src/lib/movement.ts
+++ b/src/lib/movement.ts
@@ -18,3 +18,18 @@ export function pickMovementBucketSeconds(rangeMs: number): number {
   const ONE_DAY_MS = 24 * 60 * 60 * 1000
   return rangeMs > ONE_DAY_MS ? MOVEMENT_BUCKET_WEEK_SECONDS : MOVEMENT_BUCKET_DAY_SECONDS
 }
+
+/**
+ * Density gate for the movement bucket chart: a bucket is rendered only if at
+ * least this many of its epochs cross RESTLESS_SCORE_MIN ("real activity").
+ * Filters phantom-session flicker (1-3 stray epochs/bucket) without affecting
+ * real sessions (~6-10 non-still epochs in 30 min, per the doc score table).
+ *
+ * Scales with bucket width so a sparse signal in a wide bucket is still cut,
+ * while a narrow 5-min day-view bucket needs only 2 hits to qualify.
+ */
+export const MIN_BUCKET_NONSTILL_FLOOR = 2
+
+export function pickMinBucketNonStillEpochs(bucketSeconds: number): number {
+  return Math.max(MIN_BUCKET_NONSTILL_FLOOR, Math.floor(bucketSeconds / 600))
+}

--- a/src/lib/movement.ts
+++ b/src/lib/movement.ts
@@ -31,5 +31,7 @@ export function pickMovementBucketSeconds(rangeMs: number): number {
 export const MIN_BUCKET_NONSTILL_FLOOR = 2
 
 export function pickMinBucketNonStillEpochs(bucketSeconds: number): number {
-  return Math.max(MIN_BUCKET_NONSTILL_FLOOR, Math.floor(bucketSeconds / 600))
+  const availableEpochs = Math.floor(bucketSeconds / 60)
+  const desired = Math.max(MIN_BUCKET_NONSTILL_FLOOR, Math.floor(bucketSeconds / 600))
+  return Math.min(availableEpochs, desired)
 }

--- a/src/lib/occupancy.ts
+++ b/src/lib/occupancy.ts
@@ -1,0 +1,170 @@
+/**
+ * Virtual occupancy sensor — single source of truth shared by the HomeKit
+ * OccupancySensor accessory and the web-app PresenceCard.
+ *
+ * Combines two signals via OR:
+ *
+ *   1. Movement signal (catches an active occupant).
+ *      `MAX(movement.total_movement)` over the last MOVEMENT_WINDOW_MS,
+ *      compared to RESTLESS_SCORE_MIN. Identical to the original HomeKit logic.
+ *
+ *   2. Level signal (catches a still occupant — deep sleep, etc.).
+ *      Live capSense2 channel readings vs the per-side calibration baseline
+ *      from `calibration_profiles`, with reference-channel compensation.
+ *      Mirrors the Python sleep-detector's per-sample presence check.
+ *
+ * Movement alone is blind to a person who is lying perfectly still; level
+ * alone is blind to brief presence events that don't sustain a baseline
+ * deviation. The OR closes both gaps.
+ */
+
+import { and, eq, gte, sql } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db/biometrics'
+import { calibrationProfiles, movement } from '@/src/db/biometrics-schema'
+import { getLatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+import { RESTLESS_SCORE_MIN } from '@/src/lib/movement'
+import type { Side } from '@/src/hardware/types'
+
+const MOVEMENT_WINDOW_MS = 15 * 60_000
+/** capSense2 nominally arrives at ~2 Hz. >30s gap = sensor / stream down. */
+const CAPSENSE_STALE_MS = 30_000
+/** Nominal reference-channel value used when the calibration profile is
+ *  missing a `ref.mean` field (older profiles). Matches the documented
+ *  capSense2 reference baseline. */
+const REF_NOMINAL = 1.16
+
+export interface MovementSignal {
+  active: boolean
+  peakScore: number
+}
+
+export interface LevelSignal {
+  active: boolean
+  /** Sum of compensated per-channel deviation from baseline, or null when
+   *  the signal can't be evaluated (no frame, stale frame, no calibration). */
+  deviation: number | null
+  /** Calibration threshold the deviation must exceed, or null when unavailable. */
+  threshold: number | null
+  /** Milliseconds since the latest capSense2 frame was received, or null
+   *  when no frame has ever been seen. */
+  ageMs: number | null
+}
+
+export interface OccupancyResult {
+  occupied: boolean
+  movement: MovementSignal
+  level: LevelSignal
+}
+
+interface CapSenseCalibration {
+  channels: { A: { mean: number }, B: { mean: number }, C: { mean: number } }
+  threshold: number
+  format: string
+  ref?: { mean: number }
+}
+
+export function getOccupancy(side: Side): OccupancyResult {
+  const movementSignal = readMovementSignal(side)
+  const levelSignal = readLevelSignal(side)
+  return {
+    occupied: movementSignal.active || levelSignal.active,
+    movement: movementSignal,
+    level: levelSignal,
+  }
+}
+
+function readMovementSignal(side: Side): MovementSignal {
+  try {
+    const since = new Date(Date.now() - MOVEMENT_WINDOW_MS)
+    const [row] = biometricsDb
+      .select({ peak: sql<number>`MAX(${movement.totalMovement})` })
+      .from(movement)
+      .where(and(eq(movement.side, side), gte(movement.timestamp, since)))
+      .limit(1)
+      .all()
+    const peak = row?.peak ?? 0
+    return { active: peak >= RESTLESS_SCORE_MIN, peakScore: peak }
+  }
+  catch {
+    return { active: false, peakScore: 0 }
+  }
+}
+
+function readLevelSignal(side: Side): LevelSignal {
+  const snap = getLatestCapSenseSnapshot()
+  if (!snap) {
+    return { active: false, deviation: null, threshold: null, ageMs: null }
+  }
+
+  const ageMs = Date.now() - snap.receivedAtMs
+  if (ageMs > CAPSENSE_STALE_MS) {
+    return { active: false, deviation: null, threshold: null, ageMs }
+  }
+
+  // Pod-3 legacy capSense uses a scalar-per-side and a different calibration
+  // shape; level scoring there is not implemented (movement signal still works).
+  if (snap.type !== 'capSense2') {
+    return { active: false, deviation: null, threshold: null, ageMs }
+  }
+
+  const cal = readCapSenseCalibration(side)
+  if (!cal) {
+    return { active: false, deviation: null, threshold: null, ageMs }
+  }
+
+  const values = side === 'left' ? snap.left : snap.right
+  if (!Array.isArray(values) || values.length < 6) {
+    return { active: false, deviation: null, threshold: cal.threshold, ageMs }
+  }
+
+  const avgPair = (x: number, y: number): number => (x + y) / 2
+  const a = avgPair(values[0], values[1])
+  const b = avgPair(values[2], values[3])
+  const c = avgPair(values[4], values[5])
+
+  let refDelta = 0
+  if (values.length >= 8) {
+    const ref = avgPair(values[6], values[7])
+    const refNominal = cal.ref?.mean ?? REF_NOMINAL
+    refDelta = ref - refNominal
+  }
+
+  const deviation = (a - refDelta - cal.channels.A.mean)
+    + (b - refDelta - cal.channels.B.mean)
+    + (c - refDelta - cal.channels.C.mean)
+
+  return {
+    active: deviation > cal.threshold,
+    deviation,
+    threshold: cal.threshold,
+    ageMs,
+  }
+}
+
+function readCapSenseCalibration(side: Side): CapSenseCalibration | null {
+  try {
+    const [row] = biometricsDb
+      .select({ parameters: calibrationProfiles.parameters })
+      .from(calibrationProfiles)
+      .where(and(
+        eq(calibrationProfiles.side, side),
+        eq(calibrationProfiles.sensorType, 'capacitance'),
+        eq(calibrationProfiles.status, 'completed'),
+      ))
+      .limit(1)
+      .all()
+    if (!row) return null
+    const parsed = row.parameters as CapSenseCalibration
+    if (parsed?.format !== 'capSense2') return null
+    if (typeof parsed.channels?.A?.mean !== 'number'
+      || typeof parsed.channels?.B?.mean !== 'number'
+      || typeof parsed.channels?.C?.mean !== 'number') {
+      return null
+    }
+    if (typeof parsed.threshold !== 'number') return null
+    return parsed
+  }
+  catch {
+    return null
+  }
+}

--- a/src/lib/tests/movement.test.ts
+++ b/src/lib/tests/movement.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest'
 import {
+  MIN_BUCKET_NONSTILL_FLOOR,
   MOVEMENT_BUCKET_DAY_SECONDS,
   MOVEMENT_BUCKET_WEEK_SECONDS,
+  pickMinBucketNonStillEpochs,
   pickMovementBucketSeconds,
   POSITION_CHANGE_SCORE_MIN,
   RESTLESS_SCORE_MIN,
@@ -30,5 +32,17 @@ describe('pickMovementBucketSeconds', () => {
   test('uses week buckets for ranges longer than one day', () => {
     expect(pickMovementBucketSeconds(ONE_DAY_MS + 1)).toBe(MOVEMENT_BUCKET_WEEK_SECONDS)
     expect(pickMovementBucketSeconds(7 * ONE_DAY_MS)).toBe(MOVEMENT_BUCKET_WEEK_SECONDS)
+  })
+})
+
+describe('pickMinBucketNonStillEpochs', () => {
+  test('uses the floor for small day-view buckets', () => {
+    expect(pickMinBucketNonStillEpochs(MOVEMENT_BUCKET_DAY_SECONDS)).toBe(MIN_BUCKET_NONSTILL_FLOOR)
+    expect(pickMinBucketNonStillEpochs(60)).toBe(MIN_BUCKET_NONSTILL_FLOOR)
+  })
+
+  test('scales linearly above 10 min, requiring three hits in a 30-min bucket', () => {
+    expect(pickMinBucketNonStillEpochs(MOVEMENT_BUCKET_WEEK_SECONDS)).toBe(3)
+    expect(pickMinBucketNonStillEpochs(3600)).toBe(6)
   })
 })

--- a/src/lib/tests/movement.test.ts
+++ b/src/lib/tests/movement.test.ts
@@ -38,7 +38,10 @@ describe('pickMovementBucketSeconds', () => {
 describe('pickMinBucketNonStillEpochs', () => {
   test('uses the floor for small day-view buckets', () => {
     expect(pickMinBucketNonStillEpochs(MOVEMENT_BUCKET_DAY_SECONDS)).toBe(MIN_BUCKET_NONSTILL_FLOOR)
-    expect(pickMinBucketNonStillEpochs(60)).toBe(MIN_BUCKET_NONSTILL_FLOOR)
+  })
+
+  test('caps at available epochs for sub-floor buckets', () => {
+    expect(pickMinBucketNonStillEpochs(60)).toBe(1)
   })
 
   test('scales linearly above 10 min, requiring three hits in a 30-min bucket', () => {

--- a/src/lib/tests/occupancy.test.ts
+++ b/src/lib/tests/occupancy.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+
+interface MovementRow { peak: number | null }
+interface CalRow { parameters: unknown }
+
+let movementRows: MovementRow[] = []
+let calRows: CalRow[] = []
+let snapshot: LatestCapSenseSnapshot | null = null
+
+const movementAll = vi.fn<() => MovementRow[]>(() => movementRows)
+const calAll = vi.fn<() => CalRow[]>(() => calRows)
+
+vi.mock('@/src/db/biometrics', () => ({
+  biometricsDb: {
+    select: (cols?: Record<string, unknown>) => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            all: () => {
+              // Distinguish queries by selected columns: movement uses `peak`,
+              // calibration uses `parameters`. Cheap heuristic — no SQL coupling.
+              if (cols && 'peak' in cols) return movementAll()
+              return calAll()
+            },
+          }),
+        }),
+      }),
+    }),
+  },
+}))
+
+vi.mock('@/src/db/biometrics-schema', () => ({
+  movement: { side: {}, timestamp: {}, totalMovement: {} },
+  calibrationProfiles: {
+    side: {},
+    sensorType: {},
+    status: {},
+    parameters: {},
+  },
+}))
+
+vi.mock('@/src/streaming/piezoStream', () => ({
+  getLatestCapSenseSnapshot: () => snapshot,
+}))
+
+import { getOccupancy } from '../occupancy'
+
+const FIXED_NOW = 1_778_910_000_000
+const BASELINE_CAL = {
+  channels: { A: { mean: 14.45 }, B: { mean: 13.65 }, C: { mean: 19.3 } },
+  threshold: 6.0,
+  format: 'capSense2',
+  ref: { mean: 1.157 },
+}
+
+function makeFrame(side: 'left' | 'right', values: number[]): LatestCapSenseSnapshot {
+  return {
+    type: 'capSense2',
+    ts: Math.floor(FIXED_NOW / 1000),
+    receivedAtMs: FIXED_NOW - 500,
+    left: side === 'left' ? values : [14.45, 14.45, 13.65, 13.65, 19.3, 19.3, 1.157, 1.157],
+    right: side === 'right' ? values : [14.45, 14.45, 13.65, 13.65, 19.3, 19.3, 1.157, 1.157],
+  }
+}
+
+describe('getOccupancy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(FIXED_NOW))
+    movementRows = []
+    calRows = []
+    snapshot = null
+    movementAll.mockClear()
+    calAll.mockClear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns occupied=false when both signals are quiet', () => {
+    movementRows = [{ peak: 30 }]
+    snapshot = makeFrame('left', [14.5, 14.4, 13.7, 13.6, 19.4, 19.2, 1.157, 1.157])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.occupied).toBe(false)
+    expect(r.movement.active).toBe(false)
+    expect(r.level.active).toBe(false)
+  })
+
+  it('returns occupied=true via the movement signal alone', () => {
+    movementRows = [{ peak: 350 }]
+    snapshot = null
+    const r = getOccupancy('right')
+    expect(r.movement.active).toBe(true)
+    expect(r.movement.peakScore).toBe(350)
+    expect(r.level.active).toBe(false)
+    expect(r.occupied).toBe(true)
+  })
+
+  it('returns occupied=true via the level signal alone (still occupant)', () => {
+    // Quiet movement, but channels well above baseline → deviation >> threshold
+    movementRows = [{ peak: 5 }]
+    snapshot = makeFrame('left', [25.0, 25.0, 23.0, 23.0, 30.0, 30.0, 1.157, 1.157])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.movement.active).toBe(false)
+    expect(r.level.active).toBe(true)
+    expect(r.level.deviation).not.toBeNull()
+    expect(r.level.deviation as number).toBeGreaterThan(6)
+    expect(r.occupied).toBe(true)
+  })
+
+  it('applies reference-channel compensation', () => {
+    // Channels deviate ~+3 each = +9 total; ref also drifted +1 from nominal,
+    // so compensated deviation is 9 - 3*1 = 6, NOT above threshold (6.0 strict >).
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [17.45, 17.45, 16.65, 16.65, 22.3, 22.3, 2.157, 2.157])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+  })
+
+  it('ignores stale capSense frames', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = {
+      type: 'capSense2',
+      ts: Math.floor((FIXED_NOW - 60_000) / 1000),
+      receivedAtMs: FIXED_NOW - 60_000, // 60s old → stale
+      left: [25, 25, 23, 23, 30, 30, 1.157, 1.157],
+      right: [14.45, 14.45, 13.65, 13.65, 19.3, 19.3, 1.157, 1.157],
+    }
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.deviation).toBeNull()
+    expect(r.level.ageMs).toBeGreaterThan(30_000)
+    expect(r.occupied).toBe(false)
+  })
+
+  it('skips level signal for legacy capSense (Pod 3) frames', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = {
+      type: 'capSense',
+      ts: Math.floor(FIXED_NOW / 1000),
+      receivedAtMs: FIXED_NOW - 500,
+      left: 2000,
+      right: 100,
+    }
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.deviation).toBeNull()
+  })
+
+  it('skips level signal when calibration is missing', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calRows = []
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.deviation).toBeNull()
+    expect(r.occupied).toBe(false)
+  })
+
+  it('skips level signal when calibration format is not capSense2', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calRows = [{ parameters: { ...BASELINE_CAL, format: 'capSense' } }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+  })
+
+  it('tolerates db errors and returns occupied=false', () => {
+    movementAll.mockImplementationOnce(() => {
+      throw new Error('db gone')
+    })
+    snapshot = null
+    const r = getOccupancy('left')
+    expect(r.movement.peakScore).toBe(0)
+    expect(r.occupied).toBe(false)
+  })
+})

--- a/src/lib/tests/occupancy.test.ts
+++ b/src/lib/tests/occupancy.test.ts
@@ -180,4 +180,81 @@ describe('getOccupancy', () => {
     expect(r.movement.peakScore).toBe(0)
     expect(r.occupied).toBe(false)
   })
+
+  it('skips level signal when capSense2 frame has fewer than 6 channel values', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.deviation).toBeNull()
+    expect(r.level.threshold).toBe(BASELINE_CAL.threshold)
+  })
+
+  it('skips level signal when capSense2 frame omits the reference pair', () => {
+    // 6 values, no ref pair — refDelta=0, raw deviation used directly.
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(true)
+    expect(r.level.deviation as number).toBeGreaterThan(BASELINE_CAL.threshold)
+  })
+
+  it('falls back to nominal reference baseline when calibration omits ref.mean', () => {
+    const calNoRef = { ...BASELINE_CAL }
+    delete (calNoRef as { ref?: unknown }).ref
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.16, 1.16])
+    calRows = [{ parameters: calNoRef }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(true)
+  })
+
+  it('skips level signal when calibration channels are malformed', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calRows = [{ parameters: { ...BASELINE_CAL, channels: { A: { mean: 'bad' }, B: { mean: 13.65 }, C: { mean: 19.3 } } } }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.threshold).toBeNull()
+  })
+
+  it('skips level signal when calibration threshold is missing', () => {
+    const noThreshold = { ...BASELINE_CAL } as Partial<typeof BASELINE_CAL>
+    delete noThreshold.threshold
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calRows = [{ parameters: noThreshold }]
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.threshold).toBeNull()
+  })
+
+  it('handles empty movement row (peak=null) without throwing', () => {
+    movementRows = [{ peak: null }]
+    snapshot = null
+    const r = getOccupancy('right')
+    expect(r.movement.peakScore).toBe(0)
+    expect(r.movement.active).toBe(false)
+  })
+
+  it('reads the right-side channel array on a right-side request', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('right', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calRows = [{ parameters: BASELINE_CAL }]
+    const r = getOccupancy('right')
+    expect(r.level.active).toBe(true)
+  })
+
+  it('tolerates db errors during calibration lookup', () => {
+    movementRows = [{ peak: 0 }]
+    snapshot = makeFrame('left', [25, 25, 23, 23, 30, 30, 1.157, 1.157])
+    calAll.mockImplementationOnce(() => {
+      throw new Error('cal db gone')
+    })
+    const r = getOccupancy('left')
+    expect(r.level.active).toBe(false)
+    expect(r.level.threshold).toBeNull()
+  })
 })

--- a/src/server/routers/biometrics.ts
+++ b/src/server/routers/biometrics.ts
@@ -14,7 +14,11 @@ import {
   calculateQualityScore,
   type SleepStagesResult,
 } from '@/src/lib/sleep-stages'
-import { POSITION_CHANGE_SCORE_MIN, RESTLESS_SCORE_MIN } from '@/src/lib/movement'
+import {
+  POSITION_CHANGE_SCORE_MIN,
+  RESTLESS_SCORE_MIN,
+  pickMinBucketNonStillEpochs,
+} from '@/src/lib/movement'
 
 /**
  * SQL fragment: movement.timestamp falls inside an existing sleep_records
@@ -318,6 +322,12 @@ export const biometricsRouter = router({
    * events-per-hour following Whoop / Garmin convention; raw PIM sums are
    * available via totalMovement for debug / power-user views.
    *
+   * Density gate: buckets with fewer than pickMinBucketNonStillEpochs(...)
+   * epochs above RESTLESS_SCORE_MIN are dropped. Filters phantom-session
+   * flicker that leaks past inBedExists (a noisy session of record can still
+   * contain many empty-bed sub-windows). See docs/sleep-detector.md "Chart
+   * aggregation" for the rationale.
+   *
    * @param bucketSeconds - 60..86400; chart bucket width (e.g. 300 for 5-min)
    */
   getMovementBuckets: publicProcedure
@@ -359,6 +369,8 @@ export const biometricsRouter = router({
         // Zod has already validated 60..86400, so no injection surface.
         const bSec = Math.floor(input.bucketSeconds)
         const bucket = sql<number>`(${movement.timestamp} / ${sql.raw(String(bSec))}) * ${sql.raw(String(bSec))}`
+        const minNonStill = pickMinBucketNonStillEpochs(bSec)
+        const nonStillEpochs = sql<number>`SUM(CASE WHEN ${movement.totalMovement} >= ${sql.raw(String(RESTLESS_SCORE_MIN))} THEN 1 ELSE 0 END)`
 
         const rows = await biometricsDb
           .select({
@@ -370,6 +382,7 @@ export const biometricsRouter = router({
           .from(movement)
           .where(and(...conditions))
           .groupBy(bucket)
+          .having(sql`${nonStillEpochs} >= ${sql.raw(String(minNonStill))}`)
           .orderBy(desc(bucket))
           .limit(input.limit)
 

--- a/src/server/routers/biometrics.ts
+++ b/src/server/routers/biometrics.ts
@@ -19,6 +19,7 @@ import {
   RESTLESS_SCORE_MIN,
   pickMinBucketNonStillEpochs,
 } from '@/src/lib/movement'
+import { getOccupancy } from '@/src/lib/occupancy'
 
 /**
  * SQL fragment: movement.timestamp falls inside an existing sleep_records
@@ -520,6 +521,44 @@ export const biometricsRouter = router({
           message: `Failed to fetch latest sleep record: ${error instanceof Error ? error.message : 'Unknown error'}`,
           cause: error,
         })
+      }
+    }),
+
+  /**
+   * Current bed occupancy for both sides. Single source of truth used by
+   * the HomeKit OccupancySensor accessory and the web-app PresenceCard.
+   * Combines the movement-table 15-min window with the live capSense2
+   * level signal vs the calibration baseline. See `src/lib/occupancy.ts`.
+   */
+  getOccupancy: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/biometrics/occupancy', protect: false, tags: ['Biometrics'] } })
+    .input(z.void().optional())
+    .output(z.object({
+      left: z.object({
+        occupied: z.boolean(),
+        movement: z.object({ active: z.boolean(), peakScore: z.number() }),
+        level: z.object({
+          active: z.boolean(),
+          deviation: z.number().nullable(),
+          threshold: z.number().nullable(),
+          ageMs: z.number().nullable(),
+        }),
+      }),
+      right: z.object({
+        occupied: z.boolean(),
+        movement: z.object({ active: z.boolean(), peakScore: z.number() }),
+        level: z.object({
+          active: z.boolean(),
+          deviation: z.number().nullable(),
+          threshold: z.number().nullable(),
+          ageMs: z.number().nullable(),
+        }),
+      }),
+    }))
+    .query(async () => {
+      return {
+        left: getOccupancy('left'),
+        right: getOccupancy('right'),
       }
     }),
 

--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -29,6 +29,7 @@ const dbMock = vi.hoisted(() => {
     chain.onConflictDoNothing = vi.fn(() => chain)
     chain.returning = vi.fn(() => chain)
     chain.groupBy = vi.fn(() => chain)
+    chain.having = vi.fn(() => chain)
     return chain
   }
 
@@ -685,6 +686,7 @@ describe('biometrics error wrapping (INTERNAL_SERVER_ERROR catches)', () => {
       onConflictDoNothing: vi.fn(() => failingChain),
       returning: vi.fn(() => failingChain),
       groupBy: vi.fn(() => failingChain),
+      having: vi.fn(() => failingChain),
     }
     dbMock[method].mockImplementationOnce(() => failingChain)
   }

--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -88,6 +88,19 @@ vi.mock('@/src/db', () => ({
 vi.mock('@/src/server/routers/raw', () => rawMock)
 vi.mock('@/src/lib/sleep-stages', () => sleepStagesMock)
 
+const occupancyMock = vi.hoisted(() => ({
+  getOccupancy: vi.fn<(side: 'left' | 'right') => {
+    occupied: boolean
+    movement: { active: boolean, peakScore: number }
+    level: { active: boolean, deviation: number | null, threshold: number | null, ageMs: number | null }
+  }>(() => ({
+    occupied: false,
+    movement: { active: false, peakScore: 0 },
+    level: { active: false, deviation: null, threshold: null, ageMs: null },
+  })),
+}))
+vi.mock('@/src/lib/occupancy', () => occupancyMock)
+
 const { biometricsRouter } = await import('@/src/server/routers/biometrics')
 const caller = biometricsRouter.createCaller({})
 
@@ -105,6 +118,7 @@ beforeEach(() => {
   sleepStagesMock.mergeIntoBlocks.mockReset().mockReturnValue([])
   sleepStagesMock.calculateDistribution.mockReset().mockReturnValue({ wake: 0, light: 0, deep: 0, rem: 0 })
   sleepStagesMock.calculateQualityScore.mockReset().mockReturnValue(0)
+  occupancyMock.getOccupancy.mockReset()
 })
 
 describe('biometrics.getSleepRecords', () => {
@@ -208,6 +222,35 @@ describe('biometrics.getLatestSleep', () => {
     ])
     const out = await caller.getLatestSleep({ side: 'left' })
     expect(out?.id).toBe(5)
+  })
+})
+
+describe('biometrics.getOccupancy', () => {
+  it('returns occupancy for both sides from the shared virtual sensor', async () => {
+    occupancyMock.getOccupancy.mockImplementation((side: 'left' | 'right') => ({
+      occupied: side === 'left',
+      movement: { active: side === 'left', peakScore: side === 'left' ? 300 : 10 },
+      level: { active: false, deviation: null, threshold: null, ageMs: null },
+    }))
+    const out = await caller.getOccupancy()
+    expect(out.left.occupied).toBe(true)
+    expect(out.left.movement.peakScore).toBe(300)
+    expect(out.right.occupied).toBe(false)
+    expect(occupancyMock.getOccupancy).toHaveBeenCalledWith('left')
+    expect(occupancyMock.getOccupancy).toHaveBeenCalledWith('right')
+  })
+
+  it('passes level signal through to the response', async () => {
+    occupancyMock.getOccupancy.mockReturnValue({
+      occupied: true,
+      movement: { active: false, peakScore: 5 },
+      level: { active: true, deviation: 12.3, threshold: 6, ageMs: 500 },
+    })
+    const out = await caller.getOccupancy()
+    expect(out.left.level.deviation).toBe(12.3)
+    expect(out.left.level.threshold).toBe(6)
+    expect(out.left.level.ageMs).toBe(500)
+    expect(out.left.level.active).toBe(true)
   })
 })
 

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -73,6 +73,40 @@ const frameIndex: FrameIndexEntry[] = []
 let indexedFilePath: string | null = null
 
 /**
+ * Last seen capSense / capSense2 frame, kept as a cheap snapshot so
+ * server-side consumers (e.g. the virtual occupancy sensor in
+ * `src/lib/occupancy.ts`) can read the live channel readings without
+ * subscribing to the WebSocket stream from within the same process.
+ *
+ * Mutated in the live broadcast loop. Cleared on RAW file switch.
+ */
+export interface LatestCapSenseSnapshot {
+  /** Frame type as emitted by firmware. */
+  type: 'capSense' | 'capSense2'
+  /** Frame timestamp (unix seconds from firmware). */
+  ts: number
+  /** Wall-clock epoch ms when the snapshot was written. Used for staleness. */
+  receivedAtMs: number
+  /** Per-side channels — capSense (Pod 3) carries a scalar; capSense2 carries the
+   *  raw `[A1,A2,B1,B2,C1,C2,ref1,ref2]` array. */
+  left: number | number[]
+  right: number | number[]
+}
+
+let latestCapSenseSnapshot: LatestCapSenseSnapshot | null = null
+
+/**
+ * Read the most recent capSense / capSense2 frame seen on the live RAW stream.
+ * Returns null until the first frame arrives or after the RAW file switches.
+ *
+ * Consumers should treat a `receivedAtMs` older than ~30s as stale — capSense2
+ * frames arrive at ~2 Hz; long gaps mean the sensor or the streamer is down.
+ */
+export function getLatestCapSenseSnapshot(): LatestCapSenseSnapshot | null {
+  return latestCapSenseSnapshot
+}
+
+/**
  * Append an entry and evict anything older than the seek-retention window.
  * Seek is capped at `SEEK_MAX_DURATION_S` so older entries are unreachable.
  * Called on every decoded frame — keep the hot path cheap (amortized O(1)).
@@ -643,6 +677,9 @@ export function startPiezoStreamServer(): WebSocketServer {
       // Reset the sidecar frame index for the new file
       frameIndex.length = 0
       indexedFilePath = latest
+      // Drop the cached capSense snapshot — old file's last frame doesn't
+      // describe the current sensor state.
+      latestCapSenseSnapshot = null
     }
 
     // Read any new bytes appended since last read
@@ -717,6 +754,25 @@ export function startPiezoStreamServer(): WebSocketServer {
                   cb(frame as Record<string, unknown>)
                 }
                 catch { /* consumer error */ }
+              }
+            }
+
+            // Update the live capSense snapshot for in-process readers (virtual
+            // occupancy sensor). Cheap O(1) copy of the small per-frame shape.
+            if (frameType === 'capSense' || frameType === 'capSense2') {
+              const left = (frame as { left: unknown }).left
+              const right = (frame as { right: unknown }).right
+              const ts = (frame as { ts: unknown }).ts
+              if (typeof ts === 'number'
+                && (typeof left === 'number' || Array.isArray(left))
+                && (typeof right === 'number' || Array.isArray(right))) {
+                latestCapSenseSnapshot = {
+                  type: frameType,
+                  ts,
+                  receivedAtMs: Date.now(),
+                  left: left as number | number[],
+                  right: right as number | number[],
+                }
               }
             }
           }

--- a/src/streaming/tests/piezoStream.test.ts
+++ b/src/streaming/tests/piezoStream.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => {
 import {
   __test__,
   broadcastFrame,
+  getLatestCapSenseSnapshot,
   onServerFrame,
   startPiezoStreamServer,
   shutdownPiezoStreamServer,
@@ -649,6 +650,48 @@ describe('piezoStream — server lifecycle and protocol', () => {
 
     await client.waitFor(m => m.type === 'capSense' && m.ts === 400)
     await client.waitFor(m => m.type === 'capSense' && m.ts === 401)
+    await client.close()
+  })
+
+  it('exposes the live capSense2 frame via getLatestCapSenseSnapshot and resets it on file switch', async () => {
+    const filePath = path.join(tmpRawDir, 'snapshot-a.RAW')
+    const channels = [14.5, 14.4, 13.7, 13.6, 19.4, 19.2, 1.157, 1.157]
+    const rec = buildOuterRecord(1, [{ type: 'capSense2', ts: 999, left: channels, right: channels }])
+    fs.writeFileSync(filePath, rec)
+    const past = Date.now() / 1000 - 60
+    fs.utimesSync(filePath, past, past)
+
+    const port = startAndPort()
+    const client = await connectClient(port)
+    await client.waitFor(m => m.type === 'capSense2' && m.ts === 999, 3000)
+
+    const snap = getLatestCapSenseSnapshot()
+    expect(snap).not.toBeNull()
+    expect(snap?.type).toBe('capSense2')
+    expect(snap?.ts).toBe(999)
+    expect(Array.isArray(snap?.left)).toBe(true)
+    expect((snap?.left as number[])[0]).toBeCloseTo(14.5)
+
+    // File switch must drop the cached snapshot.
+    const newPath = path.join(tmpRawDir, 'snapshot-b.RAW')
+    fs.writeFileSync(newPath, buildOuterRecord(1, [{ type: 'log', ts: 1000, level: 1, msg: 'x' }]))
+    fs.utimesSync(newPath, Date.now() / 1000, Date.now() / 1000)
+    await client.waitFor(m => m.type === 'log' && m.ts === 1000, 3000)
+
+    expect(getLatestCapSenseSnapshot()).toBeNull()
+    await client.close()
+  })
+
+  it('skips snapshot update when a capSense frame has a malformed payload', async () => {
+    const filePath = path.join(tmpRawDir, 'snapshot-bad.RAW')
+    // Missing ts → snapshot block's type guard rejects the frame.
+    const rec = buildOuterRecord(1, [{ type: 'capSense', left: 1, right: 2 }])
+    fs.writeFileSync(filePath, rec)
+
+    const port = startAndPort()
+    const client = await connectClient(port)
+    await client.waitFor(m => m.type === 'capSense', 3000)
+    expect(getLatestCapSenseSnapshot()).toBeNull()
     await client.close()
   })
 


### PR DESCRIPTION
## Summary

Three coupled fixes for a Pod 5 occupancy report on `192.168.1.88` showing presence (and bogus vitals charts) on an empty bed.

### Root cause — silent calibrator failure
ADR-0018 moved RAW frames to `/persistent/biometrics` tmpfs and updated module unit files. The calibrator unit was missed; its `RAW_DATA_DIR=/persistent` matched only `SEQNO.RAW` (a 16-byte cursor file), so `load_recent_records()` always returned empty.

- Every daily run logged `No capSense records available for calibration` and exited with the service marked `running`.
- All `calibration_profiles` rows for capacitance and piezo sat at `status=failed`.
- `sleep-detector` fell back to `PRESENCE_THRESHOLD = 60.0` for capSense2 → severe presence chatter (`times_exited_bed=118` and `133` in two real overnight sessions; phantom 1-2 min sessions every ~3 min on empty bed).

Fix in `modules/calibrator/sleepypod-calibrator.service`:
- `Environment="RAW_DATA_DIR=/persistent/biometrics"`
- `RequiresMountsFor=/persistent/biometrics` so a tmpfs miss surfaces as a unit failure instead of silent degradation.

Verified end-to-end on `192.168.1.88`: all six profiles re-calibrated to `status=completed` within seconds; empty-bed phantom-session attempts dropped to zero; subsequent flicker dies as `too short (<2s)` instead of persisting as multi-hour false sessions.

### Movement-based HomeKit OccupancySensor
`src/homekit/accessories/occupancySensor.ts` previously read `sleep_records.leftBedAt IS NULL`. That condition can never be true: schema declares `leftBedAt` NOT NULL, and the Python sleep-detector only `INSERT`s on session close. The accessory therefore always reported `NOT_DETECTED` — wrong in both directions.

Replaced with `MAX(movement.total_movement) >= RESTLESS_SCORE_MIN over last 15 min`. Empty bed scores ~0 after baseline subtraction; an occupant produces periodic spikes well above 50. Sidesteps the broken session lifecycle entirely.

### Movement chart density gate
`getMovementBuckets` already filters by `inBedExists()`, but a noisy persisted session (high `times_exited_bed`) can span hours and still contain mostly empty sub-windows that render as low bars.

Added a `HAVING` clause: a bucket only renders if at least `pickMinBucketNonStillEpochs(bucketSeconds) = max(2, floor(bucketSeconds/600))` of its epochs cross `RESTLESS_SCORE_MIN`. For a 30-min week-view bucket that's 3 hits; real sleep produces 6-10. Filters phantom flicker without touching real sessions.

### Docs
- `docs/sleep-detector.md` gains a Chart Aggregation section, a `MIN_BUCKET_NONSTILL_FLOOR` config row, and Known Limitation #9 capturing the calibrator/RAW-path coupling that started this thread.

## Test plan

- [x] `pnpm exec vitest run src/server/routers/tests/biometrics.test.ts src/homekit/tests/occupancySensor.test.ts src/lib/tests/movement.test.ts` — 70/70 pass.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] Pod 5 (`192.168.1.88`) hand-patched with the calibrator drop-in. All six profiles `status=completed`, phantom sessions stopped recurring within minutes.
- [ ] After OTA: HomeKit occupancy tile on `192.168.1.88` flips to OCCUPIED when an occupant gets in bed and back to NOT_DETECTED within ~15 min of leaving.
- [ ] Movement chart on the same pod's week view no longer shows scattered phantom-bucket bars; real session activity unaffected.
- [ ] Audit other Pod 5 deployments for the same `RAW_DATA_DIR=/persistent` mismatch on the calibrator unit (anything installed pre-ADR-0018 plus any OTA path that didn't refresh unit files).

## Out of scope / follow-up

- **Piezo-processor emits bogus HR/HRV/BR on empty bed.** Independent of presence; observed on both sides of `192.168.1.88` post-fix (HR=129, HR=0, HR=82 on empty mattress). Module computes vitals from piezo waveforms regardless of occupancy. Likely fix: gate emission on a presence signal from `sleep_records` and/or a tighter quality threshold. Worth a separate ticket.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update worktree-occupancy-sensor
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-occupancy-sensor/scripts/install \
  | sudo bash -s -- --branch worktree-occupancy-sensor
```

🎯 **Pin to this exact build** ([run 25978304294](https://github.com/sleepypod/core/actions/runs/25978304294) · `5f017f1`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/5f017f10e9f691d49607be0b664ee5395b6791ab/scripts/install \
  | sudo bash -s -- \
      --branch worktree-occupancy-sensor \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25978304294/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25978304294/artifacts/7038384873) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated sleep detector docs with chart aggregation details and expanded known limitations.

* **New Features**
  * Movement chart now filters low-density buckets for more meaningful daily/weekly aggregation.
  * System exposes a unified occupancy endpoint; occupancy is now shared across UI and HomeKit.
  * Live cap-sense snapshot is available for real-time detection.

* **Bug Fixes**
  * Calibrator service now surfaces missing mount/startup issues instead of failing silently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


