### PR TITLE
ci(mutation): match tracker by state:all and reopen if closed

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -248,13 +248,17 @@ jobs:
             const scoreBase = totals.killed + totals.survived + totals.timeout + totals.noCov
             const score = scoreBase > 0 ? ((totals.killed / scoreBase) * 100).toFixed(1) : '—'
 
-            // Find-or-create the pinned issue by title. No label-based
-            // lookup because labels don't enforce uniqueness.
+            // Find-or-create the pinned issue by title. Search ALL
+            // states (open + closed) because a PR description saying
+            // "Closes #543" auto-closes the tracker — and on the next
+            // run an open-only lookup misses it, creating a duplicate
+            // (see #591 vs #543 from run 25976792103). We reopen below
+            // if the match is closed.
             const title = process.env.ISSUE_TITLE
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open',
+              state: 'all',
               labels: 'mutation-testing',
               per_page: 50,
             })
@@ -309,14 +313,18 @@ jobs:
 
             let issueNumber
             if (hit) {
+              // Reopen if a "Closes #NNN" reference in a merged PR
+              // auto-closed the tracker — this issue is meant to live
+              // forever, not get retired by PR descriptions.
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: hit.number,
+                state: 'open',
                 body,
               })
               issueNumber = hit.number
-              core.info(`Updated pinned issue #${issueNumber}`)
+              core.info(`Updated pinned issue #${issueNumber}${hit.state === 'closed' ? ' (reopened)' : ''}`)
             } else {
               const created = await github.rest.issues.create({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
Fix the find-or-create logic in the mutation summary step so a closed tracker issue doesn't spawn duplicates.

**What happened:** PR #590's description included \`Closes #543\` (linking to the rolling mutation tracker). GitHub auto-closed #543 on merge. The next mutation run's lookup filtered by \`state: 'open'\`, missed the closed #543, and created a fresh issue #591.

**Fix:**
- Change \`state: 'open'\` → \`state: 'all'\` so the lookup sees both open and closed issues
- Pass \`state: 'open'\` on the \`issues.update\` call so a found-but-closed tracker gets reopened
- Note in the comment why — so the next maintainer doesn't \"clean up\" the wider lookup

Reconciled manually:
- Reopened #543 with the body from #591
- Closed #591 as a duplicate with a backlink

## Test plan

- [ ] Manually trigger the workflow on dev after merge (\`gh workflow run mutation.yml --ref dev\`)
- [ ] Confirm #543 updates in place (\`Last updated:\` line bumps) — no new issue created
- [ ] Confirm the issue's state stays \`open\` even if subsequently closed before the next run

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update ci/fix-mutation-issue-dedupe
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/ci/fix-mutation-issue-dedupe/scripts/install \
  | sudo bash -s -- --branch ci/fix-mutation-issue-dedupe
```

🎯 **Pin to this exact build** ([run 25978757534](https://github.com/sleepypod/core/actions/runs/25978757534) · `a6934b4`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a6934b451badc2ac56e496a84f55ed54b0ce77b0/scripts/install \
  | sudo bash -s -- \
      --branch ci/fix-mutation-issue-dedupe \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/25978757534/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/25978757534/artifacts/7038521927) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
