### PR TITLE
feat(homekit,mqtt): expose pod ambient temp to HomeKit and Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ the bridge resolves config in this order: `device_settings` row > env var > buil
 | `<prefix>/<device-id>/state/<side>/climate` | pod → broker | per-side temp / mode |
 | `<prefix>/<device-id>/state/water-level` | pod → broker | `low` / `ok` / `unknown` |
 | `<prefix>/<device-id>/state/biometrics/<side>` | pod → broker | latest HR / HRV / BR |
-| `<prefix>/<device-id>/state/environment/ambient` | pod → broker | `{"ts","temperature","humidity"}` (°C, %) |
+| `<prefix>/<device-id>/state/environment/ambient` | pod → broker | `{"ts": <epoch_ms>, "temperature": <number\|null>, "humidity": <number\|null>}` (°C, %) |
 | `<prefix>/<device-id>/cmd/set-temperature` | broker → pod | `{"side","temperature","duration?"}` |
 | `<prefix>/<device-id>/cmd/set-power` | broker → pod | `{"side","powered","temperature?"}` |
 | `<prefix>/<device-id>/cmd/set-alarm` | broker → pod | `{"side","vibrationIntensity","vibrationPattern","duration"}` |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ pod ship once.
 | `Bed <side> occupancy` | OccupancySensor | `sleep_records` (latest with `leftBedAt IS NULL`) | — |
 | `Snooze <side>` | Switch | `snoozeManager` | `snoozeAlarm` / `cancelSnooze` |
 | `Prime` | Switch | `primeNotification` (auto-off on completion) | `startPriming` |
+| `Pod ambient` | TemperatureSensor | `bed_temp.ambient_temp` (centidegrees → °C) | — |
 
 Thermostat is HomeKit's single-setpoint primitive (the pod hardware exposes
 one setpoint, not a heat/cool deadband). Mode `off` cuts power; `auto` powers
@@ -197,6 +198,7 @@ the bridge resolves config in this order: `device_settings` row > env var > buil
 | `<prefix>/<device-id>/state/<side>/climate` | pod → broker | per-side temp / mode |
 | `<prefix>/<device-id>/state/water-level` | pod → broker | `low` / `ok` / `unknown` |
 | `<prefix>/<device-id>/state/biometrics/<side>` | pod → broker | latest HR / HRV / BR |
+| `<prefix>/<device-id>/state/environment/ambient` | pod → broker | `{"ts","temperature","humidity"}` (°C, %) |
 | `<prefix>/<device-id>/cmd/set-temperature` | broker → pod | `{"side","temperature","duration?"}` |
 | `<prefix>/<device-id>/cmd/set-power` | broker → pod | `{"side","powered","temperature?"}` |
 | `<prefix>/<device-id>/cmd/set-alarm` | broker → pod | `{"side","vibrationIntensity","vibrationPattern","duration"}` |

--- a/docs/adr/0019-mqtt-bridge.md
+++ b/docs/adr/0019-mqtt-bridge.md
@@ -119,6 +119,11 @@ On `connect` we publish retained discovery payloads under
   command topics that round-trip through `cmd/set-temperature` and
   `cmd/set-power`.
 - `sensor` for water level, per-side heart rate, breathing rate, HRV.
+- `sensor` for ambient temperature (°C, `device_class: temperature`) and
+  ambient humidity (%, `device_class: humidity`), both reading the latest
+  `bed_temp` row from biometrics.db. One state topic
+  (`state/environment/ambient`) feeds both entities so HA's two cards
+  stay coherent on each retained refresh.
 
 Discovery prefix is overridable via `MQTT_HA_DISCOVERY_PREFIX` for users
 who run a non-default HA install.

--- a/src/homekit/accessories/ambientSensor.ts
+++ b/src/homekit/accessories/ambientSensor.ts
@@ -1,0 +1,70 @@
+/**
+ * HomeKit TemperatureSensor accessory bound to the Pod's ambient air sensor.
+ *
+ * The Pod's bed unit ships an ambient temperature reading alongside the
+ * fluid-temperature channels; biometrics modules persist it to
+ * bed_temp.ambient_temp (centidegrees C) at roughly 60s cadence. This
+ * accessory exposes the latest row as a generic HomeKit temperature
+ * sensor so Home / automations can react to room conditions the same
+ * way they would to any third-party thermometer.
+ *
+ * Poll cadence matches the upstream write rate — a faster poll would
+ * just return the same row.
+ */
+
+import { Service, Characteristic } from 'hap-nodejs'
+import { desc } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db'
+import { bedTemp } from '@/src/db/biometrics-schema'
+import { centiDegreesToC } from '@/src/lib/tempUtils'
+
+const POLL_MS = 60_000
+
+// Returned by onGet before the first DB read lands. HomeKit requires a
+// numeric value; 20°C is a benign room-temperature sentinel that won't
+// look like a sensor fault in the Home app.
+const NEUTRAL_C = 20
+
+export interface AmbientSensorAccessory {
+  service: Service
+  stop: () => void
+}
+
+async function readAmbientC(): Promise<number | null> {
+  try {
+    const [row] = await biometricsDb
+      .select({ ambientTemp: bedTemp.ambientTemp })
+      .from(bedTemp)
+      .orderBy(desc(bedTemp.timestamp))
+      .limit(1)
+    if (!row || row.ambientTemp == null) return null
+    return centiDegreesToC(row.ambientTemp)
+  }
+  catch (e) {
+    console.warn('[homekit] ambient sensor read failed:', e instanceof Error ? e.message : e)
+    return null
+  }
+}
+
+export function buildAmbientSensor(): AmbientSensorAccessory {
+  const service = new Service.TemperatureSensor('Pod ambient', 'ambient')
+  let lastC: number = NEUTRAL_C
+
+  service.getCharacteristic(Characteristic.CurrentTemperature)
+    .onGet(() => lastC)
+
+  const refresh = async (): Promise<void> => {
+    const c = await readAmbientC()
+    if (c == null) return
+    lastC = c
+    service.updateCharacteristic(Characteristic.CurrentTemperature, c)
+  }
+  void refresh()
+  const handle = setInterval(() => void refresh(), POLL_MS)
+  handle.unref?.()
+
+  return {
+    service,
+    stop: () => clearInterval(handle),
+  }
+}

--- a/src/homekit/accessories/ambientSensor.ts
+++ b/src/homekit/accessories/ambientSensor.ts
@@ -61,7 +61,7 @@ export function buildAmbientSensor(): AmbientSensorAccessory {
   }
   void refresh()
   const handle = setInterval(() => void refresh(), POLL_MS)
-  handle.unref?.()
+  handle.unref()
 
   return {
     service,

--- a/src/homekit/bridge.ts
+++ b/src/homekit/bridge.ts
@@ -30,6 +30,7 @@ const ADVERTISER = {
 } as const
 type Advertiser = typeof ADVERTISER[keyof typeof ADVERTISER]
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
+import { buildAmbientSensor } from './accessories/ambientSensor'
 import { buildOccupancySensor } from './accessories/occupancySensor'
 import { buildPowerSwitch } from './accessories/powerSwitch'
 import { buildPrimeSwitch } from './accessories/primeSwitch'
@@ -189,6 +190,12 @@ export async function startBridge(monitor: DacMonitor): Promise<void> {
   primeAcc.addService(prime.service)
   accessory.addBridgedAccessory(primeAcc)
   localStoppers.push(prime.stop)
+
+  const ambient = buildAmbientSensor()
+  const ambientAcc = wrapAccessory('Pod ambient', 'ambient', identity.username)
+  ambientAcc.addService(ambient.service)
+  accessory.addBridgedAccessory(ambientAcc)
+  localStoppers.push(ambient.stop)
 
   try {
     await accessory.publish({

--- a/src/homekit/tests/ambientSensor.test.ts
+++ b/src/homekit/tests/ambientSensor.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Characteristic } from 'hap-nodejs'
+
+// Hoisted DB mock — drives readAmbientC by stubbing the chained
+// biometricsDb.select().from().orderBy().limit() call.
+const dbMock = vi.hoisted(() => {
+  const state: { row: { ambientTemp: number | null } | null, throws: boolean } = {
+    row: null,
+    throws: false,
+  }
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      orderBy: vi.fn(() => ({
+        limit: vi.fn(async () => {
+          if (state.throws) throw new Error('biometrics db down')
+          return state.row ? [state.row] : []
+        }),
+      })),
+    })),
+  }))
+  return { state, select }
+})
+
+vi.mock('@/src/db', () => ({
+  biometricsDb: { select: dbMock.select },
+}))
+
+import { buildAmbientSensor } from '../accessories/ambientSensor'
+
+describe('ambientSensor accessory', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    dbMock.state.row = null
+    dbMock.state.throws = false
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reads latest ambient_temp (centidegrees) and converts to Celsius', async () => {
+    dbMock.state.row = { ambientTemp: 2150 } // 21.5°C
+    const { service, stop } = buildAmbientSensor()
+    // First refresh is queued by buildAmbientSensor — drain the microtask
+    // before sampling so the converted value is in place.
+    await vi.runOnlyPendingTimersAsync()
+    await Promise.resolve()
+    await Promise.resolve()
+    const value = await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()
+    expect(value).toBeCloseTo(21.5, 2)
+    stop()
+  })
+
+  it('returns the neutral 20°C sentinel before the first DB row resolves', async () => {
+    // No row queued; readAmbientC returns null and lastC stays at the sentinel.
+    const { service, stop } = buildAmbientSensor()
+    const value = await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()
+    expect(value).toBe(20)
+    stop()
+  })
+
+  it('keeps last known value when the latest row has a null ambient_temp', async () => {
+    dbMock.state.row = { ambientTemp: 2000 } // 20°C — happens to match sentinel
+    const { service, stop } = buildAmbientSensor()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    dbMock.state.row = { ambientTemp: null }
+    await vi.advanceTimersByTimeAsync(60_000)
+    const value = await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()
+    expect(value).toBe(20)
+    stop()
+  })
+
+  it('swallows DB errors and leaves the cached value untouched', async () => {
+    dbMock.state.row = { ambientTemp: 2500 } // 25°C
+    const { service, stop } = buildAmbientSensor()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()).toBeCloseTo(25, 2)
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    dbMock.state.throws = true
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(warnSpy).toHaveBeenCalled()
+    // 25°C still cached.
+    expect(await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()).toBeCloseTo(25, 2)
+    warnSpy.mockRestore()
+    stop()
+  })
+
+  it('polls the DB on a 60s cadence', async () => {
+    dbMock.state.row = { ambientTemp: 2000 }
+    const { stop } = buildAmbientSensor()
+    const before = dbMock.select.mock.calls.length
+    await vi.advanceTimersByTimeAsync(180_000)
+    // Three additional polls in 180s.
+    expect(dbMock.select.mock.calls.length).toBeGreaterThanOrEqual(before + 3)
+    stop()
+  })
+
+  it('stop() halts the poll interval', async () => {
+    const { stop } = buildAmbientSensor()
+    await Promise.resolve()
+    const after = dbMock.select.mock.calls.length
+    stop()
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(dbMock.select.mock.calls.length).toBe(after)
+  })
+})

--- a/src/homekit/tests/ambientSensor.test.ts
+++ b/src/homekit/tests/ambientSensor.test.ts
@@ -59,15 +59,16 @@ describe('ambientSensor accessory', () => {
   })
 
   it('keeps last known value when the latest row has a null ambient_temp', async () => {
-    dbMock.state.row = { ambientTemp: 2000 } // 20°C — happens to match sentinel
+    dbMock.state.row = { ambientTemp: 2500 } // 25°C — distinct from the 20°C sentinel
     const { service, stop } = buildAmbientSensor()
+    await vi.runOnlyPendingTimersAsync()
     await Promise.resolve()
     await Promise.resolve()
 
     dbMock.state.row = { ambientTemp: null }
     await vi.advanceTimersByTimeAsync(60_000)
     const value = await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()
-    expect(value).toBe(20)
+    expect(value).toBeCloseTo(25, 2)
     stop()
   })
 

--- a/src/homekit/tests/ambientSensor.test.ts
+++ b/src/homekit/tests/ambientSensor.test.ts
@@ -4,7 +4,7 @@ import { Characteristic } from 'hap-nodejs'
 // Hoisted DB mock — drives readAmbientC by stubbing the chained
 // biometricsDb.select().from().orderBy().limit() call.
 const dbMock = vi.hoisted(() => {
-  const state: { row: { ambientTemp: number | null } | null, throws: boolean } = {
+  const state: { row: { ambientTemp: number | null } | null, throws: false | true | string } = {
     row: null,
     throws: false,
   }
@@ -12,7 +12,10 @@ const dbMock = vi.hoisted(() => {
     from: vi.fn(() => ({
       orderBy: vi.fn(() => ({
         limit: vi.fn(async () => {
-          if (state.throws) throw new Error('biometrics db down')
+          if (state.throws !== false) {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error
+            throw typeof state.throws === 'string' ? state.throws : new Error('biometrics db down')
+          }
           return state.row ? [state.row] : []
         }),
       })),
@@ -82,9 +85,27 @@ describe('ambientSensor accessory', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     dbMock.state.throws = true
     await vi.advanceTimersByTimeAsync(60_000)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[homekit] ambient sensor read failed:',
+      'biometrics db down',
+    )
     // 25°C still cached.
     expect(await service.getCharacteristic(Characteristic.CurrentTemperature).handleGetRequest()).toBeCloseTo(25, 2)
+    warnSpy.mockRestore()
+    stop()
+  })
+
+  it('logs the raw value when a non-Error is thrown from the DB', async () => {
+    dbMock.state.throws = 'plain string boom'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { stop } = buildAmbientSensor()
+    await vi.runOnlyPendingTimersAsync()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[homekit] ambient sensor read failed:',
+      'plain string boom',
+    )
     warnSpy.mockRestore()
     stop()
   })

--- a/src/homekit/tests/bridge.test.ts
+++ b/src/homekit/tests/bridge.test.ts
@@ -53,11 +53,13 @@ const m = vi.hoisted(() => {
     snoozeStop: vi.fn(),
     powerStop: vi.fn(),
     primeStop: vi.fn(),
+    ambientStop: vi.fn(),
     buildThermostatService: vi.fn(),
     buildOccupancySensor: vi.fn(),
     buildSnoozeSwitch: vi.fn(),
     buildPowerSwitch: vi.fn(),
     buildPrimeSwitch: vi.fn(),
+    buildAmbientSensor: vi.fn(),
     initHapStorage: vi.fn(),
     loadOrCreateIdentity: vi.fn(),
     readPairedControllers: vi.fn(),
@@ -92,6 +94,9 @@ vi.mock('../accessories/powerSwitch', () => ({
 vi.mock('../accessories/primeSwitch', () => ({
   buildPrimeSwitch: m.buildPrimeSwitch,
 }))
+vi.mock('../accessories/ambientSensor', () => ({
+  buildAmbientSensor: m.buildAmbientSensor,
+}))
 vi.mock('../storage', () => ({
   initHapStorage: m.initHapStorage,
   loadOrCreateIdentity: m.loadOrCreateIdentity,
@@ -125,12 +130,14 @@ describe('homekit bridge', () => {
     m.snoozeStop.mockClear()
     m.powerStop.mockClear()
     m.primeStop.mockClear()
+    m.ambientStop.mockClear()
 
     m.buildThermostatService.mockImplementation(() => ({ service: fakeService, stop: m.thermostatStop }))
     m.buildOccupancySensor.mockImplementation(() => ({ service: fakeService, stop: m.occupancyStop }))
     m.buildSnoozeSwitch.mockImplementation(() => ({ service: fakeService, stop: m.snoozeStop }))
     m.buildPowerSwitch.mockImplementation(() => ({ service: fakeService, stop: m.powerStop }))
     m.buildPrimeSwitch.mockImplementation(() => ({ service: fakeService, stop: m.primeStop }))
+    m.buildAmbientSensor.mockImplementation(() => ({ service: fakeService, stop: m.ambientStop }))
 
     m.loadOrCreateIdentity.mockReturnValue({
       username: 'AA:BB:CC:DD:EE:FF',
@@ -146,12 +153,12 @@ describe('homekit bridge', () => {
     vi.clearAllMocks()
   })
 
-  it('startBridge wires Thermostat + Occupancy + Snooze + Power per side, plus Prime', async () => {
+  it('startBridge wires Thermostat + Occupancy + Snooze + Power per side, plus Prime and Ambient', async () => {
     const { startBridge } = await import('../bridge')
     await startBridge(fakeMonitor)
 
-    // 2 sides × 4 per-side accessories + 1 prime = 9 bridged accessories
-    expect(m.bridgeInstance?.addBridgedAccessory).toHaveBeenCalledTimes(9)
+    // 2 sides × 4 per-side accessories + 1 prime + 1 ambient = 10 bridged accessories
+    expect(m.bridgeInstance?.addBridgedAccessory).toHaveBeenCalledTimes(10)
 
     // Builders called with the expected sides.
     expect(m.buildThermostatService).toHaveBeenCalledWith('left', fakeMonitor)
@@ -163,6 +170,7 @@ describe('homekit bridge', () => {
     expect(m.buildSnoozeSwitch).toHaveBeenCalledWith('left')
     expect(m.buildSnoozeSwitch).toHaveBeenCalledWith('right')
     expect(m.buildPrimeSwitch).toHaveBeenCalledTimes(1)
+    expect(m.buildAmbientSensor).toHaveBeenCalledTimes(1)
   })
 
   it('startBridge constructs the bridge with lowercase "sleepypod" name', async () => {
@@ -202,6 +210,7 @@ describe('homekit bridge', () => {
     expect(m.snoozeStop).toHaveBeenCalledTimes(2)
     expect(m.powerStop).toHaveBeenCalledTimes(2)
     expect(m.primeStop).toHaveBeenCalledTimes(1)
+    expect(m.ambientStop).toHaveBeenCalledTimes(1)
   })
 
   it('stopBridge fires every stopper and clears the singleton', async () => {
@@ -213,6 +222,7 @@ describe('homekit bridge', () => {
     expect(m.thermostatStop).toHaveBeenCalledTimes(2)
     expect(m.powerStop).toHaveBeenCalledTimes(2)
     expect(m.primeStop).toHaveBeenCalledTimes(1)
+    expect(m.ambientStop).toHaveBeenCalledTimes(1)
     expect(getStatus().running).toBe(false)
   })
 

--- a/src/streaming/mqttBridge.ts
+++ b/src/streaming/mqttBridge.ts
@@ -19,6 +19,7 @@
  *   <prefix>/<device-id>/state/<side>/climate        — per-side temperature/mode
  *   <prefix>/<device-id>/state/water-level           — low | ok | unknown
  *   <prefix>/<device-id>/state/biometrics/<side>     — latest HR/HRV/BR summary
+ *   <prefix>/<device-id>/state/environment/ambient   — ambient temp (°C) + humidity (%)
  *   <prefix>/<device-id>/cmd/set-temperature         — JSON {side, temperature, duration?}
  *   <prefix>/<device-id>/cmd/set-power               — JSON {side, powered, temperature?}
  *   <prefix>/<device-id>/cmd/set-alarm               — JSON {side, vibrationIntensity, vibrationPattern, duration}
@@ -38,7 +39,8 @@ import mqtt, { type IClientOptions, type IClientPublishOptions, type MqttClient 
 import { eq, desc } from 'drizzle-orm'
 import { db, biometricsDb } from '@/src/db'
 import { deviceSettings, deviceState } from '@/src/db/schema'
-import { vitals } from '@/src/db/biometrics-schema'
+import { bedTemp, vitals } from '@/src/db/biometrics-schema'
+import { centiDegreesToC, centiPercentToPercent } from '@/src/lib/tempUtils'
 import { onServerFrame } from './piezoStream'
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 
@@ -314,6 +316,38 @@ function publishHaDiscovery(): void {
     JSON.stringify(sensor('water_level', 'Water level', topic('state', 'water-level'), '{{ value_json.level }}')),
     RETAINED_QOS_0,
   )
+
+  // Ambient temperature + humidity from bed_temp. Two HA sensor entities
+  // sharing one state topic so a single retained payload feeds both.
+  const ambientTopic = topic('state', 'environment', 'ambient')
+  const ambientTemp = sensor(
+    'ambient_temperature',
+    'Ambient temperature',
+    ambientTopic,
+    '{{ value_json.temperature }}',
+    '°C',
+  )
+  ;(ambientTemp as Record<string, unknown>).device_class = 'temperature'
+  ;(ambientTemp as Record<string, unknown>).state_class = 'measurement'
+  safePublish(
+    `${haPrefix}/sensor/${id}/ambient_temperature/config`,
+    JSON.stringify(ambientTemp),
+    RETAINED_QOS_0,
+  )
+  const ambientHumidity = sensor(
+    'ambient_humidity',
+    'Ambient humidity',
+    ambientTopic,
+    '{{ value_json.humidity }}',
+    '%',
+  )
+  ;(ambientHumidity as Record<string, unknown>).device_class = 'humidity'
+  ;(ambientHumidity as Record<string, unknown>).state_class = 'measurement'
+  safePublish(
+    `${haPrefix}/sensor/${id}/ambient_humidity/config`,
+    JSON.stringify(ambientHumidity),
+    RETAINED_QOS_0,
+  )
   for (const side of ['left', 'right'] as const) {
     safePublish(
       `${haPrefix}/sensor/${id}/${side}_heart_rate/config`,
@@ -401,6 +435,28 @@ async function publishState(): Promise<void> {
     catch (err) {
       console.warn(`[mqtt] biometrics publish (${side}) failed:`, err instanceof Error ? err.message : err)
     }
+  }
+
+  try {
+    const [latestEnv] = await biometricsDb
+      .select({
+        timestamp: bedTemp.timestamp,
+        ambientTemp: bedTemp.ambientTemp,
+        humidity: bedTemp.humidity,
+      })
+      .from(bedTemp)
+      .orderBy(desc(bedTemp.timestamp))
+      .limit(1)
+    if (latestEnv) {
+      safePublish(topic('state', 'environment', 'ambient'), JSON.stringify({
+        ts: latestEnv.timestamp.getTime(),
+        temperature: latestEnv.ambientTemp != null ? centiDegreesToC(latestEnv.ambientTemp) : null,
+        humidity: latestEnv.humidity != null ? centiPercentToPercent(latestEnv.humidity) : null,
+      }), RETAINED_QOS_0)
+    }
+  }
+  catch (err) {
+    console.warn('[mqtt] ambient environment publish failed:', err instanceof Error ? err.message : err)
   }
 }
 

--- a/src/streaming/mqttBridge.ts
+++ b/src/streaming/mqttBridge.ts
@@ -295,6 +295,7 @@ function publishHaDiscovery(): void {
       payload_not_available: 'offline',
       state_topic: stateTopic,
       value_template: template,
+      state_class: 'measurement',
       device: dev,
     }
     if (unit) cfg.unit_of_measurement = unit
@@ -327,8 +328,7 @@ function publishHaDiscovery(): void {
     '{{ value_json.temperature }}',
     '°C',
   )
-  ;(ambientTemp as Record<string, unknown>).device_class = 'temperature'
-  ;(ambientTemp as Record<string, unknown>).state_class = 'measurement'
+  ambientTemp.device_class = 'temperature'
   safePublish(
     `${haPrefix}/sensor/${id}/ambient_temperature/config`,
     JSON.stringify(ambientTemp),
@@ -341,8 +341,7 @@ function publishHaDiscovery(): void {
     '{{ value_json.humidity }}',
     '%',
   )
-  ;(ambientHumidity as Record<string, unknown>).device_class = 'humidity'
-  ;(ambientHumidity as Record<string, unknown>).state_class = 'measurement'
+  ambientHumidity.device_class = 'humidity'
   safePublish(
     `${haPrefix}/sensor/${id}/ambient_humidity/config`,
     JSON.stringify(ambientHumidity),

--- a/src/streaming/tests/mqttBridge.test.ts
+++ b/src/streaming/tests/mqttBridge.test.ts
@@ -925,16 +925,19 @@ describe('mqttBridge — ambient environment', () => {
     expect(tempCfg).toBeDefined()
     expect(humCfg).toBeDefined()
 
-    // Confirm device_class fields are wired so HA renders the right icons.
+    // Confirm device_class + state_class fields are wired so HA renders the
+    // right icons and enables long-term statistics.
     const tempPayloadCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/ambient_temperature/config'))
     const tempPayload = JSON.parse(tempPayloadCall?.[1] as string)
     expect(tempPayload.device_class).toBe('temperature')
+    expect(tempPayload.state_class).toBe('measurement')
     expect(tempPayload.unit_of_measurement).toBe('°C')
     expect(tempPayload.state_topic).toMatch(/state\/environment\/ambient$/)
 
     const humPayloadCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/ambient_humidity/config'))
     const humPayload = JSON.parse(humPayloadCall?.[1] as string)
     expect(humPayload.device_class).toBe('humidity')
+    expect(humPayload.state_class).toBe('measurement')
     expect(humPayload.unit_of_measurement).toBe('%')
 
     await shutdownMqttBridge()

--- a/src/streaming/tests/mqttBridge.test.ts
+++ b/src/streaming/tests/mqttBridge.test.ts
@@ -18,7 +18,7 @@ const dbMock = vi.hoisted(() => {
     biometricsRow: any | null
     deviceStateRows: any[]
     bedTempRow: any | null
-    throwOnBedTemp: boolean
+    throwOnBedTemp: false | true | string
   } = {
     row: undefined,
     throwOnSelect: false,
@@ -48,7 +48,12 @@ const dbMock = vi.hoisted(() => {
         })),
         orderBy: vi.fn(() => ({
           limit: vi.fn(async () => {
-            if (state.throwOnBedTemp) throw new Error('bed_temp boom')
+            if (state.throwOnBedTemp !== false) {
+              // eslint-disable-next-line @typescript-eslint/only-throw-error
+              throw typeof state.throwOnBedTemp === 'string'
+                ? state.throwOnBedTemp
+                : new Error('bed_temp boom')
+            }
             return state.bedTempRow ? [state.bedTempRow] : []
           }),
         })),
@@ -1015,6 +1020,25 @@ describe('mqttBridge — ambient environment', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[mqtt] ambient environment publish failed:',
       expect.stringContaining('bed_temp boom'),
+    )
+    warnSpy.mockRestore()
+
+    await shutdownMqttBridge()
+  })
+
+  it('logs the raw value when a non-Error is thrown from the bed_temp query', async () => {
+    dbMock.state.throwOnBedTemp = 'plain string boom'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fake = await startBridgeWithFake({ config: { haDiscovery: false } })
+    fake.connected = true
+    fake.emit('connect')
+
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[mqtt] ambient environment publish failed:',
+      'plain string boom',
     )
     warnSpy.mockRestore()
 

--- a/src/streaming/tests/mqttBridge.test.ts
+++ b/src/streaming/tests/mqttBridge.test.ts
@@ -12,18 +12,28 @@ import os from 'node:os'
 // Hoisted state shared with the @/src/db mock factory — lets each test stub
 // the device_settings row that resolveConfig will read.
 const dbMock = vi.hoisted(() => {
-  const state: { row: any | undefined, throwOnSelect: boolean, biometricsRow: any | null, deviceStateRows: any[] } = {
+  const state: {
+    row: any | undefined
+    throwOnSelect: boolean
+    biometricsRow: any | null
+    deviceStateRows: any[]
+    bedTempRow: any | null
+    throwOnBedTemp: boolean
+  } = {
     row: undefined,
     throwOnSelect: false,
     biometricsRow: null,
     deviceStateRows: [],
+    bedTempRow: null,
+    throwOnBedTemp: false,
   }
-  // The bridge calls db.select() three ways:
+  // The bridge calls db.select() four ways:
   //   1. .from(deviceSettings).limit(1)         — resolveConfig
   //   2. .from(deviceState)                     — publishState (iterable of rows)
   //   3. .from(vitals).where(...).orderBy(...).limit(1) — biometrics fetch
+  //   4. .from(bedTemp).orderBy(...).limit(1)   — ambient environment fetch
   // The mock returns a thenable from .from() so case 2 (await of the from()
-  // result) iterates state.deviceStateRows; cases 1/3 chain through.
+  // result) iterates state.deviceStateRows; cases 1/3/4 chain through.
   const select = vi.fn(() => ({
     from: vi.fn(() => {
       const fromObj: any = {
@@ -35,6 +45,12 @@ const dbMock = vi.hoisted(() => {
           orderBy: vi.fn(() => ({
             limit: vi.fn(async () => state.biometricsRow ? [state.biometricsRow] : []),
           })),
+        })),
+        orderBy: vi.fn(() => ({
+          limit: vi.fn(async () => {
+            if (state.throwOnBedTemp) throw new Error('bed_temp boom')
+            return state.bedTempRow ? [state.bedTempRow] : []
+          }),
         })),
         // Make `.from(deviceState)` itself awaitable so `for (const row of
         // sides)` after `await db.select().from(deviceState)` iterates rows.
@@ -194,6 +210,8 @@ beforeEach(() => {
   dbMock.state.throwOnSelect = false
   dbMock.state.biometricsRow = null
   dbMock.state.deviceStateRows = []
+  dbMock.state.bedTempRow = null
+  dbMock.state.throwOnBedTemp = false
   mqttMock.state.nextClient = null
   mqttMock.state.throwOnConnect = null
   mqttMock.connect.mockClear()
@@ -890,6 +908,112 @@ describe('mqttBridge — frame subscription', () => {
     piezoMock.state.listener?.({ type: 'deviceStatus' })
 
     expect(fake.publish).not.toHaveBeenCalled()
+
+    await shutdownMqttBridge()
+  })
+})
+
+describe('mqttBridge — ambient environment', () => {
+  it('publishes HA discovery for ambient temperature and humidity sensors', async () => {
+    const fake = await startBridgeWithFake({ config: { haDiscovery: true } })
+    fake.connected = true
+    fake.emit('connect')
+
+    const topics = fake.publish.mock.calls.map(([t]) => t as string)
+    const tempCfg = topics.find(t => t.endsWith('/ambient_temperature/config'))
+    const humCfg = topics.find(t => t.endsWith('/ambient_humidity/config'))
+    expect(tempCfg).toBeDefined()
+    expect(humCfg).toBeDefined()
+
+    // Confirm device_class fields are wired so HA renders the right icons.
+    const tempPayloadCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/ambient_temperature/config'))
+    const tempPayload = JSON.parse(tempPayloadCall?.[1] as string)
+    expect(tempPayload.device_class).toBe('temperature')
+    expect(tempPayload.unit_of_measurement).toBe('°C')
+    expect(tempPayload.state_topic).toMatch(/state\/environment\/ambient$/)
+
+    const humPayloadCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/ambient_humidity/config'))
+    const humPayload = JSON.parse(humPayloadCall?.[1] as string)
+    expect(humPayload.device_class).toBe('humidity')
+    expect(humPayload.unit_of_measurement).toBe('%')
+
+    await shutdownMqttBridge()
+  })
+
+  it('converts centidegrees + centipercent into the published state payload', async () => {
+    dbMock.state.bedTempRow = {
+      timestamp: new Date('2026-05-01T12:00:00Z'),
+      ambientTemp: 2150, // 21.5°C
+      humidity: 4530, // 45.30%
+    }
+    const fake = await startBridgeWithFake({ config: { haDiscovery: false } })
+    fake.connected = true
+    fake.emit('connect')
+
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    const ambientCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/state/environment/ambient'))
+    expect(ambientCall).toBeDefined()
+    const payload = JSON.parse(ambientCall?.[1] as string)
+    expect(payload.temperature).toBeCloseTo(21.5, 2)
+    expect(payload.humidity).toBeCloseTo(45.3, 2)
+    expect(payload.ts).toBe(new Date('2026-05-01T12:00:00Z').getTime())
+
+    await shutdownMqttBridge()
+  })
+
+  it('publishes nulls when bed_temp columns are NULL', async () => {
+    dbMock.state.bedTempRow = {
+      timestamp: new Date('2026-05-01T12:00:00Z'),
+      ambientTemp: null,
+      humidity: null,
+    }
+    const fake = await startBridgeWithFake({ config: { haDiscovery: false } })
+    fake.connected = true
+    fake.emit('connect')
+
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    const ambientCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/state/environment/ambient'))
+    const payload = JSON.parse(ambientCall?.[1] as string)
+    expect(payload.temperature).toBeNull()
+    expect(payload.humidity).toBeNull()
+
+    await shutdownMqttBridge()
+  })
+
+  it('skips ambient publish when no bed_temp row exists yet', async () => {
+    dbMock.state.bedTempRow = null
+    const fake = await startBridgeWithFake({ config: { haDiscovery: false } })
+    fake.connected = true
+    fake.emit('connect')
+
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    const ambientCall = fake.publish.mock.calls.find(([t]) => typeof t === 'string' && (t as string).endsWith('/state/environment/ambient'))
+    expect(ambientCall).toBeUndefined()
+
+    await shutdownMqttBridge()
+  })
+
+  it('logs but does not throw when the bed_temp query fails', async () => {
+    dbMock.state.throwOnBedTemp = true
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fake = await startBridgeWithFake({ config: { haDiscovery: false } })
+    fake.connected = true
+    fake.emit('connect')
+
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[mqtt] ambient environment publish failed:',
+      expect.stringContaining('bed_temp boom'),
+    )
+    warnSpy.mockRestore()
 
     await shutdownMqttBridge()
   })


### PR DESCRIPTION
## Summary

- New HomeKit `TemperatureSensor` accessory **Pod ambient**, polling `biometrics.db → bed_temp.ambient_temp` every 60s (centidegrees → °C, with a 20°C sentinel before the first read).
- MQTT bridge publishes retained `state/environment/ambient` (`{ts, temperature, humidity}`) on every refresh and on connect.
- HA discovery announces two sensor entities reading the same state topic: `ambient_temperature` (`device_class: temperature`, °C) and `ambient_humidity` (`device_class: humidity`, %).
- README + ADR 0019 updated to document the new accessory, the new topic, and the discovery payloads.

## Why

Pod owners already get climate control + biometrics in Home / HA, but the ambient air sensor on the bed unit was only exposed inside the web app. Surfacing it as a stock temperature sensor lets HA automations and Apple Home treat the pod like any third-party thermometer (e.g. "if bedroom > 26°C, turn cooling on") without scripting against tRPC.

## Test plan

- [x] `pnpm exec vitest run src/homekit src/streaming` — 334 passing (incl. 6 new ambient-sensor cases, 5 new MQTT ambient cases, updated bridge wiring assertions)
- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean (only the pre-existing stryker.config.mjs warning)
- [ ] Pair to a real pod, confirm the **Pod ambient** tile in Apple Home tracks room temperature
- [ ] With MQTT enabled + HA discovery on, confirm `sensor.<device-id>_ambient_temperature` and `sensor.<device-id>_ambient_humidity` appear under the pod's HA device page

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update worktree-add-ambient-sensor-hk-ha
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-add-ambient-sensor-hk-ha/scripts/install \
  | sudo bash -s -- --branch worktree-add-ambient-sensor-hk-ha
```

🎯 **Pin to this exact build** ([run 26200506602](https://github.com/sleepypod/core/actions/runs/26200506602) · `e2d686e`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/e2d686e3e4f1c292b07d66df8141b973b53feb85/scripts/install \
  | sudo bash -s -- \
      --branch worktree-add-ambient-sensor-hk-ha \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26200506602/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26200506602/artifacts/7125610664) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HomeKit accessory for Pod ambient temperature sensor with automatic data synchronization
  * Extended MQTT bridge to publish ambient temperature and humidity measurements to environment state topic
  * Enabled Home Assistant MQTT discovery for ambient temperature and humidity sensors

* **Documentation**
  * Updated README with new Pod ambient sensor and MQTT topic information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


