### PR TITLE
fix(sleep-detector): debounce presence to stop session fragmentation + runaway durations

### DIFF
--- a/modules/sleep-detector/main.py
+++ b/modules/sleep-detector/main.py
@@ -739,7 +739,11 @@ class SessionTracker:
 
         # Safety net: force-close a runaway session that never reaches the
         # absence timeout, capping sleep_duration_seconds at MAX_SESSION_S.
+        # Only when still debounced-present — once absent, the absence-timeout
+        # path above closes at the true exit edge, so the cap must not move
+        # left_bed_at forward to the cap timestamp.
         if (self._session_start is not None
+                and self._debounced_present
                 and ts - self._session_start.timestamp() >= MAX_SESSION_S):
             self._close_session(self._session_start.timestamp() + MAX_SESSION_S)
 

--- a/modules/sleep-detector/main.py
+++ b/modules/sleep-detector/main.py
@@ -84,6 +84,20 @@ SLEEPYPOD_DB = Path(os.environ.get("DATABASE_URL", "file:/persistent/sleepypod-d
 ABSENCE_TIMEOUT_S = 120
 # Minimum session length to record (filters out accidental detections)
 MIN_SESSION_S = 300
+# Presence debounce / hysteresis: a present<->absent flip is only committed
+# after the new raw state has persisted for this many seconds. Without it,
+# brief capSense dropouts (sub-second flaps at 2 Hz while the occupant is
+# genuinely in bed) each split the session and bump times_exited_bed, yielding
+# dozens of <15min fragments with 66-109 bogus exits overnight (pod 88 field
+# debug 2026-06-10). Must be < ABSENCE_TIMEOUT_S so debounced absence still
+# closes the session on a real bed-exit.
+PRESENCE_DEBOUNCE_S = 30.0
+# Hard upper bound on a single session. Belt-and-suspenders against a session
+# that never closes (e.g. presence flapping that historically kept resetting
+# the absence timer, producing 2736/2850min runaway durations). A continuous
+# presence span beyond this is force-closed at the cap rather than persisted as
+# a multi-day sleep_record.
+MAX_SESSION_S = 16 * 3600
 # How often to write a movement row (seconds)
 MOVEMENT_INTERVAL_S = 60
 # Fallback presence threshold when uncalibrated
@@ -587,6 +601,13 @@ class SessionTracker:
     _interval_start: Optional[float] = None
     _was_present: bool = False
     _exit_count: int = 0
+    # Debounced (committed) presence state and the ts at which it began.
+    # Distinct from the raw per-sample `present`: only flips after a candidate
+    # state survives PRESENCE_DEBOUNCE_S (see _apply_debounce).
+    _debounced_present: bool = False
+    _state_since: Optional[float] = None
+    _pending_state: Optional[bool] = None
+    _pending_since: Optional[float] = None
     _movement_buf: list = field(default_factory=list)
     _last_movement_write: float = field(default_factory=time.time)
     _prev_values: Optional[list] = None  # previous sample's channel values
@@ -639,31 +660,70 @@ class SessionTracker:
 
         self._update(ts, present, delta)
 
+    def _apply_debounce(self, ts: float, raw_present: bool) -> bool:
+        """Fold the raw per-sample presence into the committed (debounced)
+        state. A flip is only committed once the differing raw state has
+        persisted for PRESENCE_DEBOUNCE_S; transient flaps are cancelled.
+
+        On commit, _state_since is set to the ts at which the new state
+        actually began (the first differing sample), so interval edges and
+        the session entry time reflect the true transition, not commit time.
+
+        Returns True iff the committed state flipped on this call.
+        """
+        if raw_present == self._debounced_present:
+            # Raw agrees with the committed state — cancel any pending flip.
+            self._pending_state = None
+            self._pending_since = None
+            return False
+
+        if self._pending_state != raw_present:
+            # New candidate differing from committed state — start its dwell.
+            self._pending_state = raw_present
+            self._pending_since = ts
+            return False
+
+        if (self._pending_since is not None
+                and ts - self._pending_since >= PRESENCE_DEBOUNCE_S):
+            self._debounced_present = raw_present
+            self._state_since = self._pending_since
+            self._pending_state = None
+            self._pending_since = None
+            return True
+
+        return False
+
     def _update(self, ts: float, present: bool, movement: float) -> None:
         self._movement_buf.append(movement)
         self._flush_movement(ts)
 
-        if present:
+        # Debounce raw presence so brief capSense dropouts don't fragment the
+        # session or inflate times_exited_bed (pod 88 field debug 2026-06-10).
+        changed = self._apply_debounce(ts, present)
+        # Timestamp of the true transition when one just committed, else `ts`.
+        edge_ts = self._state_since if changed and self._state_since is not None else ts
+
+        if self._debounced_present:
             if self._session_start is None:
-                # New session starts
-                self._session_start = datetime.fromtimestamp(ts, tz=timezone.utc)
-                self._interval_start = ts
+                # New session starts at the true entry time.
+                self._session_start = datetime.fromtimestamp(edge_ts, tz=timezone.utc)
+                self._interval_start = edge_ts
                 self._was_present = True
                 log.info("%s: session started at %s", self.side, self._session_start.isoformat())
 
-            elif not self._was_present and self._interval_start is not None:
+            elif changed and self._interval_start is not None:
                 # Returning from absence — close absent interval, open present interval
-                self._absent_intervals.append([self._interval_start, ts])
-                self._interval_start = ts
+                self._absent_intervals.append([self._interval_start, edge_ts])
+                self._interval_start = edge_ts
 
             self._last_present_ts = ts
             self._was_present = True
 
         else:
-            if self._was_present and self._interval_start is not None:
-                # Just went absent — close present interval, open absent interval
-                self._present_intervals.append([self._interval_start, ts])
-                self._interval_start = ts
+            if changed and self._was_present and self._interval_start is not None:
+                # Confirmed bed-exit — close present interval, open absent interval
+                self._present_intervals.append([self._interval_start, edge_ts])
+                self._interval_start = edge_ts
                 self._exit_count += 1
 
             self._was_present = False
@@ -676,6 +736,12 @@ class SessionTracker:
                 # avoid emitting absent intervals with end < start
                 close_ts = self._interval_start if self._interval_start is not None else self._last_present_ts
                 self._close_session(close_ts)
+
+        # Safety net: force-close a runaway session that never reaches the
+        # absence timeout, capping sleep_duration_seconds at MAX_SESSION_S.
+        if (self._session_start is not None
+                and ts - self._session_start.timestamp() >= MAX_SESSION_S):
+            self._close_session(self._session_start.timestamp() + MAX_SESSION_S)
 
     def _close_session(self, left_ts: float) -> None:
         if self._session_start is None:
@@ -721,6 +787,10 @@ class SessionTracker:
         self._interval_start = None
         self._was_present = False
         self._exit_count = 0
+        self._debounced_present = False
+        self._state_since = None
+        self._pending_state = None
+        self._pending_since = None
         self._prev_values = None  # avoid stale delta on next session start
         self._movement_buf = []   # discard leftover deltas from session end
         self._epoch_scores.clear()

--- a/modules/sleep-detector/test_main.py
+++ b/modules/sleep-detector/test_main.py
@@ -230,3 +230,90 @@ class TestSharedConnectionHolder:
         assert holder.conn is replacement
         # The original closed-handle is no longer referenced by the holder, so
         # any tracker reading from holder.conn observes the live connection.
+
+
+def _tracker():
+    """A SessionTracker wired to an in-memory DB. calibration/pump_gate are
+    unused by _update, so None is sufficient for presence/session tests."""
+    holder = main.DBHolder(_make_db())
+    main._db_write_failures = 0
+    return main.SessionTracker(side="left", db=holder,
+                               calibration=None, pump_gate=None)
+
+
+def _feed(t, samples):
+    """Feed (ts, present) pairs through _update with zero movement."""
+    for ts, present in samples:
+        t._update(ts, present, 0.0)
+
+
+def _rows(t):
+    return t.db.conn.execute(
+        "SELECT sleep_duration_seconds, times_exited_bed FROM sleep_records"
+    ).fetchall()
+
+
+class TestPresenceDebounce:
+    """Pod 88 field debug 2026-06-10: brief capSense dropouts fragmented one
+    overnight presence span into dozens of <15min sleep_records with 66-109
+    bogus bed-exits and runaway durations. Presence is now debounced."""
+
+    def test_brief_dropout_does_not_increment_exit_or_split_session(self):
+        t = _tracker()
+        base = 1_777_000_000.0
+        samples = []
+        # Establish committed presence (sustain past PRESENCE_DEBOUNCE_S).
+        samples += [(base, True), (base + 31, True)]
+        # 8h in bed at 2 Hz would be huge; sample sparsely but inject many
+        # sub-debounce dropouts — each a single absent sample immediately
+        # followed by present. None should commit a flip.
+        ts = base + 31
+        for _ in range(50):
+            ts += 60
+            samples.append((ts, False))   # brief dropout
+            samples.append((ts + 1, True))  # back within 1s — under debounce
+        # Real morning exit: sustained absence past debounce + absence timeout.
+        exit_ts = ts + 3600
+        samples.append((exit_ts, False))
+        samples.append((exit_ts + 31, False))   # commits absent flip → 1 exit
+        samples.append((exit_ts + 200, False))  # > ABSENCE_TIMEOUT_S → close
+        _feed(t, samples)
+
+        rows = _rows(t)
+        assert len(rows) == 1
+        duration_s, exits = rows[0]
+        assert exits == 1
+        # One continuous span: duration ~ (exit_ts - base), well over an hour.
+        assert duration_s >= 3600
+
+    def test_sustained_absence_counts_single_exit(self):
+        t = _tracker()
+        base = 1_777_000_000.0
+        samples = [(base, True), (base + 31, True)]
+        # Genuine bed-exit: absence sustained past debounce, then past the
+        # absence timeout so the session closes on that one exit.
+        leave = base + 4000
+        samples += [(leave, False), (leave + 31, False), (leave + 200, False)]
+        _feed(t, samples)
+
+        rows = _rows(t)
+        assert len(rows) == 1
+        _duration, exits = rows[0]
+        assert exits == 1
+
+    def test_runaway_session_is_capped(self):
+        t = _tracker()
+        base = 1_777_000_000.0
+        samples = [(base, True), (base + 31, True)]
+        # Presence that never goes absent for > MAX_SESSION_S of wall-clock.
+        ts = base + 31
+        while ts < base + main.MAX_SESSION_S + 7200:
+            ts += 600
+            samples.append((ts, True))
+        _feed(t, samples)
+
+        rows = _rows(t)
+        assert len(rows) >= 1
+        # No row exceeds the hard cap.
+        for duration_s, _exits in rows:
+            assert duration_s <= main.MAX_SESSION_S


### PR DESCRIPTION
## Why

Pod 88 (Pod 5 J55) field debug 2026-06-10: `sleep_records` degenerated — one overnight presence span fragmented into dozens of <15min sessions with **66-109 bogus bed-exits**, and durations ran away to **2736/2850min (45-47h)**. Raw vitals/movement/bed_temp streams were intact, so this was a detection bug, not data loss.

Root cause in `modules/sleep-detector/main.py` `_update()`: raw per-sample `capSense` presence drove `_exit_count` and session/interval transitions directly. At 2 Hz a single noisy dropout (sub-second) immediately counted a bed-exit and split the session; the constant flapping back to present kept resetting `_last_present_ts`, so `ts - _last_present_ts >= ABSENCE_TIMEOUT_S` never fired and sessions never closed.

## What

- **Debounce / hysteresis** (`PRESENCE_DEBOUNCE_S = 30s`): a present↔absent flip is only committed after the differing raw state persists for the dwell window. Brief dropouts are cancelled — they no longer increment `times_exited_bed` or split the session. `_apply_debounce()` records the true transition timestamp so interval edges and the session entry time stay accurate. Dwell `< ABSENCE_TIMEOUT_S` so a real exit still closes the session.
- **Runaway cap** (`MAX_SESSION_S = 16h`): belt-and-suspenders force-close so no `sleep_record` can persist a multi-day `sleep_duration_seconds`.

## Test plan

`modules/sleep-detector/test_main.py` — `TestPresenceDebounce`:
- `test_brief_dropout_does_not_increment_exit_or_split_session` — 50 sub-debounce dropouts across one span → exactly **1 record, 1 exit**.
- `test_sustained_absence_counts_single_exit` — a genuine sustained absence → 1 exit.
- `test_runaway_session_is_capped` — presence past `MAX_SESSION_S` → no row exceeds the cap.

```
uv run --with pytest pytest -q test_main.py   # 23 passed
```

## Follow-up (manual, pod 88)

Existing garbage rows (`sleep_records` ~id 300-316) predate this fix and live in the pod's `biometrics.db`; they need a one-time cleanup over SSH (not done here to avoid mutating live data unprompted):

```sql
-- inspect first
SELECT id, sleep_duration_seconds/60 AS min, times_exited_bed FROM sleep_records WHERE id BETWEEN 300 AND 316;
-- then delete the fragments/runaways
DELETE FROM sleep_records WHERE sleep_duration_seconds > 16*3600 OR times_exited_bed > 20;
```

Separate minor (not addressed): pod clock is UTC, so nightly dates label as the next UTC day.

Closes sleepypod-core-71.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Presence debouncing with 30-second dwell time applied to bed occupancy detection
  * Session duration capped at maximum 16 hours with automatic closure of long-running sessions
  * Session timestamps now aligned to actual state transition times

* **Tests**
  * Added comprehensive test coverage for presence debounce behavior and session duration limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/sleep-detector-presence-debounce
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/sleep-detector-presence-debounce/scripts/install \
  | sudo bash -s -- --branch fix/sleep-detector-presence-debounce
```

🎯 **Pin to this exact build** ([run 27320090177](https://github.com/sleepypod/core/actions/runs/27320090177) · `332570f`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/332570fed0a82a1c1f9172125e7b69c4f1eb536b/scripts/install \
  | sudo bash -s -- \
      --branch fix/sleep-detector-presence-debounce \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27320090177/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27320090177/artifacts/7553491736) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

