### PR TITLE
ci(mutation): bump github-script to v9 for Node 24 runtime

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Comment on PR (labeled PR runs only)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs')
@@ -212,7 +212,7 @@ jobs:
       - name: Update pinned tracking issue (scheduled runs only)
         id: update-issue
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           ISSUE_TITLE: '📊 Mutation testing — weekly baseline'
         with:
@@ -397,7 +397,7 @@ jobs:
 
       - name: Compute aggregated row
         id: compute
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs')


### PR DESCRIPTION
## Why

The weekly mutation run ([run 26679315747](https://github.com/sleepypod/core/actions/runs/26679315747)) raises Node.js 20 deprecation annotations on two jobs — `summarize` and `record-baseline`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/github-script@v7`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`actions/github-script@v7` is the only action in the repo still pinned to a Node 20 release; every other action (`checkout@v6`, `setup-node@v6`, `download-artifact@v8`, `upload-artifact@v7`) is already on a Node 24 major.

## What

Bump all three `actions/github-script@v7` usages in `.github/workflows/mutation.yml` to `@v9` (Node 24):

- `Comment on PR` step (PR-labeled runs)
- `Update pinned tracking issue` step (`summarize` job)
- `Compute aggregated row` step (`record-baseline` job)

### Why v9 is safe for these scripts

v9's breaking changes are limited to:
- `require('@actions/github')` no longer works in-script
- `getOctokit` is now an injected parameter (can't be `const`/`let` redeclared)

None of the three scripts touch either — they only use `require('fs')`/`require('path')` (Node built-ins) plus the standard `github.rest.*`, `context`, and `core` globals, all unchanged in v9.

## Test plan

- [x] `git diff` confirms the only change is `v7` → `v9` on the three `uses:` lines; indentation and YAML structure unchanged.
- [x] Confirmed 3 `@v9` / 0 `@v7` remaining in the workflow.
- [ ] After merge, the next scheduled (or manually dispatched) mutation run should no longer emit the Node.js 20 deprecation annotation on the `summarize` and `record-baseline` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update ci/mutation-github-script-node24
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/ci/mutation-github-script-node24/scripts/install \
  | sudo bash -s -- --branch ci/mutation-github-script-node24
```

🎯 **Pin to this exact build** ([run 26691633977](https://github.com/sleepypod/core/actions/runs/26691633977) · `a15deda`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a15deda978d696b460ff96539ffe49dc577aabc2/scripts/install \
  | sudo bash -s -- \
      --branch ci/mutation-github-script-node24 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26691633977/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26691633977/artifacts/7310401530) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
