### PR TITLE
fix(update-card): require service bounce before re-blocking WAN

### DIFF
--- a/src/components/status/UpdateCard.tsx
+++ b/src/components/status/UpdateCard.tsx
@@ -35,6 +35,16 @@ export function UpdateCard() {
   const didUnblockRef = useRef(false)
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cancelledRef = useRef(false)
+  /**
+   * Version snapshot captured right before sp-update runs. Polling uses
+   * this to distinguish "service is still the old build" from "service
+   * restarted on the new build" — without it, the first poll racily
+   * succeeds against the still-running old service and the UI re-blocks
+   * WAN mid-download, killing the in-progress update.
+   */
+  const baselineVersionRef = useRef<{ commitHash: string, buildDate: string } | null>(null)
+  /** Set to true once a poll fails — proves the service actually went down. */
+  const sawDownRef = useRef(false)
 
   // Clean up poll timer on unmount and re-block internet if needed
   useEffect(() => {
@@ -130,6 +140,14 @@ export function UpdateCard() {
     const branch = selectedBranch
       ?? (versionData?.branch !== 'unknown' ? versionData?.branch : undefined)
 
+    // Snapshot the current build so polling can tell when sp-update has
+    // actually restarted the service on the new code (vs. the old service
+    // still serving the API mid-download).
+    baselineVersionRef.current = versionData
+      ? { commitHash: versionData.commitHash, buildDate: versionData.buildDate }
+      : null
+    sawDownRef.current = false
+
     try {
       await triggerUpdate.mutateAsync({ branch })
       setUpdateState('reconnecting')
@@ -145,18 +163,47 @@ export function UpdateCard() {
 
   const pollForReconnection = () => {
     let attempts = 0
-    const maxAttempts = 60 // ~2 minutes at 2s intervals
+    const maxAttempts = 90 // ~3 minutes at 2s intervals — sp-update can stay up for a while before stopping the service
 
     const check = async () => {
       if (cancelledRef.current) return
       attempts++
       try {
-        await version.refetch()
-        // Success — service is back
-        await reblockIfNeeded()
-        setUpdateState('idle')
+        // Use the direct fetch path so a network/server error throws
+        // cleanly — useQuery.refetch() resolves on error and would make
+        // the down-detection below silently false.
+        const next = await utils.system.getVersion.fetch({})
+
+        const baseline = baselineVersionRef.current
+        const versionChanged = baseline !== null
+          && (next.commitHash !== baseline.commitHash || next.buildDate !== baseline.buildDate)
+
+        // Only call this "done" once we've proven the service actually
+        // bounced. Otherwise we're talking to the old next-server still
+        // serving the pre-update build — re-blocking WAN here kills
+        // sp-update's still-pending tarball download.
+        if (versionChanged || sawDownRef.current) {
+          // Keep the React-Query cache in sync with what we just fetched
+          // so other consumers re-render with the new version.
+          utils.system.getVersion.setData({}, next)
+          await reblockIfNeeded()
+          setUpdateState('idle')
+          return
+        }
+
+        // Old service is still up; sp-update hasn't reached `systemctl
+        // stop` yet. Keep polling without unblocking guarantees.
+        if (attempts < maxAttempts && !cancelledRef.current) {
+          pollTimerRef.current = setTimeout(check, 2000)
+        }
+        else if (!cancelledRef.current) {
+          await reblockIfNeeded()
+          setUpdateState('error')
+          setErrorMessage('Service did not restart on a new build. Check pod manually.')
+        }
       }
       catch {
+        sawDownRef.current = true
         if (attempts < maxAttempts && !cancelledRef.current) {
           pollTimerRef.current = setTimeout(check, 2000)
         }


### PR DESCRIPTION
## Summary

The web UI update flow racily re-blocks WAN mid-download, killing the in-progress `sp-update`.

**Race:**
1. User clicks **Allow & Update** → UI calls `setInternetAccess({blocked:false})` → server flushes iptables. ✅
2. UI calls `triggerUpdate` → server spawns `sp-update` **detached** and the mutation returns immediately.
3. UI schedules `pollForReconnection()`, first poll at +5s.
4. `sp-update` order: pre-flight → `tar` backup of `/home/dac/sleepypod-core` → `systemctl stop sleepypod.service` → **then** `curl -fSL "$RELEASE_URL" | tar xz` (`scripts/bin/sp-update:203`). Service stop typically happens 5–15s in.
5. At t+5s the old service is **still running** → `version.refetch()` resolves → UI treats this as "service is back" and calls `reblockIfNeeded()` → iptables re-blocked.
6. `sp-update` then hits the release-tarball `curl` with WAN blocked → fails → cleanup → service starts on OLD code.

User-visible symptom: pressing **Check for Updates** appears to do nothing.

## Fix

- Snapshot `{commitHash, buildDate}` from `versionData` immediately before `triggerUpdate`.
- In `pollForReconnection`, only call the update "done" when **either** the version actually changed **or** a poll has already failed (proves the service bounced).
- Switch from `version.refetch()` (resolves on error) to `utils.system.getVersion.fetch({})` (throws on error) so the down-detection signal is real.
- Bumped `maxAttempts` 60→90 (~2min → ~3min) because the legitimate window is now longer.
- Sync the new value into the React-Query cache via `utils.system.getVersion.setData` so other consumers re-render without an extra round-trip.

## Test plan

- [ ] With WAN blocked: press **Check for Updates** → **Allow & Update**. Confirm:
  - UI shows "Reconnecting..." while sp-update downloads/builds.
  - WAN stays **open** for the full download/build window (no premature re-block).
  - After service restarts on the new build, version chip updates and WAN is re-blocked.
- [ ] With WAN already open: press **Check for Updates** → **Confirm Update**. Same expectations minus the unblock/re-block.
- [ ] If sp-update fails before stopping the service (e.g. preflight error): polling eventually times out with a clear error rather than incorrectly succeeding.
- [ ] Manual `journalctl -u sleepypod -f` confirms a single stop + start cycle, not a stop → mid-WAN-block → fail → restart-on-old-code sequence.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/update-card-reblock-race
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/update-card-reblock-race/scripts/install \
  | sudo bash -s -- --branch fix/update-card-reblock-race
```

🎯 **Pin to this exact build** ([run 26426829683](https://github.com/sleepypod/core/actions/runs/26426829683) · `3d78692`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/3d78692e5d095766f42b6a19c2f8733870010014/scripts/install \
  | sudo bash -s -- \
      --branch fix/update-card-reblock-race \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26426829683/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26426829683/artifacts/7207132478) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
