### PR TITLE
fix(auto-off): live-presence auto-off + opt-in safety features

### DIFF
--- a/src/components/Settings/SettingsScreen.tsx
+++ b/src/components/Settings/SettingsScreen.tsx
@@ -174,6 +174,14 @@ interface SettingsData {
 function SidesTab({ data }: { data: SettingsData }) {
   const [selectedSide, setSelectedSide] = useState<'left' | 'right'>('left')
   const { leftName, rightName } = useSideNames()
+  // Drives the auto-off toggle gate: the feature is only safe where presence
+  // can be sensed. Polls so a side that comes online (calibration completes,
+  // sensor stream resumes) re-enables the toggle without a manual refresh.
+  const { data: occupancy } = trpc.biometrics.getOccupancy.useQuery(undefined, {
+    refetchInterval: 10000,
+    refetchOnWindowFocus: false,
+  })
+  const presenceAvailable = occupancy?.[selectedSide].available ?? null
 
   return (
     <section className="space-y-4">
@@ -201,6 +209,7 @@ function SidesTab({ data }: { data: SettingsData }) {
       <SideSettingsForm
         side={selectedSide}
         sideData={selectedSide === 'left' ? data.sides.left : data.sides.right}
+        presenceAvailable={presenceAvailable}
       />
     </section>
   )

--- a/src/components/Settings/SideSettingsForm.tsx
+++ b/src/components/Settings/SideSettingsForm.tsx
@@ -17,6 +17,13 @@ interface SideData {
 interface SideSettingsFormProps {
   side: 'left' | 'right'
   sideData: SideData
+  /**
+   * Whether presence can be sensed for this side (calibrated capSense2 + fresh
+   * frame). `null` while the occupancy query is loading. When `false`, auto-off
+   * can't reliably tell the bed is empty, so the toggle is gated off — enabling
+   * it would do nothing (the watcher stands down on unsensable presence).
+   */
+  presenceAvailable: boolean | null
 }
 
 const AUTO_OFF_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90, 120] as const
@@ -24,7 +31,7 @@ const AUTO_OFF_DURATION_OPTIONS = [5, 10, 15, 30, 45, 60, 90, 120] as const
 /**
  * Per-side settings: name, away mode, always on, and auto-off for a single side.
  */
-export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
+export function SideSettingsForm({ side, sideData, presenceAvailable }: SideSettingsFormProps) {
   const d = sideData ?? {
     side,
     name: side === 'left' ? 'Left' : 'Right',
@@ -39,11 +46,12 @@ export function SideSettingsForm({ side, sideData }: SideSettingsFormProps) {
     <SideCard
       key={`${d.name}-${d.awayMode}-${d.alwaysOn}-${d.autoOffEnabled}-${d.autoOffMinutes}`}
       data={d}
+      presenceAvailable={presenceAvailable}
     />
   )
 }
 
-function SideCard({ data }: { data: SideData }) {
+function SideCard({ data, presenceAvailable }: { data: SideData, presenceAvailable: boolean | null }) {
   const utils = trpc.useUtils()
   const [name, setName] = useState(data.name)
   const [awayMode, setAwayMode] = useState(data.awayMode)
@@ -57,6 +65,11 @@ function SideCard({ data }: { data: SideData }) {
 
   const isPending = mutation.isPending
   const sideLabel = data.side === 'left' ? 'Left' : 'Right'
+  // Block enabling auto-off when presence can't be sensed; always allow turning
+  // it off. `null` (loading) is treated as available to avoid a flicker that
+  // would block the toggle before the occupancy query resolves.
+  const presenceUnavailable = presenceAvailable === false
+  const autoOffToggleDisabled = isPending || (presenceUnavailable && !autoOffEnabled)
 
   function handleNameBlur() {
     const trimmed = name.trim()
@@ -181,10 +194,19 @@ function SideCard({ data }: { data: SideData }) {
         <Toggle
           enabled={autoOffEnabled}
           onToggle={handleAutoOffToggle}
-          disabled={isPending}
+          disabled={autoOffToggleDisabled}
           label={`Toggle auto-off for ${sideLabel} side`}
         />
       </div>
+
+      {/* Presence-sensing gate: explain why auto-off is unavailable / inactive */}
+      {presenceUnavailable && (
+        <p className="mt-2 text-xs text-amber-400/80">
+          {autoOffEnabled
+            ? 'Presence sensing is unavailable, so auto-off is currently inactive. Calibrate the capacitance sensor for this side to restore it.'
+            : 'Requires presence sensing. Calibrate the capacitance sensor for this side to enable auto-off.'}
+        </p>
+      )}
 
       {/* Auto-off duration picker (shown when enabled) */}
       {autoOffEnabled && (

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -43,13 +43,16 @@ export async function seedDefaultData() {
       // Wrap all inserts in a transaction for atomicity
       // Note: better-sqlite3 transactions are synchronous — cannot use async/await
       db.transaction((tx) => {
-        // Insert default device settings
+        // Insert default device settings. pumpStallProtectionEnabled is set
+        // explicitly to false (opt-in): it acts on flow/RPM data not all pods
+        // report consistently, and a power-cutting feature must not default on.
         tx.insert(deviceSettings).values({
           id: 1,
           timezone: 'America/Los_Angeles',
           temperatureUnit: 'F',
           rebootDaily: false,
           primePodDaily: false,
+          pumpStallProtectionEnabled: false,
         }).run()
 
         // Insert default side settings

--- a/src/db/migrations/0011_opt_in_pump_stall.sql
+++ b/src/db/migrations/0011_opt_in_pump_stall.sql
@@ -1,0 +1,38 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_device_settings` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`timezone` text DEFAULT 'America/Los_Angeles' NOT NULL,
+	`temperature_unit` text DEFAULT 'F' NOT NULL,
+	`reboot_daily` integer DEFAULT false NOT NULL,
+	`reboot_time` text DEFAULT '03:00',
+	`prime_pod_daily` integer DEFAULT false NOT NULL,
+	`prime_pod_time` text DEFAULT '14:00',
+	`led_night_mode_enabled` integer DEFAULT false NOT NULL,
+	`led_day_brightness` integer DEFAULT 100 NOT NULL,
+	`led_night_brightness` integer DEFAULT 0 NOT NULL,
+	`led_night_start_time` text DEFAULT '22:00',
+	`led_night_end_time` text DEFAULT '07:00',
+	`global_max_on_hours` integer,
+	`mqtt_enabled` integer,
+	`mqtt_url` text,
+	`mqtt_username` text,
+	`mqtt_password` text,
+	`mqtt_topic_prefix` text,
+	`mqtt_ha_discovery` integer,
+	`mqtt_tls_enabled` integer,
+	`mqtt_tls_insecure` integer,
+	`homekit_enabled` integer DEFAULT false NOT NULL,
+	`pump_stall_protection_enabled` integer DEFAULT false NOT NULL,
+	`pump_stall_rpm_threshold` integer DEFAULT 500 NOT NULL,
+	`pump_stall_dwell_samples` integer DEFAULT 2 NOT NULL,
+	`pump_stall_auto_recovery_enabled` integer DEFAULT false NOT NULL,
+	`pump_stall_recovery_rpm` integer DEFAULT 1500 NOT NULL,
+	`pump_stall_recovery_samples` integer DEFAULT 3 NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_device_settings`("id", "timezone", "temperature_unit", "reboot_daily", "reboot_time", "prime_pod_daily", "prime_pod_time", "led_night_mode_enabled", "led_day_brightness", "led_night_brightness", "led_night_start_time", "led_night_end_time", "global_max_on_hours", "mqtt_enabled", "mqtt_url", "mqtt_username", "mqtt_password", "mqtt_topic_prefix", "mqtt_ha_discovery", "mqtt_tls_enabled", "mqtt_tls_insecure", "homekit_enabled", "pump_stall_protection_enabled", "pump_stall_rpm_threshold", "pump_stall_dwell_samples", "pump_stall_auto_recovery_enabled", "pump_stall_recovery_rpm", "pump_stall_recovery_samples", "created_at", "updated_at") SELECT "id", "timezone", "temperature_unit", "reboot_daily", "reboot_time", "prime_pod_daily", "prime_pod_time", "led_night_mode_enabled", "led_day_brightness", "led_night_brightness", "led_night_start_time", "led_night_end_time", "global_max_on_hours", "mqtt_enabled", "mqtt_url", "mqtt_username", "mqtt_password", "mqtt_topic_prefix", "mqtt_ha_discovery", "mqtt_tls_enabled", "mqtt_tls_insecure", "homekit_enabled", "pump_stall_protection_enabled", "pump_stall_rpm_threshold", "pump_stall_dwell_samples", "pump_stall_auto_recovery_enabled", "pump_stall_recovery_rpm", "pump_stall_recovery_samples", "created_at", "updated_at" FROM `device_settings`;--> statement-breakpoint
+DROP TABLE `device_settings`;--> statement-breakpoint
+ALTER TABLE `__new_device_settings` RENAME TO `device_settings`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/src/db/migrations/meta/0011_snapshot.json
+++ b/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,909 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e3155188-e2d7-40f9-8c2c-bb1f06ebf877",
+  "prevId": "7c046539-5dbd-4829-9b69-8d414874b744",
+  "tables": {
+    "alarm_schedules": {
+      "name": "alarm_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_intensity": {
+          "name": "vibration_intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vibration_pattern": {
+          "name": "vibration_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rise'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alarm_temperature": {
+          "name": "alarm_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_alarm_schedules_side_day": {
+          "name": "idx_alarm_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_settings": {
+      "name": "device_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'America/Los_Angeles'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'F'"
+        },
+        "reboot_daily": {
+          "name": "reboot_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "reboot_time": {
+          "name": "reboot_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'03:00'"
+        },
+        "prime_pod_daily": {
+          "name": "prime_pod_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "prime_pod_time": {
+          "name": "prime_pod_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'14:00'"
+        },
+        "led_night_mode_enabled": {
+          "name": "led_night_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "led_day_brightness": {
+          "name": "led_day_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "led_night_brightness": {
+          "name": "led_night_brightness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "led_night_start_time": {
+          "name": "led_night_start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'22:00'"
+        },
+        "led_night_end_time": {
+          "name": "led_night_end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'07:00'"
+        },
+        "global_max_on_hours": {
+          "name": "global_max_on_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_enabled": {
+          "name": "mqtt_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_url": {
+          "name": "mqtt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_username": {
+          "name": "mqtt_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_password": {
+          "name": "mqtt_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_topic_prefix": {
+          "name": "mqtt_topic_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_ha_discovery": {
+          "name": "mqtt_ha_discovery",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_tls_enabled": {
+          "name": "mqtt_tls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mqtt_tls_insecure": {
+          "name": "mqtt_tls_insecure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "homekit_enabled": {
+          "name": "homekit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pump_stall_protection_enabled": {
+          "name": "pump_stall_protection_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pump_stall_rpm_threshold": {
+          "name": "pump_stall_rpm_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500
+        },
+        "pump_stall_dwell_samples": {
+          "name": "pump_stall_dwell_samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "pump_stall_auto_recovery_enabled": {
+          "name": "pump_stall_auto_recovery_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pump_stall_recovery_rpm": {
+          "name": "pump_stall_recovery_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1500
+        },
+        "pump_stall_recovery_samples": {
+          "name": "pump_stall_recovery_samples",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_state": {
+      "name": "device_state",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_temperature": {
+          "name": "current_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_temperature": {
+          "name": "target_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_powered": {
+          "name": "is_powered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_alarm_vibrating": {
+          "name": "is_alarm_vibrating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "water_level": {
+          "name": "water_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "powered_on_at": {
+          "name": "powered_on_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "power_schedules": {
+      "name": "power_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_time": {
+          "name": "on_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "off_time": {
+          "name": "off_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "on_temperature": {
+          "name": "on_temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_power_schedules_side_day": {
+          "name": "idx_power_schedules_side_day",
+          "columns": [
+            "side",
+            "day_of_week"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_once_sessions": {
+      "name": "run_once_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_points": {
+          "name": "set_points",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wake_time": {
+          "name": "wake_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_run_once_side_status": {
+          "name": "idx_run_once_side_status",
+          "columns": [
+            "side",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "side_settings": {
+      "name": "side_settings",
+      "columns": {
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "away_mode": {
+          "name": "away_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "always_on": {
+          "name": "always_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_enabled": {
+          "name": "auto_off_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_off_minutes": {
+          "name": "auto_off_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "away_start": {
+          "name": "away_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "away_return": {
+          "name": "away_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_health": {
+      "name": "system_health",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "component": {
+          "name": "component",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "system_health_component_unique": {
+          "name": "system_health_component_unique",
+          "columns": [
+            "component"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tap_gestures": {
+      "name": "tap_gestures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tap_type": {
+          "name": "tap_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature_change": {
+          "name": "temperature_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature_amount": {
+          "name": "temperature_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_behavior": {
+          "name": "alarm_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_snooze_duration": {
+          "name": "alarm_snooze_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alarm_inactive_behavior": {
+          "name": "alarm_inactive_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "uq_tap_side_type": {
+          "name": "uq_tap_side_type",
+          "columns": [
+            "side",
+            "tap_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "temperature_schedules": {
+      "name": "temperature_schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_temp_schedules_side_day_time": {
+          "name": "idx_temp_schedules_side_day_time",
+          "columns": [
+            "side",
+            "day_of_week",
+            "time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779732358053,
       "tag": "0010_greedy_hercules",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1780252685801,
+      "tag": "0011_opt_in_pump_stall",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -50,13 +50,14 @@ export const deviceSettings = sqliteTable('device_settings', {
   homekitEnabled: integer('homekit_enabled', { mode: 'boolean' })
     .notNull()
     .default(false),
-  // Pump-stall safety guard. Default-on with conservative thresholds per
-  // ADR 0022: a side whose pump RPM stays under the trip threshold for
-  // dwellSamples consecutive frames is powered off until the user
-  // re-enables it. Auto-recovery is opt-in.
+  // Pump-stall safety guard (ADR 0022): a side whose pump RPM stays under the
+  // trip threshold for dwellSamples consecutive frames is powered off until the
+  // user re-enables it. Opt-in (default off) — it acts on flow/RPM data that
+  // not all pods report consistently, and a power-cutting feature must not fire
+  // on missing data. Auto-recovery is separately opt-in.
   pumpStallProtectionEnabled: integer('pump_stall_protection_enabled', { mode: 'boolean' })
     .notNull()
-    .default(true),
+    .default(false),
   pumpStallRpmThreshold: integer('pump_stall_rpm_threshold').notNull().default(500),
   pumpStallDwellSamples: integer('pump_stall_dwell_samples').notNull().default(2),
   pumpStallAutoRecoveryEnabled: integer('pump_stall_auto_recovery_enabled', { mode: 'boolean' })

--- a/src/homekit/tests/occupancySensor.test.ts
+++ b/src/homekit/tests/occupancySensor.test.ts
@@ -13,6 +13,7 @@ import { buildOccupancySensor } from '../accessories/occupancySensor'
 function result(occupied: boolean): OccupancyResult {
   return {
     occupied,
+    available: false,
     movement: { active: occupied, peakScore: occupied ? 660 : 12 },
     level: { active: false, deviation: null, threshold: null, ageMs: null },
   }

--- a/src/lib/occupancy.ts
+++ b/src/lib/occupancy.ts
@@ -54,6 +54,16 @@ export interface OccupancyResult {
   occupied: boolean
   movement: MovementSignal
   level: LevelSignal
+  /**
+   * True when presence can be sensed reliably enough to act on its ABSENCE —
+   * i.e. the level signal is evaluable (fresh capSense2 frame + completed
+   * calibration). Only the level signal detects a perfectly still occupant;
+   * movement alone reads a motionless sleeper as empty. Consumers that power
+   * hardware off on "empty" (autoOffWatcher) must check this first and stand
+   * down when false, so missing/uncalibrated biometrics never trigger an
+   * action.
+   */
+  available: boolean
 }
 
 interface CapSenseCalibration {
@@ -70,6 +80,7 @@ export function getOccupancy(side: Side): OccupancyResult {
     occupied: movementSignal.active || levelSignal.active,
     movement: movementSignal,
     level: levelSignal,
+    available: levelSignal.deviation !== null,
   }
 }
 

--- a/src/server/routers/biometrics.ts
+++ b/src/server/routers/biometrics.ts
@@ -539,6 +539,10 @@ export const biometricsRouter = router({
     .output(z.object({
       left: z.object({
         occupied: z.boolean(),
+        // True when presence can be sensed reliably enough to act on absence
+        // (fresh capSense2 frame + completed calibration). The Settings UI
+        // gates the auto-off toggle on this.
+        available: z.boolean(),
         movement: z.object({ active: z.boolean(), peakScore: z.number() }),
         level: z.object({
           active: z.boolean(),
@@ -549,6 +553,10 @@ export const biometricsRouter = router({
       }),
       right: z.object({
         occupied: z.boolean(),
+        // True when presence can be sensed reliably enough to act on absence
+        // (fresh capSense2 frame + completed calibration). The Settings UI
+        // gates the auto-off toggle on this.
+        available: z.boolean(),
         movement: z.object({ active: z.boolean(), peakScore: z.number() }),
         level: z.object({
           active: z.boolean(),

--- a/src/server/routers/settings.ts
+++ b/src/server/routers/settings.ts
@@ -174,7 +174,7 @@ export const settingsRouter = router({
             ledNightEndTime: '07:00',
             globalMaxOnHours: null,
             homekitEnabled: false,
-            pumpStallProtectionEnabled: true,
+            pumpStallProtectionEnabled: false,
             pumpStallRpmThreshold: 500,
             pumpStallDwellSamples: 2,
             pumpStallAutoRecoveryEnabled: false,

--- a/src/server/routers/tests/biometrics.test.ts
+++ b/src/server/routers/tests/biometrics.test.ts
@@ -91,10 +91,12 @@ vi.mock('@/src/lib/sleep-stages', () => sleepStagesMock)
 const occupancyMock = vi.hoisted(() => ({
   getOccupancy: vi.fn<(side: 'left' | 'right') => {
     occupied: boolean
+    available: boolean
     movement: { active: boolean, peakScore: number }
     level: { active: boolean, deviation: number | null, threshold: number | null, ageMs: number | null }
   }>(() => ({
     occupied: false,
+    available: false,
     movement: { active: false, peakScore: 0 },
     level: { active: false, deviation: null, threshold: null, ageMs: null },
   })),
@@ -229,6 +231,7 @@ describe('biometrics.getOccupancy', () => {
   it('returns occupancy for both sides from the shared virtual sensor', async () => {
     occupancyMock.getOccupancy.mockImplementation((side: 'left' | 'right') => ({
       occupied: side === 'left',
+      available: false,
       movement: { active: side === 'left', peakScore: side === 'left' ? 300 : 10 },
       level: { active: false, deviation: null, threshold: null, ageMs: null },
     }))
@@ -243,10 +246,12 @@ describe('biometrics.getOccupancy', () => {
   it('passes level signal through to the response', async () => {
     occupancyMock.getOccupancy.mockReturnValue({
       occupied: true,
+      available: true,
       movement: { active: false, peakScore: 5 },
       level: { active: true, deviation: 12.3, threshold: 6, ageMs: 500 },
     })
     const out = await caller.getOccupancy()
+    expect(out.left.available).toBe(true)
     expect(out.left.level.deviation).toBe(12.3)
     expect(out.left.level.threshold).toBe(6)
     expect(out.left.level.ageMs).toBe(500)

--- a/src/services/autoOffWatcher.ts
+++ b/src/services/autoOffWatcher.ts
@@ -1,21 +1,31 @@
 /**
  * Auto-Off Watcher Service
  *
- * Polls the biometrics DB `sleep_records` table for bed-exit events.
- * When a side has no presence for longer than `autoOffMinutes`, powers
- * off that side via the shared hardware client.
+ * Powers a side off after it has been empty for `autoOffMinutes`, using the
+ * LIVE occupancy sensor (`src/lib/occupancy.ts`) — the same signal HomeKit and
+ * the web PresenceCard use — rather than the `sleep_records` table.
  *
- * Per-side countdown timers reset on bed re-entry and cancel if the side
- * is already off or a run-once session is active.
+ * Why not sleep_records: the Python sleep-detector only writes a row when a
+ * session CLOSES (both entered_bed_at and left_bed_at set, entered < left).
+ * While someone is in bed no row exists for the current session, so the latest
+ * row is the PREVIOUS night with an hours-old left_bed_at. Deriving presence
+ * from that made the watcher think the bed had been empty for hours and power a
+ * just-powered side off within seconds. See sleepypod-core-64.
+ *
+ * Fail-safe: auto-off only acts on a POSITIVE, reliable "empty" reading. If the
+ * presence signal isn't available for a side (no fresh capSense2 frame, or no
+ * completed calibration — `getOccupancy().available === false`), the per-side
+ * timer stands down entirely. Missing or inconsistent biometrics never trigger
+ * a power-off; the global wall-clock cap remains the independent backstop.
  */
 
-import { eq, and, desc } from 'drizzle-orm'
-import { db, biometricsDb } from '@/src/db'
+import { eq, and } from 'drizzle-orm'
+import { db } from '@/src/db'
 import { deviceSettings, sideSettings, deviceState, runOnceSessions } from '@/src/db/schema'
-import { sleepRecords } from '@/src/db/biometrics-schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
+import { getOccupancy } from '@/src/lib/occupancy'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -26,22 +36,15 @@ const SIDES = ['left', 'right'] as const
 type Side = (typeof SIDES)[number]
 
 // ---------------------------------------------------------------------------
-// Per-side timer state
+// Per-side empty-since state
 // ---------------------------------------------------------------------------
 
-interface SideTimer {
-  /** setTimeout handle for the pending auto-off */
-  timer: ReturnType<typeof setTimeout> | null
-  /** Unix-ms when the timer was started (bed-exit time) */
-  startedAt: number | null
-  /** The configured timeout in ms when the timer was created */
-  timeoutMs: number | null
-}
-
-const timers: Record<Side, SideTimer> = {
-  left: { timer: null, startedAt: null, timeoutMs: null },
-  right: { timer: null, startedAt: null, timeoutMs: null },
-}
+/**
+ * Unix-ms when a side was first observed empty-while-sensable, or null when the
+ * side is occupied, off, exempt, or presence can't be sensed. The countdown to
+ * power-off is `now - emptySince >= autoOffMinutes`.
+ */
+const emptySince: Record<Side, number | null> = { left: null, right: null }
 
 let pollHandle: ReturnType<typeof setInterval> | null = null
 
@@ -52,14 +55,9 @@ const pendingPowerOffs = new Set<Promise<void>>()
 // Helpers
 // ---------------------------------------------------------------------------
 
-function clearSideTimer(side: Side): void {
-  const t = timers[side]
-  if (t.timer) {
-    clearTimeout(t.timer)
-    t.timer = null
-    t.startedAt = null
-    t.timeoutMs = null
-  }
+/** Reset a side's empty-since stamp (occupied, off, exempt, or unsensable). */
+function clearEmptySince(side: Side): void {
+  emptySince[side] = null
 }
 
 /** Check whether the side currently has power. */
@@ -167,42 +165,22 @@ function getPoweredOnAtMs(side: Side): number | null {
 }
 
 /**
- * Get the most recent sleep record for a side.
- * Returns the record or null if none exists.
+ * Live presence for a side. Returns:
+ *   'occupied'    — someone is in bed (movement or calibrated level signal)
+ *   'empty'       — reliably sensed empty (level signal evaluable, not occupied)
+ *   'unsensable'  — presence can't be sensed; auto-off must stand down
  */
-function getLatestSleepRecord(side: Side) {
+function presenceState(side: Side): 'occupied' | 'empty' | 'unsensable' {
   try {
-    const [row] = biometricsDb
-      .select()
-      .from(sleepRecords)
-      .where(eq(sleepRecords.side, side))
-      .orderBy(desc(sleepRecords.leftBedAt))
-      .limit(1)
-      .all()
-    return row ?? null
+    const occ = getOccupancy(side)
+    if (occ.occupied) return 'occupied'
+    if (!occ.available) return 'unsensable'
+    return 'empty'
   }
   catch {
-    return null
+    // Treat any failure to read presence as unsensable — fail safe.
+    return 'unsensable'
   }
-}
-
-/**
- * Check whether the user is currently in bed by comparing enteredBedAt
- * and leftBedAt from the latest sleep record. If `enteredBedAt > leftBedAt`,
- * a new session started after the last exit — the user is back in bed.
- */
-function isUserInBed(side: Side): boolean {
-  const record = getLatestSleepRecord(side)
-  if (!record) return false
-
-  const enteredMs = record.enteredBedAt instanceof Date
-    ? record.enteredBedAt.getTime()
-    : (record.enteredBedAt as number) * 1000
-  const leftMs = record.leftBedAt instanceof Date
-    ? record.leftBedAt.getTime()
-    : (record.leftBedAt as number) * 1000
-
-  return enteredMs > leftMs
 }
 
 /** Power off a side via the shared hardware client. */
@@ -250,6 +228,7 @@ async function powerOffSide(side: Side): Promise<void> {
  * Fire powerOffSide and track the promise so shutdown can await it.
  */
 function firePowerOff(side: Side): void {
+  clearEmptySince(side)
   const p = powerOffSide(side).finally(() => {
     pendingPowerOffs.delete(p)
   })
@@ -260,16 +239,6 @@ function firePowerOff(side: Side): void {
 // Core poll logic
 // ---------------------------------------------------------------------------
 
-/**
- * Determine whether a side currently has bed presence.
- *
- * The sleep-detector writes a `sleep_records` row when a session ends
- * (i.e. the person has left the bed). If the most recent record's
- * `leftBedAt` is recent (within the poll window), we consider
- * presence lost. If there is no record or the most recent exit was
- * long ago and the side is still powered, we assume they are in bed
- * (the session hasn't closed yet).
- */
 function evaluateSide(
   side: Side,
   config: Record<Side, SideConfig>,
@@ -279,7 +248,7 @@ function evaluateSide(
 
   // Side already off — nothing to evaluate for either cap
   if (!isSidePowered(side)) {
-    clearSideTimer(side)
+    clearEmptySince(side)
     return
   }
 
@@ -287,14 +256,14 @@ function evaluateSide(
   // the global cap. Run-once is the user's explicit "keep on until X"; the
   // always-on flag is the perpetual-stay-on directive.
   if (hasActiveRunOnce(side) || cfg.alwaysOn) {
-    clearSideTimer(side)
+    clearEmptySince(side)
     return
   }
 
-  // ── Global wall-clock cap (runs independently of sleep_records) ──────────
+  // ── Global wall-clock cap (runs independently of presence) ───────────────
   // If a side has been powered for > globalMaxOnHours, force it off. This is
   // the safety net that fires even when the biometrics pipeline is broken or
-  // the sleep-detector missed a bed-exit.
+  // presence can't be sensed at all.
   if (globalMaxOnHours != null && globalMaxOnHours > 0) {
     const poweredOnAtMs = getPoweredOnAtMs(side)
     if (poweredOnAtMs != null) {
@@ -308,111 +277,53 @@ function evaluateSide(
         console.log(
           `[auto-off] ${side}: global max-on cap exceeded (${globalMaxOnHours}h), powering off`,
         )
-        clearSideTimer(side)
         firePowerOff(side)
         return
       }
     }
   }
 
-  // ── Per-side bed-exit timer ──────────────────────────────────────────────
+  // ── Per-side presence-based auto-off ─────────────────────────────────────
   // Feature disabled for this side
   if (!cfg.enabled) {
-    clearSideTimer(side)
+    clearEmptySince(side)
     return
   }
 
-  const record = getLatestSleepRecord(side)
-  if (!record) {
-    // No sleep records yet — cannot determine presence for the bed-exit path.
-    // The global cap above still applies independently.
-    clearSideTimer(side)
+  const presence = presenceState(side)
+
+  // Fail-safe: if presence can't be sensed (no fresh capSense2 frame / no
+  // calibration), never auto-off on missing data. Reset the countdown so a
+  // later loss of signal doesn't carry stale empty time. The global cap above
+  // is the only thing that may still power a side off in this state.
+  if (presence === 'unsensable') {
+    clearEmptySince(side)
     return
   }
 
-  // Don't arm if the user has returned to bed
-  // (enteredBedAt > leftBedAt means a new session started after the exit)
-  if (isUserInBed(side)) {
-    clearSideTimer(side)
+  // Live occupant — reset the countdown.
+  if (presence === 'occupied') {
+    clearEmptySince(side)
     return
   }
 
-  const leftBedAtMs = record.leftBedAt instanceof Date
-    ? record.leftBedAt.getTime()
-    : (record.leftBedAt as number) * 1000
-  const nowMs = Date.now()
+  // presence === 'empty' and reliably sensed. Stamp the first empty observation,
+  // then fire once the bed has been continuously empty for the timeout.
+  const now = Date.now()
+  const since = emptySince[side]
+  if (since == null) {
+    emptySince[side] = now
+    console.log(`[auto-off] ${side}: bed empty, auto-off in ${cfg.minutes}min if still empty`)
+    return
+  }
+
+  const emptyMs = now - since
   const timeoutMs = cfg.minutes * 60_000
-  const msSinceBedExit = nowMs - leftBedAtMs
-
-  // If past the timeout, fire immediately. Previously this branch was gated
-  // by `msSinceBedExit <= timeoutMs + 2 * POLL_INTERVAL_MS`; that "grace
-  // window" would give up past ~32min and leave the side on forever when
-  // the user left bed long ago and didn't return. The global cap is the
-  // catch-all for wall-clock staleness; here we just fire on any past-due
-  // bed-exit so long as the user hasn't re-entered bed.
-  if (msSinceBedExit > timeoutMs) {
-    clearSideTimer(side)
-    // Re-check conditions before actually powering off
-    if (!isSidePowered(side)) return
-    if (hasActiveRunOnce(side)) return
-    if (isUserInBed(side)) return
-    const freshConfig = getAutoOffConfig()
-    if (!freshConfig[side].enabled || freshConfig[side].alwaysOn) return
-
+  if (emptyMs >= timeoutMs) {
     console.log(
-      `[auto-off] ${side}: bed exit ${Math.round(msSinceBedExit / 1000)}s ago (past ${cfg.minutes}min timeout), powering off`,
+      `[auto-off] ${side}: empty for ${Math.round(emptyMs / 1000)}s (past ${cfg.minutes}min timeout), powering off`,
     )
     firePowerOff(side)
-    return
-  }
-
-  // Bed exit is recent -- check if we need to start or update a timer
-  const existing = timers[side]
-
-  if (existing.timer) {
-    // Timer already running. If it targets the same bed-exit event, keep it.
-    // If the config (minutes) changed, restart with the new timeout.
-    if (existing.startedAt === leftBedAtMs && existing.timeoutMs === timeoutMs) {
-      return // timer is correct
-    }
-    // Config changed or different exit event -- restart
-    clearSideTimer(side)
-  }
-
-  // Start countdown timer
-  const remainingMs = Math.max(0, timeoutMs - msSinceBedExit)
-  console.log(
-    `[auto-off] ${side}: bed exit detected, auto-off in ${Math.round(remainingMs / 1000)}s`,
-  )
-
-  timers[side] = {
-    timer: setTimeout(() => {
-      timers[side] = { timer: null, startedAt: null, timeoutMs: null }
-      // Re-check conditions before actually powering off
-      if (!isSidePowered(side)) return
-      if (hasActiveRunOnce(side)) return
-      const freshConfig = getAutoOffConfig()
-      if (!freshConfig[side].enabled || freshConfig[side].alwaysOn) return
-
-      // Verify the bed-exit that armed this timer is still the latest
-      const latestRecord = getLatestSleepRecord(side)
-      if (latestRecord) {
-        const latestLeftBedMs = latestRecord.leftBedAt instanceof Date
-          ? latestRecord.leftBedAt.getTime()
-          : (latestRecord.leftBedAt as number) * 1000
-        if (latestLeftBedMs !== leftBedAtMs) return // newer event; evaluateSide will re-arm
-      }
-
-      // Fix 1: Check live presence before firing — user may have returned
-      if (isUserInBed(side)) {
-        console.log(`[auto-off] ${side}: user returned to bed, skipping power-off`)
-        return
-      }
-
-      firePowerOff(side)
-    }, remainingMs),
-    startedAt: leftBedAtMs,
-    timeoutMs,
   }
 }
 
@@ -450,8 +361,8 @@ export async function stopAutoOffWatcher(): Promise<void> {
     clearInterval(pollHandle)
     pollHandle = null
   }
-  clearSideTimer('left')
-  clearSideTimer('right')
+  clearEmptySince('left')
+  clearEmptySince('right')
 
   // Await any in-flight powerOffSide() calls
   if (pendingPowerOffs.size > 0) {
@@ -463,26 +374,27 @@ export async function stopAutoOffWatcher(): Promise<void> {
 }
 
 /**
- * Restart timers after settings change.
- * Called when autoOffEnabled or autoOffMinutes is updated via the API.
+ * Re-evaluate after a settings change. Resets the empty-since countdown for
+ * both sides so a freshly-changed timeout/enable starts clean, then polls.
+ * Called when autoOffEnabled / autoOffMinutes / globalMaxOnHours is updated.
  */
 export function restartAutoOffTimers(): void {
-  // Fix 3: Don't poll if watcher is not running (e.g. in CI)
+  // Don't poll if watcher is not running (e.g. in CI)
   if (!pollHandle) return
 
-  clearSideTimer('left')
-  clearSideTimer('right')
+  clearEmptySince('left')
+  clearEmptySince('right')
   poll()
 }
 
 /**
- * Cancel the auto-off timer for a specific side without re-evaluating.
+ * Cancel the auto-off countdown for a specific side without re-evaluating.
  * Called when a scheduled power-on fires — the side is being turned on
  * intentionally, so any pending auto-off countdown should be aborted.
  */
 export function cancelAutoOffTimer(side: Side): void {
-  if (timers[side].timer) {
-    console.log(`[auto-off] ${side}: timer cancelled (scheduled power-on)`)
-    clearSideTimer(side)
+  if (emptySince[side] != null) {
+    console.log(`[auto-off] ${side}: countdown cancelled (scheduled power-on)`)
+    clearEmptySince(side)
   }
 }

--- a/src/services/tests/autoOffWatcher.test.ts
+++ b/src/services/tests/autoOffWatcher.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type BetterSqlite3 from 'better-sqlite3'
+import type { OccupancyResult } from '@/src/lib/occupancy'
 
 // ── Shared mocks ──────────────────────────────────────────────────────────
 const setPower = vi.fn(async () => {})
@@ -14,28 +15,46 @@ vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
   broadcastMutationStatus: vi.fn(),
 }))
 
-// In-memory primary + biometrics DBs
+vi.mock('@/src/hardware/deviceStateSync', () => ({
+  markSideMutated: vi.fn(),
+}))
+
+// Live occupancy is the presence source (replaces sleep_records). Per-side
+// result is read from this mutable map so each test can shape presence.
+let mockOccupancy: Record<'left' | 'right', OccupancyResult>
+
+function occ(occupied: boolean, available: boolean): OccupancyResult {
+  return {
+    occupied,
+    available,
+    movement: { active: occupied, peakScore: occupied ? 660 : 0 },
+    level: {
+      active: occupied,
+      deviation: available ? (occupied ? 999 : 0) : null,
+      threshold: available ? 500 : null,
+      ageMs: available ? 100 : null,
+    },
+  }
+}
+
+vi.mock('@/src/lib/occupancy', () => ({
+  getOccupancy: (side: 'left' | 'right') => mockOccupancy[side],
+}))
+
+// In-memory primary DB — a real sqlite so `where(side)` actually filters.
 vi.mock('@/src/db', async () => {
   const BetterSqlite3 = (await import('better-sqlite3')).default
   const { drizzle } = await import('drizzle-orm/better-sqlite3')
   const schema = await import('@/src/db/schema')
-  const biometricsSchema = await import('@/src/db/biometrics-schema')
   const primary = new BetterSqlite3(':memory:')
   primary.pragma('foreign_keys = ON')
-  const bio = new BetterSqlite3(':memory:')
-  bio.pragma('foreign_keys = ON')
   return {
     db: drizzle(primary, { schema }),
-    biometricsDb: drizzle(bio, { schema: biometricsSchema }),
     sqlite: primary,
-    biometricsSqlite: bio,
     closeDatabase: vi.fn(),
-    closeBiometricsDatabase: vi.fn(),
   }
 })
 
-// The mock above adds `biometricsSqlite` alongside the real module's exports.
-// Cast the import so TypeScript sees the augmented shape.
 import * as dbModule from '@/src/db'
 import {
   startAutoOffWatcher,
@@ -43,12 +62,12 @@ import {
   restartAutoOffTimers,
   cancelAutoOffTimer,
 } from '@/src/services/autoOffWatcher'
-const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
-  biometricsSqlite: BetterSqlite3.Database
-}
+
+const { sqlite } = dbModule as typeof dbModule & { sqlite: BetterSqlite3.Database }
+
+const POLL_MS = 30_000
 
 function resetSchema(): void {
-  // Wipe and recreate everything the watcher reads.
   ;(sqlite as any).exec(`
     DROP TABLE IF EXISTS device_settings;
     DROP TABLE IF EXISTS side_settings;
@@ -106,22 +125,9 @@ function resetSchema(): void {
     );
 
     INSERT INTO device_settings (id) VALUES (1);
-    INSERT INTO side_settings (side, name) VALUES ('left', 'Left'), ('right', 'Right');
+    INSERT INTO side_settings (side, name, auto_off_enabled, auto_off_minutes)
+      VALUES ('left', 'Left', 1, 30), ('right', 'Right', 1, 30);
     INSERT INTO device_state (side, is_powered) VALUES ('left', 0), ('right', 0);
-  `)
-  ;(biometricsSqlite as any).exec(`
-    DROP TABLE IF EXISTS sleep_records;
-    CREATE TABLE sleep_records (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      side TEXT NOT NULL,
-      entered_bed_at INTEGER NOT NULL,
-      left_bed_at INTEGER NOT NULL,
-      sleep_duration_seconds INTEGER NOT NULL,
-      times_exited_bed INTEGER NOT NULL DEFAULT 0,
-      present_intervals TEXT,
-      not_present_intervals TEXT,
-      created_at INTEGER NOT NULL
-    );
   `)
 }
 
@@ -139,14 +145,14 @@ function setSideSettings(side: 'left' | 'right', patch: Partial<{
   const current = (sqlite as any)
     .prepare('SELECT * FROM side_settings WHERE side=?')
     .get(side)
-  const merged = {
-    auto_off_enabled: patch.autoOffEnabled ?? current.auto_off_enabled,
-    auto_off_minutes: patch.autoOffMinutes ?? current.auto_off_minutes,
-    always_on: patch.alwaysOn ?? current.always_on,
-  }
   ;(sqlite as any)
     .prepare('UPDATE side_settings SET auto_off_enabled=?, auto_off_minutes=?, always_on=? WHERE side=?')
-    .run(merged.auto_off_enabled, merged.auto_off_minutes, merged.always_on, side)
+    .run(
+      patch.autoOffEnabled ?? current.auto_off_enabled,
+      patch.autoOffMinutes ?? current.auto_off_minutes,
+      patch.alwaysOn ?? current.always_on,
+      side,
+    )
 }
 
 function setGlobalCap(hours: number | null): void {
@@ -155,763 +161,174 @@ function setGlobalCap(hours: number | null): void {
     .run(hours)
 }
 
-function insertSleepRecord(side: 'left' | 'right', enteredAtMs: number, leftAtMs: number): void {
-  ;(biometricsSqlite as any)
-    .prepare(`
-      INSERT INTO sleep_records
-        (side, entered_bed_at, left_bed_at, sleep_duration_seconds, created_at)
-      VALUES (?, ?, ?, ?, ?)
-    `)
-    .run(
-      side,
-      Math.floor(enteredAtMs / 1000),
-      Math.floor(leftAtMs / 1000),
-      Math.max(0, Math.floor((leftAtMs - enteredAtMs) / 1000)),
-      Math.floor(leftAtMs / 1000),
-    )
-}
-
 function insertActiveRunOnce(side: 'left' | 'right'): void {
   ;(sqlite as any)
     .prepare(`
-      INSERT INTO run_once_sessions
-        (side, set_points, wake_time, expires_at, status)
+      INSERT INTO run_once_sessions (side, set_points, wake_time, expires_at, status)
       VALUES (?, '[]', '07:00', ?, 'active')
     `)
     .run(side, Math.floor(Date.now() / 1000) + 3600)
 }
 
-/**
- * Run an immediate poll and flush one microtask turn so any async
- * firePowerOff() promises settle before assertions.
- */
-async function pollAndFlush(): Promise<void> {
-  // startAutoOffWatcher polls synchronously on start; stopping then starting
-  // again gives us a fresh poll we can flush.
-  await stopAutoOffWatcher()
-  startAutoOffWatcher()
-  // Allow the fire-and-forget powerOffSide promise to resolve.
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
-}
-
 beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
   setPower.mockClear()
   connect.mockClear()
   resetSchema()
+  // Default: left powered now, presence available + empty.
+  setSideOn('left', Date.now())
+  mockOccupancy = { left: occ(false, true), right: occ(false, true) }
 })
 
 afterEach(async () => {
   await stopAutoOffWatcher()
+  vi.useRealTimers()
 })
 
-// ── ygg-8: grace-window give-up removed ──────────────────────────────────
-
-describe('per-side auto-off (grace-window fix, ygg-8)', () => {
-  it('fires when bed exit was 2h ago and side is still on (was previously skipped)', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000) // powered 3h ago
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000) // exit 2h ago
-
-    await pollAndFlush()
-
+describe('autoOffWatcher — live presence', () => {
+  it('powers off a side that is reliably empty past the timeout', async () => {
+    startAutoOffWatcher() // poll@0 stamps emptySince
+    expect(setPower).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(31 * 60_000)
     expect(setPower).toHaveBeenCalledWith('left', false)
   })
 
-  it('does not fire if side is already off', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    // left stays is_powered=0
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    await pollAndFlush()
-
+  it('does NOT power off before the timeout elapses', async () => {
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(20 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('does not fire if user returned to bed after the exit', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    // Earlier: exit 2h ago; newer: entered again 30min ago, left 1min ago? No —
-    // a single latest row with enteredBedAt > leftBedAt signals currently in bed.
-    insertSleepRecord('left', now - 30 * 60_000, now - 60 * 60_000) // entered 30min ago > left 60min ago = in bed
-
-    await pollAndFlush()
-
+  it('does NOT power off while the bed is occupied, however long', async () => {
+    mockOccupancy.left = occ(true, true)
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(90 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('is suppressed by an active run-once session', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-    insertActiveRunOnce('left')
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('is suppressed by always_on = true', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30, alwaysOn: 1 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    await pollAndFlush()
-
+  it('resets the countdown when the occupant returns mid-timeout', async () => {
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(20 * 60_000) // empty 20min
+    mockOccupancy.left = occ(true, true) // back in bed
+    await vi.advanceTimersByTimeAsync(POLL_MS) // poll observes occupied → reset
+    mockOccupancy.left = occ(false, true) // leaves again
+    await vi.advanceTimersByTimeAsync(20 * 60_000) // only 20min since reset
     expect(setPower).not.toHaveBeenCalled()
   })
 })
 
-// ── ygg-7: global wall-clock cap ─────────────────────────────────────────
-
-describe('global auto-off cap (ygg-7)', () => {
-  it('does not fire when cap is NULL (disabled)', async () => {
-    const now = Date.now()
-    setGlobalCap(null)
-    setSideOn('left', now - 20 * 3600_000) // on for 20h
-    // auto_off_enabled left at 0 to isolate the global-cap path
-
-    await pollAndFlush()
-
+describe('autoOffWatcher — fail-safe on unsensable presence', () => {
+  it('does NOT power off when presence sensing is unavailable', async () => {
+    mockOccupancy.left = occ(false, false) // empty-looking but unsensable
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(120 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('fires when a side has been on longer than the cap', async () => {
-    const now = Date.now()
-    setGlobalCap(1) // 1 hour
-    setSideOn('left', now - 65 * 60_000) // 65 min ago
-
-    await pollAndFlush()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
+  it('regression (sleepypod-core-64): never reaps a just-powered side without calibration', async () => {
+    mockOccupancy.left = occ(false, false)
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(35 * 60_000)
+    expect(setPower).not.toHaveBeenCalled()
   })
+})
 
-  it('does not fire when a side has been on less than the cap', async () => {
-    const now = Date.now()
-    setGlobalCap(1) // 1 hour
-    setSideOn('left', now - 30 * 60_000) // 30 min ago
-
-    await pollAndFlush()
-
+describe('autoOffWatcher — exemptions', () => {
+  it('skips a side that is already off', async () => {
+    ;(sqlite as any).prepare('UPDATE device_state SET is_powered=0, powered_on_at=NULL WHERE side=?').run('left')
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('is suppressed by an active run-once session', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000) // 5h past cap
-    insertActiveRunOnce('left')
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('is suppressed by always_on = true', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000) // 5h past cap
+  it('skips alwaysOn sides', async () => {
     setSideSettings('left', { alwaysOn: 1 })
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('skips the cap if poweredOnAt is in the future (clock-sanity guard)', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now + 3600_000) // future — looks corrupted
-    await pollAndFlush()
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('skips the cap if poweredOnAt is more than 7 days old (stale-seed guard)', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 10 * 86_400_000) // 10 days ago
-    await pollAndFlush()
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('fires even when per-side auto-off is disabled (global cap is independent)', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 90 * 60_000) // 90 min ago
-    setSideSettings('left', { autoOffEnabled: 0 }) // per-side OFF
-
-    await pollAndFlush()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-})
-
-// ── Edge cases & untouched branches ──────────────────────────────────────
-
-describe('per-side auto-off (timer arming, no record, error paths)', () => {
-  it('does nothing when feature enabled but no sleep record exists yet', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 10 * 60_000)
-    // no sleep record inserted -- exercises the "no record" branch
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('does not fire when bed exit is recent (timer armed, not yet expired)', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000) // exit 5min ago, 30min cap
-
-    await pollAndFlush()
-
-    // Timer is armed but won't fire in this synchronous window
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('logs but swallows errors when powerOffSide hardware call rejects', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    setPower.mockRejectedValueOnce(new Error('hardware offline'))
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    await pollAndFlush()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-    expect(errSpy).toHaveBeenCalled()
-    errSpy.mockRestore()
-  })
-
-  it('logs non-Error thrown values from powerOffSide', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    setPower.mockRejectedValueOnce('string failure')
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    await pollAndFlush()
-
-    expect(errSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to power off left'),
-      'string failure',
-    )
-    errSpy.mockRestore()
-  })
-
-  it('survives db.select errors in evaluateSide via the poll-level catch', async () => {
-    // Drop the device_state table mid-flight to make isSidePowered() throw past
-    // its inner catch -- actually inner catch returns false. Better: drop
-    // side_settings to break getAutoOffConfig (already inner-caught -> defaults).
-    // To reach the poll-level outer catch (line 427), break a non-caught path:
-    // drop device_settings AFTER getGlobalMaxOnHours has run is hard. Instead
-    // we rely on the inner catches; this test just confirms no throw escapes.
-    ;(sqlite as any).exec('DROP TABLE side_settings;')
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    await expect(pollAndFlush()).resolves.toBeUndefined()
-
-    errSpy.mockRestore()
-  })
-
-  it('returns defaults when device_settings is missing (global cap path)', async () => {
-    const now = Date.now()
-    ;(sqlite as any).exec('DROP TABLE device_settings;')
-    setSideOn('left', now - 5 * 3600_000)
-    // auto_off_enabled left at default 0 -- only global cap path engaged,
-    // and global cap returns null on error so no fire
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-    errSpy.mockRestore()
-  })
-
-  it('treats a side as unpowered when device_state read throws', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    // Drop after seeding -- isSidePowered() catches and returns false, the
-    // side is treated as already off, no power-off is dispatched.
-    ;(sqlite as any).exec('DROP TABLE device_state;')
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('treats run-once as inactive when run_once_sessions read throws', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000) // past cap
-    // Drop only run_once_sessions -- evaluateSide reaches hasActiveRunOnce()
-    // for the active side, the catch returns false, and the global cap fires.
-    ;(sqlite as any).exec('DROP TABLE run_once_sessions;')
-
-    await pollAndFlush()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('treats the latest record as null when sleep_records read throws', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    // Drop biometrics-side records -- getLatestSleepRecord catches and
-    // returns null; evaluateSide should bail without firing.
-    ;(biometricsSqlite as any).exec('DROP TABLE sleep_records;')
-
-    await pollAndFlush()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('treats poweredOnAt as null when device_state schema is broken mid-flight', async () => {
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000)
-    // Replace device_state with a schema missing powered_on_at so the SELECT
-    // throws -- inner catch returns null, the global cap path is skipped.
-    ;(sqlite as any).exec(`
-      DROP TABLE device_state;
-      CREATE TABLE device_state (
-        side TEXT PRIMARY KEY,
-        is_powered INTEGER NOT NULL DEFAULT 1
-      );
-      INSERT INTO device_state (side, is_powered) VALUES ('left', 1), ('right', 0);
-    `)
-
-    await pollAndFlush()
-
-    // Cap path skipped (poweredOnAt unknown) and per-side path also returns
-    // (no sleep record path will run since auto-off feature defaults to off
-    // after the table-drop above wiped side_settings... actually side_settings
-    // is intact -- just verify no crash and no fire from the cap.
-    expect(setPower).not.toHaveBeenCalled()
-  })
-})
-
-// ── Timer firing under fake timers ───────────────────────────────────────
-
-describe('per-side auto-off (fake-timer firing)', () => {
-  beforeEach(() => {
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] })
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('fires the armed timer once the timeout elapses', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000) // exit 5min ago
-
-    startAutoOffWatcher() // arms a setTimeout for ~25min
-
-    // Advance past the timeout window
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    // Flush microtasks for firePowerOff promise chain
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('skips firing when user returned to bed before the timer expires', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
     startAutoOffWatcher()
-
-    // Before the timer fires, simulate re-entry: insert a newer record where
-    // enteredBedAt > leftBedAt
-    insertSleepRecord('left', now - 1 * 60_000, now - 4 * 60_000)
-
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    await Promise.resolve()
-
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('skips firing when latest record matches but user is back in bed (live-presence guard)', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    const leftAt = now - 5 * 60_000
-    insertSleepRecord('left', now - 90 * 60_000, leftAt) // armed exit
-
-    startAutoOffWatcher()
-
-    // Skim past most of the polling interval. The setTimeout fires at ~25min;
-    // the last poll before that runs at 24m30s. We advance to 24m45s, then
-    // stamp the user back in bed (same leftBedAt, newer enteredBedAt) so that
-    // when the setTimeout fires at 25m, the match-event check passes but the
-    // live-presence check trips.
-    await vi.advanceTimersByTimeAsync(24 * 60_000 + 45_000)
-    ;(biometricsSqlite as any)
-      .prepare('UPDATE sleep_records SET entered_bed_at=? WHERE side=? AND left_bed_at=?')
-      .run(Math.floor((now - 1 * 60_000) / 1000), 'left', Math.floor(leftAt / 1000))
-
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    await vi.advanceTimersByTimeAsync(2 * 60_000)
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-    expect(logSpy.mock.calls.some(args =>
-      typeof args[0] === 'string' && args[0].includes('user returned to bed'),
-    )).toBe(true)
-    logSpy.mockRestore()
-  })
-
-  it('skips firing when the latest bed-exit changed before the timer expires', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher()
-
-    // Newer exit overrides the armed one (different leftBedAt, still out of bed)
-    insertSleepRecord('left', now - 80 * 60_000, now - 2 * 60_000)
-
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    await Promise.resolve()
-
-    // Newer event => callback returns; evaluateSide will re-arm on next poll
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('skips firing when side is no longer powered when callback runs', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher()
-
-    // User powered the side off manually before the timer expires
-    ;(sqlite as any).prepare('UPDATE device_state SET is_powered=0 WHERE side=?').run('left')
-
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('skips firing when run-once becomes active before callback runs', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher()
-
+  it('skips sides with an active run-once session', async () => {
     insertActiveRunOnce('left')
-
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    await Promise.resolve()
-
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('skips firing when feature is disabled before callback runs', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher()
-
+  it('does not run the per-side timer when autoOffEnabled is false', async () => {
     setSideSettings('left', { autoOffEnabled: 0 })
-
-    await vi.advanceTimersByTimeAsync(26 * 60_000)
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('keeps an existing timer when poll re-evaluates same exit/timeout', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher() // arms timer
-    // Drive the polling interval so evaluateSide re-runs and hits the
-    // "timer already correct -- keep it" early return
-    await vi.advanceTimersByTimeAsync(30_000)
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('restarts an armed timer when autoOffMinutes changes via restartAutoOffTimers', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
     startAutoOffWatcher()
-    // Shorten timeout so a newly-armed timer fires sooner; restart re-polls
-    setSideSettings('left', { autoOffMinutes: 6 })
-    restartAutoOffTimers()
-
-    // 6min cap, exit was 5min ago, so ~1min remains
-    await vi.advanceTimersByTimeAsync(2 * 60_000)
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('cancelAutoOffTimer aborts a pending countdown without re-evaluation', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 5 * 60_000)
-
-    startAutoOffWatcher() // arms timer
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    cancelAutoOffTimer('left')
-
-    // Cancel logs the cancellation message; no power-off should have fired
-    // synchronously (the next interval poll WILL re-arm, but the cancel
-    // itself is the contract under test).
-    expect(logSpy.mock.calls.some(args =>
-      typeof args[0] === 'string' && args[0].includes('timer cancelled'),
-    )).toBe(true)
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
-    logSpy.mockRestore()
-  })
-
-  it('cancelAutoOffTimer is a no-op when no timer is set', () => {
-    // No prior arming -- exercise the early-exit branch
-    expect(() => cancelAutoOffTimer('right')).not.toThrow()
   })
 })
 
-// ── Lifecycle helpers ────────────────────────────────────────────────────
+describe('autoOffWatcher — global wall-clock cap', () => {
+  it('fires even when presence is unsensable', async () => {
+    setGlobalCap(8)
+    mockOccupancy.left = occ(false, false)
+    setSideOn('left', Date.now() - 9 * 3600_000) // 9h ago, past 8h cap
+    startAutoOffWatcher()
+    await vi.advanceTimersByTimeAsync(POLL_MS)
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
 
-describe('watcher lifecycle', () => {
-  it('startAutoOffWatcher is idempotent (second call is a no-op)', () => {
+  it('does not fire before the cap is exceeded', async () => {
+    setGlobalCap(8)
+    mockOccupancy.left = occ(true, true) // occupied → per-side path won't fire
+    setSideOn('left', Date.now() - 2 * 3600_000) // 2h ago
     startAutoOffWatcher()
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await vi.advanceTimersByTimeAsync(POLL_MS)
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('treats a future powered_on_at as suspicious and skips', async () => {
+    setGlobalCap(8)
+    mockOccupancy.left = occ(true, true)
+    setSideOn('left', Date.now() + 3600_000) // 1h in the future
     startAutoOffWatcher()
-    // Second start should not log "Watcher started" again
-    const startedCalls = logSpy.mock.calls.filter(args =>
-      typeof args[0] === 'string' && args[0].includes('Watcher started'),
-    )
-    expect(startedCalls).toHaveLength(0)
-    logSpy.mockRestore()
+    await vi.advanceTimersByTimeAsync(POLL_MS)
+    expect(setPower).not.toHaveBeenCalled()
+  })
+})
+
+describe('autoOffWatcher — lifecycle', () => {
+  it('startAutoOffWatcher is idempotent', async () => {
+    startAutoOffWatcher()
+    startAutoOffWatcher() // no-op
+    await vi.advanceTimersByTimeAsync(31 * 60_000)
+    expect(setPower).toHaveBeenCalledTimes(1)
+  })
+
+  it('stopAutoOffWatcher is safe when never started', async () => {
+    await expect(stopAutoOffWatcher()).resolves.toBeUndefined()
   })
 
   it('restartAutoOffTimers does nothing if watcher is not running', () => {
-    // Ensure watcher is stopped
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    restartAutoOffTimers()
-    // No "bed exit detected" or other poll-side logs should appear
-    expect(logSpy).not.toHaveBeenCalled()
-    logSpy.mockRestore()
+    expect(() => restartAutoOffTimers()).not.toThrow()
+    expect(setPower).not.toHaveBeenCalled()
   })
 
-  it('stopAutoOffWatcher awaits in-flight power-off promises', async () => {
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    // Make setPower hang briefly so the in-flight set is non-empty when stop runs
-    const resolveBox: { fn: (() => void) | null } = { fn: null }
-    setPower.mockImplementationOnce(
-      () => new Promise<void>((resolve) => { resolveBox.fn = () => resolve() }),
-    )
-
+  it('restartAutoOffTimers resets the countdown so it starts fresh', async () => {
     startAutoOffWatcher()
-    // Allow synchronous poll to fire firePowerOff
-    await Promise.resolve()
-    await Promise.resolve()
-
-    const stopP = stopAutoOffWatcher()
-    // stop is now waiting on the pending power-off
-    resolveBox.fn?.()
-    await stopP
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('stopAutoOffWatcher is safe to call when never started', async () => {
-    await expect(stopAutoOffWatcher()).resolves.toBeUndefined()
+    await vi.advanceTimersByTimeAsync(20 * 60_000) // empty 20min
+    restartAutoOffTimers() // resets emptySince
+    await vi.advanceTimersByTimeAsync(20 * 60_000) // only 20min since reset
+    expect(setPower).not.toHaveBeenCalled()
   })
 })
 
-// ── Mutation-killing boundary tests ──────────────────────────────────────
-//
-// These pin equality boundaries that survive coarse "well past the cap" tests:
-// strict `>` vs `>=`, `< 0` vs `<= 0`, `> 0` vs `>= 0`. Each uses fake-timer
-// freezing so msSinceX can hit the cap exactly to one millisecond.
-
-describe('boundary equality (kills `>`/`>=`, `< 0`/`<= 0`, `> 0`/`>= 0` mutants)', () => {
-  beforeEach(() => {
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
-    vi.setSystemTime(new Date('2026-05-10T00:00:00Z'))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('isUserInBed returns false when enteredBedAt equals leftBedAt — strict `>` boundary', async () => {
-    // Kills L205 `enteredMs > leftMs` → `>=`. Equal timestamps must NOT count
-    // as "in bed", otherwise auto-off is suppressed forever the moment a
-    // session row is written with simultaneous in/out (sensor noise edge case).
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 31 * 60_000, now - 31 * 60_000) // entered == left
-
-    await pollAndFlush()
-    await Promise.resolve()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('global cap of 0 is disabled (kills `> 0` → `>= 0` mutant on L298)', async () => {
-    // With `>= 0`, a cap of 0 would treat any positive msSincePowerOn as
-    // "exceeded" and power off any newly-on side. The strict `> 0` guard
-    // keeps 0 meaning "feature disabled".
-    const now = Date.now()
-    setGlobalCap(0)
-    setSideOn('left', now - 90 * 60_000) // 90min on — would fire if 0 were enabled
-
-    await pollAndFlush()
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('global cap does not fire when msSincePowerOn equals capMs exactly (kills `>` → `>=` on L307)', async () => {
-    // With `>=`, a side powered for exactly the cap would be cut at the tick.
-    // The strict `>` means the cap is a *ceiling* — fires only after exceeding.
-    const now = Date.now()
-    setGlobalCap(1) // 1h = 3_600_000ms
-    setSideOn('left', now - 3_600_000) // exactly 1h ago
-
-    await pollAndFlush()
-    await Promise.resolve()
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-
-  it('clock-sanity 7-day window is strict `>` — fires at exactly 7 days (kills `> 7d` → `>= 7d` on L306)', async () => {
-    // With `>=`, a side powered exactly 7 days ago would be flagged
-    // "suspicious" and the cap path would skip — a real 1-week heater would
-    // never auto-off. The strict `>` flags only stranger-than-7-day values.
-    const now = Date.now()
-    setGlobalCap(1) // 1h cap, clearly exceeded by 7d
-    setSideOn('left', now - 7 * 86_400_000) // exactly 7 days ago
-
-    await pollAndFlush()
-    await Promise.resolve()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
-  })
-
-  it('per-side timeout does not fire-immediate at exact boundary (kills `>` → `>=` on L353)', async () => {
-    // With `>=`, a bed-exit exactly at the timeout would skip the timer-arming
-    // path and fire immediately on the same poll. The strict `>` means at the
-    // boundary we arm a 0ms timer instead (subtle but matters: the firePowerOff
-    // path skips the bed-presence re-check inside the timer callback).
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 60 * 60_000)
-    insertSleepRecord('left', now - 90 * 60_000, now - 30 * 60_000) // exit exactly 30min ago == timeoutMs
-
+describe('autoOffWatcher — cancelAutoOffTimer', () => {
+  it('resets a pending countdown so a later empty period starts fresh', async () => {
     startAutoOffWatcher()
-    // Synchronous poll on start: original arms a 0ms timer (not yet fired);
-    // mutated `>=` would fire firePowerOff synchronously. Without advancing
-    // timers, setPower must not be observed.
-    await Promise.resolve()
-    await Promise.resolve()
-
+    await vi.advanceTimersByTimeAsync(20 * 60_000)
+    cancelAutoOffTimer('left') // scheduled power-on aborts the countdown
+    await vi.advanceTimersByTimeAsync(20 * 60_000)
     expect(setPower).not.toHaveBeenCalled()
   })
-})
 
-// ── More mutation-killing tests (lifecycle + DB writes) ──────────────────
-
-describe('restartAutoOffTimers is gated by pollHandle (kills L471 mutant)', () => {
-  it('does not invoke poll() when watcher is not running, even when conditions would fire', async () => {
-    // Kills `if (!pollHandle) return` → removing the guard. With the guard
-    // gone, restartAutoOffTimers would fall through to poll() and the global
-    // cap path would fire on a side that is past-cap. The contract is that
-    // the watcher must be explicitly started before any power-off can fire.
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000) // 5h past cap
-
-    // Watcher never started.
-    restartAutoOffTimers()
-    // Flush any fire-and-forget promise.
-    await new Promise(resolve => setImmediate(resolve))
-    await new Promise(resolve => setImmediate(resolve))
-
-    expect(setPower).not.toHaveBeenCalled()
-  })
-})
-
-describe('powerOffSide DB write (kills L226 `isPowered: false` → `true`)', () => {
-  it('clears device_state.isPowered to 0 after firing', async () => {
-    // Pins the value written into device_state. A mutation flipping the
-    // literal to `true` would leave isPowered=1 in the DB and the next status
-    // poll would see "still on" until the DAC reconciles.
-    const now = Date.now()
-    setSideSettings('left', { autoOffEnabled: 1, autoOffMinutes: 30 })
-    setSideOn('left', now - 3 * 3600_000)
-    insertSleepRecord('left', now - 4 * 3600_000, now - 2 * 3600_000)
-
-    await pollAndFlush()
-
-    const row = (sqlite as any)
-      .prepare('SELECT is_powered FROM device_state WHERE side=?')
-      .get('left')
-    expect(row.is_powered).toBe(0)
-  })
-})
-
-describe('getAutoOffConfig defaults (kills L110 boolean mutants)', () => {
-  it('alwaysOn defaults to false when side_settings read throws — cap still fires', async () => {
-    // Kills `alwaysOn: false` → `true` in the catch-path defaults. Without
-    // side_settings the cap path must still treat alwaysOn as false (i.e.,
-    // not exempt the side); with the mutation, alwaysOn=true would silently
-    // suppress every cap-driven power-off after a DB read failure.
-    const now = Date.now()
-    setGlobalCap(1)
-    setSideOn('left', now - 5 * 3600_000) // 5h past cap
-    ;(sqlite as any).exec('DROP TABLE side_settings;')
-
-    await pollAndFlush()
-
-    expect(setPower).toHaveBeenCalledWith('left', false)
+  it('is a no-op when no countdown is set', () => {
+    expect(() => cancelAutoOffTimer('right')).not.toThrow()
   })
 })


### PR DESCRIPTION
## Why

trinity reported a heated side that engaged for a few seconds after setting temp, then flipped back to **off** — pod never sustained. Disabling **Settings → Sides → Auto-off when empty** fixed it. Root cause: `autoOffWatcher` derived presence from the `sleep_records` table, which the sleep-detector only writes on session **close** (`entered_bed_at < left_bed_at` always). So `isUserInBed()` was structurally always false, and a powered side whose last session ended hours ago was reaped on the next 30s poll (and immediately on settings-save). It got worse in warm weather because restless/uncalibrated nights left presence undetected.

This is a regression from #450, which removed the per-side grace-window that had been the only thing sparing a powered side with a stale record.

## What

- **`autoOffWatcher` now reads live presence** via `getOccupancy()` (movement OR calibrated capSense2 level) — the same signal HomeKit and the web PresenceCard use — instead of `sleep_records`.
- **Fail-safe**: when presence can't be sensed for a side (no fresh capSense2 frame / no completed calibration → `available === false`), the watcher **stands down** rather than powering off. Missing/inconsistent biometrics never trigger a power-off. The global wall-clock cap remains the independent backstop.
- **UI gate**: `occupancy` exposes `available`; `biometrics.getOccupancy` returns it; the Settings auto-off toggle is disabled (with an explanatory note) when presence sensing is unavailable for the side.
- **Pump-stall protection → opt-in** (default `false`). It also acts on flow/RPM data not all pods report consistently, and a power-cutting safety feature must not fire on missing data. Migration `0011` resets existing installs to off; fresh installs seed off.

## Test plan

- `tsc --noEmit` clean; ESLint clean on changed files.
- **965/965** unit tests pass across services/lib/routers/homekit/scheduler/hardware.
- New `autoOffWatcher` suite (real in-memory sqlite + occupancy mock) covers: empty-past-timeout powers off; occupied never powers off; countdown reset on return; **fail-safe when unsensable** (regression for sleepypod-core-64); exemptions (off/alwaysOn/run-once/disabled); global cap fires even when unsensable; future-`poweredOnAt` skip; lifecycle + cancel.
- Manual: with auto-off on and a calibrated side, set temp → stays engaged; pull capSense → toggle greys out, side is not reaped.

Closes sleepypod-core-64.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/auto-off-live-presence
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/auto-off-live-presence/scripts/install \
  | sudo bash -s -- --branch fix/auto-off-live-presence
```

🎯 **Pin to this exact build** ([run 26721351749](https://github.com/sleepypod/core/actions/runs/26721351749) · `a8c4199`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a8c419940bdc6787a905e4d80d089a837dc19028/scripts/install \
  | sudo bash -s -- \
      --branch fix/auto-off-live-presence \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26721351749/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26721351749/artifacts/7319207313) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

