### PR TITLE
fix(sp-update): biometrics-archiver helper exit code triggered silent OTA rollback

### DIFF
--- a/scripts/lib/biometrics-archiver-helpers
+++ b/scripts/lib/biometrics-archiver-helpers
@@ -128,5 +128,12 @@ install_biometrics_archiver() {
       rm -f "$dst.tmp.$$"
     fi
   done
-  [ "$archived" -gt 0 ] && echo "Archived $archived stranded pre-tmpfs RAW files"
+  # NOTE: must be an `if` block, not `[ ] && echo`. Under set -euo pipefail
+  # at the caller (sp-update / scripts/install), a function whose last
+  # statement is `test && cmd` returns the test's exit code — 1 when
+  # archived=0 (the common steady state on a migrated pod). That bubbled up
+  # as a silent OTA rollback on every upgrade. See sp-update test 2026-05-16.
+  if [ "$archived" -gt 0 ]; then
+    echo "Archived $archived stranded pre-tmpfs RAW files"
+  fi
 }


### PR DESCRIPTION
## Summary
Last line of `install_biometrics_archiver` is `[ "$archived" -gt 0 ] && echo "..."`. When `archived=0` (the steady state on any pod already past first-install migration), the test returns 1, `&&` short-circuits, and the function returns 1.

Both `sp-update` and `scripts/install` call this function directly under `set -euo pipefail`. A non-zero return → set -e fires → script exits → `cleanup` trap rolls back code + database.

Replaced with an explicit `if`-block so the function returns 0 unconditionally.

## How this manifested
Every OTA on a migrated pod silently rolled back to the prior code. The visible symptom was `/api/system/version` reporting `commitHash: "unknown"` — because the .git-info from the new tarball was overwritten by the rollback restoring the previous (pre-tarball) state. Caught while testing #586 / #587 on 192.168.1.88 today.

## Test plan
- [ ] `sp-update dev` on 192.168.1.88 succeeds (no "Update failed, rolling back" line)
- [ ] `/api/system/version` returns a real `commitHash` (matches the dev tip) after the OTA
- [ ] Re-running `sp-update dev` is idempotent — no rollback, service stays active

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/biometrics-archiver-return-code
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/biometrics-archiver-return-code/scripts/install \
  | sudo bash -s -- --branch fix/biometrics-archiver-return-code
```

🎯 **Pin to this exact build** ([run 25956748190](https://github.com/sleepypod/core/actions/runs/25956748190) · `02b4f0f`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/02b4f0fa23cd894192fe7ee41b4ffc1401d50444/scripts/install \
  | sudo bash -s -- \
      --branch fix/biometrics-archiver-return-code \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25956748190/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25956748190/artifacts/7031779519) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
