### PR TITLE
fix(install): drop v6 rules file from free-sleep detection

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -314,13 +314,11 @@ detect_free_sleep_conflict() {
   done
   [ -d /home/dac/free-sleep ]                && FREE_SLEEP_FINDINGS+=("directory:    /home/dac/free-sleep")
   [ -d /persistent/free-sleep-data ]         && FREE_SLEEP_FINDINGS+=("directory:    /persistent/free-sleep-data")
-  # Only the v6 rules file is a unique free-sleep indicator — sleepypod's
-  # own block_wan persists /etc/iptables/iptables.rules but never the v6
-  # file, so flagging the v4 file would false-positive on every reinstall.
-  [ -f /etc/iptables/ip6tables.rules ]       && FREE_SLEEP_FINDINGS+=("persisted:    /etc/iptables/ip6tables.rules")
-  # Last `[ test ] && side_effect` returns 1 when the test is false. Under
-  # set -e, that propagates out and kills install at the preflight call on
-  # any clean pod. Explicit return 0 keeps the function's exit status sane.
+  # Do NOT check /etc/iptables/{iptables,ip6tables}.rules — both paths are
+  # stock Pod 5 firmware: /lib/systemd/system/{iptables,ip6tables}.service
+  # ship enabled and ExecStart=iptables-restore on those files. Presence
+  # alone says nothing about free-sleep. The systemd units and home/data
+  # dirs are unambiguous; free-sleep installs all of them.
   return 0
 }
 


### PR DESCRIPTION
## Summary

`detect_free_sleep_conflict` flagged `/etc/iptables/ip6tables.rules` as a free-sleep marker, but that path is **stock Pod 5 firmware** — `/lib/systemd/system/ip6tables.service` ships enabled and `ExecStart=ip6tables-restore -w -- /etc/iptables/ip6tables.rules`. Same goes for the v4 sibling. So the file's presence says nothing about whether free-sleep was ever installed.

This false-positives on fresh-reset pods that have never seen free-sleep, with no recovery short of `--purge-free-sleep` or deleting a stock file (which also breaks stock `ip6tables.service`). User report on 2026-05-25 (pod 88): clean pod, install bailed citing only `persisted: /etc/iptables/ip6tables.rules` with no services or dirs.

The systemd unit and `/home/dac/free-sleep` / `/persistent/free-sleep-data` directory checks are unambiguous and free-sleep installs all of them, so dropping the v6-file check costs no real detection power.

## Test plan

- [x] `bash -n scripts/install` parses
- [x] On pod 88 (clean of free-sleep, has stock `iptables.service` / `ip6tables.service` enabled), running just `detect_free_sleep_conflict` now returns 0 findings — preflight passes
- [ ] User reruns install on the affected pod and confirms preflight no longer aborts
- [ ] Manual test: with a real `/home/dac/free-sleep` dir present, preflight still trips (unambiguous markers still work)

## Background

This is the second bug in the same detector. PR #603 fixed the `set -e` exit-code false-positive (when the v6 file was absent, the last `[ -f ]` test returned 1 and aborted via set -e). This PR removes the underlying wrong premise that the v6 file is a free-sleep-unique indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced conflict detection during installation to provide more accurate identification of existing installations, ignoring iptables rules files which may be present as part of standard system configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/install-freesleep-detect-stock-v6
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/install-freesleep-detect-stock-v6/scripts/install \
  | sudo bash -s -- --branch fix/install-freesleep-detect-stock-v6
```

🎯 **Pin to this exact build** ([run 26424259960](https://github.com/sleepypod/core/actions/runs/26424259960) · `0c6c156`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/0c6c156a2ae4602098c26f9545ee95da9179fcb9/scripts/install \
  | sudo bash -s -- \
      --branch fix/install-freesleep-detect-stock-v6 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26424259960/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26424259960/artifacts/7206309076) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
