### PR TITLE
fix(install): detect_free_sleep_conflict aborts install on clean pods

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -318,6 +318,10 @@ detect_free_sleep_conflict() {
   # own block_wan persists /etc/iptables/iptables.rules but never the v6
   # file, so flagging the v4 file would false-positive on every reinstall.
   [ -f /etc/iptables/ip6tables.rules ]       && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/ip6tables.rules")
+  # Last `[ test ] && side_effect` returns 1 when the test is false. Under
+  # set -e, that propagates out and kills install at the preflight call on
+  # any clean pod. Explicit return 0 keeps the function's exit status sane.
+  return 0
 }
 
 purge_free_sleep() {


### PR DESCRIPTION
## Summary

`scripts/install:307` — `detect_free_sleep_conflict()` ends with:

\`\`\`bash
[ -f /etc/iptables/ip6tables.rules ] && FREE_SLEEP_FINDINGS+=("persisted: ...")
\`\`\`

When the file is absent (every clean pod), the test returns 1. Because that's the function's last statement, its exit code becomes 1, and \`set -e\` aborts at the \`preflight_free_sleep_conflict\` call on line 354. Hit deploying #602 to .88 — pod had no free-sleep artifacts at all but install still bailed with:

\`\`\`
Failed line:    354
Failed command: [ -f /etc/iptables/ip6tables.rules ]
\`\`\`

Fix: explicit \`return 0\` at the end of the function. Keeps the \`[ test ] && side_effect\` idiom (it's clean to read) without leaking its exit status.

## Test plan

- [x] Local apply, re-run install on .88 — proceeds past preflight as expected
- [ ] `bash -n scripts/install` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation script behavior to ensure stable completion of preflight validation checks on all systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/install-freesleep-detect-return
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/install-freesleep-detect-return/scripts/install \
  | sudo bash -s -- --branch fix/install-freesleep-detect-return
```

🎯 **Pin to this exact build** ([run 26083145064](https://github.com/sleepypod/core/actions/runs/26083145064) · `31bb4cf`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/31bb4cfa31236076e387dc7c545014373cd2f287/scripts/install \
  | sudo bash -s -- \
      --branch fix/install-freesleep-detect-return \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26083145064/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26083145064/artifacts/7077497475) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
