### PR TITLE
fix(flow-chart): record RPM when firmware omits frzHealth.temps

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -1035,6 +1035,11 @@ Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
+# RAW frames live in the tmpfs at /persistent/biometrics (ADR 0018).
+# Without this override piezoStream defaults to /persistent and tries to
+# decode the 16-byte SEQNO.RAW bookkeeping file as CBOR — sensor streaming
+# and flow_readings stay empty.
+Environment="RAW_DATA_DIR=/persistent/biometrics"
 # The \`+\` prefix runs ExecStartPre as root regardless of User=. Needed
 # for /deviceinfo symlink creation (root-owned) and sp-maintenance
 # (journal vacuum, /tmp cleanup, pnpm store prune).

--- a/src/components/Sensors/FlowrateChart.tsx
+++ b/src/components/Sensors/FlowrateChart.tsx
@@ -66,11 +66,14 @@ export function FlowrateChart() {
 
     if (!raw || raw.length === 0) return []
 
-    // Data is already in chronological order from the API
+    // Data is already in chronological order from the API.
+    // leftFlowrateCd/rightFlowrateCd are stored as raw×100 to keep the table
+    // integer-typed; divide back to degrees so the chart and the live readout
+    // share a unit.
     const points: FlowChartDataPoint[] = raw.map(d => ({
       time: new Date(d.timestamp).getTime(),
-      leftFlow: d.leftFlowrateCd,
-      rightFlow: d.rightFlowrateCd,
+      leftFlow: d.leftFlowrateCd != null ? d.leftFlowrateCd / 100 : null,
+      rightFlow: d.rightFlowrateCd != null ? d.rightFlowrateCd / 100 : null,
       leftRpm: d.leftPumpRpm,
       rightRpm: d.rightPumpRpm,
     }))
@@ -85,7 +88,7 @@ export function FlowrateChart() {
 
   const leftKey = viewMode === 'flowrate' ? 'leftFlow' as const : 'leftRpm' as const
   const rightKey = viewMode === 'flowrate' ? 'rightFlow' as const : 'rightRpm' as const
-  const unitLabel = viewMode === 'flowrate' ? 'cd' : 'RPM'
+  const unitLabel = viewMode === 'flowrate' ? '' : 'RPM'
 
   // Compute Y-axis domain
   const allValues = chartData.flatMap(d => [d[leftKey], d[rightKey]].filter((v): v is number => v !== null))

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -59,6 +59,20 @@ export function getAlarmState(): { left: boolean, right: boolean } {
   }
 }
 
+/**
+ * Extract a well-formed pump object from a frzHealth side. Returns the pump
+ * only when `side.pump.rpm` is a finite number — otherwise frzHealth-shaped
+ * frames with a null/garbled pump would crash the downstream insert.
+ */
+function pumpOf(side: unknown): { rpm: number } | null {
+  if (!side || typeof side !== 'object') return null
+  const pump = (side as { pump?: unknown }).pump
+  if (!pump || typeof pump !== 'object') return null
+  const rpm = (pump as { rpm?: unknown }).rpm
+  if (typeof rpm !== 'number' || !Number.isFinite(rpm)) return null
+  return { rpm }
+}
+
 // ── Flow anomaly detection thresholds ──
 const PUMP_FAILURE_RPM_MIN = 50 // pump "running" but below this = suspicious
 const FLOWRATE_NEAR_ZERO_CD = 5 // centidegrees — effectively zero flow
@@ -189,13 +203,10 @@ export class DeviceStateSync {
   recordFlowData(frame: Record<string, unknown>): void {
     // Guard: only process frzHealth frames (could be piezo, capSense, bedTemp, etc.)
     // `temps` is optional per WireFrzHealth — many pods emit frzHealth without it,
-    // so gate on `pump` only and treat flowrate as missing when absent.
-    const left = frame.left
-    const right = frame.right
-    if (
-      !left || typeof left !== 'object' || !('pump' in left)
-      || !right || typeof right !== 'object' || !('pump' in right)
-    ) return
+    // so gate on a well-formed `pump` only and treat flowrate as missing when absent.
+    const leftPump = pumpOf(frame.left)
+    const rightPump = pumpOf(frame.right)
+    if (!leftPump || !rightPump) return
 
     const frzHealth = frame as {
       left: { pump: { rpm: number }, temps?: { flowrate?: number } }

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -188,16 +188,18 @@ export class DeviceStateSync {
   /** Write flow/pump data to biometrics DB, rate-limited to once per 60s. */
   recordFlowData(frame: Record<string, unknown>): void {
     // Guard: only process frzHealth frames (could be piezo, capSense, bedTemp, etc.)
+    // `temps` is optional per WireFrzHealth — many pods emit frzHealth without it,
+    // so gate on `pump` only and treat flowrate as missing when absent.
     const left = frame.left
     const right = frame.right
     if (
-      !left || typeof left !== 'object' || !('pump' in left) || !('temps' in left)
-      || !right || typeof right !== 'object' || !('pump' in right) || !('temps' in right)
+      !left || typeof left !== 'object' || !('pump' in left)
+      || !right || typeof right !== 'object' || !('pump' in right)
     ) return
 
     const frzHealth = frame as {
-      left: { pump: { rpm: number }, temps: { flowrate?: number } }
-      right: { pump: { rpm: number }, temps: { flowrate?: number } }
+      left: { pump: { rpm: number }, temps?: { flowrate?: number } }
+      right: { pump: { rpm: number }, temps?: { flowrate?: number } }
     }
 
     const now = Date.now()
@@ -235,8 +237,8 @@ export class DeviceStateSync {
 
   /** Check for flow/pump anomalies on each frzHealth frame. */
   private checkFlowAnomalies(frzHealth: {
-    left: { pump: { rpm: number }, temps: { flowrate?: number } }
-    right: { pump: { rpm: number }, temps: { flowrate?: number } }
+    left: { pump: { rpm: number }, temps?: { flowrate?: number } }
+    right: { pump: { rpm: number }, temps?: { flowrate?: number } }
   }, now: number): void {
     const leftRpm = frzHealth.left.pump.rpm
     const rightRpm = frzHealth.right.pump.rpm

--- a/src/hardware/tests/deviceStateSync.test.ts
+++ b/src/hardware/tests/deviceStateSync.test.ts
@@ -518,6 +518,15 @@ describe('DeviceStateSync — recordFlowData', () => {
     expect(row?.right_flowrate_cd).toBeNull()
   })
 
+  it('ignores frames where pump is null or rpm is not a finite number', () => {
+    sync.recordFlowData({ left: { pump: null }, right: { pump: { rpm: 100 } } })
+    sync.recordFlowData({ left: { pump: { rpm: 100 } }, right: { pump: null } })
+    sync.recordFlowData({ left: { pump: { rpm: 'fast' } }, right: { pump: { rpm: 100 } } })
+    sync.recordFlowData({ left: { pump: { rpm: Number.NaN } }, right: { pump: { rpm: 100 } } })
+    sync.recordFlowData({ left: { pump: {} }, right: { pump: { rpm: 100 } } })
+    expect(readFlowReadings().length).toBe(0)
+  })
+
   it('logs and swallows when biometricsDb flow write fails', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     ;(biometricsSqlite as any).exec(`DROP TABLE flow_readings`)

--- a/src/hardware/tests/deviceStateSync.test.ts
+++ b/src/hardware/tests/deviceStateSync.test.ts
@@ -506,6 +506,18 @@ describe('DeviceStateSync — recordFlowData', () => {
     expect(row?.right_flowrate_cd).toBeNull()
   })
 
+  it('writes RPM with null flowrate when frame has no temps key at all', () => {
+    sync.recordFlowData({
+      left: { pump: { rpm: 150 } },
+      right: { pump: { rpm: 175 } },
+    })
+    const row = readFlowReadings()[0]
+    expect(row?.left_pump_rpm).toBe(150)
+    expect(row?.right_pump_rpm).toBe(175)
+    expect(row?.left_flowrate_cd).toBeNull()
+    expect(row?.right_flowrate_cd).toBeNull()
+  })
+
   it('logs and swallows when biometricsDb flow write fails', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     ;(biometricsSqlite as any).exec(`DROP TABLE flow_readings`)


### PR DESCRIPTION
## Summary

The flow rate chart at `/en/status` was blank because of **two** independent bugs in the streaming → DB pipeline:

1. **`recordFlowData` guard rejected frames without `temps`.** `temps?` is optional per `WireFrzHealth`, but the guard required it, dropping every frame on pods whose firmware omits it (and losing the pump RPM portion as collateral). Gate on `pump` only.
2. **`RAW_DATA_DIR` defaulted to `/persistent`.** The actual RAW data files live at `/persistent/biometrics/` per ADR 0018. The default made `piezoStream` try to decode the 16-byte `/persistent/SEQNO.RAW` pointer file as CBOR — `[sensorStream] Resync: no 0xa2 marker (got 0xc9)`. No frzHealth frames decoded → `flow_readings` stayed empty across all pods. Plumbed `RAW_DATA_DIR=/persistent/biometrics` through `sleepypod.service` in `scripts/install`.

Also: rescaled stored centidegrees back to degrees in the chart so historical and live readouts share a unit.

## Verification on Pod 5 (192.168.1.88)

- Applied the systemd drop-in equivalent of the installer change.
- WS frzHealth frames now flow (firmware reports e.g. `flowrate=25.625, rpm=2004`).
- `flow_readings` populates as expected:
  ```
  rows=2
  id=314 leftFlowrateCd=2563 rightPumpRpm=2004
  id=315 leftFlowrateCd=2556 rightPumpRpm=2004
  ```
- Existing pods need the new env var — either redeploy via `scripts/install`, or write the drop-in:
  ```
  mkdir -p /etc/systemd/system/sleepypod.service.d
  printf '[Service]\nEnvironment="RAW_DATA_DIR=/persistent/biometrics"\n' > /etc/systemd/system/sleepypod.service.d/raw-data-dir.conf
  systemctl daemon-reload && systemctl restart sleepypod
  ```

## Known follow-up (not in this PR)

`piezoStream.ts:665` short-circuits the file-decode loop when no WebSocket client is connected, which means `flow_readings` only accumulates while someone has the Sensors page open. This is fine for the chart's primary use case but should be tracked as a separate ticket for true continuous history.

## Test plan

- [x] Added unit test: `recordFlowData` writes RPM with null flowrate when frame has no `temps` key.
- [x] `pnpm vitest run` — 1666 passed.
- [x] `pnpm tsc --noEmit` clean.
- [x] Deployed to Pod 5 (192.168.1.88) — frzHealth frames decoded, flow_readings rows landed within 60 s.
- [x] Confirmed historical chart values match live readout in degrees (≈25.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when sensor data is incomplete—the system now accepts frames missing temperature readings and records null flow values instead of rejecting them.
  * Fixed flow rate chart scaling and corrected display units so historical flow readings display accurately.

* **Tests**
  * Added test coverage for handling incomplete sensor data scenarios.

* **Chores**
  * Installer now sets RAW_DATA_DIR to avoid misinterpreting raw bookkeeping files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/flow-rate-chart-no-temps
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/flow-rate-chart-no-temps/scripts/install \
  | sudo bash -s -- --branch fix/flow-rate-chart-no-temps
```

🎯 **Pin to this exact build** ([run 26014033586](https://github.com/sleepypod/core/actions/runs/26014033586) · `1a80246`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/1a802469e5d53afd7a2328dee8d181e97fc420ea/scripts/install \
  | sudo bash -s -- \
      --branch fix/flow-rate-chart-no-temps \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26014033586/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26014033586/artifacts/7049727419) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

