### PR TITLE
fix(settings): debounce pump-safety number inputs to onBlur

### DIFF
--- a/src/components/Settings/DeviceSettingsForm.tsx
+++ b/src/components/Settings/DeviceSettingsForm.tsx
@@ -251,16 +251,27 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
     save({ pumpStallProtectionEnabled: next })
   }
 
+  // Pump-safety number inputs: update state on every keystroke but only clamp
+  // + save on blur so partial values like "5" → "500" aren't clamped to the
+  // min mid-type and don't fire a mutation per character.
   function handlePumpStallThreshold(rpm: number) {
-    const clamped = Math.max(100, Math.min(1500, Math.round(rpm)))
+    setPumpStallThreshold(rpm)
+  }
+
+  function commitPumpStallThreshold() {
+    const clamped = Math.max(100, Math.min(1500, Math.round(pumpStallThreshold)))
     setPumpStallThreshold(clamped)
-    save({ pumpStallRpmThreshold: clamped })
+    if (clamped !== device.pumpStallRpmThreshold) save({ pumpStallRpmThreshold: clamped })
   }
 
   function handlePumpStallDwell(samples: number) {
-    const clamped = Math.max(1, Math.min(10, Math.round(samples)))
+    setPumpStallDwell(samples)
+  }
+
+  function commitPumpStallDwell() {
+    const clamped = Math.max(1, Math.min(10, Math.round(pumpStallDwell)))
     setPumpStallDwell(clamped)
-    save({ pumpStallDwellSamples: clamped })
+    if (clamped !== device.pumpStallDwellSamples) save({ pumpStallDwellSamples: clamped })
   }
 
   function handlePumpAutoRecoverToggle() {
@@ -270,15 +281,23 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
   }
 
   function handlePumpRecoveryRpm(rpm: number) {
-    const clamped = Math.max(500, Math.min(3000, Math.round(rpm)))
+    setPumpRecoveryRpm(rpm)
+  }
+
+  function commitPumpRecoveryRpm() {
+    const clamped = Math.max(500, Math.min(3000, Math.round(pumpRecoveryRpm)))
     setPumpRecoveryRpm(clamped)
-    save({ pumpStallRecoveryRpm: clamped })
+    if (clamped !== device.pumpStallRecoveryRpm) save({ pumpStallRecoveryRpm: clamped })
   }
 
   function handlePumpRecoverySamples(samples: number) {
-    const clamped = Math.max(1, Math.min(10, Math.round(samples)))
+    setPumpRecoverySamples(samples)
+  }
+
+  function commitPumpRecoverySamples() {
+    const clamped = Math.max(1, Math.min(10, Math.round(pumpRecoverySamples)))
     setPumpRecoverySamples(clamped)
-    save({ pumpStallRecoverySamples: clamped })
+    if (clamped !== device.pumpStallRecoverySamples) save({ pumpStallRecoverySamples: clamped })
   }
 
   const showToast = isPending || savedFlash
@@ -575,6 +594,7 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
                 step={50}
                 value={pumpStallThreshold}
                 onChange={e => handlePumpStallThreshold(Number(e.target.value))}
+                onBlur={commitPumpStallThreshold}
                 disabled={isPending}
                 className="h-11 w-28 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
               />
@@ -591,6 +611,7 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
                 step={1}
                 value={pumpStallDwell}
                 onChange={e => handlePumpStallDwell(Number(e.target.value))}
+                onBlur={commitPumpStallDwell}
                 disabled={isPending}
                 className="h-11 w-28 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
               />
@@ -621,6 +642,7 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
                     step={50}
                     value={pumpRecoveryRpm}
                     onChange={e => handlePumpRecoveryRpm(Number(e.target.value))}
+                    onBlur={commitPumpRecoveryRpm}
                     disabled={isPending}
                     className="h-11 w-28 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
                   />
@@ -637,6 +659,7 @@ export function DeviceSettingsForm({ device }: { device: DeviceSettings }) {
                     step={1}
                     value={pumpRecoverySamples}
                     onChange={e => handlePumpRecoverySamples(Number(e.target.value))}
+                    onBlur={commitPumpRecoverySamples}
                     disabled={isPending}
                     className="h-11 w-28 rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 text-sm font-medium text-white outline-none transition-colors focus:border-sky-500 disabled:cursor-not-allowed disabled:opacity-40"
                   />


### PR DESCRIPTION
## Summary
- Pump-safety number inputs (trip threshold, dwell, recovery RPM, recovery samples) fired a `settings.updateDevice` mutation on every keystroke and clamped to the min mid-type, so typing \`500\` became \`100\` after the first character.
- Switch to update-on-change / clamp-and-save-on-blur, matching the existing \`commitLedDay\` / \`commitLedNightBrightness\` pattern in the same file.
- \`maxOnHours\` has the same shape but was left untouched — scope-limited to what was reported.

## Test plan
- [ ] Open Settings, toggle pump safety on
- [ ] In **Trip threshold (RPM)**, clear the field and type \`500\` — value stays as typed, no \"Saving…\" toast per keystroke
- [ ] Tab/blur the field — single save fires, value persists
- [ ] Enter an out-of-range value (e.g. \`50\` or \`5000\`) and blur — value clamps to the valid range and saves
- [ ] Repeat for dwell samples, recovery RPM, recovery samples

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pump-safety-input-debounce
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pump-safety-input-debounce/scripts/install \
  | sudo bash -s -- --branch fix/pump-safety-input-debounce
```

🎯 **Pin to this exact build** ([run 26421910255](https://github.com/sleepypod/core/actions/runs/26421910255) · `9c6bb84`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/9c6bb847b318085e2936370f097a506acdaf4ea9/scripts/install \
  | sudo bash -s -- \
      --branch fix/pump-safety-input-debounce \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26421910255/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26421910255/artifacts/7205580001) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
