### PR TITLE
ci: pin .git-info from github context in dev and main release workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Pin commit metadata into .git-info
+        # prebuild writes .git-info via `git rev-parse` from the CI checkout.
+        # Overwrite with explicit github-context values so the file is correct
+        # even if a future prebuild change starts skipping the write.
+        run: |
+          jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg hash "${GITHUB_SHA:0:7}" \
+            --arg title "$(git log -1 --format=%s)" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{branch:$branch, commitHash:$hash, commitTitle:$title, buildDate:$date}' \
+            > .git-info
+
       - name: Set install script default branch
         run: sed -i 's/__BRANCH__/${{ github.ref_name }}/' scripts/install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Pin commit metadata into .git-info
+        # prebuild writes .git-info via `git rev-parse` from the CI checkout.
+        # Overwrite with explicit github-context values so the file is correct
+        # even if a future prebuild change starts skipping the write.
+        run: |
+          jq -n \
+            --arg branch "${{ github.ref_name }}" \
+            --arg hash "${GITHUB_SHA:0:7}" \
+            --arg title "$(git log -1 --format=%s)" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{branch:$branch, commitHash:$hash, commitTitle:$title, buildDate:$date}' \
+            > .git-info
+
       - name: Set install script default branch
         run: sed -i 's/__BRANCH__/${{ github.ref_name }}/' scripts/install
 


### PR DESCRIPTION
## Summary
Backports the defensive `jq` write of `.git-info` from `branch-release.yml` (#586) to `dev-release.yml` and `release.yml`. Runs after `pnpm build` and overwrites prebuild's git-derived output with explicit values from the GitHub event context.

## Why
Symmetry across all three release workflows. Prebuild's `git rev-parse --short HEAD` works fine in the standard CI checkout, but it's brittle — if `prebuild` ever stops running, gets reordered, or the script changes how it sources commit info, devices silently regress to `commitHash: "unknown"`. Pinning from `${{ github.sha }}` makes the file a deterministic build artifact.

## Test plan
- [ ] Next dev push: `dev-latest` release contains a `.git-info` whose `commitHash` matches the short github.sha
- [ ] Same for next main release once semantic-release fires
- [ ] No regression in `/system/version` on a pod after `sp-update dev`

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update chore/git-info-defensive-write
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/chore/git-info-defensive-write/scripts/install \
  | sudo bash -s -- --branch chore/git-info-defensive-write
```

🎯 **Pin to this exact build** ([run 25956912924](https://github.com/sleepypod/core/actions/runs/25956912924) · `8a3c5cc`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/8a3c5cc6cfd8b8f4d9c77ab55b0044df0256e313/scripts/install \
  | sudo bash -s -- \
      --branch chore/git-info-defensive-write \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25956912924/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25956912924/artifacts/7031829102) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
