### PR TITLE
feat(install): storage-aware placement for node_modules and swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ boundary; the in-app unit preference is unaffected.
 The bridge's HomeKit identity (MAC-style username, pincode, setupId) is
 **deterministically derived** from a hardware-rooted seed (eMMC CID →
 machine-id → random fallback) via HKDF, and cached at
-`/persistent/sleepypod-data/homekit/identity.json`. A `/persistent` wipe or
+`$DATA_DIR/homekit/identity.json` (where `$DATA_DIR` is the picker-chosen
+data dir — see [`scripts/README.md`](scripts/README.md#file-locations);
+typically `/persistent/sleepypod-data/homekit/identity.json` on Pod 4/5).
+A `/persistent` wipe or
 firmware reflash regenerates the **same** identity, so iOS still recognizes
 the bridge — you only re-pair, your automations and rooms stay intact. See
 **[ADR 0020](docs/adr/0020-homekit-identity-derivation.md)** for the full

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -148,10 +148,12 @@ Downloaded from `nodejs.org/dist/` for `linux-arm64`. No package manager require
 | Path | Contents |
 |---|---|
 | `/home/dac/sleepypod-core` | App source + `node_modules` + `.next` build |
-| `/persistent/sleepypod-data/sleepypod.db` | Config database |
-| `/persistent/sleepypod-data/biometrics.db` | Biometrics database |
+| `$DATA_DIR/sleepypod.db` | Config database — `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size) and persisted to `/etc/sleepypod/data-dir`. Default on Pod 4/5: `/persistent/sleepypod-data/sleepypod.db`; on Pod 3 + SD card: `/sleepypod-data/sleepypod.db`. |
+| `$DATA_DIR/biometrics.db` | Biometrics database — same path resolution as above. |
+| `/etc/sleepypod/data-dir` | Pointer file with the chosen `$DATA_DIR`. Read by `sp-update` / `sp-maintenance` / `sp-bundle-logs` / `sp-uninstall` / `scripts/pod/detect`. |
 | `/home/dac/sleepypod-core/.env` | Environment config |
 | `/opt/sleepypod/modules/` | Python biometrics modules |
+| `/opt/sleepypod/python/` | `uv`-managed CPython (used when the firmware's `/usr/bin/python3` stdlib is incomplete — see `scripts/pod/capabilities`). |
 | `/usr/local/bin/sp-*` | CLI shortcuts |
 
 ## CLI Shortcuts (on the pod)

--- a/docs/wiki/topics/deployment.md
+++ b/docs/wiki/topics/deployment.md
@@ -84,7 +84,7 @@ uv (~30MB) is downloaded during install. Each biometrics module gets a `.venv/` 
 | Node.js | Binary tarball install |
 | DAC socket | Auto-detected from frank.sh |
 
-Key file locations: app at `/home/dac/sleepypod-core`, config DB at `/persistent/sleepypod-data/sleepypod.db`, biometrics DB at `/persistent/sleepypod-data/biometrics.db`.
+Key file locations: app at `/home/dac/sleepypod-core`, config DB at `$DATA_DIR/sleepypod.db`, biometrics DB at `$DATA_DIR/biometrics.db`. `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size; defaults: `/persistent/sleepypod-data` on Pod 4/5, `/sleepypod-data` on Pod 3 + SD card) and recorded in `/etc/sleepypod/data-dir` — `cat` that file on the Pod to see the live value.
 
 ## Coexistence with free-sleep
 

--- a/docs/wiki/topics/deployment.md
+++ b/docs/wiki/topics/deployment.md
@@ -84,7 +84,7 @@ uv (~30MB) is downloaded during install. Each biometrics module gets a `.venv/` 
 | Node.js | Binary tarball install |
 | DAC socket | Auto-detected from frank.sh |
 
-Key file locations: app at `/home/dac/sleepypod-core`, config DB at `$DATA_DIR/sleepypod.db`, biometrics DB at `$DATA_DIR/biometrics.db`. `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size; defaults: `/persistent/sleepypod-data` on Pod 4/5, `/sleepypod-data` on Pod 3 + SD card) and recorded in `/etc/sleepypod/data-dir` — `cat` that file on the Pod to see the live value.
+Key file locations: app at `/home/dac/sleepypod-core`, config DB at `/persistent/sleepypod-data/sleepypod.db`, biometrics DB at `/persistent/sleepypod-data/biometrics.db`.
 
 ## Coexistence with free-sleep
 

--- a/modules/archive-push/sleepypod-archive-push.service
+++ b/modules/archive-push/sleepypod-archive-push.service
@@ -8,6 +8,11 @@ Wants=network-online.target
 Type=oneshot
 User=sleepypod
 Group=sleepypod
+# Paths are rewritten at install time — `/persistent/sleepypod-data`
+# becomes the picker-chosen $DATA_DIR (see scripts/install archive-push
+# block) so this matches where biometrics.db actually lives.
+Environment="BIOMETRICS_DB_PATH=/persistent/sleepypod-data/biometrics.db"
+Environment="ARCHIVE_PUSH_STAGING_DIR=/persistent/sleepypod-data/archive-push-staging"
 ExecStart=/usr/local/bin/sleepypod-archive-push
 Nice=10
 IOSchedulingClass=idle

--- a/modules/calibrator/sleepypod-calibrator.service
+++ b/modules/calibrator/sleepypod-calibrator.service
@@ -19,6 +19,10 @@ EnvironmentFile=-/etc/sleepypod/modules/calibrator.env
 Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
+# Path is rewritten at install time by install_module() — /persistent/sleepypod-data
+# becomes the picker-chosen $DATA_DIR so the calibrator (reader) and the
+# tRPC trigger writer (next-server) agree on a path that exists.
+Environment="CALIBRATION_TRIGGER_PATH=/persistent/sleepypod-data/.calibrate-trigger"
 Environment="CALIBRATION_HOUR=6"
 
 # Resource limits (calibration loads up to 6h of sensor data into numpy

--- a/modules/environment-monitor/README.md
+++ b/modules/environment-monitor/README.md
@@ -29,14 +29,16 @@ The freezer table only populates on hardware that actually emits `frzTemp` frame
 # Live logs (decisions, dropped sentinels, fatal errors)
 journalctl -u sleepypod-environment-monitor.service -f
 
-# Most recent rows
-sqlite3 /persistent/sleepypod-data/biometrics.db \
+# Most recent rows ($DATA_DIR is read from /etc/sleepypod/data-dir;
+# typically /persistent/sleepypod-data on Pod 4/5, /sleepypod-data on Pod 3 + SD)
+DATA_DIR="$(cat /etc/sleepypod/data-dir 2>/dev/null || echo /persistent/sleepypod-data)"
+sqlite3 "$DATA_DIR/biometrics.db" \
   'SELECT * FROM bed_temp ORDER BY timestamp DESC LIMIT 3;'
-sqlite3 /persistent/sleepypod-data/biometrics.db \
+sqlite3 "$DATA_DIR/biometrics.db" \
   'SELECT * FROM freezer_temp ORDER BY timestamp DESC LIMIT 3;'
 
 # Health row (component='environment-monitor' is updated on start/exit)
-sqlite3 /persistent/sleepypod-data/sleepypod.db \
+sqlite3 "$DATA_DIR/sleepypod.db" \
   "SELECT * FROM system_health WHERE component='environment-monitor';"
 ```
 
@@ -45,8 +47,8 @@ sqlite3 /persistent/sleepypod-data/sleepypod.db \
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `RAW_DATA_DIR` | `/persistent` | Directory the RAW follower tails. The systemd unit overrides to `/persistent/biometrics` (tmpfs) — see ADR-0018. |
-| `BIOMETRICS_DATABASE_URL` | `file:/persistent/sleepypod-data/biometrics.db` | Sink for `bed_temp` / `freezer_temp` rows. |
-| `DATABASE_URL` | `file:/persistent/sleepypod-data/sleepypod.db` | Used only to write `system_health` heartbeats. |
+| `BIOMETRICS_DATABASE_URL` | `file:/persistent/sleepypod-data/biometrics.db` | Sink for `bed_temp` / `freezer_temp` rows. The systemd unit overrides to `file:$DATA_DIR/biometrics.db` (install-time `sed` substitution against the picker-chosen `$DATA_DIR` — see `scripts/install` `install_module()`). |
+| `DATABASE_URL` | `file:/persistent/sleepypod-data/sleepypod.db` | Used only to write `system_health` heartbeats. Same `$DATA_DIR` override as above. |
 
 ## Python version
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -239,7 +239,7 @@ Each module has a `pyproject.toml` and `uv.lock`. The install script runs `uv sy
 ## File Locations
 
 - **Installation**: `/home/dac/sleepypod-core/`
-- **Database**: `/persistent/sleepypod-data/sleepypod.db` (SQLite with Drizzle ORM)
+- **Database**: `$DATA_DIR/sleepypod.db` — `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size) and persisted to `/etc/sleepypod/data-dir`. Default on Pod 4/5: `/persistent/sleepypod-data`; on Pod 3 + SD card: `/sleepypod-data`. Override with `bash scripts/install --data-dir <path>`.
 - **Service**: `/etc/systemd/system/sleepypod.service`
 - **Environment**: `/home/dac/sleepypod-core/.env`
 
@@ -269,7 +269,7 @@ Common issues:
 Reset database:
 ```bash
 cd /home/dac/sleepypod-core
-rm /persistent/sleepypod-data/sleepypod.db
+rm "$(cat /etc/sleepypod/data-dir 2>/dev/null || echo /persistent/sleepypod-data)/sleepypod.db"
 pnpm db:generate
 pnpm db:push
 sp-restart

--- a/scripts/bin/sp-bundle-logs
+++ b/scripts/bin/sp-bundle-logs
@@ -30,7 +30,13 @@ for arg in "$@"; do
 done
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 HOMEKIT_DIR="$DATA_DIR/homekit"
 INSTALL_LOG="/tmp/sleepypod-install.log"
 

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -6,7 +6,13 @@ set -euo pipefail
 # Called by sleepypod.service ExecStartPre so it runs before the app starts.
 # Keeps disk usage in check on the pod's limited storage (~6GB).
 
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 INSTALL_DIR="/home/dac/sleepypod-core"
 
 echo "=== SleepyPod Maintenance ==="

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -23,7 +23,14 @@ for arg in "$@"; do
 done
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+# The pointer itself is cleaned up by `rm -rf /etc/sleepypod` below.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 MODULES_DIR="/opt/sleepypod/modules"
 
 if [ "$FORCE" != true ]; then

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -310,6 +310,16 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   if ! command -v uv &>/dev/null; then
     echo "Warning: uv not found — biometrics modules not synced. Re-run the full installer."
   fi
+  # Probe the firmware's /usr/bin/python3 for stdlib integrity. Pod 5
+  # firmware (debian variant) ships 3.9.9 with unittest, dataclasses,
+  # and pyexpat stripped — version check passes, uv would happily bind
+  # the venv to it, modules crash at startup. Mirror install_module()'s
+  # behavior here so OTAs don't silently revert to the broken interpreter.
+  # If capabilities is missing (transitional install), default to "true"
+  # to keep the previous behavior (no managed-Python forcing).
+  if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
+    source "$INSTALL_DIR/scripts/pod/capabilities"
+  fi
   for mod in piezo-processor sleep-detector environment-monitor calibrator cover-buttons; do
     if [ -d "$INSTALL_DIR/modules/$mod" ]; then
       mkdir -p "$MODULES_DEST/$mod"
@@ -322,13 +332,29 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       # re-link, not a full re-download.
       rm -rf "$MODULES_DEST/$mod/.venv"
       if command -v uv &>/dev/null; then
-        (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
+        _uv_sync_args=(--frozen)
+        if [ "${SYSTEM_PYTHON_STDLIB_INTACT:-true}" = "false" ]; then
+          _uv_sync_args+=(--python-preference only-managed)
+        fi
+        (cd "$MODULES_DEST/$mod" && uv sync "${_uv_sync_args[@]}") \
           || echo "Warning: uv sync failed for module $mod"
+        unset _uv_sync_args
         chmod -R o+rX "$MODULES_DEST/$mod/.venv" 2>/dev/null || true
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then
-        cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
+        # Substitute the chosen $DATA_DIR for the baked-in
+        # /persistent/sleepypod-data — the unit's ReadWritePaths= and
+        # DATABASE_URL=/CALIBRATION_TRIGGER_PATH= reference it, and on
+        # installs where the picker chose /sleepypod-data the hardcoded
+        # path doesn't exist → systemd "Failed to set up mount
+        # namespacing". Mirrors install_module() in scripts/install so
+        # OTAs don't stomp the substituted unit with a vanilla copy.
+        _data_dir_sed=${DATA_DIR//|/\\|}
+        sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+          "$MODULES_DEST/$mod/$svc" > "/etc/systemd/system/$svc"
+        chmod 0644 "/etc/systemd/system/$svc"
+        unset _data_dir_sed
         systemctl daemon-reload
         systemctl enable "$svc" 2>/dev/null || true
         systemctl restart "$svc" 2>/dev/null || true

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -348,10 +348,14 @@ if [ -d "$INSTALL_DIR/modules" ]; then
         # DATABASE_URL=/CALIBRATION_TRIGGER_PATH= reference it, and on
         # installs where the picker chose /sleepypod-data the hardcoded
         # path doesn't exist → systemd "Failed to set up mount
-        # namespacing". Mirrors install_module() in scripts/install so
-        # OTAs don't stomp the substituted unit with a vanilla copy.
-        _data_dir_sed=${DATA_DIR//|/\\|}
-        sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+        # namespacing". Mirrors install_module() in scripts/install
+        # (boundary match + replacement escapes) so OTAs don't stomp
+        # the substituted unit with a vanilla copy. Keep the two
+        # sed expressions in sync.
+        _data_dir_sed=${DATA_DIR//\\/\\\\}
+        _data_dir_sed=${_data_dir_sed//&/\\&}
+        _data_dir_sed=${_data_dir_sed//|/\\|}
+        sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
           "$MODULES_DEST/$mod/$svc" > "/etc/systemd/system/$svc"
         chmod 0644 "/etc/systemd/system/$svc"
         unset _data_dir_sed

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -310,7 +310,7 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   if ! command -v uv &>/dev/null; then
     echo "Warning: uv not found — biometrics modules not synced. Re-run the full installer."
   fi
-  # Probe the firmware's /usr/bin/python3 for stdlib integrity. Pod 5
+  # Probe the firmware's /usr/bin/python3 for stdlib integrity. Pod 3
   # firmware (debian variant) ships 3.9.9 with unittest, dataclasses,
   # and pyexpat stripped — version check passes, uv would happily bind
   # the venv to it, modules crash at startup. Mirror install_module()'s

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -16,7 +16,13 @@ export PATH="/usr/local/bin:$PATH"
 # No git required — uses GitHub's tarball API.
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
 BRANCH="${1:-main}"
 

--- a/scripts/install
+++ b/scripts/install
@@ -79,6 +79,9 @@ elif [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
   DATA_DIR="$(cat /etc/sleepypod/data-dir)"
   DATA_DIR_REASON="cached from prior install (/etc/sleepypod/data-dir)"
 else
+  # Pick by TOTAL partition size, not free space + headroom like the
+  # node_modules / swap pickers — the DBs grow unbounded over the Pod's
+  # life, so the partition with the most ultimate capacity wins.
   _rootfs_total_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $2}')
   _rootfs_total_mb=${_rootfs_total_mb:-0}
   if mountpoint -q /persistent 2>/dev/null; then
@@ -668,6 +671,10 @@ if [ "$DATA_DIR" != "$LEGACY_DATA_DIR" ] && [ -d "$LEGACY_DATA_DIR" ] \
    && [ -z "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
   echo "Migrating data dir from $LEGACY_DATA_DIR to $DATA_DIR..."
   mkdir -p "$(dirname "$DATA_DIR")"
+  # An aborted prior run can leave $DATA_DIR as an empty dir (the guard
+  # above allows that). Drop it so mv renames LEGACY into place rather
+  # than nesting it as $DATA_DIR/sleepypod-data. No-op when absent.
+  rmdir "$DATA_DIR" 2>/dev/null || true
   mv "$LEGACY_DATA_DIR" "$DATA_DIR"
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -1546,10 +1546,22 @@ else
     # file or directory". ReadWritePaths= is a unit directive so an
     # EnvironmentFile drop-in can't fix it — substitution at install
     # time is the only path.
+    #
+    # The match requires /persistent/sleepypod-data to be followed by
+    # one of [/" \t] (path separator, env-value quote closer, or
+    # whitespace) OR end-of-line, so any future hardcoded path that
+    # legitimately starts with the same stem (e.g.
+    # /persistent/sleepypod-data-old/foo) is NOT partially rewritten.
+    # The replacement is sed-escaped for `\` and `&` so an exotic
+    # --data-dir override can't trigger sed's whole-match (&) or
+    # escape (\) substitution syntax. sp-update has the same block —
+    # keep them in sync.
     if [ -f "$dest/$service" ]; then
-      _data_dir_sed=${DATA_DIR//|/\\|}
-      sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" "$dest/$service" \
-        > "/etc/systemd/system/$service"
+      _data_dir_sed=${DATA_DIR//\\/\\\\}
+      _data_dir_sed=${_data_dir_sed//&/\\&}
+      _data_dir_sed=${_data_dir_sed//|/\\|}
+      sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
+        "$dest/$service" > "/etc/systemd/system/$service"
       chmod 0644 "/etc/systemd/system/$service"
       unset _data_dir_sed
       systemctl daemon-reload
@@ -1609,11 +1621,15 @@ if [ -d "$PUSH_SRC" ]; then
 
   install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
   # Substitute $DATA_DIR for the baked-in /persistent/sleepypod-data —
-  # ReadWritePaths= in the unit references that path and the namespace
-  # bind-mount fails when the picker chose /sleepypod-data. Same fix as
-  # install_module() above.
-  _data_dir_sed=${DATA_DIR//|/\\|}
-  sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+  # ReadWritePaths= + BIOMETRICS_DB_PATH= + ARCHIVE_PUSH_STAGING_DIR= in
+  # the unit reference that path and the namespace bind-mount fails
+  # when the picker chose /sleepypod-data. Defensive boundary match +
+  # replacement escapes — same regex as install_module() above, see
+  # the comment there for the boundary-match rationale.
+  _data_dir_sed=${DATA_DIR//\\/\\\\}
+  _data_dir_sed=${_data_dir_sed//&/\\&}
+  _data_dir_sed=${_data_dir_sed//|/\\|}
+  sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
     "$PUSH_SRC/sleepypod-archive-push.service" \
     > /etc/systemd/system/sleepypod-archive-push.service
   chmod 0644 /etc/systemd/system/sleepypod-archive-push.service

--- a/scripts/install
+++ b/scripts/install
@@ -1502,10 +1502,24 @@ else
     # If system python3 is in range it's used; otherwise uv downloads a
     # compatible managed interpreter into UV_PYTHON_INSTALL_DIR (set above
     # to /opt/sleepypod/python so User=dac modules can execute it).
-    (cd "$dest" && uv sync --frozen) || {
+    #
+    # Exception: Pod 3 firmware (debian variant) ships /usr/bin/python3
+    # = 3.9.9 with `unittest`, `dataclasses`, and `pyexpat` stripped from
+    # the stdlib. The version range check passes so uv would happily
+    # bind to it, then the module crashes at startup with
+    # `ModuleNotFoundError: No module named 'unittest'` once numpy lazy-
+    # imports numpy.testing. Force uv onto a managed interpreter when
+    # the stdlib probe (scripts/pod/capabilities) says it's not intact.
+    _uv_sync_args=(--frozen)
+    if [ "${SYSTEM_PYTHON_STDLIB_INTACT:-true}" = "false" ]; then
+      _uv_sync_args+=(--python-preference only-managed)
+    fi
+    (cd "$dest" && uv sync "${_uv_sync_args[@]}") || {
       echo "Warning: uv sync failed for module $name"
+      unset _uv_sync_args
       return
     }
+    unset _uv_sync_args
 
     # Ensure non-root service users (User=dac on calibrator + env-monitor)
     # can read the venv dir + traverse the managed-Python symlink target.

--- a/scripts/install
+++ b/scripts/install
@@ -41,8 +41,10 @@ INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
 RESTORE_MODE=false
-NODE_MODULES_DIR=""
-SWAP_DIR=""
+# Preserve env-supplied overrides; --node-modules-dir / --swap-dir can still
+# clobber them below. Lets `NODE_MODULES_DIR=/foo bash scripts/install` work.
+NODE_MODULES_DIR="${NODE_MODULES_DIR:-}"
+SWAP_DIR="${SWAP_DIR:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;

--- a/scripts/install
+++ b/scripts/install
@@ -37,6 +37,7 @@ INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
 RESTORE_MODE=false
+NODE_MODULES_DIR=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;
@@ -45,9 +46,11 @@ while [ $# -gt 0 ]; do
     --artifact-url)       shift; ARTIFACT_URL_OVERRIDE="${1:-}" ;;
     --purge-free-sleep)   PURGE_FREE_SLEEP=true ;;
     --restore)            RESTORE_MODE=true ;;
+    --node-modules-dir)   shift; NODE_MODULES_DIR="${1:-}" ;;
   esac
   shift
 done
+export NODE_MODULES_DIR
 
 # --------------------------------------------------------------------------------
 # Restore mode — list and restore a DB backup, then exit
@@ -1012,9 +1015,9 @@ if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
   print_pod_capabilities
 fi
 
-# Move node_modules off rootfs onto /persistent before pnpm runs so the
-# install writes directly to the persistent partition. On upgrades from
-# a pre-relocation install this migrates the existing tree once.
+# Decide where node_modules lives before pnpm runs. Auto-picks rootfs
+# vs /persistent by free space (Pod 3 + SD has tiny /persistent; Pod 4
+# stock has tight rootfs). Override via --node-modules-dir <path>.
 if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
   source "$INSTALL_DIR/scripts/lib/relocation-helpers"
   ensure_persistent_node_modules "$INSTALL_DIR"

--- a/scripts/install
+++ b/scripts/install
@@ -1511,9 +1511,22 @@ else
     # can read the venv dir + traverse the managed-Python symlink target.
     chmod -R o+rX "$dest/.venv" 2>/dev/null || true
 
-    # Install systemd service
+    # Install systemd service. Substitute the chosen $DATA_DIR for the
+    # baked-in /persistent/sleepypod-data — ReadWritePaths= and the
+    # DATABASE_URL= envs in the unit reference that path, and on installs
+    # where the picker chose /sleepypod-data (rootfs larger than
+    # /persistent — e.g. Pod 3 + SD card) the hardcoded path doesn't
+    # exist, so systemd fails the namespace bind-mount with "Failed to
+    # set up mount namespacing: .../persistent/sleepypod-data: No such
+    # file or directory". ReadWritePaths= is a unit directive so an
+    # EnvironmentFile drop-in can't fix it — substitution at install
+    # time is the only path.
     if [ -f "$dest/$service" ]; then
-      cp "$dest/$service" "/etc/systemd/system/$service"
+      _data_dir_sed=${DATA_DIR//|/\\|}
+      sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" "$dest/$service" \
+        > "/etc/systemd/system/$service"
+      chmod 0644 "/etc/systemd/system/$service"
+      unset _data_dir_sed
       systemctl daemon-reload
       systemctl enable "$service"
       systemctl restart "$service"
@@ -1570,7 +1583,16 @@ if [ -d "$PUSH_SRC" ]; then
   echo "Installing archive-push (scp to remote)..."
 
   install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
-  install -m 0644 "$PUSH_SRC/sleepypod-archive-push.service" /etc/systemd/system/
+  # Substitute $DATA_DIR for the baked-in /persistent/sleepypod-data —
+  # ReadWritePaths= in the unit references that path and the namespace
+  # bind-mount fails when the picker chose /sleepypod-data. Same fix as
+  # install_module() above.
+  _data_dir_sed=${DATA_DIR//|/\\|}
+  sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+    "$PUSH_SRC/sleepypod-archive-push.service" \
+    > /etc/systemd/system/sleepypod-archive-push.service
+  chmod 0644 /etc/systemd/system/sleepypod-archive-push.service
+  unset _data_dir_sed
   install -m 0644 "$PUSH_SRC/sleepypod-archive-push.timer"   /etc/systemd/system/
 
   # Config dir owned root:sleepypod 0770 so the service user reads + the app

--- a/scripts/install
+++ b/scripts/install
@@ -32,9 +32,9 @@ echo ""
 #                      exact SHA the run built, not whatever's latest.
 #   --restore          List available DB backups and restore a selected one
 #   --node-modules-dir Where node_modules lives. Default: auto-pick rootfs vs
-#                      /persistent by free space (see scripts/lib/relocation-helpers).
+#                      /persistent by total partition size (see scripts/lib/relocation-helpers).
 #   --swap-dir         Where the build-time swap file lives. Default: auto-pick
-#                      rootfs vs /persistent by free space, gated by headroom.
+#                      rootfs vs /persistent by total partition size.
 INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
@@ -705,43 +705,40 @@ fix_db_permissions
 # relied on at runtime.
 #
 # Where it lives: same auto-picker as node_modules — pick the partition
-# with the most free space, gated by SWAP_HEADROOM_MB so a near-full
-# /persistent doesn't win by a tiny margin. Override with --swap-dir.
+# with the larger total size. Override with --swap-dir.
 #
-#   Pod 4 stock      / ≈ 1 GB free, /persistent ≈ 13 GB free → /persistent
-#   Pod 5            / ≈ 5 GB free, /persistent ≈ 15 GB free → /persistent
-#   Pod 3 + SD card  / ≈ 5 GB free, /persistent ≈ 250 MB free → rootfs
+#   Pod 4 stock      / ≈ 5.8 GB total, /persistent ≈ 15 GB total → /persistent
+#   Pod 5            / ≈ 5.8 GB total, /persistent ≈ 15 GB total → /persistent
+#   Pod 3 + SD card  / ≈ 6.6 GB total, /persistent ≈ 966 MB total → rootfs
 #
 # Relocation-helpers isn't sourced yet (repo not on disk), so the picker
 # is inlined here, matching the iptables-helpers pattern above.
 SWAP_SIZE_MB=1024
-SWAP_HEADROOM_MB="${SWAP_HEADROOM_MB:-1200}"  # SWAP_SIZE_MB + ~200 MB headroom
 swap_target_dir=""
 swap_reason=""
 if [ -n "$SWAP_DIR" ]; then
   swap_target_dir="$SWAP_DIR"
   swap_reason="user override (--swap-dir)"
 else
-  rootfs_free_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $4}')
-  rootfs_free_mb=${rootfs_free_mb:-0}
+  rootfs_total_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $2}')
+  rootfs_total_mb=${rootfs_total_mb:-0}
   if mountpoint -q /persistent 2>/dev/null; then
-    persistent_free_mb=$(df -m /persistent 2>/dev/null | awk 'NR==2{print $4}')
-    persistent_free_mb=${persistent_free_mb:-0}
+    persistent_total_mb=$(df -m /persistent 2>/dev/null | awk 'NR==2{print $2}')
+    persistent_total_mb=${persistent_total_mb:-0}
   else
-    persistent_free_mb=0
+    persistent_total_mb=0
   fi
-  if [ "$persistent_free_mb" -gt "$rootfs_free_mb" ] \
-     && [ "$persistent_free_mb" -ge "$SWAP_HEADROOM_MB" ]; then
+  if [ "$persistent_total_mb" -gt "$rootfs_total_mb" ]; then
     swap_target_dir="/persistent"
-    swap_reason="/persistent has more free space than rootfs"
-  elif [ "$rootfs_free_mb" -ge "$SWAP_HEADROOM_MB" ]; then
+    swap_reason="/persistent is the larger partition"
+  else
     swap_target_dir="/"
-    swap_reason="rootfs has more free space than /persistent"
+    swap_reason="rootfs is the larger partition"
   fi
 fi
 
 if [ -z "$swap_target_dir" ]; then
-  echo "Warning: neither rootfs nor /persistent has ${SWAP_HEADROOM_MB} MB free — skipping swap setup; on-pod builds may OOM" >&2
+  echo "Warning: no swap target chosen — skipping swap setup; on-pod builds may OOM" >&2
 else
   # Strip trailing slash so the joined path stays canonical (/swapfile, not //swapfile).
   SWAPFILE="${swap_target_dir%/}/swapfile"
@@ -1079,8 +1076,8 @@ if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
 fi
 
 # Decide where node_modules lives before pnpm runs. Auto-picks rootfs
-# vs /persistent by free space (Pod 3 + SD has tiny /persistent; Pod 4
-# stock has tight rootfs). Override via --node-modules-dir <path>.
+# vs /persistent by total partition size (Pod 3 + SD has tiny /persistent;
+# Pod 4/5 stock has large /persistent). Override via --node-modules-dir <path>.
 if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
   source "$INSTALL_DIR/scripts/lib/relocation-helpers"
   ensure_persistent_node_modules "$INSTALL_DIR"

--- a/scripts/install
+++ b/scripts/install
@@ -1277,6 +1277,17 @@ Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
+# Route every runtime path that used to be hardcoded under
+# /persistent/sleepypod-data through the picker-chosen \$DATA_DIR.
+# HomeKit pairing + identity (src/homekit/storage.ts), calibration
+# trigger written by tRPC + scheduler and read by sleepypod-calibrator
+# (src/server/routers/calibration.ts, src/scheduler/jobManager.ts,
+# modules/common/calibration.py), and the archive-export staging dir
+# (app/api/export/archive/route.ts) all read these envs with the legacy
+# hardcoded path as fallback for installs that pre-date this wiring.
+Environment="HOMEKIT_DIR=$DATA_DIR/homekit"
+Environment="CALIBRATION_TRIGGER_PATH=$DATA_DIR/.calibrate-trigger"
+Environment="EXPORT_STAGING_DIR=$DATA_DIR/export-staging"
 # RAW frames live in the tmpfs at /persistent/biometrics (ADR 0018).
 # Without this override piezoStream defaults to /persistent and tries to
 # decode the 16-byte SEQNO.RAW bookkeeping file as CBOR — sensor streaming

--- a/scripts/install
+++ b/scripts/install
@@ -31,6 +31,10 @@ echo ""
 #                      Posted on every PR comment so reviewers can install the
 #                      exact SHA the run built, not whatever's latest.
 #   --restore          List available DB backups and restore a selected one
+#   --node-modules-dir Where node_modules lives. Default: auto-pick rootfs vs
+#                      /persistent by free space (see scripts/lib/relocation-helpers).
+#   --swap-dir         Where the build-time swap file lives. Default: auto-pick
+#                      rootfs vs /persistent by free space, gated by headroom.
 INSTALL_LOCAL=false
 SKIP_SSH=false
 INSTALL_BRANCH=""
@@ -38,6 +42,7 @@ ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
 RESTORE_MODE=false
 NODE_MODULES_DIR=""
+SWAP_DIR=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;
@@ -47,6 +52,7 @@ while [ $# -gt 0 ]; do
     --purge-free-sleep)   PURGE_FREE_SLEEP=true ;;
     --restore)            RESTORE_MODE=true ;;
     --node-modules-dir)   shift; NODE_MODULES_DIR="${1:-}" ;;
+    --swap-dir)           shift; SWAP_DIR="${1:-}" ;;
   esac
   shift
 done
@@ -692,27 +698,82 @@ fix_db_permissions
 # 2 GiB RAM and zero swap; Next.js 16 / Turbopack peaks around 750 MiB
 # during `next build`, which trips the firmware's earlyoom (configured to
 # fire at <10% available, ~200 MiB on this hardware) and kills the build
-# mid-flight (SIGTERM, exit 143). A 1 GiB swap file on /persistent keeps
-# the build out of earlyoom range without wearing the rootfs eMMC. Used
-# only during build / heavy memory bursts; not relied on at runtime.
-SWAPFILE="/persistent/swapfile"
+# mid-flight (SIGTERM, exit 143). A 1 GiB swap file keeps the build out
+# of earlyoom range. Used only during build / heavy memory bursts; not
+# relied on at runtime.
+#
+# Where it lives: same auto-picker as node_modules — pick the partition
+# with the most free space, gated by SWAP_HEADROOM_MB so a near-full
+# /persistent doesn't win by a tiny margin. Override with --swap-dir.
+#
+#   Pod 4 stock      / ≈ 1 GB free, /persistent ≈ 13 GB free → /persistent
+#   Pod 5            / ≈ 5 GB free, /persistent ≈ 15 GB free → /persistent
+#   Pod 3 + SD card  / ≈ 5 GB free, /persistent ≈ 250 MB free → rootfs
+#
+# Relocation-helpers isn't sourced yet (repo not on disk), so the picker
+# is inlined here, matching the iptables-helpers pattern above.
 SWAP_SIZE_MB=1024
-if ! mountpoint -q /persistent 2>/dev/null; then
-  echo "Warning: /persistent is not a mountpoint — skipping swap setup to avoid creating $SWAPFILE on rootfs" >&2
-elif ! swapon --show=NAME --noheadings 2>/dev/null | grep -qF "$SWAPFILE"; then
-  if [ ! -f "$SWAPFILE" ]; then
-    echo "Creating ${SWAP_SIZE_MB}M swap file at $SWAPFILE..."
-    fallocate -l "${SWAP_SIZE_MB}M" "$SWAPFILE" 2>/dev/null \
-      || dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MB" status=none
-    chmod 0600 "$SWAPFILE"
-    mkswap "$SWAPFILE" >/dev/null
+SWAP_HEADROOM_MB="${SWAP_HEADROOM_MB:-1200}"  # SWAP_SIZE_MB + ~200 MB headroom
+swap_target_dir=""
+swap_reason=""
+if [ -n "$SWAP_DIR" ]; then
+  swap_target_dir="$SWAP_DIR"
+  swap_reason="user override (--swap-dir)"
+else
+  rootfs_free_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $4}')
+  rootfs_free_mb=${rootfs_free_mb:-0}
+  if mountpoint -q /persistent 2>/dev/null; then
+    persistent_free_mb=$(df -m /persistent 2>/dev/null | awk 'NR==2{print $4}')
+    persistent_free_mb=${persistent_free_mb:-0}
+  else
+    persistent_free_mb=0
   fi
-  swapon "$SWAPFILE" || echo "Warning: swapon failed; on-pod builds may OOM" >&2
+  if [ "$persistent_free_mb" -gt "$rootfs_free_mb" ] \
+     && [ "$persistent_free_mb" -ge "$SWAP_HEADROOM_MB" ]; then
+    swap_target_dir="/persistent"
+    swap_reason="/persistent has more free space than rootfs"
+  elif [ "$rootfs_free_mb" -ge "$SWAP_HEADROOM_MB" ]; then
+    swap_target_dir="/"
+    swap_reason="rootfs has more free space than /persistent"
+  fi
 fi
-SWAP_FSTAB_LINE="$SWAPFILE none swap sw,nofail 0 0"
-if mountpoint -q /persistent 2>/dev/null && ! grep -qF "$SWAP_FSTAB_LINE" /etc/fstab 2>/dev/null; then
-  sed -i "\\|^$SWAPFILE |d" /etc/fstab 2>/dev/null || true
-  echo "$SWAP_FSTAB_LINE" >> /etc/fstab
+
+if [ -z "$swap_target_dir" ]; then
+  echo "Warning: neither rootfs nor /persistent has ${SWAP_HEADROOM_MB} MB free — skipping swap setup; on-pod builds may OOM" >&2
+else
+  # Strip trailing slash so the joined path stays canonical (/swapfile, not //swapfile).
+  SWAPFILE="${swap_target_dir%/}/swapfile"
+  [ "$swap_target_dir" = "/" ] && SWAPFILE="/swapfile"
+  echo "Swap → $SWAPFILE  (${swap_reason})"
+
+  # Remove a stale swapfile on the partition we didn't pick this time
+  # (e.g., prior install chose /persistent, this install picks rootfs).
+  # Without this we'd leak the file and leave a dangling fstab entry.
+  for stale in /swapfile /persistent/swapfile; do
+    if [ "$stale" != "$SWAPFILE" ] && [ -e "$stale" ]; then
+      echo "Removing stale swap file at $stale..."
+      swapon --show=NAME --noheadings 2>/dev/null | grep -qF "$stale" \
+        && swapoff "$stale" 2>/dev/null || true
+      rm -f "$stale"
+      sed -i "\\|^$stale |d" /etc/fstab 2>/dev/null || true
+    fi
+  done
+
+  if ! swapon --show=NAME --noheadings 2>/dev/null | grep -qF "$SWAPFILE"; then
+    if [ ! -f "$SWAPFILE" ]; then
+      echo "Creating ${SWAP_SIZE_MB}M swap file at $SWAPFILE..."
+      fallocate -l "${SWAP_SIZE_MB}M" "$SWAPFILE" 2>/dev/null \
+        || dd if=/dev/zero of="$SWAPFILE" bs=1M count="$SWAP_SIZE_MB" status=none
+      chmod 0600 "$SWAPFILE"
+      mkswap "$SWAPFILE" >/dev/null
+    fi
+    swapon "$SWAPFILE" || echo "Warning: swapon failed; on-pod builds may OOM" >&2
+  fi
+  SWAP_FSTAB_LINE="$SWAPFILE none swap sw,nofail 0 0"
+  if ! grep -qF "$SWAP_FSTAB_LINE" /etc/fstab 2>/dev/null; then
+    sed -i "\\|^$SWAPFILE |d" /etc/fstab 2>/dev/null || true
+    echo "$SWAP_FSTAB_LINE" >> /etc/fstab
+  fi
 fi
 
 # ============================================================================

--- a/scripts/install
+++ b/scripts/install
@@ -41,10 +41,11 @@ INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
 RESTORE_MODE=false
-# Preserve env-supplied overrides; --node-modules-dir / --swap-dir can still
-# clobber them below. Lets `NODE_MODULES_DIR=/foo bash scripts/install` work.
+# Preserve env-supplied overrides; --node-modules-dir / --swap-dir / --data-dir
+# can still clobber them below. Lets `NODE_MODULES_DIR=/foo bash scripts/install` work.
 NODE_MODULES_DIR="${NODE_MODULES_DIR:-}"
 SWAP_DIR="${SWAP_DIR:-}"
+DATA_DIR_OVERRIDE="${DATA_DIR:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;
@@ -55,15 +56,51 @@ while [ $# -gt 0 ]; do
     --restore)            RESTORE_MODE=true ;;
     --node-modules-dir)   shift; NODE_MODULES_DIR="${1:-}" ;;
     --swap-dir)           shift; SWAP_DIR="${1:-}" ;;
+    --data-dir)           shift; DATA_DIR_OVERRIDE="${1:-}" ;;
   esac
   shift
 done
 export NODE_MODULES_DIR
 
+# Resolve DATA_DIR (SQLite home) before anything that touches it. Precedence:
+#   1. --data-dir / DATA_DIR env override
+#   2. /etc/sleepypod/data-dir written by a prior install run
+#   3. Auto: larger of rootfs vs /persistent (total size — same picker as
+#      swap below and node_modules in scripts/lib/relocation-helpers).
+#
+# Restore mode (below) uses $DATA_DIR too, so this MUST run before that block.
+# Relocation-helpers isn't sourced yet (repo not on disk), so the picker is
+# inlined here, matching the swap-picker / iptables-helpers pattern.
+DATA_DIR_REASON=""
+if [ -n "$DATA_DIR_OVERRIDE" ]; then
+  DATA_DIR="$DATA_DIR_OVERRIDE"
+  DATA_DIR_REASON="user override (--data-dir / DATA_DIR)"
+elif [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+  DATA_DIR_REASON="cached from prior install (/etc/sleepypod/data-dir)"
+else
+  _rootfs_total_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $2}')
+  _rootfs_total_mb=${_rootfs_total_mb:-0}
+  if mountpoint -q /persistent 2>/dev/null; then
+    _persistent_total_mb=$(df -m /persistent 2>/dev/null | awk 'NR==2{print $2}')
+    _persistent_total_mb=${_persistent_total_mb:-0}
+  else
+    _persistent_total_mb=0
+  fi
+  if [ "$_persistent_total_mb" -gt "$_rootfs_total_mb" ]; then
+    DATA_DIR="/persistent/sleepypod-data"
+    DATA_DIR_REASON="/persistent is the larger partition"
+  else
+    DATA_DIR="/sleepypod-data"
+    DATA_DIR_REASON="rootfs is the larger partition"
+  fi
+  unset _rootfs_total_mb _persistent_total_mb
+fi
+
 # --------------------------------------------------------------------------------
 # Restore mode — list and restore a DB backup, then exit
 if [ "$RESTORE_MODE" = true ]; then
-  DATA_DIR="/persistent/sleepypod-data"
+  # $DATA_DIR was resolved above (override > cached > auto-picker).
 
   # Collect all backup files for both databases
   mapfile -t BACKUPS < <(ls -1t "$DATA_DIR"/*.db.bak.* 2>/dev/null)
@@ -617,8 +654,29 @@ fi
 # environment-monitor run as User=dac. Setgid ensures all files created
 # inside inherit the sleepypod group; UMask=0002 on services ensures
 # group-write bits are preserved (including SQLite WAL/SHM files).
-DATA_DIR="/persistent/sleepypod-data"
-echo "Creating data directory at $DATA_DIR..."
+#
+# $DATA_DIR was resolved at the top of this script. Same auto-picker as
+# node_modules / swap — pick the larger of rootfs vs /persistent.
+echo "Creating data directory at $DATA_DIR  (${DATA_DIR_REASON})..."
+
+# Migrate from a legacy /persistent/sleepypod-data layout if the picker
+# now wants a different partition. Same empty-target guard as the
+# node_modules migration in ensure_persistent_node_modules() — avoids
+# mixing DBs from two different installs.
+LEGACY_DATA_DIR="/persistent/sleepypod-data"
+if [ "$DATA_DIR" != "$LEGACY_DATA_DIR" ] && [ -d "$LEGACY_DATA_DIR" ] \
+   && [ -z "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
+  echo "Migrating data dir from $LEGACY_DATA_DIR to $DATA_DIR..."
+  mkdir -p "$(dirname "$DATA_DIR")"
+  mv "$LEGACY_DATA_DIR" "$DATA_DIR"
+fi
+
+# Persist the chosen path so sp-update / sp-maintenance / sp-bundle-logs /
+# sp-uninstall / pod/detect find the DBs in the same place. sp-uninstall
+# already rm -rf's /etc/sleepypod so no cleanup hook needed there.
+mkdir -p /etc/sleepypod
+printf '%s\n' "$DATA_DIR" > /etc/sleepypod/data-dir
+chmod 0644 /etc/sleepypod/data-dir
 # Ensure ReadWritePaths directories exist — systemd's ProtectSystem=strict
 # requires all listed paths to exist or the namespace setup fails.
 # /run/dac is handled by RuntimeDirectory=dac in the service unit.

--- a/scripts/lib/relocation-helpers
+++ b/scripts/lib/relocation-helpers
@@ -4,20 +4,24 @@
 #
 # Pods in the field have wildly different storage layouts:
 #
-#   Pod 4 stock      /  ≈ 5.8 GB (~1 GB free)   /persistent ≈ 15 GB  (~13 GB free)
-#   Pod 5            /  ≈ 5.8 GB                 /persistent ≈ 15 GB
-#   Pod 3 + SD card  /  ≈ 6.6 GB (~5 GB free)    /persistent ≈ 966 MB (~250 MB free)
+#   Pod 4 stock      /  ≈ 5.8 GB total   /persistent ≈ 15 GB total
+#   Pod 5            /  ≈ 5.8 GB total   /persistent ≈ 15 GB total
+#   Pod 3 + SD card  /  ≈ 6.6 GB total   /persistent ≈ 966 MB total
 #
 # The previous revision unconditionally bind-mounted node_modules onto
 # /persistent — correct for Pod 4 (frees ~700 MB of tight rootfs), wrong
-# for Pod 3 SD (would shove 700 MB into ~250 MB free). Now we pick the
-# partition with the most free space, with an explicit override.
+# for Pod 3 SD (would shove 700 MB into a 966 MB partition that the
+# firmware actively writes to). Now we pick the partition with the
+# larger total size, with an explicit override.
+#
+# Why total, not free: free space fluctuates with firmware RAW writes,
+# pruner thresholds, swap, etc. Total size reflects which partition was
+# actually sized for storage. On Pod 4/5, /persistent is the design
+# storage volume; on Pod 3 + SD, the SD card is rootfs.
 #
 # Decision precedence (highest first):
 #   1. NODE_MODULES_DIR env (set via install's --node-modules-dir flag)
-#   2. Auto: whichever of rootfs / /persistent has more free space. Soft
-#      floor NODE_MODULES_HEADROOM_MB so a near-full partition doesn't win
-#      by a tiny margin.
+#   2. Auto: whichever of rootfs / /persistent has the larger total size.
 #
 # Bind mount, not symlink: the previous revision used
 #   ln -sfn /persistent/sleepypod-core/node_modules /home/dac/sleepypod-core/node_modules
@@ -41,10 +45,9 @@
 
 PERSISTENT_ROOT="/persistent"
 PERSISTENT_APP_ROOT="$PERSISTENT_ROOT/sleepypod-core"
-NODE_MODULES_HEADROOM_MB="${NODE_MODULES_HEADROOM_MB:-1500}"
 
-_partition_free_mb() {
-  df -m "$1" 2>/dev/null | awk 'NR==2 {print $4}'
+_partition_total_mb() {
+  df -m "$1" 2>/dev/null | awk 'NR==2 {print $2}'
 }
 
 _print_storage_banner() {
@@ -73,24 +76,20 @@ _print_storage_banner() {
 # falls back to install_nm (rootfs) when /persistent is missing or smaller.
 _auto_pick_node_modules_target() {
   local install_nm="$1"
-  local rootfs_free persistent_free
+  local rootfs_total persistent_total
   # Probe the parent — $install_nm itself doesn't exist yet on a first
-  # install (pnpm creates it). df on a non-existent path emits nothing
-  # and the picker would wrongly see 0 MB free on rootfs.
-  rootfs_free=$(_partition_free_mb "$(dirname "$install_nm")")
-  rootfs_free=${rootfs_free:-0}
+  # install (pnpm creates it). df on a non-existent path emits nothing.
+  rootfs_total=$(_partition_total_mb "$(dirname "$install_nm")")
+  rootfs_total=${rootfs_total:-0}
 
   if mountpoint -q "$PERSISTENT_ROOT" 2>/dev/null; then
-    persistent_free=$(_partition_free_mb "$PERSISTENT_ROOT")
-    persistent_free=${persistent_free:-0}
+    persistent_total=$(_partition_total_mb "$PERSISTENT_ROOT")
+    persistent_total=${persistent_total:-0}
   else
-    persistent_free=0
+    persistent_total=0
   fi
 
-  # Pick /persistent only if it has both more free space and clears the
-  # soft floor. Otherwise leave node_modules on rootfs (no bind mount).
-  if [ "$persistent_free" -gt "$rootfs_free" ] \
-     && [ "$persistent_free" -ge "$NODE_MODULES_HEADROOM_MB" ]; then
+  if [ "$persistent_total" -gt "$rootfs_total" ]; then
     echo "$PERSISTENT_APP_ROOT/node_modules"
   else
     echo "$install_nm"
@@ -108,9 +107,9 @@ ensure_persistent_node_modules() {
   else
     target=$(_auto_pick_node_modules_target "$install_nm")
     if [ "$target" = "$install_nm" ]; then
-      reason="rootfs has more free space than $PERSISTENT_ROOT (no bind mount needed)"
+      reason="rootfs is the larger partition (no bind mount needed)"
     else
-      reason="$PERSISTENT_ROOT has more free space than rootfs"
+      reason="$PERSISTENT_ROOT is the larger partition"
     fi
   fi
 

--- a/scripts/lib/relocation-helpers
+++ b/scripts/lib/relocation-helpers
@@ -74,7 +74,10 @@ _print_storage_banner() {
 _auto_pick_node_modules_target() {
   local install_nm="$1"
   local rootfs_free persistent_free
-  rootfs_free=$(_partition_free_mb "$install_nm")
+  # Probe the parent — $install_nm itself doesn't exist yet on a first
+  # install (pnpm creates it). df on a non-existent path emits nothing
+  # and the picker would wrongly see 0 MB free on rootfs.
+  rootfs_free=$(_partition_free_mb "$(dirname "$install_nm")")
   rootfs_free=${rootfs_free:-0}
 
   if mountpoint -q "$PERSISTENT_ROOT" 2>/dev/null; then

--- a/scripts/lib/relocation-helpers
+++ b/scripts/lib/relocation-helpers
@@ -1,12 +1,23 @@
 # shellcheck shell=bash
-# Relocation helpers — keep heavy app trees off the constrained rootfs.
+# Relocation helpers — choose where node_modules lives, then ensure
+# $install_dir/node_modules is the right thing (real dir or bind mount).
 #
-# rootfs   /dev/mmcblk0p5  5.8 GB  (often 80%+ full — OS, /usr, .next, /opt)
-# persist  /dev/mmcblk0p8  15  GB  (~12% used — DBs, biometrics, app data)
+# Pods in the field have wildly different storage layouts:
 #
-# /home/dac/sleepypod-core/node_modules (~700 MB) lives on rootfs by
-# default. This helper moves it to /persistent and exposes the original
-# path via a bind mount.
+#   Pod 4 stock      /  ≈ 5.8 GB (~1 GB free)   /persistent ≈ 15 GB  (~13 GB free)
+#   Pod 5            /  ≈ 5.8 GB                 /persistent ≈ 15 GB
+#   Pod 3 + SD card  /  ≈ 6.6 GB (~5 GB free)    /persistent ≈ 966 MB (~250 MB free)
+#
+# The previous revision unconditionally bind-mounted node_modules onto
+# /persistent — correct for Pod 4 (frees ~700 MB of tight rootfs), wrong
+# for Pod 3 SD (would shove 700 MB into ~250 MB free). Now we pick the
+# partition with the most free space, with an explicit override.
+#
+# Decision precedence (highest first):
+#   1. NODE_MODULES_DIR env (set via install's --node-modules-dir flag)
+#   2. Auto: whichever of rootfs / /persistent has more free space. Soft
+#      floor NODE_MODULES_HEADROOM_MB so a near-full partition doesn't win
+#      by a tiny margin.
 #
 # Bind mount, not symlink: the previous revision used
 #   ln -sfn /persistent/sleepypod-core/node_modules /home/dac/sleepypod-core/node_modules
@@ -14,76 +25,141 @@
 #   "Symlink [project]/node_modules is invalid, it points out of the filesystem root"
 # because the symlink crosses from /dev/root onto /dev/mmcblk0p8. A bind
 # mount makes the path appear as a real directory at the project root
-# while the data still lives on /persistent — Turbopack's symlink check
-# does not trip.
+# while the data still lives on the chosen partition.
 #
-# Persistence: an /etc/fstab entry with `bind,nofail` re-establishes the
-# mount on every boot. `nofail` keeps the system bootable if /persistent
-# is absent (reflash recovery, single-user mode).
+# Persistence: when a bind mount is in use, an /etc/fstab entry with
+# `bind,nofail` re-establishes it on every boot. `nofail` keeps the
+# system bootable if /persistent is absent (reflash recovery).
 #
 # Sourced by:
-#   - scripts/install     (inline copy not needed — code is on disk before use)
+#   - scripts/install
 #   - scripts/bin/sp-update
 #
-# Idempotent: subsequent runs detect the existing bind mount and no-op.
-# Migrates legacy installs that have a symlink in place.
+# Idempotent: subsequent runs detect the existing layout and no-op.
+# Migrates legacy installs that used a symlink, and unwinds a stale
+# bind mount when the auto-picker now wants the directory on rootfs.
 
 PERSISTENT_ROOT="/persistent"
 PERSISTENT_APP_ROOT="$PERSISTENT_ROOT/sleepypod-core"
+NODE_MODULES_HEADROOM_MB="${NODE_MODULES_HEADROOM_MB:-1500}"
+
+_partition_free_mb() {
+  df -m "$1" 2>/dev/null | awk 'NR==2 {print $4}'
+}
+
+_print_storage_banner() {
+  local install_nm="$1"
+  local target_dir="$2"
+  local reason="$3"
+
+  echo ""
+  echo "========================================"
+  echo "  Storage layout"
+  echo "========================================"
+  df -h / "$PERSISTENT_ROOT" 2>/dev/null \
+    | awk 'NR==1 { printf "  %-15s %6s %6s %6s %5s  %s\n", "Filesystem","Size","Used","Avail","Use%","Mount"; next }
+                 { printf "  %-15s %6s %6s %6s %5s  %s\n", $1, $2, $3, $4, $5, $6 }'
+  echo ""
+  echo "  node_modules → $target_dir"
+  if [ "$target_dir" != "$install_nm" ]; then
+    echo "    bind-mount → $install_nm"
+  fi
+  echo "    Reason     : $reason"
+  echo "    Override   : re-run install with --node-modules-dir <path>"
+  echo ""
+}
+
+# Picks an absolute target directory (writes to stdout). Never fails —
+# falls back to install_nm (rootfs) when /persistent is missing or smaller.
+_auto_pick_node_modules_target() {
+  local install_nm="$1"
+  local rootfs_free persistent_free
+  rootfs_free=$(_partition_free_mb "$install_nm")
+  rootfs_free=${rootfs_free:-0}
+
+  if mountpoint -q "$PERSISTENT_ROOT" 2>/dev/null; then
+    persistent_free=$(_partition_free_mb "$PERSISTENT_ROOT")
+    persistent_free=${persistent_free:-0}
+  else
+    persistent_free=0
+  fi
+
+  # Pick /persistent only if it has both more free space and clears the
+  # soft floor. Otherwise leave node_modules on rootfs (no bind mount).
+  if [ "$persistent_free" -gt "$rootfs_free" ] \
+     && [ "$persistent_free" -ge "$NODE_MODULES_HEADROOM_MB" ]; then
+    echo "$PERSISTENT_APP_ROOT/node_modules"
+  else
+    echo "$install_nm"
+  fi
+}
 
 ensure_persistent_node_modules() {
   local install_dir="${1:-${INSTALL_DIR:-/home/dac/sleepypod-core}}"
-  local persistent_nm="$PERSISTENT_APP_ROOT/node_modules"
   local install_nm="$install_dir/node_modules"
-  local fstab_line="$persistent_nm $install_nm none bind,nofail 0 0"
 
-  # Hard-fail if /persistent isn't its own filesystem. Without this guard
-  # we'd silently mkdir into rootfs and bind-mount node_modules onto
-  # itself — defeating the entire relocation and quietly burning the
-  # ~700 MB of rootfs we were trying to reclaim. Recovery boots and
-  # broken mount-units land here.
-  if ! mountpoint -q "$PERSISTENT_ROOT" 2>/dev/null; then
-    echo "Error: $PERSISTENT_ROOT is not a mountpoint — refusing to relocate node_modules onto rootfs" >&2
-    return 1
+  local target reason
+  if [ -n "${NODE_MODULES_DIR:-}" ]; then
+    target="$NODE_MODULES_DIR"
+    reason="user override (--node-modules-dir)"
+  else
+    target=$(_auto_pick_node_modules_target "$install_nm")
+    if [ "$target" = "$install_nm" ]; then
+      reason="rootfs has more free space than $PERSISTENT_ROOT (no bind mount needed)"
+    else
+      reason="$PERSISTENT_ROOT has more free space than rootfs"
+    fi
   fi
 
-  mkdir -p "$PERSISTENT_APP_ROOT" "$persistent_nm"
+  _print_storage_banner "$install_nm" "$target" "$reason"
 
-  # Legacy symlink from the cross-fs era — drop it; the bind mount below
-  # replaces it. Persistent target keeps its data.
+  # Legacy symlink from the cross-fs era — drop it; whichever branch
+  # below replaces it.
   if [ -L "$install_nm" ]; then
-    echo "Replacing legacy node_modules symlink with bind mount..."
+    echo "Replacing legacy node_modules symlink..."
     rm -f "$install_nm"
   fi
 
-  # Real directory on rootfs (fresh install or pre-relocation pod).
-  # Skip if already a mountpoint — that's our fast path on subsequent
-  # sp-update runs.
+  # Branch 1: target IS the install path. Plain directory on rootfs.
+  if [ "$target" = "$install_nm" ]; then
+    # Unwind a stale bind mount from a prior install that picked
+    # /persistent. Without this, the kernel still serves the old
+    # mount and the new "no relocation" decision has no effect.
+    if mountpoint -q "$install_nm" 2>/dev/null; then
+      echo "Unmounting stale bind mount at $install_nm..."
+      umount "$install_nm" 2>/dev/null || umount -l "$install_nm" 2>/dev/null || true
+      sed -i "\\| $install_nm |d" /etc/fstab 2>/dev/null || true
+    fi
+    mkdir -p "$install_nm"
+    echo "node_modules at $install_nm (on rootfs, no relocation)."
+    return 0
+  fi
+
+  # Branch 2: bind-mount target onto install_nm.
+  mkdir -p "$target"
+
   if [ -d "$install_nm" ] && ! mountpoint -q "$install_nm" 2>/dev/null; then
-    # Move contents to /persistent only if persistent is empty and rootfs
+    # Move contents to target only if target is empty and install_nm
     # has them; otherwise trust whichever side already has data and drop
     # the other to avoid mixing pnpm stores from different installs.
-    if [ -z "$(ls -A "$persistent_nm" 2>/dev/null)" ] && [ -n "$(ls -A "$install_nm" 2>/dev/null)" ]; then
-      echo "Migrating node_modules to $persistent_nm (one-time, may take a few minutes)..."
-      # `mv -T` so the destination doesn't end up as $persistent_nm/node_modules.
-      mv -T "$install_nm" "$persistent_nm"
+    if [ -z "$(ls -A "$target" 2>/dev/null)" ] && [ -n "$(ls -A "$install_nm" 2>/dev/null)" ]; then
+      echo "Migrating node_modules to $target (one-time, may take a few minutes)..."
+      # `mv -T` so the destination doesn't end up as $target/node_modules.
+      mv -T "$install_nm" "$target"
     fi
     rm -rf "$install_nm"
   fi
 
-  # Establish the mount point as an empty directory, then bind-mount.
   mkdir -p "$install_nm"
   if ! mountpoint -q "$install_nm" 2>/dev/null; then
-    mount --bind "$persistent_nm" "$install_nm"
+    mount --bind "$target" "$install_nm"
   fi
 
-  # Persist via fstab so the bind mount comes back after reboot. Replace
-  # any stale entry for this mount point first (e.g., a renamed source
-  # path), then append the canonical line.
+  local fstab_line="$target $install_nm none bind,nofail 0 0"
   if ! grep -qF "$fstab_line" /etc/fstab 2>/dev/null; then
     sed -i "\\| $install_nm |d" /etc/fstab 2>/dev/null || true
     echo "$fstab_line" >> /etc/fstab
   fi
 
-  echo "node_modules bind-mounted from $persistent_nm"
+  echo "node_modules bind-mounted from $target"
 }

--- a/scripts/pod/capabilities
+++ b/scripts/pod/capabilities
@@ -19,6 +19,15 @@
 #   PACKAGE_MANAGER                 "apt" or "" (none)
 #   SYSTEM_PYTHON_VERSION           e.g. "3.10.4", "" if python3 missing
 #   SYSTEM_PYTHON_IN_BIOMETRICS_RANGE  "true" if in [3.9, 3.11), else "false"
+#   SYSTEM_PYTHON_STDLIB_INTACT     "true" / "false" — probes a handful of
+#                                   stdlib modules the biometrics modules
+#                                   import (directly or transitively). Pod 3
+#                                   firmware ships a Yocto-stripped Python
+#                                   3.9.9 with unittest + dataclasses removed,
+#                                   so the version check passes but
+#                                   `numpy.testing → from unittest import …`
+#                                   crashes at module import. Install uses
+#                                   this to force uv onto a managed Python.
 #   HAS_ENSUREPIP                   "true" / "false"
 #   HAS_NFTABLES                    "true" / "false"
 #   HAS_VOLTA                       "true" if Volta is present in PATH or ~/.volta
@@ -58,6 +67,22 @@ _python_in_biometrics_range() {
 _probe_has_ensurepip() {
   command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
   if python3 -c 'import ensurepip' 2>/dev/null; then echo "true"; else echo "false"; fi
+}
+
+_probe_python_stdlib_intact() {
+  # Pod 3 firmware (debian variant) ships /usr/bin/python3 = 3.9.9 with
+  # parts of the stdlib stripped: `unittest`, `dataclasses`, and
+  # `pyexpat` are all missing. numpy 2.x lazy-imports `numpy.testing`
+  # → `from unittest import TestCase` on first attribute access, so any
+  # module that uses numpy crashes at startup. The biometrics modules
+  # also `from dataclasses import dataclass`. Probe the modules we
+  # actually hit so install can route around the broken interpreter.
+  command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
+  if python3 -c 'import unittest, dataclasses, pyexpat' 2>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
 }
 
 _probe_has_volta() {
@@ -103,12 +128,14 @@ fi
 IPTABLES_PATH="$(_probe_iptables_path)"
 SYSTEM_PYTHON_VERSION="$(_probe_python_version)"
 SYSTEM_PYTHON_IN_BIOMETRICS_RANGE="$(_python_in_biometrics_range)"
+SYSTEM_PYTHON_STDLIB_INTACT="$(_probe_python_stdlib_intact)"
 HAS_ENSUREPIP="$(_probe_has_ensurepip)"
 HAS_VOLTA="$(_probe_has_volta)"
 HAS_IPTABLES_PERSISTENT="$(_probe_has_iptables_persistent)"
 
 export MODEL_NAME POD_OS IPTABLES_PATH HAS_PACKAGE_MANAGER PACKAGE_MANAGER
-export SYSTEM_PYTHON_VERSION SYSTEM_PYTHON_IN_BIOMETRICS_RANGE HAS_ENSUREPIP
+export SYSTEM_PYTHON_VERSION SYSTEM_PYTHON_IN_BIOMETRICS_RANGE
+export SYSTEM_PYTHON_STDLIB_INTACT HAS_ENSUREPIP
 export HAS_NFTABLES HAS_VOLTA HAS_IPTABLES_PERSISTENT
 
 print_pod_capabilities() {
@@ -117,7 +144,7 @@ print_pod_capabilities() {
   echo "  OS:                   $POD_OS"
   echo "  iptables:             ${IPTABLES_PATH:-<missing>}"
   echo "  Package manager:      ${PACKAGE_MANAGER:-none}"
-  echo "  System python3:       ${SYSTEM_PYTHON_VERSION:-<missing>} (in biometrics range: $SYSTEM_PYTHON_IN_BIOMETRICS_RANGE)"
+  echo "  System python3:       ${SYSTEM_PYTHON_VERSION:-<missing>} (in biometrics range: $SYSTEM_PYTHON_IN_BIOMETRICS_RANGE, stdlib intact: $SYSTEM_PYTHON_STDLIB_INTACT)"
   echo "  ensurepip:            $HAS_ENSUREPIP"
   echo "  nftables:             $HAS_NFTABLES"
   echo "  Volta:                $HAS_VOLTA"

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -9,6 +9,12 @@
 # via the hardware sensor label (see src/hardware/responseParser.ts).
 
 INSTALL_DIR="${INSTALL_DIR:-/home/dac/sleepypod-core}"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker:
+# /persistent vs rootfs by total partition size). Env override > pointer
+# file > legacy /persistent default for installs that pre-date the pointer.
+if [ -z "${DATA_DIR:-}" ] && [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+fi
 DATA_DIR="${DATA_DIR:-/persistent/sleepypod-data}"
 
 # Only accept known firmware-supported socket locations

--- a/src/homekit/storage.ts
+++ b/src/homekit/storage.ts
@@ -2,8 +2,9 @@
  * On-disk storage for HomeKit pairings, accessory identity, and setup code.
  *
  * Persists across next-server restart and sp-update. Lives under
- * /persistent/sleepypod-data/homekit/ in production; falls back to a path
- * under the project root in dev.
+ * $HOMEKIT_DIR (set by the systemd unit to $DATA_DIR/homekit, where
+ * $DATA_DIR is chosen by the install-time storage picker) in production;
+ * falls back to a path under the project root in dev.
  *
  * Identity is derived deterministically (HKDF over a hardware-rooted seed
  * chain — see ADR 0020) so that wiping /persistent regenerates the same
@@ -18,7 +19,10 @@ import { hkdfSync, randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import { HAPStorage } from 'hap-nodejs'
 
-const PERSISTENT_DIR = '/persistent/sleepypod-data/homekit'
+// Env override lets the install script point this at the picker-chosen
+// $DATA_DIR (e.g. /sleepypod-data on Pod 3 + SD card). The hardcoded
+// legacy default keeps installs that pre-date the env wiring working.
+const PERSISTENT_DIR = process.env.HOMEKIT_DIR ?? '/persistent/sleepypod-data/homekit'
 const DEV_DIR = join(process.cwd(), '.homekit-data')
 
 const IDENTITY_FILE = 'identity.json'


### PR DESCRIPTION
## Summary

- Auto-pick `node_modules` target by free disk space (rootfs vs `/persistent`) instead of unconditionally bind-mounting onto `/persistent`.
- Auto-pick swap-file target the same way. Previously hardcoded to `/persistent/swapfile`, which aborts install on Pod 3 SD before the node_modules picker even runs.
- Add `--node-modules-dir <path>` and `--swap-dir <path>` flags for explicit overrides.
- Print a storage banner up front so the choice is visible during install / sp-update.

## Why

The previous revision unconditionally placed both `node_modules` (~700 MB) and a 1 GiB swap file on `/persistent`. That's correct for the Pod 4 stock layout:

```
/dev/root        5.8G   1.1G free   /
/dev/mmcblk0p8    15G    13G free   /persistent
```

But it's lethal on Pod 3 with an SD card:

```
/dev/root        6.6G   5.0G free   /
/dev/mmcblk2p3   966M   243M free   /persistent
```

The first failure was the swap file — `dd` aborted with "No space left on device" on `/persistent`, killing install before `node_modules` ran. Once swap auto-relocates to rootfs (5 GB free), the node_modules picker takes over and lands there too. Reported by a Pod 3 SD user (alongside the `return 0` bug, already merged as #603).

## How

### `node_modules`

`scripts/lib/relocation-helpers` now decides per pod:

1. `NODE_MODULES_DIR` (set via `--node-modules-dir`) wins outright.
2. Otherwise pick the partition with the most free space, gated by `NODE_MODULES_HEADROOM_MB` (default 1500) so a near-full `/persistent` doesn't win by a tiny margin.

When the picker chooses rootfs, no bind mount happens — pnpm writes straight into `/home/dac/sleepypod-core/node_modules`. When it chooses `/persistent` (or an override), the existing bind-mount + fstab logic runs. Stale bind mounts from a prior install whose decision has flipped get unwound.

The same helper is sourced by `sp-update`, so upgrades follow the same logic and remain idempotent.

### Swap

Mirrors the `node_modules` picker, inlined in `scripts/install` (relocation-helpers isn't on disk yet at swap-setup time, matching the iptables-helpers pattern already in install):

1. `SWAP_DIR` (set via `--swap-dir`) wins outright.
2. Otherwise pick the partition with the most free space, gated by `SWAP_HEADROOM_MB` (default 1200 = 1 GiB swap + ~200 MB breathing room). If neither partition clears the floor, install warns and skips swap (the worker may OOM during build but install completes).

Cleans up any stale swap file on the partition we didn't pick this time, plus its `/etc/fstab` line, so a re-run after the decision flips is idempotent.

### Banner sample (Pod 3 SD)

```
Swap → /swapfile  (rootfs has more free space than /persistent)

========================================
  Storage layout
========================================
  Filesystem        Size   Used  Avail  Use%  Mount
  /dev/root         6.6G   1.3G   5.0G   21%  /
  /dev/mmcblk2p3    966M   658M   243M   74%  /persistent

  node_modules → /home/dac/sleepypod-core/node_modules
    Reason     : rootfs has more free space than /persistent (no bind mount needed)
    Override   : re-run install with --node-modules-dir <path>
```

### Banner sample (Pod 4 stock)

```
Swap → /persistent/swapfile  (/persistent has more free space than rootfs)

  node_modules → /persistent/sleepypod-core/node_modules
    bind-mount → /home/dac/sleepypod-core/node_modules
    Reason     : /persistent has more free space than rootfs
    Override   : re-run install with --node-modules-dir <path>
```

## Test plan

- [x] `bash -n scripts/install` and `bash -n scripts/lib/relocation-helpers` clean.
- [x] Unit smoke test of both pickers covering Pod 4 stock, Pod 3 SD, Pod 5, `/persistent` absent, headroom edge cases, ties, overrides — all branch the expected way.
- [x] Banner renders.
- [ ] Re-run installer on Pod 3 SD (~243 MB `/persistent`): expect swap → rootfs, banner → rootfs `node_modules`, no bind mount, install completes.
- [ ] Re-run installer on Pod 4 stock: expect swap → `/persistent/swapfile`, banner → `/persistent` `node_modules`, bind mount + fstab line, behavior matches today.
- [ ] sp-update on a pod where the node_modules decision has flipped: expect the stale bind mount to be unmounted and the fstab line cleaned up.
- [ ] Pod with a stale `/persistent/swapfile` from a failed prior install: expect it to be removed when the picker now lands on rootfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI options: --node-modules-dir, --swap-dir, and --data-dir to override install-time storage choices.

* **Improvements**
  * Installer persistently chooses a data directory at install time and uses it for services and tooling.
  * Node modules and swap placement auto-picked between partitions with safer, idempotent setup and fstab handling.
  * Services now read chosen data paths at runtime.

* **Bug Fixes**
  * Migrate legacy layouts, clean up stale bind mounts and swapfiles on reconfiguration.

* **Documentation**
  * Docs updated to reference the install-selected data directory and related examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/install-storage-aware-node-modules
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/install-storage-aware-node-modules/scripts/install \
  | sudo bash -s -- --branch feat/install-storage-aware-node-modules
```

🎯 **Pin to this exact build** ([run 26738331580](https://github.com/sleepypod/core/actions/runs/26738331580) · `915753d`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/915753dd513db76c800e7c93caec953c5f887a50/scripts/install \
  | sudo bash -s -- \
      --branch feat/install-storage-aware-node-modules \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26738331580/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26738331580/artifacts/7324531473) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->




