### PR TITLE
fix(side-selector): button edges meet at center under link icon

### DIFF
--- a/src/components/SideSelector/SideSelector.tsx
+++ b/src/components/SideSelector/SideSelector.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx'
 import { Link, LinkIcon, Power, TrendingDown, TrendingUp } from 'lucide-react'
-import { useSide, type Side } from '@/src/providers/SideProvider'
+import { useSide } from '@/src/providers/SideProvider'
 import { useDeviceStatus } from '@/src/hooks/useDeviceStatus'
 import { useSideNames } from '@/src/hooks/useSideNames'
 import { determineTrend, ensureF, formatTemp } from '@/src/lib/tempUtils'
@@ -34,7 +34,6 @@ export const SideSelector = () => {
         )}
       >
         <SideButton
-          side="left"
           label={leftName}
           isSelected={selectedSide === 'left' || selectedSide === 'both'}
           isLinked={isLinked}
@@ -42,7 +41,6 @@ export const SideSelector = () => {
           onSelect={() => selectSide('left')}
         />
         <SideButton
-          side="right"
           label={rightName}
           isSelected={selectedSide === 'right' || selectedSide === 'both'}
           isLinked={isLinked}
@@ -73,7 +71,6 @@ export const SideSelector = () => {
 }
 
 interface SideButtonProps {
-  side: Side
   label: string
   isSelected: boolean
   isLinked: boolean
@@ -88,7 +85,6 @@ interface SideButtonProps {
 }
 
 const SideButton = ({
-  side,
   label,
   isSelected,
   isLinked,
@@ -116,7 +112,6 @@ const SideButton = ({
       className={clsx(
         'flex-1 flex flex-col items-center py-3 px-2 rounded-[12px] sm:py-[14px] sm:px-4',
         'bg-transparent text-zinc-500 cursor-pointer transition-all duration-200 ease-in-out',
-        side === 'left' ? 'mr-3 sm:mr-4' : 'ml-3 sm:ml-4',
         showIndividualHighlight && 'bg-[rgb(30,42,58)] border border-sky-500/30',
       )}
     >


### PR DESCRIPTION
## Summary

- Drops the per-button `mr-3 sm:mr-4` / `ml-3 sm:ml-4` from `SideButton` so the two `flex-1` children meet exactly at 50% of the container.
- The absolute-positioned link button at `left-1/2 -translate-x-1/2` now straddles that edge through its center, restoring the original design.
- Removes the now-unused `side` prop (and stale `Side` type import).

## Why

7ad591d (browser UI parity with sleepypod-ios #239) bumped per-button margins from `mr-2/ml-2` to `mr-3 sm:mr-4 / ml-3 sm:ml-4`. With `flex-1`, that left each button's inner edge 12–16 px short of the container's horizontal center, so the selected-side blue border no longer ran through the link icon's middle — visible regression on every page that renders the selector.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` 0 errors (2 pre-existing warnings unrelated)
- [ ] Manual: deploy to a pod, confirm the blue selection border on each side passes through the link icon's center on both mobile and `sm+` breakpoints

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/side-selector-edge-alignment
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/side-selector-edge-alignment/scripts/install \
  | sudo bash -s -- --branch fix/side-selector-edge-alignment
```

🎯 **Pin to this exact build** ([run 26431910586](https://github.com/sleepypod/core/actions/runs/26431910586) · `56ea10b`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/56ea10b425d6850bac509df5015dc54848fb0dd8/scripts/install \
  | sudo bash -s -- \
      --branch fix/side-selector-edge-alignment \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26431910586/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26431910586/artifacts/7208802524) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
