### PR TITLE
fix(streaming): deflake piezoStream subscription-filter fan-out test

### DIFF
--- a/src/streaming/tests/piezoStream.test.ts
+++ b/src/streaming/tests/piezoStream.test.ts
@@ -954,15 +954,24 @@ describe('piezoStream — server lifecycle and protocol', () => {
 
   it('respects subscription filter during live streaming fan-out', async () => {
     const filePath = path.join(tmpRawDir, 'sub-filter.RAW')
-    const recs = [
-      buildOuterRecord(1, [{ type: 'capSense', ts: 1500, left: 0, right: 0 }]),
-      buildOuterRecord(2, [{ type: 'log', ts: 1501, level: 1, msg: 'hi' }]),
-    ]
-    fs.writeFileSync(filePath, Buffer.concat(recs))
+    // Create the file empty so the follower latches onto it, but withhold the
+    // frames until the subscription filter is confirmed. Writing the records up
+    // front races the tailing loop against the subscribe message: a tick that
+    // fires before the filter is installed fans out capSense under the default
+    // (all-types) subscription and the assertion flakes.
+    fs.writeFileSync(filePath, Buffer.alloc(0))
     const port = startAndPort()
     const client = await connectClient(port)
     client.ws.send(JSON.stringify({ type: 'subscribe', sensors: ['log'] }))
     await client.waitFor(m => m.type === 'subscribed')
+
+    // Filter is in place — now append both frames. capSense (seq 1) is parsed
+    // before log (seq 2) in the same tick, so once log arrives capSense has
+    // already been processed and filtered. No wall-clock ordering assumption.
+    fs.appendFileSync(filePath, Buffer.concat([
+      buildOuterRecord(1, [{ type: 'capSense', ts: 1500, left: 0, right: 0 }]),
+      buildOuterRecord(2, [{ type: 'log', ts: 1501, level: 1, msg: 'hi' }]),
+    ]))
 
     await client.waitFor(m => m.type === 'log' && m.ts === 1501, 3000)
     // capSense must NOT have reached the client because it filtered to ['log'].


### PR DESCRIPTION
## Why
`src/streaming/tests/piezoStream.test.ts > 'respects subscription filter during live streaming fan-out'` flaked in full parallel CI (`sleepypod-core-65`). It passed 3/3 in isolation but intermittently failed at `piezoStream.test.ts:969` expecting the `capSense` frame to be undefined.

## Root cause
The test wrote both the `capSense` and `log` records to the RAW file **before** the server started, then connected and sent `{ type: 'subscribe', sensors: ['log'] }`. A new client defaults to the all-types subscription (`undefined` filter). The periodic file-tailing loop (`piezoStream.ts`, `setInterval`) could fire and fan out the already-on-disk `capSense` frame before the client's `subscribe` message was processed — leaking `capSense` to the client. Under parallel CI load the subscribe message is more likely to lose that race, so the assertion failed.

## Fix
Create the RAW file empty so the follower latches onto it, send `subscribe`, wait for the `subscribed` ack, and **only then** append the `capSense`/`log` frames. The filter is guaranteed installed before any frame is tailed. Within the single append, `capSense` (seq 1) is parsed before `log` (seq 2) in the same tick, so once `log` is delivered `capSense` has already been processed and filtered — no wall-clock ordering assumption.

## Test plan
- Target test 20/20 green in isolation
- Full `piezoStream.test.ts` file 3/3 green (58 tests)
- `eslint` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved streaming subscription filter test reliability by adjusting operation sequencing to eliminate race conditions during live data fan-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/flaky-piezostream-fanout
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/flaky-piezostream-fanout/scripts/install \
  | sudo bash -s -- --branch fix/flaky-piezostream-fanout
```

🎯 **Pin to this exact build** ([run 26739572044](https://github.com/sleepypod/core/actions/runs/26739572044) · `20cb549`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/20cb549e4a38f2a569590f2ded8e1a6e053d5ee8/scripts/install \
  | sudo bash -s -- \
      --branch fix/flaky-piezostream-fanout \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/26739572044/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/26739572044/artifacts/7325004820) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
