### PR TITLE
feat(sp-update): build per-branch tarballs in CI; consume them on device

### DIFF
--- a/.github/workflows/branch-release-cleanup.yml
+++ b/.github/workflows/branch-release-cleanup.yml
@@ -1,0 +1,31 @@
+name: Branch Release Cleanup
+
+# Drop the rolling `<slug>-latest` prerelease + tag when a feature branch is
+# deleted. Without this, every short-lived branch would accrete a permanent
+# prerelease in the GitHub Releases page.
+
+on:
+  delete:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch' && github.event.ref != 'main' && github.event.ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute tag
+        id: slug
+        run: |
+          REF="${{ github.event.ref }}"
+          SLUG="${REF//\//-}"
+          echo "tag=${SLUG}-latest" >> "$GITHUB_OUTPUT"
+
+      - name: Drop rolling release + tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.slug.outputs.tag }}"
+          # Idempotent — 404 (branch never had a prerelease) is fine.
+          gh release delete "$TAG" --yes --cleanup-tag --repo "${{ github.repository }}" 2>/dev/null || true

--- a/.github/workflows/branch-release.yml
+++ b/.github/workflows/branch-release.yml
@@ -1,0 +1,91 @@
+name: Branch Release
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - dev
+
+concurrency:
+  group: branch-release-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+
+      - name: Compute branch slug
+        id: slug
+        run: |
+          SLUG="${GITHUB_REF_NAME//\//-}"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "tag=${SLUG}-latest" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: SP_BRANCH="${{ github.ref_name }}" pnpm build
+
+      - name: Pin commit metadata into .git-info
+        # prebuild writes .git-info from `git rev-parse` in the CI checkout,
+        # but on-device fallback paths (no .git in tarball) regress to
+        # commitHash="unknown". Overwrite with explicit values from the
+        # GitHub event so the version endpoint always shows the real SHA.
+        run: |
+          jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg hash "${GITHUB_SHA:0:7}" \
+            --arg title "$(git log -1 --format=%s)" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{branch:$branch, commitHash:$hash, commitTitle:$title, buildDate:$date}' \
+            > .git-info
+
+      - name: Set install script default branch
+        run: sed -i "s|__BRANCH__|${{ github.ref_name }}|" scripts/install
+
+      - name: Create deploy tarball
+        run: |
+          tar czf /tmp/sleepypod-core.tar.gz \
+            --exclude='node_modules' \
+            --exclude='.git' \
+            --exclude='.env*' \
+            --exclude='*.db' \
+            --exclude='*.db-*' \
+            --exclude='test-results' \
+            --exclude='.serena' \
+            --exclude='.claude' \
+            .
+          mv /tmp/sleepypod-core.tar.gz .
+
+      - name: Publish rolling branch release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.slug.outputs.tag }}"
+          # --cleanup-tag drops the prior release + tag atomically. 404 (first
+          # push of a new branch) is expected; the `|| true` swallows it.
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          gh release create "$TAG" sleepypod-core.tar.gz \
+            --target "${{ github.sha }}" \
+            --title "Branch: ${{ github.ref_name }} (latest)" \
+            --notes "Rolling pre-built release from branch \`${{ github.ref_name }}\`.
+
+          **Commit:** ${{ github.sha }}
+          **Updated:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --prerelease

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -177,14 +177,25 @@ fi
 WORK_DIR=$(mktemp -d)
 HAS_BUILD=false
 
-# Try CI release by tag — works for any branch with a GitHub Release (main, dev, etc.)
-RELEASE_TAG="$BRANCH"
-[ "$RELEASE_TAG" = "latest" ] && RELEASE_TAG="main"
-# Rolling dev tag was renamed from `dev` to `dev-latest` in #427.
-[ "$RELEASE_TAG" = "dev" ] && RELEASE_TAG="dev-latest"
-echo "Checking for CI release (tag: $RELEASE_TAG)..."
-RELEASE_URL=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}" \
-  | grep -o '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \
+# Resolve the release endpoint. Mirrors scripts/install so OTA updates use
+# the same CI-built tarballs as fresh installs:
+#   main / latest      → releases/latest (semantic-release vX.Y.Z asset)
+#   dev                → releases/tags/dev-latest      (built by dev-release.yml)
+#   <other branch>     → releases/tags/<slug>-latest   (built by branch-release.yml)
+# Slugging matches branch-release.yml: `feat/foo` → `feat-foo-latest`.
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "latest" ]; then
+  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+  echo "Checking for CI release (latest stable)..."
+elif [ "$BRANCH" = "dev" ]; then
+  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/dev-latest"
+  echo "Checking for CI release (tag: dev-latest)..."
+else
+  RELEASE_TAG="${BRANCH//\//-}-latest"
+  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}"
+  echo "Checking for CI release (tag: $RELEASE_TAG)..."
+fi
+RELEASE_URL=$(curl -sf "$RELEASE_API" \
+  | grep -om1 '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \
   | grep -o 'https://[^"]*' || true)
 
 if [ -n "$RELEASE_URL" ]; then


### PR DESCRIPTION
## Summary
- Add `.github/workflows/branch-release.yml` — push to any non-main/dev branch publishes a rolling `<slug>-latest` prerelease (built tarball with `.next`).
- Add `.github/workflows/branch-release-cleanup.yml` — branch delete drops the matching release + tag.
- Update `scripts/bin/sp-update` — resolve `main`/`latest` via `releases/latest` (semantic-release semver), `dev` via `dev-latest`, anything else via `<slug>-latest`. Mirrors `scripts/install`.

## Why
- `sp-update` was 404'ing on `releases/tags/main` (no such tag — semantic-release publishes `vX.Y.Z`) and on every feature branch, falling through to on-device `pnpm build` against a GitHub source tarball that contains no `.git`. Result: every OTA on `main` compiled TS on the pod and the version endpoint reported `commitHash: "unknown"`.
- Public-repo Actions minutes are free, so building all branches in CI is essentially free.

## Test plan
- [ ] Push lands; `branch-release.yml` runs on this branch and publishes `worktree-sp-update-builder-latest` with a `sleepypod-core.tar.gz` asset
- [ ] On a test pod: `sp-update worktree-sp-update-builder` downloads the CI tarball (no `pnpm build` line in output)
- [ ] `/system/version` returns a real `commitHash` (not `"unknown"`)
- [ ] After PR merge + branch delete, `branch-release-cleanup.yml` drops the `worktree-sp-update-builder-latest` release
- [ ] `sp-update` (no args, defaults to main) resolves the latest semver release instead of falling back to source build

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update worktree-sp-update-builder
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-sp-update-builder/scripts/install \
  | sudo bash -s -- --branch worktree-sp-update-builder
```

🎯 **Pin to this exact build** ([run 25952855925](https://github.com/sleepypod/core/actions/runs/25952855925) · `e45db6a`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/e45db6a1995acb64d7cfca356300a5343637595f/scripts/install \
  | sudo bash -s -- \
      --branch worktree-sp-update-builder \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25952855925/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25952855925/artifacts/7030499576) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
