### PR TITLE
install: prefer <slug>-latest Releases over nightly.link for feature branches

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -631,12 +631,19 @@ else
   DOWNLOAD_DIR=$(mktemp -d)
   HAS_BUILD=false
 
-  # Try CI release first (includes pre-built .next)
+  # Try CI release first (includes pre-built .next). Mirrors sp-update:
+  #   main / latest  → releases/latest          (semantic-release vX.Y.Z)
+  #   dev            → releases/tags/dev-latest (rolling, dev-release.yml)
+  #   <other>        → releases/tags/<slug>-latest (branch-release.yml)
+  # `feat/foo` slugs to `feat-foo-latest` to match branch-release.yml.
   if [ "$DOWNLOAD_BRANCH" = "main" ] || [ "$DOWNLOAD_BRANCH" = "latest" ]; then
     RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
   elif [ "$DOWNLOAD_BRANCH" = "dev" ]; then
     # Rolling dev tag was renamed from `dev` to `dev-latest` in #427.
     RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/dev-latest"
+  else
+    RELEASE_TAG="${DOWNLOAD_BRANCH//\//-}-latest"
+    RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}"
   fi
 
   if [ -n "${RELEASE_API:-}" ]; then


### PR DESCRIPTION
## Summary
`scripts/install` now mirrors `sp-update` (#586): for feature branches it looks up `releases/tags/<slug>-latest` first, then falls back to nightly.link.

## Why
After #586, `sp-update <branch>` resolves feature branches via Releases (anonymous, durable, fast — direct `api.github.com` hit). `scripts/install` was still going through nightly.link (third-party proxy, sometimes flaky, 30-day artifact TTL). That asymmetry showed up as: `sp-update feat/foo` works, `curl install | bash -s -- --branch feat/foo` flakes.

Same `feat/foo` → `feat-foo-latest` slug rule branch-release.yml uses.

## Behaviour after
- main / latest → `releases/latest` (unchanged)
- dev → `releases/tags/dev-latest` (unchanged)
- feat/foo → **`releases/tags/feat-foo-latest`** (new), nightly.link fallback if not yet built

## Test plan
- [ ] Fresh install of this branch via `curl ... | sudo bash -s -- --branch feat/install-slug-lookup` downloads the Release (not nightly.link)
- [ ] `/system/version` returns a real commit hash
- [ ] On a branch whose `branch-release.yml` hasn't finished yet, install falls back to nightly.link cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installer to support CI releases for branch-specific deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/install-slug-lookup
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/install-slug-lookup/scripts/install \
  | sudo bash -s -- --branch feat/install-slug-lookup
```

🎯 **Pin to this exact build** ([run 25956408121](https://github.com/sleepypod/core/actions/runs/25956408121) · `e520b43`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/e520b436b3e135e1643364eb298471d593b90ad6/scripts/install \
  | sudo bash -s -- \
      --branch feat/install-slug-lookup \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25956408121/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25956408121/artifacts/7031667915) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
