### PR TITLE
docs(build): lead PR install block with sp-update; explain each path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,13 +81,20 @@ jobs:
           <details open>
           <summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>
 
-          🚀 **Latest build of \`$HEAD_REF\`** — rebuilds every push, zero auth:
+          Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use \`sp-update\` instead; it's on disk and opens WAN as its first step.
+
+          🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
+          \`\`\`bash
+          sudo sp-update $HEAD_REF
+          \`\`\`
+
+          🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
           \`\`\`bash
           curl -fsSL https://raw.githubusercontent.com/$REPO/$HEAD_REF/scripts/install \\
             | sudo bash -s -- --branch $HEAD_REF
           \`\`\`
 
-          🎯 **Pin to this exact build** ([run $RUN_ID]($SERVER/$REPO/actions/runs/$RUN_ID) · \`$SHORT_SHA\`):
+          🎯 **Pin to this exact build** ([run $RUN_ID]($SERVER/$REPO/actions/runs/$RUN_ID) · \`$SHORT_SHA\`) — fresh-pod path, locked to one CI artifact for reproducible review:
           \`\`\`bash
           curl -fsSL https://raw.githubusercontent.com/$REPO/$HEAD_SHA/scripts/install \\
             | sudo bash -s -- \\


### PR DESCRIPTION
## Summary

The auto-generated **Beam this PR onto a sleepypod** block in every PR body offered only two `curl … | sudo bash` snippets. Both hang silently on any already-installed pod, because:

- the egress firewall DROPs `github.com` / `raw.githubusercontent.com` outbound by default, and
- the `unblock_wan` function lives **inside** `scripts/install` — i.e. inside the very file curl is trying to fetch.

Hit this an hour ago testing PR #584 on `192.168.1.88` — `curl | bash` hung indefinitely with an empty `/tmp/sleepypod-install.log`.

## Changes

Three snippets, in order of which one the reviewer most likely wants:

1. **🔄 Already on a sleepypod** (new, lead) — `sudo sp-update <branch>`. Works because `sp-update` is on disk at `/usr/local/bin/sp-update` and unblocks WAN as its first step.
2. **🚀 Fresh pod / first install** (existing curl path, demoted) — bootstraps from GitHub. Only viable when the firewall isn't up yet.
3. **🎯 Pin to this exact build** (existing artifact-url path, kept) — fresh-pod path, locked to one CI artifact for reproducible review.

Also adds a one-paragraph "why" so future-you doesn't repeat the same mistake.

## Test plan

- [x] YAML parses; block renders cleanly under `<details>` (eyeballed the diff).
- [ ] Next PR opened (or `Update PR install block` workflow re-run) shows all three snippets in the right order.
- [ ] On `192.168.1.88` (already installed): `sudo sp-update <branch>` works; on a fresh pod, the curl path still works.

## Refs

- Discovered while testing #584 on Pod 5 `192.168.1.88`.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update chore/install-block-sp-update
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/chore/install-block-sp-update/scripts/install \
  | sudo bash -s -- --branch chore/install-block-sp-update
```

🎯 **Pin to this exact build** ([run 25952294518](https://github.com/sleepypod/core/actions/runs/25952294518) · `141775b`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/141775b68b4ea54fc858f4aa8beb105da163ca3e/scripts/install \
  | sudo bash -s -- \
      --branch chore/install-block-sp-update \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25952294518/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25952294518/artifacts/7030318051) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
