### PR TITLE
Stop sp-update from breaking biometrics modules when uv is missing

### DIFF
--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -297,38 +297,53 @@ if [ -d "$INSTALL_DIR/modules" ]; then
   export UV_CACHE_DIR="/opt/sleepypod/uv-cache"
   mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
   chmod 0755 /opt/sleepypod "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" 2>/dev/null || true
-  if [ -d "$INSTALL_DIR/modules/common" ]; then
-    mkdir -p "$MODULES_DEST/common"
-    cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
-  fi
+  # uv is required to (re)build each module's .venv. The per-module sync
+  # below wipes the existing .venv before rebuilding, so running it without
+  # uv would leave previously-working biometrics modules dead (203/EXEC) on
+  # a venv that can't be recreated. Install uv first (same source as the
+  # full installer); if it still isn't available, skip the module sync
+  # entirely and leave the running modules untouched rather than
+  # half-upgrading into a broken state.
   if ! command -v uv &>/dev/null; then
-    echo "Warning: uv not found — biometrics modules not synced. Re-run the full installer."
+    echo "uv not found — installing (required to rebuild biometrics module venvs)..."
+    curl -LsSf https://astral.sh/uv/install.sh \
+      | UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh || true
   fi
-  for mod in piezo-processor sleep-detector environment-monitor calibrator cover-buttons; do
-    if [ -d "$INSTALL_DIR/modules/$mod" ]; then
-      mkdir -p "$MODULES_DEST/$mod"
-      cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
-      rm -rf "$MODULES_DEST/$mod/venv"
-      # Also wipe .venv so OTAs pick up the shared UV_PYTHON_INSTALL_DIR
-      # set above — otherwise a pre-v1.7.3 venv's bin/python symlink keeps
-      # pointing at /home/root/.local/share/uv/… and User=dac modules fail
-      # to exec. uv's content-addressable cache means this is a cheap
-      # re-link, not a full re-download.
-      rm -rf "$MODULES_DEST/$mod/.venv"
-      if command -v uv &>/dev/null; then
+
+  if ! command -v uv &>/dev/null; then
+    echo "ERROR: uv unavailable — skipping biometrics module sync." >&2
+    echo "       Existing modules keep their current venvs and units (left running)," >&2
+    echo "       but RAW/biometrics fixes in this update are NOT deployed." >&2
+    echo "       Re-run the full installer once uv can be installed." >&2
+  else
+    if [ -d "$INSTALL_DIR/modules/common" ]; then
+      mkdir -p "$MODULES_DEST/common"
+      cp -r "$INSTALL_DIR/modules/common/." "$MODULES_DEST/common/"
+    fi
+    for mod in piezo-processor sleep-detector environment-monitor calibrator cover-buttons; do
+      if [ -d "$INSTALL_DIR/modules/$mod" ]; then
+        mkdir -p "$MODULES_DEST/$mod"
+        cp -r "$INSTALL_DIR/modules/$mod/." "$MODULES_DEST/$mod/"
+        rm -rf "$MODULES_DEST/$mod/venv"
+        # Also wipe .venv so OTAs pick up the shared UV_PYTHON_INSTALL_DIR
+        # set above — otherwise a pre-v1.7.3 venv's bin/python symlink keeps
+        # pointing at /home/root/.local/share/uv/… and User=dac modules fail
+        # to exec. uv's content-addressable cache means this is a cheap
+        # re-link, not a full re-download.
+        rm -rf "$MODULES_DEST/$mod/.venv"
         (cd "$MODULES_DEST/$mod" && uv sync --frozen) \
           || echo "Warning: uv sync failed for module $mod"
         chmod -R o+rX "$MODULES_DEST/$mod/.venv" 2>/dev/null || true
+        svc="sleepypod-$mod.service"
+        if [ -f "$MODULES_DEST/$mod/$svc" ]; then
+          cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
+          systemctl daemon-reload
+          systemctl enable "$svc" 2>/dev/null || true
+          systemctl restart "$svc" 2>/dev/null || true
+        fi
       fi
-      svc="sleepypod-$mod.service"
-      if [ -f "$MODULES_DEST/$mod/$svc" ]; then
-        cp "$MODULES_DEST/$mod/$svc" "/etc/systemd/system/$svc"
-        systemctl daemon-reload
-        systemctl enable "$svc" 2>/dev/null || true
-        systemctl restart "$svc" 2>/dev/null || true
-      fi
-    fi
-  done
+    done
+  fi
 fi
 
 # Biometrics archiver — tmpfs RAW writes + frank.sh cd patch. Module


### PR DESCRIPTION
## What

When `uv` is absent, `sp-update` now (1) tries to install it from the same source as the full installer, and (2) if that still fails, **skips the biometrics module sync entirely** instead of half-upgrading into a broken state.

## Why

The old uv-missing path only printed `Warning: uv not found — biometrics modules not synced` and then **ran the destructive loop anyway**. For each module it would:

1. `rm -rf .venv` (wipe the working virtualenv),
2. skip `uv sync` (no uv → venv never rebuilt),
3. `cp` the unit + `systemctl restart`.

Net effect: an OTA update on a pod without `uv` **deletes each biometrics module's venv and restarts the service into a `203/EXEC` failure** — turning previously-working modules off, with only an easy-to-miss warning. This is the latent trap behind a Pod 3 "biometrics empty after update" report.

## Fix

- Mirror `scripts/install`: `curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh` when `uv` is missing.
- If `uv` is still unavailable, emit a loud `ERROR:` to stderr and **skip the sync** — existing venvs/units are left intact and modules keep running. (Matches the installer, which already guards module install behind `uv` being present.)
- The per-module inner `if command -v uv` guard is now redundant (the outer branch guarantees uv) and is removed, de-nesting `uv sync`.

No change to the happy path (uv present) beyond the de-nest.

## Test plan

- [x] `bash -n scripts/bin/sp-update` clean
- [ ] Pod with uv removed from PATH + no WAN: run `sp-update` → modules untouched and still active; clear ERROR printed; no venv wiped
- [ ] Pod with uv removed but WAN open: `sp-update` installs uv, then syncs modules normally
- [ ] Pod with uv present: unchanged behavior, modules sync + restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Module synchronization is now more robust. The system automatically attempts to install missing dependencies and gracefully skips module updates if required tools are unavailable, preventing corrupted states and providing explicit error messages for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/sp-update-uv-missing
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/sp-update-uv-missing/scripts/install \
  | sudo bash -s -- --branch fix/sp-update-uv-missing
```

🎯 **Pin to this exact build** ([run 26729920241](https://github.com/sleepypod/core/actions/runs/26729920241) · `628fff6`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/628fff6337a11c7bd6acd915e782cf1df57e0378/scripts/install \
  | sudo bash -s -- \
      --branch fix/sp-update-uv-missing \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26729920241/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26729920241/artifacts/7321662855) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
