### PR TITLE
fix(install): Pod 5 install hardening — iptables lock, frank-less RAW redirect, env-monitor crash

### DIFF
--- a/modules/biometrics-archiver/frank.service.d/sleepypod-biometrics-tmpfs.conf
+++ b/modules/biometrics-archiver/frank.service.d/sleepypod-biometrics-tmpfs.conf
@@ -6,3 +6,11 @@
 Wants=sleepypod-tmpfs-prep.service
 After=sleepypod-tmpfs-prep.service
 RequiresMountsFor=/persistent/biometrics
+
+[Service]
+# On Pod variants with frank.sh, the patched shim does `cd /persistent/biometrics`
+# itself and this is a no-op (shell cd wins). On newer Pod 5 variants without
+# the shim, frank.service ExecStarts frankenfirmware directly — without this
+# override, ~1 GB/day of RAW frames lands on /persistent eMMC instead of the
+# tmpfs at /persistent/biometrics, wearing the flash.
+WorkingDirectory=/persistent/biometrics

--- a/modules/environment-monitor/README.md
+++ b/modules/environment-monitor/README.md
@@ -1,0 +1,53 @@
+# environment-monitor
+
+Python sidecar that follows `/persistent/*.RAW` (CBOR-encoded sensor stream from `frankenfirmware`) and writes ambient, bed-zone, and freezer-loop temperatures into `biometrics.db`.
+
+## What it writes
+
+| Table | Columns | Source record |
+| --- | --- | --- |
+| `bed_temp` | `ambient_temp`, `mcu_temp`, `humidity`, six bed-zone thermistors (`{left,right}_{outer,center,inner}_temp`) | `bedTemp` (Pod 3/4) and `bedTemp2` (Pod 5) frames |
+| `freezer_temp` | `ambient_temp`, `heatsink_temp`, `left_water_temp`, `right_water_temp` | `frzTemp` frames |
+
+All values are stored in centidegrees C / centipercent so the schema is integer-typed and dialect-free. The two record dialects (`bedTemp` vs `bedTemp2`) are normalized in `modules/common/dialect.py` before insertion.
+
+## Downsampling
+
+Each record type is rate-limited to **one row per 60 seconds** (`DOWNSAMPLE_INTERVAL_S`), matching the vitals cadence used by `piezo-processor`. The firmware emits these frames much faster (every few seconds); at full rate the table would grow ~21k rows/day per record type. The downsample cursor only advances on a successful insert — an all-sentinel frame doesn't block the next 60s of valid samples.
+
+## Sentinel filtering
+
+Disconnected freezer sensors emit `-327.68 °C` (`0x8000` / `0xFFFF` in the raw u16 domain) instead of throwing. `_safe_freezer_centidegrees` drops these plus any reading outside `[-50 °C, 125 °C]` so `freezer_temp` never accumulates implausible spikes. See [ADR-0021](../../docs/adr/) for the rationale and #325 for the original incident.
+
+## When `freezer_temp` is empty
+
+The freezer table only populates on hardware that actually emits `frzTemp` frames — Pod 5 cover-only variants (no chiller hardware) won't write to it. That's expected, not a bug. `bed_temp` should still populate on every Pod generation.
+
+## Operational signals
+
+```bash
+# Live logs (decisions, dropped sentinels, fatal errors)
+journalctl -u sleepypod-environment-monitor.service -f
+
+# Most recent rows
+sqlite3 /persistent/sleepypod-data/biometrics.db \
+  'SELECT * FROM bed_temp ORDER BY timestamp DESC LIMIT 3;'
+sqlite3 /persistent/sleepypod-data/biometrics.db \
+  'SELECT * FROM freezer_temp ORDER BY timestamp DESC LIMIT 3;'
+
+# Health row (component='environment-monitor' is updated on start/exit)
+sqlite3 /persistent/sleepypod-data/sleepypod.db \
+  "SELECT * FROM system_health WHERE component='environment-monitor';"
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RAW_DATA_DIR` | `/persistent` | Directory the RAW follower tails. The systemd unit overrides to `/persistent/biometrics` (tmpfs) — see ADR-0018. |
+| `BIOMETRICS_DATABASE_URL` | `file:/persistent/sleepypod-data/biometrics.db` | Sink for `bed_temp` / `freezer_temp` rows. |
+| `DATABASE_URL` | `file:/persistent/sleepypod-data/sleepypod.db` | Used only to write `system_health` heartbeats. |
+
+## Python version
+
+Pinned to `>=3.9,<3.11` to match the stock Pod interpreter (Pod 5 ships 3.9.9). Avoid PEP 604 union syntax (`int | None`) in this module — use `Optional[int]` from `typing` instead.

--- a/modules/environment-monitor/main.py
+++ b/modules/environment-monitor/main.py
@@ -23,6 +23,7 @@ import sqlite3
 import threading
 from pathlib import Path
 from datetime import datetime, timezone
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -59,7 +60,7 @@ _FRZ_MIN_CENTIDEGREES = -5000
 _FRZ_MAX_CENTIDEGREES = 12500
 
 
-def _safe_freezer_centidegrees(val) -> int | None:
+def _safe_freezer_centidegrees(val) -> Optional[int]:
     """Validate a raw firmware centidegrees value for freezer_temp insertion.
 
     Rejects sentinel values (disconnected sensor) and out-of-range values

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -59,6 +59,9 @@ for svc in "${SERVICES[@]}"; do
   rm -f "/etc/systemd/system/$svc"
 done
 
+# Drop-ins installed by sp-update (e.g. iptables-lockfile.conf for older pods).
+rm -rf /etc/systemd/system/sleepypod.service.d
+
 # Restore frank.sh from the most recent pre-tmpfs backup BEFORE the mount
 # is torn down — otherwise frank's cwd disappears mid-restart.
 if ls /opt/eight/bin/frank.sh.bak-pre-tmpfs-* >/dev/null 2>&1; then

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -341,6 +341,21 @@ if [ -f "$INSTALL_DIR/scripts/lib/biometrics-archiver-helpers" ]; then
   install_biometrics_archiver
 fi
 
+# Self-heal the xtables lockfile env for pods installed before this fix.
+# Without it, setInternetAccess crashes the first time a user toggles WAN
+# ("can't open lock file /run/xtables.lock: Permission denied"). The main
+# unit gets this Environment= line in fresh installs; for OTA upgrades we
+# drop it in so we don't have to rewrite the entire service unit.
+XTABLES_DROPIN=/etc/systemd/system/sleepypod.service.d/iptables-lockfile.conf
+if [ ! -f "$XTABLES_DROPIN" ]; then
+  mkdir -p "$(dirname "$XTABLES_DROPIN")"
+  cat > "$XTABLES_DROPIN" << 'EOF'
+[Service]
+Environment="XTABLES_LOCKFILE=/run/dac/xtables.lock"
+EOF
+  systemctl daemon-reload
+fi
+
 # Install CLI tools from new source.
 #
 # Use `install` (atomic mkstemp + rename) instead of `cp` — sp-update is

--- a/scripts/install
+++ b/scripts/install
@@ -1044,6 +1044,11 @@ Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
 # decode the 16-byte SEQNO.RAW bookkeeping file as CBOR — sensor streaming
 # and flow_readings stay empty.
 Environment="RAW_DATA_DIR=/persistent/biometrics"
+# Use a writable xtables lock under RuntimeDirectory=dac. The default
+# /run/xtables.lock is root:root 0600 — CAP_NET_ADMIN doesn't bypass the
+# file mode, so setInternetAccess fails with "can't open lock file ...
+# Permission denied" the first time a user toggles WAN from the UI.
+Environment="XTABLES_LOCKFILE=/run/dac/xtables.lock"
 # The \`+\` prefix runs ExecStartPre as root regardless of User=. Needed
 # for /deviceinfo symlink creation (root-owned) and sp-maintenance
 # (journal vacuum, /tmp cleanup, pnpm store prune).

--- a/scripts/lib/biometrics-archiver-helpers
+++ b/scripts/lib/biometrics-archiver-helpers
@@ -78,7 +78,11 @@ install_biometrics_archiver() {
       echo "frank.sh already patched — skipping"
     fi
   else
-    echo "Warning: /opt/eight/bin/frank.sh not found — skipping patch (not a Pod?)"
+    # Newer Pod 5 firmware variants don't ship the frank.sh shell shim —
+    # frankenfirmware is started directly by frank.service. The drop-in
+    # we installed above sets WorkingDirectory=/persistent/biometrics, so
+    # the redirect still applies via systemd instead of a shell cd.
+    echo "frank.sh absent (newer firmware variant) — relying on systemd WorkingDirectory= to redirect RAW writes"
   fi
 
   # Restart sleepypod modules so they pick up RAW_DATA_DIR=/persistent/biometrics.

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -76,8 +76,10 @@ detect_dac_sock() {
     fi
   done
 
-  # Priority 4: Default to Pod 5 path
-  echo "Warning: dac.sock not found, using default: /persistent/deviceinfo/dac.sock" >&2
+  # Priority 4: Default to Pod 5 path. Common at fresh-install time —
+  # frankenfirmware hasn't restarted yet, so the socket file doesn't
+  # exist and frank.sh may be absent on newer Pod 5 firmware variants.
+  echo "dac.sock not yet present — assuming Pod 5 default (/persistent/deviceinfo/dac.sock)" >&2
   echo "/persistent/deviceinfo/dac.sock"
 }
 


### PR DESCRIPTION
## Summary

Bundles the four issues NAAAA hit installing on a frank-less Pod 5 (reported in Discord, 5/21).

- **env-monitor crash loop on Python 3.9.9** — `int | None` (PEP 604) requires 3.10+. Replaced with `Optional[int]`. Module pins `requires-python = ">=3.9,<3.11"`, Pod 5 ships 3.9.9, so the service was crash-looping at import time on every restart. Regression from PR #483.
- **iptables `xtables.lock` permission denied** — `setInternetAccess` (`iptables -F`) crashed the first time a user toggled WAN. Service runs as `User=sleepypod` with `CAP_NET_ADMIN`, but the default `/run/xtables.lock` is `root:root 0600` and the cap doesn't bypass file mode. Fix: `Environment="XTABLES_LOCKFILE=/run/dac/xtables.lock"` (the `RuntimeDirectory=dac` is owned by the service user). For pods already installed pre-fix, `sp-update` writes the same env via an idempotent `sleepypod.service.d/iptables-lockfile.conf` drop-in so OTA self-heals.
- **RAW frames hitting eMMC on frank-less Pod 5 variants** — older Pod 5 firmware ships `/opt/eight/bin/frank.sh` which we patch to `cd /persistent/biometrics` (tmpfs). Newer variants drop the shim — `frank.service` ExecStarts `frankenfirmware` directly, our cd-patch no-ops, and ~1 GB/day of RAW frames land on `/persistent` eMMC. Add `WorkingDirectory=/persistent/biometrics` to the `frank.service` drop-in: no-op on shim pods (shell `cd` still wins), real redirect on shimless pods.
- **Misleading install warnings** — `"Warning: /opt/eight/bin/frank.sh not found — skipping patch (not a Pod?)"` and `"Warning: dac.sock not found, using default: ..."` made working installs look broken. Replaced with informational lines that explain what's happening.

Adds `modules/environment-monitor/README.md` (first per-module README) covering what writes to `bed_temp` / `freezer_temp`, why `freezer_temp` can be empty on cover-only Pod 5, debug commands, and a note about the Python 3.9 syntax constraint.

## Test plan

**Verified live on eight-pod (Pod 5 J55, frank-shim variant):**

- [x] `frank.service` drop-in parses, `daemon-reload` clean, `systemctl restart frank.service` succeeds, `frankenfirmware` cwd remains `/persistent/biometrics` (shell `cd` wins as expected)
- [x] `systemctl show frank.service -p WorkingDirectory` → `/persistent/biometrics`
- [x] A/B for the iptables fix under the **exact same `AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW`** as the real service via `systemd-run --uid=sleepypod`:
  - without `XTABLES_LOCKFILE` → `Fatal: can't open lock file /run/xtables.lock: Permission denied` (NAAAA's exact error)
  - with `XTABLES_LOCKFILE=/run/dac-test/xtables.lock` → `iptables -L OUTPUT` succeeds, lockfile created at `/run/dac-test/xtables.lock` owned by sleepypod

**CI / unit tests:**

- [x] `pnpm test src/server/routers/tests/system.test.ts` — 34/34 pass
- [x] `pnpm test src/hardware/tests/iptablesCheck.test.ts` — 18/18 pass
- [x] `bash -n` clean on `scripts/install`, `scripts/bin/sp-update`, `scripts/bin/sp-uninstall`, `scripts/pod/detect`, `scripts/lib/biometrics-archiver-helpers`
- [x] env-monitor smoke test (`_safe_freezer_centidegrees` sentinels, range gate, accept path) passes after the `Optional[int]` change

**For users picking up the fix:**

- [ ] Existing pods: `sp-update` writes the drop-in, no full re-install needed
- [ ] Fresh installs: main unit gets the env directly
- [ ] `sp-uninstall` removes `sleepypod.service.d/` along with the rest

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update worktree-naaa
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/worktree-naaa/scripts/install \
  | sudo bash -s -- --branch worktree-naaa
```

🎯 **Pin to this exact build** ([run 26418923280](https://github.com/sleepypod/core/actions/runs/26418923280) · `19a7fba`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/19a7fba13d955c907aceb6eb29b881bbf62e3846/scripts/install \
  | sudo bash -s -- \
      --branch worktree-naaa \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26418923280/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26418923280/artifacts/7204635008) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved permission issues when configuring internet access by setting explicit xtables lockfile path.
  * Fixed biometrics archiver to correctly write raw frames to temporary storage on Pod 5 variants.

* **Documentation**
  * Added comprehensive documentation for the environment monitoring module, including data processing behavior and configuration details.

* **Chores**
  * Improved installation and uninstallation scripts to properly manage systemd service configuration overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->