### PR TITLE
test(biometrics): cover getVitalsBaseline mean/SD and edge cases

### DIFF
--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -291,6 +291,90 @@ describe('biometrics.getVitalsSummary', () => {
   })
 })
 
+describe('biometrics.getVitalsBaseline', () => {
+  it('returns null when sampleCount=0', async () => {
+    dbState.rowsQueue.push([{
+      hrMean: null, hrSqMean: null,
+      hrvMean: null, hrvSqMean: null,
+      brMean: null, brSqMean: null,
+      sampleCount: 0,
+    }])
+    const out = await caller.getVitalsBaseline({ side: 'left', days: 30 })
+    expect(out).toBeNull()
+  })
+
+  it('computes mean and SD via E[X²] − E[X]² when variance > 0', async () => {
+    // hr: mean=60, sqMean=3604 → variance=4 → SD=2
+    // hrv: mean=50, sqMean=2509 → variance=9 → SD=3
+    // br: mean=14, sqMean=200 → variance=4 → SD=2
+    dbState.rowsQueue.push([{
+      hrMean: '60', hrSqMean: '3604',
+      hrvMean: '50', hrvSqMean: '2509',
+      brMean: '14', brSqMean: '200',
+      sampleCount: 100,
+    }])
+    const out = await caller.getVitalsBaseline({ side: 'left', days: 30 })
+    expect(out).toEqual({
+      hrMean: 60, hrSD: 2,
+      hrvMean: 50, hrvSD: 3,
+      brMean: 14, brSD: 2,
+      sampleCount: 100,
+      windowDays: 30,
+    })
+  })
+
+  it('returns SD=0 when variance is non-positive (single sample / no spread)', async () => {
+    // mean=60, sqMean=3600 → variance=0 → SD=0
+    dbState.rowsQueue.push([{
+      hrMean: '60', hrSqMean: '3600',
+      hrvMean: '50', hrvSqMean: '2500',
+      brMean: '14', brSqMean: '196',
+      sampleCount: 1,
+    }])
+    const out = await caller.getVitalsBaseline({ side: 'left', days: 30 })
+    expect(out?.hrSD).toBe(0)
+    expect(out?.hrvSD).toBe(0)
+    expect(out?.brSD).toBe(0)
+  })
+
+  it('returns null SD for metrics whose mean or sqMean is null', async () => {
+    // hr present, hrv mean null, br sqMean null
+    dbState.rowsQueue.push([{
+      hrMean: '60', hrSqMean: '3604',
+      hrvMean: null, hrvSqMean: '2509',
+      brMean: '14', brSqMean: null,
+      sampleCount: 50,
+    }])
+    const out = await caller.getVitalsBaseline({ side: 'left', days: 30 })
+    expect(out?.hrMean).toBe(60)
+    expect(out?.hrSD).toBe(2)
+    expect(out?.hrvMean).toBeNull()
+    expect(out?.hrvSD).toBeNull()
+    expect(out?.brMean).toBe(14)
+    expect(out?.brSD).toBeNull()
+  })
+
+  it('echoes the requested days as windowDays (custom window)', async () => {
+    dbState.rowsQueue.push([{
+      hrMean: '60', hrSqMean: '3604',
+      hrvMean: null, hrvSqMean: null,
+      brMean: null, brSqMean: null,
+      sampleCount: 5,
+    }])
+    const out = await caller.getVitalsBaseline({ side: 'right', days: 7 })
+    expect(out?.windowDays).toBe(7)
+    expect(out?.sampleCount).toBe(5)
+  })
+
+  it('wraps DB errors as INTERNAL_SERVER_ERROR', async () => {
+    dbMock.select.mockImplementationOnce(() => {
+      throw new Error('db blew up')
+    })
+    await expect(caller.getVitalsBaseline({ side: 'left', days: 30 }))
+      .rejects.toThrow(/Failed to calculate vitals baseline: db blew up/)
+  })
+})
+
 describe('biometrics.reportVitals / reportVitalsBatch', () => {
   it('reportVitals returns written:1', async () => {
     const out = await caller.reportVitals({


### PR DESCRIPTION
## Summary

Follow-up to #597. Codecov flagged the new `getVitalsBaseline` procedure as 0% (15 lines missing), dropping patch coverage to 70%. Adds 6 targeted tests against the existing `biometrics.test.ts` mocking pattern.

Coverage on `src/server/routers/biometrics.ts` after this PR:
- lines: 100% (197/197)
- statements: 100% (216/216)
- functions: 100% (27/27)
- branches: 91.45% (182/199)

## What's tested

- `sampleCount === 0` → returns `null`
- Happy path: mean + SD computed via `E[X²] − E[X]²` with positive variance
- `variance <= 0` → SD coerced to `0` (single sample, no spread)
- Per-metric null handling when `mean` or `sqMean` is null on any of hr/hrv/br
- Custom `days` parameter echoed as `windowDays`
- DB error wrapped as `INTERNAL_SERVER_ERROR` with descriptive message

## Test plan

- [x] `pnpm test src/server/routers/tests/biometrics.test.ts` — 65/65 passing
- [x] Full suite: 1672 passing / 1 skipped (was 1666 before)
- [x] Coverage verified locally with `--coverage` JSON summary

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/biometrics-vitals-baseline
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/biometrics-vitals-baseline/scripts/install \
  | sudo bash -s -- --branch test/biometrics-vitals-baseline
```

🎯 **Pin to this exact build** ([run 26014243952](https://github.com/sleepypod/core/actions/runs/26014243952) · `2f1a139`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/2f1a13990200914c2cf475b266fafcac38cf0450/scripts/install \
  | sudo bash -s -- \
      --branch test/biometrics-vitals-baseline \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26014243952/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26014243952/artifacts/7049801134) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
