### PR TITLE
Capture RAW frame routing in sp-bundle-logs

### DIFF
--- a/scripts/bin/sp-bundle-logs
+++ b/scripts/bin/sp-bundle-logs
@@ -4,7 +4,8 @@ set -uo pipefail
 # sp-bundle-logs — one-shot diagnostic capture for support handoffs.
 #
 # Produces /tmp/sleepypod-bundle-<ts>.tar.gz with journals, systemctl status,
-# pod capabilities, network state, and version info. Designed to be shared
+# pod capabilities, raw frame routing, network state, and version info.
+# Designed to be shared
 # verbatim on Discord/GitHub, so secrets in .env and HomeKit pairing state
 # are redacted by default. Pass --no-redact for self-debugging when you
 # actually want the raw bytes.
@@ -120,6 +121,38 @@ fi
 capture "data/ls-sleepypod-data.txt" ls -la "$DATA_DIR"
 capture "data/ls-homekit.txt"        ls -la "$HOMEKIT_DIR"
 capture "data/ls-modules.txt"        ls -la /opt/sleepypod/modules
+
+# --- raw frame routing ----------------------------------------------------
+# The most common "biometrics are empty" cause is readers tailing a
+# different directory than the firmware writes .RAW frames to. Pod 3
+# firmware and the Pod 5 tmpfs redirect both land in /persistent/biometrics;
+# a stale unit defaults to /persistent and only sees the 16-byte SEQNO.RAW
+# bookkeeping file. Capture where frames actually land, where each reader
+# looks, and the tmpfs mount state so this is diagnosable from the bundle
+# alone instead of asking the user to hand-run probes.
+mkdir -p "$STAGE/raw"
+capture "raw/ls-persistent-RAW.txt" bash -c 'ls -la /persistent/*.RAW 2>&1'
+capture "raw/ls-biometrics.txt"     bash -c 'ls -la /persistent/biometrics/ 2>&1'
+capture "raw/mounts.txt"            bash -c 'mount | grep -iE "persistent|biometrics|tmpfs" || true'
+
+# Where is the firmware actually writing? Resolve its open .RAW fds.
+{
+  echo "$ readlink /proc/<frankenfirmware>/fd/*"
+  fw_pid="$(pgrep frankenfirmware 2>/dev/null | head -1)"
+  echo "frankenfirmware pid: ${fw_pid:-not running}"
+  if [ -n "${fw_pid:-}" ]; then
+    for fd in /proc/"$fw_pid"/fd/*; do
+      tgt="$(readlink "$fd" 2>/dev/null || true)"
+      case "$tgt" in *.RAW) echo "writing: $tgt" ;; esac
+    done
+  fi
+} > "$STAGE/raw/firmware-open-files.txt" 2>&1
+
+# Effective RAW_DATA_DIR each reader resolves (inline Environment + drop-ins).
+for svc in sleepypod sleepypod-piezo-processor sleepypod-sleep-detector \
+           sleepypod-environment-monitor sleepypod-calibrator; do
+  capture "raw/env-$svc.txt" systemctl show -p Environment "$svc.service"
+done
 
 # --- install log ---------------------------------------------------------
 if [ -f "$INSTALL_LOG" ]; then

--- a/scripts/bin/sp-bundle-logs
+++ b/scripts/bin/sp-bundle-logs
@@ -149,9 +149,14 @@ capture "raw/mounts.txt"            bash -c 'mount | grep -iE "persistent|biomet
 } > "$STAGE/raw/firmware-open-files.txt" 2>&1
 
 # Effective RAW_DATA_DIR each reader resolves (inline Environment + drop-ins).
+# Filter to RAW_DATA_DIR only — the full Environment property can carry
+# secrets and would break the bundle's safe-to-share default. Strip the
+# `Environment=` property prefix first so the match works regardless of
+# which position RAW_DATA_DIR holds in the unit.
 for svc in sleepypod sleepypod-piezo-processor sleepypod-sleep-detector \
            sleepypod-environment-monitor sleepypod-calibrator; do
-  capture "raw/env-$svc.txt" systemctl show -p Environment "$svc.service"
+  capture "raw/env-$svc.txt" bash -c \
+    'systemctl show -p Environment "$1.service" | sed "s/^Environment=//" | tr " " "\n" | grep -E "^RAW_DATA_DIR=" || true' _ "$svc"
 done
 
 # --- install log ---------------------------------------------------------


### PR DESCRIPTION
## What

Adds a **raw frame routing** section to `sp-bundle-logs` so the "sensors are empty / no biometrics" failure mode is diagnosable from the bundle alone, without asking the user to hand-run probes over SSH.

New captures under `raw/` in the bundle:
- `ls-persistent-RAW.txt` — `/persistent/*.RAW` (does only the 16-byte `SEQNO.RAW` exist?)
- `ls-biometrics.txt` — `/persistent/biometrics/` contents (the canonical RAW dir per ADR 0018)
- `firmware-open-files.txt` — resolves `frankenfirmware`'s open `.RAW` fds → **where frames actually land**
- `mounts.txt` — tmpfs/biometrics mount state
- `env-<svc>.txt` — effective `RAW_DATA_DIR` each reader resolves (`systemctl show -p Environment`), so a **stale unit still pointing at `/persistent`** is obvious

## Why

A Pod 3 user reported empty temperature/capacitance/piezo calibration. Triage took several manual round-trips: `ls /persistent/*.RAW` (only `SEQNO.RAW`), then `readlink /proc/$(pgrep frankenfirmware)/fd/*` to discover the firmware was actually writing to `/persistent/biometrics/`. The code fix (`RAW_DATA_DIR=/persistent/biometrics` everywhere) already shipped in #584 — the remaining gap is that `sp-bundle-logs`, our support-handoff tool, captured none of these signals. The three datapoints that resolve this class of issue are exactly what's added here.

This is purely additive (new `capture()` calls, same redaction model — RAW listings, mounts, and `RAW_DATA_DIR` env are non-secret). No behavior change to existing captures.

## Test plan

- [x] `bash -n scripts/bin/sp-bundle-logs` clean
- [ ] On a pod: run `sp-bundle-logs`, extract, confirm `raw/` contains the five files and `firmware-open-files.txt` shows the firmware's open `.RAW` path
- [ ] Confirm `env-*.txt` shows the effective `RAW_DATA_DIR` per service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic bundle to capture comprehensive raw frame routing information, including directory listings, mount details, and reader service configuration for improved troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pod3-raw-data-dir
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pod3-raw-data-dir/scripts/install \
  | sudo bash -s -- --branch fix/pod3-raw-data-dir
```

🎯 **Pin to this exact build** ([run 26728901315](https://github.com/sleepypod/core/actions/runs/26728901315) · `ec2320c`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/ec2320c8ceacdd1c07d91eba3472eee2a5b24801/scripts/install \
  | sudo bash -s -- \
      --branch fix/pod3-raw-data-dir \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26728901315/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26728901315/artifacts/7321332837) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

