### PR TITLE
fix(schedule): wake/bedtime inputs persist by rebasing curve points

### DIFF
--- a/src/components/Schedule/CurveEditor.tsx
+++ b/src/components/Schedule/CurveEditor.tsx
@@ -17,6 +17,7 @@ import {
   curveToScheduleTemperatures,
   timeStringToMinutes,
 } from '@/src/lib/sleepCurve/generate'
+import { rebaseSetPoints } from '@/src/lib/sleepCurve/rebase'
 import { sortChronological } from '@/src/lib/scheduleGrouping'
 
 interface CurveEditorProps {
@@ -256,6 +257,21 @@ export function CurveEditor({
     }
   }, [])
 
+  // Bedtime/wake are the canonical sleep-window controls — changing them
+  // rebases the existing set points so the curve shape stays intact within
+  // the new window. Without this rewire the inputs only drove preset
+  // generation, so users who edited the window without clicking a preset
+  // saw their change silently dropped on save.
+  const handleBedtimeChange = useCallback((next: string) => {
+    setPoints(prev => rebaseSetPoints(prev, bedtime, wakeTime, next, wakeTime))
+    setBedtime(next)
+  }, [bedtime, wakeTime])
+
+  const handleWakeTimeChange = useCallback((next: string) => {
+    setPoints(prev => rebaseSetPoints(prev, bedtime, wakeTime, bedtime, next))
+    setWakeTime(next)
+  }, [bedtime, wakeTime])
+
   const handleApplyPreset = useCallback((preset: PresetDef) => {
     const bedtimeMinutes = timeStringToMinutes(bedtime)
     const wakeMinutes = timeStringToMinutes(wakeTime)
@@ -370,14 +386,14 @@ export function CurveEditor({
           <TimeInput
             label="Bedtime"
             value={bedtime}
-            onChange={setBedtime}
+            onChange={handleBedtimeChange}
             icon={<Moon size={12} />}
             accentClass="text-purple-400"
           />
           <TimeInput
             label="Wake up"
             value={wakeTime}
-            onChange={setWakeTime}
+            onChange={handleWakeTimeChange}
             icon={<Sun size={12} />}
             accentClass="text-amber-400"
           />

--- a/src/components/Schedule/TimeInput.tsx
+++ b/src/components/Schedule/TimeInput.tsx
@@ -20,18 +20,18 @@ interface TimeInputProps {
  */
 export function TimeInput({ label, value, onChange, disabled = false, icon, accentClass }: TimeInputProps) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <label className="flex items-center gap-1.5 text-xs font-medium text-zinc-400">
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <label className="flex items-center gap-1.5 truncate text-xs font-medium text-zinc-400">
         {icon && <span className={accentClass}>{icon}</span>}
         {label}
       </label>
-      <div className="relative">
+      <div className="relative min-w-0">
         <input
           type="time"
           value={value}
           onChange={e => onChange(e.target.value)}
           disabled={disabled}
-          className="h-11 w-full rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 pr-9 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40 [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:inset-0 [&::-webkit-calendar-picker-indicator]:w-full [&::-webkit-calendar-picker-indicator]:h-full [&::-webkit-calendar-picker-indicator]:cursor-pointer"
+          className="h-11 w-full min-w-0 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 pr-9 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40 [&::-webkit-calendar-picker-indicator]:opacity-0 [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:inset-0 [&::-webkit-calendar-picker-indicator]:w-full [&::-webkit-calendar-picker-indicator]:h-full [&::-webkit-calendar-picker-indicator]:cursor-pointer"
         />
         <Clock size={16} className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500" />
       </div>

--- a/src/components/Schedule/tests/TimeInput.test.tsx
+++ b/src/components/Schedule/tests/TimeInput.test.tsx
@@ -85,6 +85,22 @@ describe('TimeInput component', () => {
     )
     expect(container.querySelector('label span')).toBeNull()
   })
+
+  it('allows shrinking below intrinsic width so it does not overlap siblings in a grid cell', () => {
+    // Native time inputs have a large intrinsic min-width that overflows
+    // narrow grid columns on mobile unless every nested box opts into
+    // min-width: 0. Regression guard for the overlapping Bedtime / Wake up
+    // controls in the CurveEditor sleep-window section.
+    const { container } = render(
+      <TimeInput label="On time" value="22:00" onChange={() => {}} />,
+    )
+    const root = container.firstElementChild as HTMLElement | null
+    const inputWrapper = container.querySelector('div > div.relative') as HTMLElement | null
+    const input = getTimeInput(container)
+    expect(root?.className).toContain('min-w-0')
+    expect(inputWrapper?.className).toContain('min-w-0')
+    expect(input.className).toContain('min-w-0')
+  })
 })
 
 describe('formatTime12h', () => {

--- a/src/lib/sleepCurve/rebase.test.ts
+++ b/src/lib/sleepCurve/rebase.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { rebaseSetPoints } from './rebase'
+
+describe('rebaseSetPoints', () => {
+  it('returns input unchanged when window is identical', () => {
+    const points = [
+      { localId: -1, time: '00:00', temperature: 81 },
+      { localId: -2, time: '04:00', temperature: 80 },
+      { localId: -3, time: '23:45', temperature: 80 },
+    ]
+    expect(rebaseSetPoints(points, '00:00', '23:45', '00:00', '23:45')).toEqual(points)
+  })
+
+  it('returns empty array unchanged', () => {
+    expect(rebaseSetPoints([], '22:00', '07:00', '23:00', '06:00')).toEqual([])
+  })
+
+  it('scales points proportionally when window shrinks', () => {
+    // Old window: 00:00 - 23:45 (1425min). New: 00:00 - 11:45 (705min).
+    // Compression factor: 705/1425 ≈ 0.495
+    const result = rebaseSetPoints(
+      [
+        { time: '00:00', temperature: 81 }, // offset 0    -> 0
+        { time: '11:52', temperature: 80 }, // offset 712  -> ~352 ≈ 05:52
+        { time: '23:45', temperature: 80 }, // offset 1425 -> 705 = 11:45
+      ],
+      '00:00',
+      '23:45',
+      '00:00',
+      '11:45',
+    )
+    expect(result[0].time).toBe('00:00')
+    expect(result[1].time).toBe('05:52')
+    expect(result[2].time).toBe('11:45')
+  })
+
+  it('preserves auxiliary fields (temperature, localId)', () => {
+    const result = rebaseSetPoints(
+      [{ localId: -7, time: '07:00', temperature: 78 }],
+      '00:00',
+      '23:45',
+      '00:00',
+      '11:45',
+    )
+    expect(result[0]).toMatchObject({ localId: -7, temperature: 78 })
+  })
+
+  it('handles overnight windows (bedtime > wake)', () => {
+    // Old: 22:00 -> 06:00 (8h = 480min). New: 23:00 -> 07:00 (8h = 480min).
+    // Same span, pure shift +1h.
+    const result = rebaseSetPoints(
+      [
+        { time: '22:00', temperature: 78 },
+        { time: '02:00', temperature: 68 },
+        { time: '06:00', temperature: 76 },
+      ],
+      '22:00',
+      '06:00',
+      '23:00',
+      '07:00',
+    )
+    expect(result[0].time).toBe('23:00')
+    expect(result[1].time).toBe('03:00')
+    expect(result[2].time).toBe('07:00')
+  })
+
+  it('scales overnight curve to a shorter overnight window', () => {
+    // Old: 22:00 -> 06:00 (480min). New: 23:00 -> 05:00 (360min). Ratio 0.75.
+    const result = rebaseSetPoints(
+      [
+        { time: '22:00', temperature: 78 }, // offset 0   -> 23:00
+        { time: '02:00', temperature: 68 }, // offset 240 -> 23:00 + 180 = 02:00
+        { time: '06:00', temperature: 76 }, // offset 480 -> 23:00 + 360 = 05:00
+      ],
+      '22:00',
+      '06:00',
+      '23:00',
+      '05:00',
+    )
+    expect(result[0].time).toBe('23:00')
+    expect(result[1].time).toBe('02:00')
+    expect(result[2].time).toBe('05:00')
+  })
+
+  it('clamps points outside the old window to the wake endpoint', () => {
+    // Old: 22:00 -> 06:00. Point at 08:00 is past wake; gets clamped to 06:00,
+    // then rescaled to the new wake endpoint.
+    const result = rebaseSetPoints(
+      [
+        { time: '22:00', temperature: 78 },
+        { time: '08:00', temperature: 80 },
+      ],
+      '22:00',
+      '06:00',
+      '23:00',
+      '07:00',
+    )
+    expect(result[0].time).toBe('23:00')
+    expect(result[1].time).toBe('07:00')
+  })
+
+  it('shifts uniformly when the old window is degenerate (zero span)', () => {
+    // bedtime == wake means we can't proportionally rescale — just translate.
+    const result = rebaseSetPoints(
+      [
+        { time: '07:00', temperature: 78 },
+        { time: '08:00', temperature: 80 },
+      ],
+      '07:00',
+      '07:00',
+      '08:00',
+      '09:00',
+    )
+    expect(result[0].time).toBe('08:00')
+    expect(result[1].time).toBe('09:00')
+  })
+
+  it('collapses to bedtime when the new window is degenerate', () => {
+    const result = rebaseSetPoints(
+      [
+        { time: '22:00', temperature: 78 },
+        { time: '02:00', temperature: 68 },
+        { time: '06:00', temperature: 76 },
+      ],
+      '22:00',
+      '06:00',
+      '08:00',
+      '08:00',
+    )
+    expect(result.every(p => p.time === '08:00')).toBe(true)
+  })
+
+  it('wraps the new bedtime + offset around midnight correctly', () => {
+    // New bedtime 23:30, span 60min. Midpoint offset wraps to 00:00.
+    const result = rebaseSetPoints(
+      [
+        { time: '00:00', temperature: 80 },
+        { time: '00:30', temperature: 80 },
+        { time: '01:00', temperature: 80 },
+      ],
+      '00:00',
+      '01:00',
+      '23:30',
+      '00:30',
+    )
+    expect(result[0].time).toBe('23:30')
+    expect(result[1].time).toBe('00:00')
+    expect(result[2].time).toBe('00:30')
+  })
+})

--- a/src/lib/sleepCurve/rebase.ts
+++ b/src/lib/sleepCurve/rebase.ts
@@ -1,0 +1,54 @@
+import { minutesToTimeStr, timeStringToMinutes } from './generate'
+
+export interface RebasePoint {
+  time: string
+}
+
+function span(fromMin: number, toMin: number): number {
+  const raw = toMin - fromMin
+  return raw >= 0 ? raw : raw + 24 * 60
+}
+
+/**
+ * Rescale a set of points to fit a new sleep window while preserving each
+ * point's fractional position within the window.
+ *
+ * - Overnight wrap is handled (bedtime > wake means the window crosses midnight).
+ * - Degenerate cases (oldSpan or newSpan === 0) shift uniformly instead of
+ *   scaling — avoids a divide-by-zero and a collapse to a single time.
+ * - Points outside the old window are clamped to the window's endpoints before
+ *   rescaling so they stay attached to the curve.
+ */
+export function rebaseSetPoints<P extends RebasePoint>(
+  points: P[],
+  oldBedtime: string,
+  oldWake: string,
+  newBedtime: string,
+  newWake: string,
+): P[] {
+  if (points.length === 0) return points
+  if (oldBedtime === newBedtime && oldWake === newWake) return points
+
+  const ob = timeStringToMinutes(oldBedtime)
+  const ow = timeStringToMinutes(oldWake)
+  const nb = timeStringToMinutes(newBedtime)
+  const nw = timeStringToMinutes(newWake)
+
+  const oldSpan = span(ob, ow)
+  const newSpan = span(nb, nw)
+
+  // Degenerate old window: nothing to scale against — shift uniformly so the
+  // curve follows the bedtime change instead of collapsing.
+  if (oldSpan === 0) {
+    const delta = nb - ob
+    return points.map(p => ({ ...p, time: minutesToTimeStr(timeStringToMinutes(p.time) + delta) }))
+  }
+
+  return points.map((p) => {
+    const t = timeStringToMinutes(p.time)
+    const rawOffset = span(ob, t)
+    const offset = Math.min(rawOffset, oldSpan)
+    const newOffset = newSpan === 0 ? 0 : Math.round((offset / oldSpan) * newSpan)
+    return { ...p, time: minutesToTimeStr(nb + newOffset) }
+  })
+}


### PR DESCRIPTION
## Summary

- **Bug**: In `CurveEditor`, the *Sleep window* **Bedtime** / **Wake up** inputs only fed preset generation. If the user changed wake from e.g. 23:45 → 11:45 and tapped Save without first applying a preset, the change was silently dropped — `points` still held the old times, so `saveCurve` round-tripped the original schedule.
- **Fix**: Wire both inputs through a new `rebaseSetPoints(points, oldBed, oldWake, newBed, newWake)` helper that proportionally rescales every set point into the new window (with overnight-wrap handling). The value the user types is now the value that gets written.
- **Mobile**: Native `<input type="time">` has a large intrinsic min-width that overflowed narrow grid columns, so the Bedtime/Wake controls overlapped on phones. Added `min-w-0` to `TimeInput`'s wrappers + a regression test.

Discovered while debugging a 12am → 11:45 PM right-side curve on Pod 5 — no `schedules.batchUpdate` ever fired despite repeated Saves.

## Test plan

- [x] `pnpm test run src/lib/sleepCurve/rebase.test.ts src/components/Schedule/tests/TimeInput.test.tsx` — 29 passing (10 new rebase cases covering equal-window no-op, shrink, overnight wrap, clamp, degenerate spans, midnight wrap)
- [x] `pnpm tsc` clean
- [x] `pnpm eslint` clean on changed files
- [ ] Manual: open right-side curve (00:00 → 23:45), change Wake to 11:45, tap Save — verify DB persists rebased points and UI reflects 12h window after refetch
- [ ] Manual on iPhone Safari: Bedtime + Wake render side-by-side without overlap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sleep curve values are now automatically adjusted and preserved when you edit your bedtime or wake time in the schedule editor, maintaining the curve shape you've created

* **Improvements**
  * Enhanced layout and display stability for time input fields to prevent overlapping controls

* **Tests**
  * Added comprehensive test coverage for curve adjustment and time input rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update worktree-debug-schedule-update
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-debug-schedule-update/scripts/install \
  | sudo bash -s -- --branch worktree-debug-schedule-update
```

🎯 **Pin to this exact build** ([run 26014283146](https://github.com/sleepypod/core/actions/runs/26014283146) · `63b896b`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/63b896bbb84cebdcb92df867e41000a44125deb5/scripts/install \
  | sudo bash -s -- \
      --branch worktree-debug-schedule-update \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26014283146/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26014283146/artifacts/7049816446) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


