### PR TITLE
test(mqtt): cover non-null flowrate branch (closes v2.3.0 codecov partials)

### DIFF
--- a/src/streaming/tests/mqttBridge.test.ts
+++ b/src/streaming/tests/mqttBridge.test.ts
@@ -1255,6 +1255,37 @@ describe('mqttBridge — publishState DB failures', () => {
     await shutdownMqttBridge()
   })
 
+  it('publishes scaled loop_temp_c when flow row has numeric flowrate', async () => {
+    dbMock.state.bedTempRow = {
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      ambientTemp: 2000,
+      humidity: 5000,
+      leftPumpRpm: 1900,
+      rightPumpRpm: 1900,
+      leftFlowrateCd: 2050, // 20.5°C
+      rightFlowrateCd: 2150, // 21.5°C
+    }
+
+    const fake = await startBridgeWithFake()
+    fake.connected = true
+    fake.emit('connect')
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+
+    const loopTempLeft = fake.publish.mock.calls.find(([t]) =>
+      String(t).endsWith('/pump/left/loop_temp_c'),
+    )
+    const loopTempRight = fake.publish.mock.calls.find(([t]) =>
+      String(t).endsWith('/pump/right/loop_temp_c'),
+    )
+    expect(loopTempLeft).toBeDefined()
+    expect(loopTempRight).toBeDefined()
+    expect(JSON.parse(String(loopTempLeft?.[1])).temperature).toBeCloseTo(20.5, 2)
+    expect(JSON.parse(String(loopTempRight?.[1])).temperature).toBeCloseTo(21.5, 2)
+
+    await shutdownMqttBridge()
+  })
+
   it('publishes pump stall as "on" when a notice is active', async () => {
     const { setPumpStallNotice, resetPumpStallNotifications } = await import('@/src/hardware/pumpStallNotification')
     resetPumpStallNotifications()


### PR DESCRIPTION
## Summary

Codecov flagged 2 partial lines on `src/streaming/mqttBridge.ts` in the v2.3.0 release PR (#621) — patch coverage 95.55%. Tracing the diff, the existing `publishes null loop_temp_c when flow row has null flowrate` test only exercises the null branch of `leftFlowrateCd != null ? .../100 : null` and the matching `rightFlowrateCd` ternary. The non-null arm of both ternaries was never hit.

This adds a sibling test that sets numeric `leftFlowrateCd: 2050` / `rightFlowrateCd: 2150` and asserts the published `loop_temp_c` payloads scale to `20.5` / `21.5` respectively — covering both non-null branches.

## Test plan

- [x] `vitest run src/streaming/tests/mqttBridge.test.ts -t loop_temp_c` — both null and numeric flow-rate tests pass
- [ ] Codecov on this PR reports `mqttBridge.ts` patch coverage 100%

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/mqtt-flow-loop-temp-coverage
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/mqtt-flow-loop-temp-coverage/scripts/install \
  | sudo bash -s -- --branch fix/mqtt-flow-loop-temp-coverage
```

🎯 **Pin to this exact build** ([run 26432922977](https://github.com/sleepypod/core/actions/runs/26432922977) · `d30111a`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/d30111a6483384de527569d2d9567d144b4835d0/scripts/install \
  | sudo bash -s -- \
      --branch fix/mqtt-flow-loop-temp-coverage \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26432922977/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26432922977/artifacts/7209152290) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for MQTT bridge temperature publishing functionality to ensure accurate scaling of temperature values across pump systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->