### PR TITLE
feat(install): storage-aware data dir (matches node_modules/swap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ boundary; the in-app unit preference is unaffected.
 The bridge's HomeKit identity (MAC-style username, pincode, setupId) is
 **deterministically derived** from a hardware-rooted seed (eMMC CID →
 machine-id → random fallback) via HKDF, and cached at
-`/persistent/sleepypod-data/homekit/identity.json`. A `/persistent` wipe or
+`$DATA_DIR/homekit/identity.json` (where `$DATA_DIR` is the picker-chosen
+data dir — see [`scripts/README.md`](scripts/README.md#file-locations);
+typically `/persistent/sleepypod-data/homekit/identity.json` on Pod 4/5).
+A `/persistent` wipe or
 firmware reflash regenerates the **same** identity, so iOS still recognizes
 the bridge — you only re-pair, your automations and rooms stay intact. See
 **[ADR 0020](docs/adr/0020-homekit-identity-derivation.md)** for the full

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -148,10 +148,12 @@ Downloaded from `nodejs.org/dist/` for `linux-arm64`. No package manager require
 | Path | Contents |
 |---|---|
 | `/home/dac/sleepypod-core` | App source + `node_modules` + `.next` build |
-| `/persistent/sleepypod-data/sleepypod.db` | Config database |
-| `/persistent/sleepypod-data/biometrics.db` | Biometrics database |
+| `$DATA_DIR/sleepypod.db` | Config database — `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size) and persisted to `/etc/sleepypod/data-dir`. Default on Pod 4/5: `/persistent/sleepypod-data/sleepypod.db`; on Pod 3 + SD card: `/sleepypod-data/sleepypod.db`. |
+| `$DATA_DIR/biometrics.db` | Biometrics database — same path resolution as above. |
+| `/etc/sleepypod/data-dir` | Pointer file with the chosen `$DATA_DIR`. Read by `sp-update` / `sp-maintenance` / `sp-bundle-logs` / `sp-uninstall` / `scripts/pod/detect`. |
 | `/home/dac/sleepypod-core/.env` | Environment config |
 | `/opt/sleepypod/modules/` | Python biometrics modules |
+| `/opt/sleepypod/python/` | `uv`-managed CPython (used when the firmware's `/usr/bin/python3` stdlib is incomplete — see `scripts/pod/capabilities`). |
 | `/usr/local/bin/sp-*` | CLI shortcuts |
 
 ## CLI Shortcuts (on the pod)

--- a/docs/wiki/topics/deployment.md
+++ b/docs/wiki/topics/deployment.md
@@ -84,7 +84,7 @@ uv (~30MB) is downloaded during install. Each biometrics module gets a `.venv/` 
 | Node.js | Binary tarball install |
 | DAC socket | Auto-detected from frank.sh |
 
-Key file locations: app at `/home/dac/sleepypod-core`, config DB at `/persistent/sleepypod-data/sleepypod.db`, biometrics DB at `/persistent/sleepypod-data/biometrics.db`.
+Key file locations: app at `/home/dac/sleepypod-core`, config DB at `$DATA_DIR/sleepypod.db`, biometrics DB at `$DATA_DIR/biometrics.db`. `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size; defaults: `/persistent/sleepypod-data` on Pod 4/5, `/sleepypod-data` on Pod 3 + SD card) and recorded in `/etc/sleepypod/data-dir` — `cat` that file on the Pod to see the live value.
 
 ## Coexistence with free-sleep
 

--- a/modules/archive-push/sleepypod-archive-push.service
+++ b/modules/archive-push/sleepypod-archive-push.service
@@ -8,6 +8,11 @@ Wants=network-online.target
 Type=oneshot
 User=sleepypod
 Group=sleepypod
+# Paths are rewritten at install time — `/persistent/sleepypod-data`
+# becomes the picker-chosen $DATA_DIR (see scripts/install archive-push
+# block) so this matches where biometrics.db actually lives.
+Environment="BIOMETRICS_DB_PATH=/persistent/sleepypod-data/biometrics.db"
+Environment="ARCHIVE_PUSH_STAGING_DIR=/persistent/sleepypod-data/archive-push-staging"
 ExecStart=/usr/local/bin/sleepypod-archive-push
 Nice=10
 IOSchedulingClass=idle

--- a/modules/calibrator/sleepypod-calibrator.service
+++ b/modules/calibrator/sleepypod-calibrator.service
@@ -19,6 +19,10 @@ EnvironmentFile=-/etc/sleepypod/modules/calibrator.env
 Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="DATABASE_URL=file:/persistent/sleepypod-data/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:/persistent/sleepypod-data/biometrics.db"
+# Path is rewritten at install time by install_module() — /persistent/sleepypod-data
+# becomes the picker-chosen $DATA_DIR so the calibrator (reader) and the
+# tRPC trigger writer (next-server) agree on a path that exists.
+Environment="CALIBRATION_TRIGGER_PATH=/persistent/sleepypod-data/.calibrate-trigger"
 Environment="CALIBRATION_HOUR=6"
 
 # Resource limits (calibration loads up to 6h of sensor data into numpy

--- a/modules/environment-monitor/README.md
+++ b/modules/environment-monitor/README.md
@@ -29,14 +29,16 @@ The freezer table only populates on hardware that actually emits `frzTemp` frame
 # Live logs (decisions, dropped sentinels, fatal errors)
 journalctl -u sleepypod-environment-monitor.service -f
 
-# Most recent rows
-sqlite3 /persistent/sleepypod-data/biometrics.db \
+# Most recent rows ($DATA_DIR is read from /etc/sleepypod/data-dir;
+# typically /persistent/sleepypod-data on Pod 4/5, /sleepypod-data on Pod 3 + SD)
+DATA_DIR="$(cat /etc/sleepypod/data-dir 2>/dev/null || echo /persistent/sleepypod-data)"
+sqlite3 "$DATA_DIR/biometrics.db" \
   'SELECT * FROM bed_temp ORDER BY timestamp DESC LIMIT 3;'
-sqlite3 /persistent/sleepypod-data/biometrics.db \
+sqlite3 "$DATA_DIR/biometrics.db" \
   'SELECT * FROM freezer_temp ORDER BY timestamp DESC LIMIT 3;'
 
 # Health row (component='environment-monitor' is updated on start/exit)
-sqlite3 /persistent/sleepypod-data/sleepypod.db \
+sqlite3 "$DATA_DIR/sleepypod.db" \
   "SELECT * FROM system_health WHERE component='environment-monitor';"
 ```
 
@@ -45,8 +47,8 @@ sqlite3 /persistent/sleepypod-data/sleepypod.db \
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `RAW_DATA_DIR` | `/persistent` | Directory the RAW follower tails. The systemd unit overrides to `/persistent/biometrics` (tmpfs) — see ADR-0018. |
-| `BIOMETRICS_DATABASE_URL` | `file:/persistent/sleepypod-data/biometrics.db` | Sink for `bed_temp` / `freezer_temp` rows. |
-| `DATABASE_URL` | `file:/persistent/sleepypod-data/sleepypod.db` | Used only to write `system_health` heartbeats. |
+| `BIOMETRICS_DATABASE_URL` | `file:/persistent/sleepypod-data/biometrics.db` | Sink for `bed_temp` / `freezer_temp` rows. The systemd unit overrides to `file:$DATA_DIR/biometrics.db` (install-time `sed` substitution against the picker-chosen `$DATA_DIR` — see `scripts/install` `install_module()`). |
+| `DATABASE_URL` | `file:/persistent/sleepypod-data/sleepypod.db` | Used only to write `system_health` heartbeats. Same `$DATA_DIR` override as above. |
 
 ## Python version
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -239,7 +239,7 @@ Each module has a `pyproject.toml` and `uv.lock`. The install script runs `uv sy
 ## File Locations
 
 - **Installation**: `/home/dac/sleepypod-core/`
-- **Database**: `/persistent/sleepypod-data/sleepypod.db` (SQLite with Drizzle ORM)
+- **Database**: `$DATA_DIR/sleepypod.db` — `$DATA_DIR` is chosen at install time (larger of `/` vs `/persistent` by total partition size) and persisted to `/etc/sleepypod/data-dir`. Default on Pod 4/5: `/persistent/sleepypod-data`; on Pod 3 + SD card: `/sleepypod-data`. Override with `bash scripts/install --data-dir <path>`.
 - **Service**: `/etc/systemd/system/sleepypod.service`
 - **Environment**: `/home/dac/sleepypod-core/.env`
 
@@ -269,7 +269,7 @@ Common issues:
 Reset database:
 ```bash
 cd /home/dac/sleepypod-core
-rm /persistent/sleepypod-data/sleepypod.db
+rm "$(cat /etc/sleepypod/data-dir 2>/dev/null || echo /persistent/sleepypod-data)/sleepypod.db"
 pnpm db:generate
 pnpm db:push
 sp-restart

--- a/scripts/bin/sp-bundle-logs
+++ b/scripts/bin/sp-bundle-logs
@@ -30,7 +30,13 @@ for arg in "$@"; do
 done
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 HOMEKIT_DIR="$DATA_DIR/homekit"
 INSTALL_LOG="/tmp/sleepypod-install.log"
 

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -6,7 +6,13 @@ set -euo pipefail
 # Called by sleepypod.service ExecStartPre so it runs before the app starts.
 # Keeps disk usage in check on the pod's limited storage (~6GB).
 
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 INSTALL_DIR="/home/dac/sleepypod-core"
 
 echo "=== SleepyPod Maintenance ==="

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -23,7 +23,14 @@ for arg in "$@"; do
 done
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+# The pointer itself is cleaned up by `rm -rf /etc/sleepypod` below.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 MODULES_DIR="/opt/sleepypod/modules"
 
 if [ "$FORCE" != true ]; then

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -310,6 +310,16 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   if ! command -v uv &>/dev/null; then
     echo "Warning: uv not found — biometrics modules not synced. Re-run the full installer."
   fi
+  # Probe the firmware's /usr/bin/python3 for stdlib integrity. Pod 5
+  # firmware (debian variant) ships 3.9.9 with unittest, dataclasses,
+  # and pyexpat stripped — version check passes, uv would happily bind
+  # the venv to it, modules crash at startup. Mirror install_module()'s
+  # behavior here so OTAs don't silently revert to the broken interpreter.
+  # If capabilities is missing (transitional install), default to "true"
+  # to keep the previous behavior (no managed-Python forcing).
+  if [ -f "$INSTALL_DIR/scripts/pod/capabilities" ]; then
+    source "$INSTALL_DIR/scripts/pod/capabilities"
+  fi
   for mod in piezo-processor sleep-detector environment-monitor calibrator cover-buttons; do
     if [ -d "$INSTALL_DIR/modules/$mod" ]; then
       mkdir -p "$MODULES_DEST/$mod"
@@ -322,13 +332,29 @@ if [ -d "$INSTALL_DIR/modules" ]; then
       # re-link, not a full re-download.
       rm -rf "$MODULES_DEST/$mod/.venv"
       if command -v uv &>/dev/null; then
-        (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
+        _uv_sync_args=(--frozen)
+        if [ "${SYSTEM_PYTHON_STDLIB_INTACT:-true}" = "false" ]; then
+          _uv_sync_args+=(--python-preference only-managed)
+        fi
+        (cd "$MODULES_DEST/$mod" && uv sync "${_uv_sync_args[@]}") \
           || echo "Warning: uv sync failed for module $mod"
+        unset _uv_sync_args
         chmod -R o+rX "$MODULES_DEST/$mod/.venv" 2>/dev/null || true
       fi
       svc="sleepypod-$mod.service"
       if [ -f "$MODULES_DEST/$mod/$svc" ]; then
-        cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
+        # Substitute the chosen $DATA_DIR for the baked-in
+        # /persistent/sleepypod-data — the unit's ReadWritePaths= and
+        # DATABASE_URL=/CALIBRATION_TRIGGER_PATH= reference it, and on
+        # installs where the picker chose /sleepypod-data the hardcoded
+        # path doesn't exist → systemd "Failed to set up mount
+        # namespacing". Mirrors install_module() in scripts/install so
+        # OTAs don't stomp the substituted unit with a vanilla copy.
+        _data_dir_sed=${DATA_DIR//|/\\|}
+        sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+          "$MODULES_DEST/$mod/$svc" > "/etc/systemd/system/$svc"
+        chmod 0644 "/etc/systemd/system/$svc"
+        unset _data_dir_sed
         systemctl daemon-reload
         systemctl enable "$svc" 2>/dev/null || true
         systemctl restart "$svc" 2>/dev/null || true

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -348,10 +348,14 @@ if [ -d "$INSTALL_DIR/modules" ]; then
         # DATABASE_URL=/CALIBRATION_TRIGGER_PATH= reference it, and on
         # installs where the picker chose /sleepypod-data the hardcoded
         # path doesn't exist → systemd "Failed to set up mount
-        # namespacing". Mirrors install_module() in scripts/install so
-        # OTAs don't stomp the substituted unit with a vanilla copy.
-        _data_dir_sed=${DATA_DIR//|/\\|}
-        sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+        # namespacing". Mirrors install_module() in scripts/install
+        # (boundary match + replacement escapes) so OTAs don't stomp
+        # the substituted unit with a vanilla copy. Keep the two
+        # sed expressions in sync.
+        _data_dir_sed=${DATA_DIR//\\/\\\\}
+        _data_dir_sed=${_data_dir_sed//&/\\&}
+        _data_dir_sed=${_data_dir_sed//|/\\|}
+        sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
           "$MODULES_DEST/$mod/$svc" > "/etc/systemd/system/$svc"
         chmod 0644 "/etc/systemd/system/$svc"
         unset _data_dir_sed

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -16,7 +16,13 @@ export PATH="/usr/local/bin:$PATH"
 # No git required — uses GitHub's tarball API.
 
 INSTALL_DIR="/home/dac/sleepypod-core"
-DATA_DIR="/persistent/sleepypod-data"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker).
+# Legacy fallback keeps installs without the pointer file working.
+if [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+else
+  DATA_DIR="/persistent/sleepypod-data"
+fi
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
 BRANCH="${1:-main}"
 

--- a/scripts/install
+++ b/scripts/install
@@ -1546,10 +1546,22 @@ else
     # file or directory". ReadWritePaths= is a unit directive so an
     # EnvironmentFile drop-in can't fix it — substitution at install
     # time is the only path.
+    #
+    # The match requires /persistent/sleepypod-data to be followed by
+    # one of [/" \t] (path separator, env-value quote closer, or
+    # whitespace) OR end-of-line, so any future hardcoded path that
+    # legitimately starts with the same stem (e.g.
+    # /persistent/sleepypod-data-old/foo) is NOT partially rewritten.
+    # The replacement is sed-escaped for `\` and `&` so an exotic
+    # --data-dir override can't trigger sed's whole-match (&) or
+    # escape (\) substitution syntax. sp-update has the same block —
+    # keep them in sync.
     if [ -f "$dest/$service" ]; then
-      _data_dir_sed=${DATA_DIR//|/\\|}
-      sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" "$dest/$service" \
-        > "/etc/systemd/system/$service"
+      _data_dir_sed=${DATA_DIR//\\/\\\\}
+      _data_dir_sed=${_data_dir_sed//&/\\&}
+      _data_dir_sed=${_data_dir_sed//|/\\|}
+      sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
+        "$dest/$service" > "/etc/systemd/system/$service"
       chmod 0644 "/etc/systemd/system/$service"
       unset _data_dir_sed
       systemctl daemon-reload
@@ -1609,11 +1621,15 @@ if [ -d "$PUSH_SRC" ]; then
 
   install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
   # Substitute $DATA_DIR for the baked-in /persistent/sleepypod-data —
-  # ReadWritePaths= in the unit references that path and the namespace
-  # bind-mount fails when the picker chose /sleepypod-data. Same fix as
-  # install_module() above.
-  _data_dir_sed=${DATA_DIR//|/\\|}
-  sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+  # ReadWritePaths= + BIOMETRICS_DB_PATH= + ARCHIVE_PUSH_STAGING_DIR= in
+  # the unit reference that path and the namespace bind-mount fails
+  # when the picker chose /sleepypod-data. Defensive boundary match +
+  # replacement escapes — same regex as install_module() above, see
+  # the comment there for the boundary-match rationale.
+  _data_dir_sed=${DATA_DIR//\\/\\\\}
+  _data_dir_sed=${_data_dir_sed//&/\\&}
+  _data_dir_sed=${_data_dir_sed//|/\\|}
+  sed -E "s|/persistent/sleepypod-data([/\"[:space:]])|${_data_dir_sed}\\1|g; s|/persistent/sleepypod-data\$|${_data_dir_sed}|g" \
     "$PUSH_SRC/sleepypod-archive-push.service" \
     > /etc/systemd/system/sleepypod-archive-push.service
   chmod 0644 /etc/systemd/system/sleepypod-archive-push.service

--- a/scripts/install
+++ b/scripts/install
@@ -1502,10 +1502,24 @@ else
     # If system python3 is in range it's used; otherwise uv downloads a
     # compatible managed interpreter into UV_PYTHON_INSTALL_DIR (set above
     # to /opt/sleepypod/python so User=dac modules can execute it).
-    (cd "$dest" && uv sync --frozen) || {
+    #
+    # Exception: Pod 3 firmware (debian variant) ships /usr/bin/python3
+    # = 3.9.9 with `unittest`, `dataclasses`, and `pyexpat` stripped from
+    # the stdlib. The version range check passes so uv would happily
+    # bind to it, then the module crashes at startup with
+    # `ModuleNotFoundError: No module named 'unittest'` once numpy lazy-
+    # imports numpy.testing. Force uv onto a managed interpreter when
+    # the stdlib probe (scripts/pod/capabilities) says it's not intact.
+    _uv_sync_args=(--frozen)
+    if [ "${SYSTEM_PYTHON_STDLIB_INTACT:-true}" = "false" ]; then
+      _uv_sync_args+=(--python-preference only-managed)
+    fi
+    (cd "$dest" && uv sync "${_uv_sync_args[@]}") || {
       echo "Warning: uv sync failed for module $name"
+      unset _uv_sync_args
       return
     }
+    unset _uv_sync_args
 
     # Ensure non-root service users (User=dac on calibrator + env-monitor)
     # can read the venv dir + traverse the managed-Python symlink target.

--- a/scripts/install
+++ b/scripts/install
@@ -1511,9 +1511,22 @@ else
     # can read the venv dir + traverse the managed-Python symlink target.
     chmod -R o+rX "$dest/.venv" 2>/dev/null || true
 
-    # Install systemd service
+    # Install systemd service. Substitute the chosen $DATA_DIR for the
+    # baked-in /persistent/sleepypod-data — ReadWritePaths= and the
+    # DATABASE_URL= envs in the unit reference that path, and on installs
+    # where the picker chose /sleepypod-data (rootfs larger than
+    # /persistent — e.g. Pod 3 + SD card) the hardcoded path doesn't
+    # exist, so systemd fails the namespace bind-mount with "Failed to
+    # set up mount namespacing: .../persistent/sleepypod-data: No such
+    # file or directory". ReadWritePaths= is a unit directive so an
+    # EnvironmentFile drop-in can't fix it — substitution at install
+    # time is the only path.
     if [ -f "$dest/$service" ]; then
-      cp "$dest/$service" "/etc/systemd/system/$service"
+      _data_dir_sed=${DATA_DIR//|/\\|}
+      sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" "$dest/$service" \
+        > "/etc/systemd/system/$service"
+      chmod 0644 "/etc/systemd/system/$service"
+      unset _data_dir_sed
       systemctl daemon-reload
       systemctl enable "$service"
       systemctl restart "$service"
@@ -1570,7 +1583,16 @@ if [ -d "$PUSH_SRC" ]; then
   echo "Installing archive-push (scp to remote)..."
 
   install -m 0755 "$PUSH_SRC/sleepypod-archive-push" /usr/local/bin/sleepypod-archive-push
-  install -m 0644 "$PUSH_SRC/sleepypod-archive-push.service" /etc/systemd/system/
+  # Substitute $DATA_DIR for the baked-in /persistent/sleepypod-data —
+  # ReadWritePaths= in the unit references that path and the namespace
+  # bind-mount fails when the picker chose /sleepypod-data. Same fix as
+  # install_module() above.
+  _data_dir_sed=${DATA_DIR//|/\\|}
+  sed "s|/persistent/sleepypod-data|${_data_dir_sed}|g" \
+    "$PUSH_SRC/sleepypod-archive-push.service" \
+    > /etc/systemd/system/sleepypod-archive-push.service
+  chmod 0644 /etc/systemd/system/sleepypod-archive-push.service
+  unset _data_dir_sed
   install -m 0644 "$PUSH_SRC/sleepypod-archive-push.timer"   /etc/systemd/system/
 
   # Config dir owned root:sleepypod 0770 so the service user reads + the app

--- a/scripts/install
+++ b/scripts/install
@@ -1277,6 +1277,17 @@ Environment="NODE_ENV=production"
 Environment="DATABASE_URL=file:$DATA_DIR/sleepypod.db"
 Environment="BIOMETRICS_DATABASE_URL=file:$DATA_DIR/biometrics.db"
 Environment="DAC_SOCK_PATH=$DAC_SOCK_PATH"
+# Route every runtime path that used to be hardcoded under
+# /persistent/sleepypod-data through the picker-chosen \$DATA_DIR.
+# HomeKit pairing + identity (src/homekit/storage.ts), calibration
+# trigger written by tRPC + scheduler and read by sleepypod-calibrator
+# (src/server/routers/calibration.ts, src/scheduler/jobManager.ts,
+# modules/common/calibration.py), and the archive-export staging dir
+# (app/api/export/archive/route.ts) all read these envs with the legacy
+# hardcoded path as fallback for installs that pre-date this wiring.
+Environment="HOMEKIT_DIR=$DATA_DIR/homekit"
+Environment="CALIBRATION_TRIGGER_PATH=$DATA_DIR/.calibrate-trigger"
+Environment="EXPORT_STAGING_DIR=$DATA_DIR/export-staging"
 # RAW frames live in the tmpfs at /persistent/biometrics (ADR 0018).
 # Without this override piezoStream defaults to /persistent and tries to
 # decode the 16-byte SEQNO.RAW bookkeeping file as CBOR — sensor streaming

--- a/scripts/install
+++ b/scripts/install
@@ -41,10 +41,11 @@ INSTALL_BRANCH=""
 ARTIFACT_URL_OVERRIDE=""
 PURGE_FREE_SLEEP=false
 RESTORE_MODE=false
-# Preserve env-supplied overrides; --node-modules-dir / --swap-dir can still
-# clobber them below. Lets `NODE_MODULES_DIR=/foo bash scripts/install` work.
+# Preserve env-supplied overrides; --node-modules-dir / --swap-dir / --data-dir
+# can still clobber them below. Lets `NODE_MODULES_DIR=/foo bash scripts/install` work.
 NODE_MODULES_DIR="${NODE_MODULES_DIR:-}"
 SWAP_DIR="${SWAP_DIR:-}"
+DATA_DIR_OVERRIDE="${DATA_DIR:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --local)              INSTALL_LOCAL=true ;;
@@ -55,15 +56,51 @@ while [ $# -gt 0 ]; do
     --restore)            RESTORE_MODE=true ;;
     --node-modules-dir)   shift; NODE_MODULES_DIR="${1:-}" ;;
     --swap-dir)           shift; SWAP_DIR="${1:-}" ;;
+    --data-dir)           shift; DATA_DIR_OVERRIDE="${1:-}" ;;
   esac
   shift
 done
 export NODE_MODULES_DIR
 
+# Resolve DATA_DIR (SQLite home) before anything that touches it. Precedence:
+#   1. --data-dir / DATA_DIR env override
+#   2. /etc/sleepypod/data-dir written by a prior install run
+#   3. Auto: larger of rootfs vs /persistent (total size — same picker as
+#      swap below and node_modules in scripts/lib/relocation-helpers).
+#
+# Restore mode (below) uses $DATA_DIR too, so this MUST run before that block.
+# Relocation-helpers isn't sourced yet (repo not on disk), so the picker is
+# inlined here, matching the swap-picker / iptables-helpers pattern.
+DATA_DIR_REASON=""
+if [ -n "$DATA_DIR_OVERRIDE" ]; then
+  DATA_DIR="$DATA_DIR_OVERRIDE"
+  DATA_DIR_REASON="user override (--data-dir / DATA_DIR)"
+elif [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+  DATA_DIR_REASON="cached from prior install (/etc/sleepypod/data-dir)"
+else
+  _rootfs_total_mb=$(df -m / 2>/dev/null | awk 'NR==2{print $2}')
+  _rootfs_total_mb=${_rootfs_total_mb:-0}
+  if mountpoint -q /persistent 2>/dev/null; then
+    _persistent_total_mb=$(df -m /persistent 2>/dev/null | awk 'NR==2{print $2}')
+    _persistent_total_mb=${_persistent_total_mb:-0}
+  else
+    _persistent_total_mb=0
+  fi
+  if [ "$_persistent_total_mb" -gt "$_rootfs_total_mb" ]; then
+    DATA_DIR="/persistent/sleepypod-data"
+    DATA_DIR_REASON="/persistent is the larger partition"
+  else
+    DATA_DIR="/sleepypod-data"
+    DATA_DIR_REASON="rootfs is the larger partition"
+  fi
+  unset _rootfs_total_mb _persistent_total_mb
+fi
+
 # --------------------------------------------------------------------------------
 # Restore mode — list and restore a DB backup, then exit
 if [ "$RESTORE_MODE" = true ]; then
-  DATA_DIR="/persistent/sleepypod-data"
+  # $DATA_DIR was resolved above (override > cached > auto-picker).
 
   # Collect all backup files for both databases
   mapfile -t BACKUPS < <(ls -1t "$DATA_DIR"/*.db.bak.* 2>/dev/null)
@@ -617,8 +654,29 @@ fi
 # environment-monitor run as User=dac. Setgid ensures all files created
 # inside inherit the sleepypod group; UMask=0002 on services ensures
 # group-write bits are preserved (including SQLite WAL/SHM files).
-DATA_DIR="/persistent/sleepypod-data"
-echo "Creating data directory at $DATA_DIR..."
+#
+# $DATA_DIR was resolved at the top of this script. Same auto-picker as
+# node_modules / swap — pick the larger of rootfs vs /persistent.
+echo "Creating data directory at $DATA_DIR  (${DATA_DIR_REASON})..."
+
+# Migrate from a legacy /persistent/sleepypod-data layout if the picker
+# now wants a different partition. Same empty-target guard as the
+# node_modules migration in ensure_persistent_node_modules() — avoids
+# mixing DBs from two different installs.
+LEGACY_DATA_DIR="/persistent/sleepypod-data"
+if [ "$DATA_DIR" != "$LEGACY_DATA_DIR" ] && [ -d "$LEGACY_DATA_DIR" ] \
+   && [ -z "$(ls -A "$DATA_DIR" 2>/dev/null)" ]; then
+  echo "Migrating data dir from $LEGACY_DATA_DIR to $DATA_DIR..."
+  mkdir -p "$(dirname "$DATA_DIR")"
+  mv "$LEGACY_DATA_DIR" "$DATA_DIR"
+fi
+
+# Persist the chosen path so sp-update / sp-maintenance / sp-bundle-logs /
+# sp-uninstall / pod/detect find the DBs in the same place. sp-uninstall
+# already rm -rf's /etc/sleepypod so no cleanup hook needed there.
+mkdir -p /etc/sleepypod
+printf '%s\n' "$DATA_DIR" > /etc/sleepypod/data-dir
+chmod 0644 /etc/sleepypod/data-dir
 # Ensure ReadWritePaths directories exist — systemd's ProtectSystem=strict
 # requires all listed paths to exist or the namespace setup fails.
 # /run/dac is handled by RuntimeDirectory=dac in the service unit.

--- a/scripts/pod/capabilities
+++ b/scripts/pod/capabilities
@@ -19,6 +19,15 @@
 #   PACKAGE_MANAGER                 "apt" or "" (none)
 #   SYSTEM_PYTHON_VERSION           e.g. "3.10.4", "" if python3 missing
 #   SYSTEM_PYTHON_IN_BIOMETRICS_RANGE  "true" if in [3.9, 3.11), else "false"
+#   SYSTEM_PYTHON_STDLIB_INTACT     "true" / "false" — probes a handful of
+#                                   stdlib modules the biometrics modules
+#                                   import (directly or transitively). Pod 3
+#                                   firmware ships a Yocto-stripped Python
+#                                   3.9.9 with unittest + dataclasses removed,
+#                                   so the version check passes but
+#                                   `numpy.testing → from unittest import …`
+#                                   crashes at module import. Install uses
+#                                   this to force uv onto a managed Python.
 #   HAS_ENSUREPIP                   "true" / "false"
 #   HAS_NFTABLES                    "true" / "false"
 #   HAS_VOLTA                       "true" if Volta is present in PATH or ~/.volta
@@ -58,6 +67,22 @@ _python_in_biometrics_range() {
 _probe_has_ensurepip() {
   command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
   if python3 -c 'import ensurepip' 2>/dev/null; then echo "true"; else echo "false"; fi
+}
+
+_probe_python_stdlib_intact() {
+  # Pod 3 firmware (debian variant) ships /usr/bin/python3 = 3.9.9 with
+  # parts of the stdlib stripped: `unittest`, `dataclasses`, and
+  # `pyexpat` are all missing. numpy 2.x lazy-imports `numpy.testing`
+  # → `from unittest import TestCase` on first attribute access, so any
+  # module that uses numpy crashes at startup. The biometrics modules
+  # also `from dataclasses import dataclass`. Probe the modules we
+  # actually hit so install can route around the broken interpreter.
+  command -v python3 >/dev/null 2>&1 || { echo "false"; return; }
+  if python3 -c 'import unittest, dataclasses, pyexpat' 2>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
 }
 
 _probe_has_volta() {
@@ -103,12 +128,14 @@ fi
 IPTABLES_PATH="$(_probe_iptables_path)"
 SYSTEM_PYTHON_VERSION="$(_probe_python_version)"
 SYSTEM_PYTHON_IN_BIOMETRICS_RANGE="$(_python_in_biometrics_range)"
+SYSTEM_PYTHON_STDLIB_INTACT="$(_probe_python_stdlib_intact)"
 HAS_ENSUREPIP="$(_probe_has_ensurepip)"
 HAS_VOLTA="$(_probe_has_volta)"
 HAS_IPTABLES_PERSISTENT="$(_probe_has_iptables_persistent)"
 
 export MODEL_NAME POD_OS IPTABLES_PATH HAS_PACKAGE_MANAGER PACKAGE_MANAGER
-export SYSTEM_PYTHON_VERSION SYSTEM_PYTHON_IN_BIOMETRICS_RANGE HAS_ENSUREPIP
+export SYSTEM_PYTHON_VERSION SYSTEM_PYTHON_IN_BIOMETRICS_RANGE
+export SYSTEM_PYTHON_STDLIB_INTACT HAS_ENSUREPIP
 export HAS_NFTABLES HAS_VOLTA HAS_IPTABLES_PERSISTENT
 
 print_pod_capabilities() {
@@ -117,7 +144,7 @@ print_pod_capabilities() {
   echo "  OS:                   $POD_OS"
   echo "  iptables:             ${IPTABLES_PATH:-<missing>}"
   echo "  Package manager:      ${PACKAGE_MANAGER:-none}"
-  echo "  System python3:       ${SYSTEM_PYTHON_VERSION:-<missing>} (in biometrics range: $SYSTEM_PYTHON_IN_BIOMETRICS_RANGE)"
+  echo "  System python3:       ${SYSTEM_PYTHON_VERSION:-<missing>} (in biometrics range: $SYSTEM_PYTHON_IN_BIOMETRICS_RANGE, stdlib intact: $SYSTEM_PYTHON_STDLIB_INTACT)"
   echo "  ensurepip:            $HAS_ENSUREPIP"
   echo "  nftables:             $HAS_NFTABLES"
   echo "  Volta:                $HAS_VOLTA"

--- a/scripts/pod/detect
+++ b/scripts/pod/detect
@@ -9,6 +9,12 @@
 # via the hardware sensor label (see src/hardware/responseParser.ts).
 
 INSTALL_DIR="${INSTALL_DIR:-/home/dac/sleepypod-core}"
+# DATA_DIR pointer is written by scripts/install (storage-aware picker:
+# /persistent vs rootfs by total partition size). Env override > pointer
+# file > legacy /persistent default for installs that pre-date the pointer.
+if [ -z "${DATA_DIR:-}" ] && [ -r /etc/sleepypod/data-dir ] && [ -s /etc/sleepypod/data-dir ]; then
+  DATA_DIR="$(cat /etc/sleepypod/data-dir)"
+fi
 DATA_DIR="${DATA_DIR:-/persistent/sleepypod-data}"
 
 # Only accept known firmware-supported socket locations

--- a/src/homekit/storage.ts
+++ b/src/homekit/storage.ts
@@ -2,8 +2,9 @@
  * On-disk storage for HomeKit pairings, accessory identity, and setup code.
  *
  * Persists across next-server restart and sp-update. Lives under
- * /persistent/sleepypod-data/homekit/ in production; falls back to a path
- * under the project root in dev.
+ * $HOMEKIT_DIR (set by the systemd unit to $DATA_DIR/homekit, where
+ * $DATA_DIR is chosen by the install-time storage picker) in production;
+ * falls back to a path under the project root in dev.
  *
  * Identity is derived deterministically (HKDF over a hardware-rooted seed
  * chain — see ADR 0020) so that wiping /persistent regenerates the same
@@ -18,7 +19,10 @@ import { hkdfSync, randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 import { HAPStorage } from 'hap-nodejs'
 
-const PERSISTENT_DIR = '/persistent/sleepypod-data/homekit'
+// Env override lets the install script point this at the picker-chosen
+// $DATA_DIR (e.g. /sleepypod-data on Pod 3 + SD card). The hardcoded
+// legacy default keeps installs that pre-date the env wiring working.
+const PERSISTENT_DIR = process.env.HOMEKIT_DIR ?? '/persistent/sleepypod-data/homekit'
 const DEV_DIR = join(process.cwd(), '.homekit-data')
 
 const IDENTITY_FILE = 'identity.json'


### PR DESCRIPTION
## Summary

Seven follow-up fixes uncovered by installing the storage-aware branch on a real Pod 3 (debian variant, `/dev/root` 6.6 GB > `/persistent` 966 MB → picker chose rootfs). The branch shipped the picker for `node_modules` + swap; this PR extends the same routing to **every** path that used to be hardcoded under `/persistent/sleepypod-data` (SQLite home, HomeKit storage, calibration trigger, export staging, archive-push staging), makes the per-module systemd units honor the chosen `$DATA_DIR`, routes around the firmware's broken `/usr/bin/python3`, mirrors both fixes into `sp-update` so OTAs don't regress, hardens the path substitution against partial-prefix collisions, and updates the docs.

## Changes

### 1. Storage-aware `DATA_DIR` (`f779291`)

Same picker as `node_modules` / swap: pick the partition with more total size for the SQLite home. Choice is persisted to `/etc/sleepypod/data-dir` so every consumer reads from one source of truth.

- `scripts/install` — adds `DATA_DIR` resolution at the top (override → cached pointer → auto-pick), migrates from legacy `/persistent/sleepypod-data` when the picker now wants a different partition, and writes the chosen path to `/etc/sleepypod/data-dir`.
- `scripts/pod/detect`, `scripts/bin/{sp-update,sp-maintenance,sp-bundle-logs,sp-uninstall}` — read the pointer file with a legacy fallback to `/persistent/sleepypod-data`, so installs that pre-date the pointer keep working.
- `scripts/README.md` — documents the new behavior + override.

### 2. Substitute `$DATA_DIR` into per-module systemd units (`e713c69`)

The per-module `.service` files (`piezo-processor`, `sleep-detector`, `environment-monitor`, `calibrator`, `cover-buttons`, `archive-push`) ship with `ReadWritePaths=/persistent/sleepypod-data` and matching `DATABASE_URL` / `BIOMETRICS_DATABASE_URL` envs baked in. When the picker chose `/sleepypod-data`, systemd failed namespace setup:

```
Failed to set up mount namespacing: /run/systemd/unit-root/persistent/sleepypod-data: No such file or directory
```

Fix: `install_module()` and the archive-push install block now `sed`-substitute `$DATA_DIR` for `/persistent/sleepypod-data` while installing each unit (`|` delimiter, with `$DATA_DIR` escaped for sed safety). `ReadWritePaths=` is a unit directive, so an `EnvironmentFile=` drop-in couldn't fix it — substitution at install time is the only path.

### 3. Route around Yocto-stripped `/usr/bin/python3` (`96373a1`)

Pod 3 firmware (debian variant) ships `/usr/bin/python3 = 3.9.9` with `unittest`, `dataclasses`, and `pyexpat` removed from the stdlib. The existing version-range check (`>=3.9,<3.11`) passed → `uv sync` bound the venv to the broken interpreter → modules crashed at startup:

```
piezo-processor  ModuleNotFoundError: No module named 'unittest'   # via numpy.testing
sleep-detector   ModuleNotFoundError: No module named 'dataclasses'
```

Fix:

- `scripts/pod/capabilities` — new `_probe_python_stdlib_intact` that runs `python3 -c 'import unittest, dataclasses, pyexpat'`. Exports `SYSTEM_PYTHON_STDLIB_INTACT`. Banner now reads `... in biometrics range: true, stdlib intact: false`.
- `scripts/install` — when `SYSTEM_PYTHON_STDLIB_INTACT=false`, `install_module()` passes `--python-preference only-managed` to `uv sync`, forcing uv to download a managed CPython (matching the pyprojects' `requires-python = ">=3.9,<3.11"`) into `UV_PYTHON_INSTALL_DIR=/opt/sleepypod/python` instead of binding to the broken system interpreter. Already-`chmod 0755`'d so `User=dac` services can exec it.

### 4. Route remaining runtime paths through `$DATA_DIR` (`9f8d7a5`)

Five runtime paths were still hardcoded `/persistent/sleepypod-data` even after the picker landed. On Pods where the picker chose `/sleepypod-data`, each one was silently broken — the install completed cleanly but features failed at runtime:

| Consumer | Path it wrote/read | Failure mode |
|---|---|---|
| `src/homekit/storage.ts` (no env override at all) | `/persistent/sleepypod-data/homekit/` | `mkdirSync` silently created a stray dir on the small `/persistent` partition, divergent from where the DB actually lives. |
| `src/server/routers/calibration.ts` (tRPC `startCalibration`) | `$CALIBRATION_TRIGGER_PATH ?? '/persistent/sleepypod-data/.calibrate-trigger'` — env never set by install | Trigger write went to a non-existent dir → ENOENT → calibration from the UI silently failed. |
| `src/scheduler/jobManager.ts` (pre-prime job) | Same env, same default | Scheduled calibration trigger never landed. |
| `modules/common/calibration.py` (calibrator reader) | Same env, never set on `sleepypod-calibrator.service` | Even if the writer had worked, the reader was watching a different dir. |
| `app/api/export/archive/route.ts` | `$EXPORT_STAGING_DIR ?? '/persistent/sleepypod-data/export-staging'` — env never set | Archive export wrote to a missing dir. |
| `modules/archive-push/sleepypod-archive-push` | `$BIOMETRICS_DB_PATH` + `$ARCHIVE_PUSH_STAGING_DIR`, both env-defaulted to `/persistent/sleepypod-data/...`, envs never set on the unit | Nightly archive-push silently no-op'd. |

Fix:

- `src/homekit/storage.ts` — read `HOMEKIT_DIR` env, fall back to the legacy path.
- `scripts/install` `sleepypod.service` heredoc — set `HOMEKIT_DIR`, `CALIBRATION_TRIGGER_PATH`, `EXPORT_STAGING_DIR`, each `= $DATA_DIR/<suffix>`.
- `modules/calibrator/sleepypod-calibrator.service` — add `CALIBRATION_TRIGGER_PATH=/persistent/sleepypod-data/.calibrate-trigger`; the install-time sed (commit 2) rewrites the path to the chosen `$DATA_DIR` so the calibrator (reader) and the next-server (writer) agree.
- `modules/archive-push/sleepypod-archive-push.service` — add `BIOMETRICS_DB_PATH` and `ARCHIVE_PUSH_STAGING_DIR` with the same legacy literal; install-time sed handles the rewrite.

Every consumer keeps its `??` / `os.environ.get(...)` fallback to the old hardcoded path, so installs that haven't been re-run yet still work — they just keep writing to `/persistent/sleepypod-data` like before.

### 5. `sp-update`: mirror `install_module`'s `$DATA_DIR` sed + managed-Python gate (`06262c3`)

`sp-update` independently re-syncs the biometrics modules on every OTA, and it had two regressions of fixes 2 and 3:

- `uv sync --frozen` ran without `--python-preference only-managed`, so an OTA on a Pod with a Yocto-stripped `/usr/bin/python3` would re-bind every module venv to the broken interpreter and crash at startup.
- The module `.service` files were `cp`'d verbatim into `/etc/systemd/system/`, stomping on the install-time `$DATA_DIR` substitution. On Pods where the picker chose `/sleepypod-data`, the next OTA would silently revert the units to `ReadWritePaths=/persistent/sleepypod-data` → namespace bind-mount failure on the next service restart.

Fix: source `scripts/pod/capabilities` (when present — keeps transitional installs working) to get `SYSTEM_PYTHON_STDLIB_INTACT`; conditionally pass `--python-preference only-managed`; replace the bare `cp` with the same `sed`-substitute block as `install_module()`. Idempotent — on Pods where the picker chose `/persistent/sleepypod-data` the substitution is a textual no-op.

### 6. Harden the `$DATA_DIR` sed against partial-prefix matches and exotic `--data-dir` (`8ebaab6`)

The original substitution from commit 2 was a plain `s|/persistent/sleepypod-data|$DATA_DIR|g`. No paths starting with `/persistent/sleepypod-data-something` exist in the units we ship today, but anchoring the match defensively now costs nothing and removes a future foot-gun.

- **Match side:** require the path to be followed by one of `[/" \t]` (path separator, env-value quote closer, or whitespace) OR end-of-line. The captured trailing char is re-emitted so the rewrite is byte-correct. Future paths like `/persistent/sleepypod-data-old/foo` are left intact.
- **Replacement side:** escape `\` and `&` in `$DATA_DIR` before splicing. A `--data-dir` override containing `&` would otherwise trigger sed's whole-match substitution; `\` would consume the next char as an escape.

Applied to all three call sites (`install_module()`, the archive-push block in `scripts/install`, and the OTA path in `sp-update`). Verified with the actual unit-file content and against the partial-prefix decoy strings (`-old`, `-2`, `store`).

### 7. Docs: replace hardcoded `/persistent/sleepypod-data` with `$DATA_DIR` (`65b3635`)

User-facing docs that copy/pasted the old path either lied or handed the reader a `sqlite3` command that ENOENTs on a Pod where the picker chose rootfs.

- `README.md` — HomeKit identity durability section.
- `docs/DEPLOYMENT.md` — File Locations table; added entries for `/etc/sleepypod/data-dir` (pointer) and `/opt/sleepypod/python` (managed interpreters).
- `docs/wiki/topics/deployment.md` — one-liner key-locations sentence.
- `modules/environment-monitor/README.md` — operational `sqlite3` examples now read `/etc/sleepypod/data-dir`; env table notes the unit-side override.

ADRs (`docs/adr/0014`, `0018`, `0020`) intentionally left alone — they describe historical state at the time the decision was made, not the current path.

## Test plan

- [x] Verified install on Pod 3 (rootfs > /persistent) — picker chose `/sleepypod-data`, reproduced the namespace bind-mount failure with commit 1 alone, fixed by commit 2.
- [x] Same Pod — modules crashed with `unittest` / `dataclasses` `ModuleNotFoundError` after commit 2, fixed by commit 3 (uv pulls managed CPython).
- [ ] On the same Pod, verify HomeKit identity lands at `$DATA_DIR/homekit/identity.json` (not `/persistent/sleepypod-data/homekit/`).
- [ ] On the same Pod, trigger calibration from the iOS app and verify `.calibrate-trigger.<ts>` appears in `$DATA_DIR/` and gets consumed by the calibrator within 10s.
- [ ] On the same Pod, trigger an archive export and verify staging happens under `$DATA_DIR/export-staging/`.
- [ ] Verify on Pod 4/5 stock (`/persistent` > rootfs) — picker should still choose `/persistent/sleepypod-data`; no behavior change expected vs the base branch (every fix is a no-op when the substituted value equals the legacy literal).
- [ ] Re-run install on the same Pod twice — second run should be idempotent (pointer file already exists, managed Python cached in `/opt/sleepypod/python`).
- [ ] `sp-update` / `sp-uninstall` / `sp-bundle-logs` / `sp-maintenance` resolve `DATA_DIR` correctly via the pointer.
- [ ] Run `sp-update` on the Pod 3 (post-install) and confirm: (a) modules still use the managed CPython (`grep python /etc/systemd/system/sleepypod-piezo-processor.service` and `ls -la /opt/sleepypod/modules/*/.venv/bin/python` resolves under `/opt/sleepypod/python`), (b) `ReadWritePaths=` in `/etc/systemd/system/sleepypod-*.service` still points at the chosen `$DATA_DIR` (not reverted to `/persistent/sleepypod-data`).

## Compatibility / migration

- Installs created before the pointer file existed: all `sp-*` tools, `pod/detect`, and every runtime consumer with an env override fall back to `/persistent/sleepypod-data`, so existing Pods keep working until the next install run (which writes the pointer and the new `Environment=` lines).
- Legacy data at `/persistent/sleepypod-data` is migrated to the new `$DATA_DIR` automatically — guarded by an empty-target check so two installs' DBs never get mixed. HomeKit pairing data + the calibration trigger live under the same dir, so they ride along with the migration.
- `/opt/sleepypod/python` and `/opt/sleepypod/uv-cache` survive `sp-uninstall` so re-installs don't re-download CPython.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable data directory selection at install time via `--data-dir` option
  * System now dynamically determines storage location from configuration instead of using a fixed path

* **Documentation**
  * Updated installation and deployment guides to explain the new data directory configuration system
  * Enhanced operational documentation with instructions for viewing and managing the active data directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sleepypod/core/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->