### PR TITLE
test(scheduler): kill LED night-mode mutants + expand mutation matrix

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,12 +39,20 @@ jobs:
       matrix:
         shard:
           # The --mutate CLI flag overrides the config's exclude patterns,
-          # so we have to repeat them here per shard. Keep these three
-          # exclusions in sync with stryker.config.mjs's mutate: block.
+          # so we repeat the exclusions here per shard. Keep these in sync
+          # with stryker.config.mjs's mutate: block. Each shard runs on
+          # its own runner in parallel; partition by module group so any
+          # single shard stays under the 90-min job timeout.
           - name: services-scheduler
-            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+            mutate: "src/services/**/*.ts,src/scheduler/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
           - name: hardware-lib
-            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.d.ts"
+            mutate: "src/hardware/**/*.ts,src/lib/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          - name: homekit
+            mutate: "src/homekit/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          - name: server
+            mutate: "src/server/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          - name: streaming-hooks-db
+            mutate: "src/streaming/**/*.ts,src/hooks/**/*.ts,src/hooks/**/*.tsx,src/db/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -51,8 +51,16 @@ jobs:
             mutate: "src/homekit/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
           - name: server
             mutate: "src/server/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
-          - name: streaming-hooks-db
-            mutate: "src/streaming/**/*.ts,src/hooks/**/*.ts,src/hooks/**/*.tsx,src/db/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          # hooks/streaming/db split into three shards: a combined shard
+          # ran a 1049-test baseline (React jsdom overhead) and tripped
+          # the 90-min timeout on PR #590. Each split shard now has a
+          # smaller per-mutant test set under perTest coverage analysis.
+          - name: streaming
+            mutate: "src/streaming/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          - name: hooks
+            mutate: "src/hooks/**/*.ts,src/hooks/**/*.tsx,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
+          - name: db
+            mutate: "src/db/**/*.ts,!src/**/tests/**,!src/**/*.test.ts,!src/**/*.test.tsx,!src/**/*.d.ts"
     name: mutate (${{ matrix.shard.name }})
     steps:
       - name: Checkout

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -386,3 +386,166 @@ describe('JobManager.checkLiveness', () => {
     expect(await manager.checkLiveness()).toEqual(['temp-1'])
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LED night-mode window — pins the initial-brightness decision when
+// scheduleLedNightMode runs at load time. The window math is delicate:
+// arithmetic on nowHour/startHour/endHour with non-zero minutes, strict <=
+// vs < boundary on start/end, and the same-day vs midnight-crossing branch.
+// Each test below was picked to kill a specific mutator class — see the
+// inline comments. Drives the private method directly via cast because
+// loadSchedules requires DB rows the stub doesn't provide.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('JobManager.scheduleLedNightMode initial brightness', () => {
+  let manager: JobManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    manager = new JobManager('UTC')
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await manager.shutdown()
+    vi.restoreAllMocks()
+  })
+
+  function run(nowIso: string): {
+    sendLed: ReturnType<typeof vi.fn>
+    scheduleJob: ReturnType<typeof vi.fn>
+  } {
+    vi.setSystemTime(new Date(nowIso))
+    const sendLed = vi.fn(async () => {})
+    ;(manager as any).sendLedBrightness = sendLed
+    const scheduleJob = vi.fn(() => ({} as any))
+    vi.spyOn(manager.getScheduler(), 'scheduleJob').mockImplementation(scheduleJob as any)
+    return { sendLed, scheduleJob }
+  }
+
+  // Same-day window: current time inside, with non-zero minutes on now —
+  // kills nowHour * 60 + nowMinute → nowHour * 60 - nowMinute (gives a
+  // smaller in-window number that still tests TRUE here) only when end is
+  // close to now. So we tighten the window: 22:05-23:05, now=22:30. With
+  // the mutation nowMinutes=22*60-30=1290 < startMinutes=1325 → DAY.
+  it('night brightness applied when current minute pushes us inside a tight same-day window (kills + → - on nowMinutes)', async () => {
+    const { sendLed } = run('2026-01-15T22:30:00Z')
+    await (manager as any).scheduleLedNightMode('22:05', '23:05', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(10)
+  })
+
+  // Same-day window: current is JUST before start, so a smaller mutated
+  // start (22*60-10=1310) would flip it to inside the window → kills the
+  // + → - mutation on startMinutes (and / 60).
+  it('day brightness when current is just before start — kills + → - on startMinutes', async () => {
+    const { sendLed } = run('2026-01-15T22:05:00Z')
+    await (manager as any).scheduleLedNightMode('22:10', '23:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(80)
+  })
+
+  // Same-day window: current is inside but past a mutated end. A smaller
+  // mutated end (22*60-30=1290) would flip it to outside → kills + → - on
+  // endMinutes (and / 60).
+  it('night brightness when current is just inside the end of a tight window — kills + → - on endMinutes', async () => {
+    const { sendLed } = run('2026-01-15T22:15:00Z')
+    await (manager as any).scheduleLedNightMode('22:00', '22:30', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(10)
+  })
+
+  // start === end: with the real `<=` we take the same-day branch which
+  // can never be true (start..start is empty) → DAY. Mutating `<=` to `<`
+  // takes the midnight branch (>= start || < end), which is always true →
+  // would flip to NIGHT. Kills `startMinutes <= endMinutes` mutators.
+  it('day brightness when start === end (degenerate window) — kills <= → < on the branch selector', async () => {
+    const { sendLed } = run('2026-01-15T03:00:00Z')
+    await (manager as any).scheduleLedNightMode('01:00', '01:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(80)
+  })
+
+  // Midnight-crossing window. Current in the "after midnight" portion
+  // (03:00 within 22:00-06:00). Mutating `||` → `&&` in the cross-midnight
+  // branch flips it to DAY because the >= startMinutes leg is false.
+  it('night when current is in the post-midnight portion of a cross-midnight window — kills || → &&', async () => {
+    const { sendLed } = run('2026-01-15T03:00:00Z')
+    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(10)
+  })
+
+  // Midnight-crossing window. Current in the "before midnight" portion
+  // (23:00 within 22:00-06:00). Mutating `||` → `&&` flips to DAY because
+  // the < endMinutes leg is false.
+  it('night when current is in the pre-midnight portion of a cross-midnight window — kills || → &&', async () => {
+    const { sendLed } = run('2026-01-15T23:00:00Z')
+    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(10)
+  })
+
+  // Same-day window with current well outside. Mutating `&&` → `||` would
+  // flip this to NIGHT because >= startMinutes alone is true.
+  it('day when current is past the same-day window — kills && → ||', async () => {
+    const { sendLed } = run('2026-01-15T08:00:00Z')
+    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(80)
+  })
+
+  // Start boundary inclusive: current === start → NIGHT. Mutating
+  // `nowMinutes >= startMinutes` to `> startMinutes` (or `< startMinutes`)
+  // would flip to DAY.
+  it('night at the exact start minute — kills >= → > on the start boundary', async () => {
+    const { sendLed } = run('2026-01-15T01:00:00Z')
+    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(10)
+  })
+
+  // End boundary exclusive: current === end → DAY. Mutating
+  // `nowMinutes < endMinutes` to `<= endMinutes` (or `>= endMinutes`)
+  // would flip to NIGHT.
+  it('day at the exact end minute — kills < → <= on the end boundary', async () => {
+    const { sendLed } = run('2026-01-15T06:00:00Z')
+    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    expect(sendLed).toHaveBeenLastCalledWith(80)
+  })
+
+  // Cron strings registered for the two recurring jobs. Kills the
+  // `${minute} ${hour} * * *` template StringLiteral mutators on lines 517
+  // and 525, plus the scheduleJob BlockStatement mutators.
+  it('registers led-night-start and led-night-end with correct cron expressions', async () => {
+    const { scheduleJob } = run('2026-01-15T12:00:00Z')
+    await (manager as any).scheduleLedNightMode('22:05', '06:45', 80, 10)
+
+    expect(scheduleJob).toHaveBeenCalledWith(
+      'led-night-start',
+      JobType.LED_BRIGHTNESS,
+      '5 22 * * *',
+      expect.any(Function),
+    )
+    expect(scheduleJob).toHaveBeenCalledWith(
+      'led-night-end',
+      JobType.LED_BRIGHTNESS,
+      '45 6 * * *',
+      expect.any(Function),
+    )
+  })
+
+  // Pin that the registered callbacks actually call sendLedBrightness
+  // with the correct per-job brightness. Kills BlockStatement mutators on
+  // the two scheduleJob arrow bodies (lines 519-522, 527-530).
+  it('scheduled callbacks send the correct brightness for night vs day', async () => {
+    const { sendLed, scheduleJob } = run('2026-01-15T12:00:00Z')
+    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+
+    // Clear the initial-apply call; we want to inspect what the cron
+    // handlers do when fired manually.
+    sendLed.mockClear()
+
+    const calls = scheduleJob.mock.calls as Array<[string, JobType, string, () => Promise<void>]>
+    const startCb = calls.find(c => c[0] === 'led-night-start')?.[3]
+    const endCb = calls.find(c => c[0] === 'led-night-end')?.[3]
+    if (!startCb || !endCb) throw new Error('expected both led-night-* callbacks registered')
+
+    await startCb()
+    expect(sendLed).toHaveBeenLastCalledWith(10) // night → night brightness
+
+    await endCb()
+    expect(sendLed).toHaveBeenLastCalledWith(80) // morning → day brightness
+  })
+})

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,18 +16,24 @@ export default {
     configFile: 'vitest.config.mts',
   },
 
-  // Start narrow: mutate only the modules that have real unit test coverage.
-  // Next.js app code (app/, components/, hooks/, utils/) is under-tested
-  // and would add hours of wall-clock time to each mutation run without
-  // telling us anything useful. Expand once we're confident the report is
-  // actionable.
+  // Mutate every module that has unit test coverage. Next.js app code
+  // (app/, components/, ui/, providers/, modules/) is under-tested and
+  // would add hours of wall-clock time without telling us anything
+  // useful — leave those out until they grow real tests.
   mutate: [
     'src/services/**/*.ts',
     'src/scheduler/**/*.ts',
     'src/hardware/**/*.ts',
     'src/lib/**/*.ts',
+    'src/homekit/**/*.ts',
+    'src/server/**/*.ts',
+    'src/streaming/**/*.ts',
+    'src/hooks/**/*.ts',
+    'src/hooks/**/*.tsx',
+    'src/db/**/*.ts',
     '!src/**/tests/**',
     '!src/**/*.test.ts',
+    '!src/**/*.test.tsx',
     '!src/**/*.d.ts',
   ],
 


### PR DESCRIPTION
## Summary
Addresses surviving mutants from the weekly mutation run tracked in #543 and expands what we mutation-test.

**Kill tests (jobManager.ts:537-543)** — 11 new tests in `src/scheduler/tests/jobManager.test.ts` covering `scheduleLedNightMode` initial-apply window logic, which had zero coverage. Each test was picked to flip behavior under exactly one mutator class:

- Tight windows with non-zero minutes (kills `nowHour * 60 + nowMinute` → `- nowMinute` / `/ 60`)
- `start === end` degenerate window (kills `<=` → `<` / `>` branch selector)
- Cross-midnight window, current in pre/post-midnight portion (kills `||` → `&&`)
- Same-day window with current past end (kills `&&` → `||`)
- Exact start / end minute boundaries (kills `>=` → `>` / `<` → `<=`)
- Cron expressions for the recurring jobs (kills `\`${minute} ${hour} * * *\`` StringLiterals)
- Scheduled-callback bodies actually call `sendLedBrightness` with night/day values (kills BlockStatement on the arrow bodies)

**Matrix expansion** — `2 → 5` shards in `.github/workflows/mutation.yml`. The previous comment in `stryker.config.mjs` said we'd expand "once the report is actionable" — at 60%+ score with two clean weekly runs, it is. Added:

- `homekit` (9 test files, 18 source files)
- `server` (14 test files, 33 source files)
- `streaming-hooks-db` (combined: 5+13+2 test files)

Each shard runs on its own runner in parallel.

Closes #543 (will reopen on next weekly baseline).

## Test plan

- [x] `pnpm test run src/scheduler/tests/jobManager.test.ts` — 31 passed (20 prior + 11 new)
- [x] `pnpm test run src/scheduler/` — 348 passed
- [x] `pnpm exec eslint src/scheduler/tests/jobManager.test.ts` — clean
- [ ] Apply `mutation-test` label → CI runs mutation on this PR across all 5 shards
- [ ] Manual: confirm next weekly run (Sat 06:00 UTC) updates #543 with the 5-shard breakdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage for LED night-mode brightness scheduling, adding comprehensive boundary and edge-case checks to ensure correct day/night brightness transitions.

* **Chores**
  * Broadened mutation-testing and CI workflow scope to include additional parts of the codebase and refined test exclusions, improving overall quality assurance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update mutation/expand-and-kill-led-night-mutants
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/mutation/expand-and-kill-led-night-mutants/scripts/install \
  | sudo bash -s -- --branch mutation/expand-and-kill-led-night-mutants
```

🎯 **Pin to this exact build** ([run 25976737672](https://github.com/sleepypod/core/actions/runs/25976737672) · `a5e98f4`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a5e98f42ae44a709e1a8f9fff4777df634afd512/scripts/install \
  | sudo bash -s -- \
      --branch mutation/expand-and-kill-led-night-mutants \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25976737672/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25976737672/artifacts/7037840363) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

