### PR TITLE
fix(install): add /usr/local/bin to sudo secure_path so 'sudo sp-update' works on fresh pods

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -656,10 +656,20 @@ fi
 # script and the API silently does nothing. Branch input is regex-
 # validated at the tRPC layer (^[a-zA-Z0-9._\-/]+$) and sp-update only
 # uses it as a tag/path component, so the privilege scope is narrow.
+#
+# The Defaults secure_path line re-adds /usr/local/bin to sudo's PATH.
+# The pod ships with the system-wide secure_path commented out in
+# /etc/sudoers, so sudo falls back to a minimal /usr/bin:/bin:/usr/sbin:/sbin
+# and `sudo sp-update dev` (the install snippet on every PR) fails with
+# "sp-update: command not found". Restoring the standard path here keeps
+# the sleepypod tools usable from any sudo shell without re-enabling the
+# system fragment, which might be commented out for a reason on the
+# vendor image.
 SUDOERS_FILE="/etc/sudoers.d/sleepypod-update"
-SUDOERS_CONTENT="sleepypod ALL=(root) NOPASSWD: /usr/local/bin/sp-update"
+SUDOERS_CONTENT='Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+sleepypod ALL=(root) NOPASSWD: /usr/local/bin/sp-update'
 SUDOERS_TMP=$(mktemp)
-echo "$SUDOERS_CONTENT" > "$SUDOERS_TMP"
+printf '%s\n' "$SUDOERS_CONTENT" > "$SUDOERS_TMP"
 chmod 0440 "$SUDOERS_TMP"
 if visudo -c -q -f "$SUDOERS_TMP"; then
   install -m 0440 -o root -g root "$SUDOERS_TMP" "$SUDOERS_FILE"


### PR DESCRIPTION
## Summary

On a fresh pod, `sudo sp-update dev` — the exact command the install snippet ships on every PR — fails with `sp-update: command not found`. Hit this while smoke-deploying the v2.3.0 release to eight-pod; only `sudo /usr/local/bin/sp-update dev` (explicit path) worked.

Root cause: the pod's `/etc/sudoers` has the standard `Defaults secure_path` line commented out, so sudo falls back to a minimal `/usr/bin:/bin:/usr/sbin:/sbin` PATH that excludes `/usr/local/bin` (where the sp-* tools live).

Fix: add a `Defaults secure_path` line to the existing `/etc/sudoers.d/sleepypod-update` fragment we already install. Scoped to our own fragment so we don't touch the vendor-shipped system fragment.

## Test plan

- [x] `visudo -c -q -f` accepts the new two-line fragment on the pod
- [x] After installing the new fragment on eight-pod: `sudo env | grep PATH` shows `/usr/local/bin` present; `sudo which sp-update` → `/usr/local/bin/sp-update`; `sudo sp-update --help` runs
- [ ] Fresh-pod install (curl bootstrap) → `sudo sp-update dev` works without explicit path

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/sudoers-secure-path
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/sudoers-secure-path/scripts/install \
  | sudo bash -s -- --branch fix/sudoers-secure-path
```

🎯 **Pin to this exact build** ([run 26434796180](https://github.com/sleepypod/core/actions/runs/26434796180) · `94f7be9`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/94f7be914197b8dd7c6057aa80c93322dde668b4/scripts/install \
  | sudo bash -s -- \
      --branch fix/sudoers-secure-path \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26434796180/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26434796180/artifacts/7209793203) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
