### PR TITLE
fix(scheduler): alarms fire vibration even when the side is off

### DIFF
--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -439,22 +439,32 @@ export class JobManager {
 
   async runAlarmJob(sched: typeof alarmSchedules.$inferSelect): Promise<void> {
     await this.withSideLock(sched.side, async () => {
-      if (!(await this.isSidePowered(sched.side))) {
-        console.log(`Skipping alarm job alarm-${sched.id} — ${sched.side} is not powered`)
-        return
-      }
+      // Vibration must fire regardless of power state — the alarm's purpose is
+      // to wake the user, who often sleeps with the bed off or on a power
+      // schedule that hasn't kicked in yet at wake time. Temperature, however,
+      // is gated on isPowered: heating an off bed contradicts the user's
+      // explicit power-off and would re-arm the same race the temperature
+      // path's gate was added to prevent (see withSideLock comment).
+      const powered = await this.isSidePowered(sched.side)
       markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
-      await client.setTemperature(sched.side, sched.alarmTemperature)
+      if (powered) {
+        await client.setTemperature(sched.side, sched.alarmTemperature)
+      }
+      else {
+        console.log(`Alarm job alarm-${sched.id} — ${sched.side} not powered; skipping temperature, firing vibration only`)
+      }
       await client.setAlarm(sched.side, {
         vibrationIntensity: sched.vibrationIntensity,
         vibrationPattern: sched.vibrationPattern,
         duration: sched.duration,
       })
       broadcastMutationStatus(sched.side, {
-        targetTemperature: sched.alarmTemperature,
-        targetLevel: fahrenheitToLevel(sched.alarmTemperature),
+        ...(powered && {
+          targetTemperature: sched.alarmTemperature,
+          targetLevel: fahrenheitToLevel(sched.alarmTemperature),
+        }),
         isAlarmVibrating: true,
       })
     })

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -414,13 +414,40 @@ describe('JobManager — job ordering and gating', () => {
       expect(setAlarm).toHaveBeenCalledOnce()
     })
 
-    it('skips alarm + temperature when side is not powered', async () => {
+    it('fires alarm but skips temperature when side is not powered', async () => {
+      // Vibration must wake the user even when the bed is off — that's the
+      // whole point of an alarm. Temperature stays gated to avoid re-heating
+      // a deliberately-off side.
       seedSidePowered('right', false)
 
       await manager.runAlarmJob(alarmSched('right'))
 
       expect(setTemperature).not.toHaveBeenCalled()
-      expect(setAlarm).not.toHaveBeenCalled()
+      expect(setAlarm).toHaveBeenCalledOnce()
+      expect(setAlarm).toHaveBeenCalledWith('right', {
+        vibrationIntensity: 100,
+        vibrationPattern: 'rise',
+        duration: 10,
+      })
+    })
+
+    it('fires alarm when side has no device_state row (treated as off)', async () => {
+      // No row inserted at all
+      await manager.runAlarmJob(alarmSched('left'))
+
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(setAlarm).toHaveBeenCalledOnce()
+    })
+
+    it('broadcast omits temperature fields but keeps isAlarmVibrating when not powered', async () => {
+      seedSidePowered('right', false)
+
+      await manager.runAlarmJob(alarmSched('right'))
+
+      expect(broadcastMutationStatus).toHaveBeenCalledOnce()
+      expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+        isAlarmVibrating: true,
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- Scheduled alarms were silently no-oping when the bed was off at wake time. `runAlarmJob` inherited the `isSidePowered` gate from the temperature path — that gate exists to prevent a same-minute temperature job from re-heating after `power_off` (see comment above `withSideLock`), but on the alarm path it suppresses the user's actual ask.
- The Test button in the alarm editor always worked because it calls `device.setAlarm` directly, which doesn't gate on power state — that's why "vibrations work" but scheduled alarms don't.
- Fix: fire `setAlarm` unconditionally. Keep `setTemperature` gated on `isPowered` so an off bed isn't quietly re-heated. The broadcast omits temperature fields when unpowered but still emits `isAlarmVibrating: true`.

## Test plan

- [x] `pnpm vitest run src/scheduler` — 176/176 pass, including the updated `alarm gating by isPowered` group:
  - fires alarm + temperature when side is powered
  - **fires alarm but skips temperature when side is not powered** (new behavior)
  - fires alarm when side has no device_state row
  - broadcast omits temperature fields but keeps `isAlarmVibrating` when not powered
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean (one pre-existing warning in `stryker.config.mjs`, untouched)
- [ ] Manual: set an alarm for ~2 min from now with the bed powered off; confirm the side vibrates at the scheduled minute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Alarm vibration now consistently triggers even when the target device is not powered, ensuring alerts are always delivered.

## Tests
* Updated test coverage to verify alarm vibration behavior when devices are unpowered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/alarm-fires-when-side-off
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/alarm-fires-when-side-off/scripts/install \
  | sudo bash -s -- --branch fix/alarm-fires-when-side-off
```

🎯 **Pin to this exact build** ([run 26058253781](https://github.com/sleepypod/core/actions/runs/26058253781) · `1469c70`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/1469c701d4732bc89f80524a5cb5dd9b91144739/scripts/install \
  | sudo bash -s -- \
      --branch fix/alarm-fires-when-side-off \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26058253781/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26058253781/artifacts/7068293100) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
