### PR TITLE
fix(biometrics): stop archive pruner dying on SIGPIPE (/persistent filling past target)

### DIFF
--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner
@@ -17,8 +17,12 @@ while :; do
     break
   fi
 
+  # awk takes the first line and consumes the rest of the stream; piping to
+  # `head -1` instead closes the pipe early and, under `set -o pipefail`,
+  # makes `sort` fail with SIGPIPE/"Broken pipe" → the whole script aborts
+  # and never prunes (archive grows unbounded, /persistent fills past target).
   oldest=$(find "$ARCHIVE_DIR" -maxdepth 1 -type f -name '*.RAW.gz' -printf '%T@ %p\n' 2>/dev/null \
-    | sort -n | head -1 | awk '{print $2}')
+    | sort -n | awk 'NR==1{print $2}')
   if [ -z "$oldest" ]; then
     echo "pruner: $used_pct% used but archive is empty — nothing to prune" >&2
     break


### PR DESCRIPTION
## Summary

The biometrics archive pruner (`modules/biometrics-archiver/sleepypod-biometrics-pruner`) has never pruned on a pod with a large archive. It exits before deleting anything, so `/persistent/biometrics-archive` grows unbounded and `/persistent` fills past the 80% target.

### Root cause
```bash
oldest=$(find ... -printf '%T@ %p\n' | sort -n | head -1 | awk '{print $2}')
```
Under `set -euo pipefail`, `head -1` closes the pipe after the first line. With a large archive (thousands of files) `sort` is still writing, gets `SIGPIPE` → `sort: write failed: 'standard output': Broken pipe`, the pipeline returns 141, and `set -e` aborts the whole script. Net effect: `pruned=0` every run, service shows `status=2/INVALIDARGUMENT`.

### Fix
Replace `sort -n | head -1 | awk '{print $2}'` with `sort -n | awk 'NR==1{print $2}'`. `awk` reads the whole stream (prints only line 1) so `sort` never gets SIGPIPE.

## Evidence (Pod 5 / .88, eight-pod)
- `/persistent` at **84%** (target <80%); `/persistent/biometrics-archive` = **9.4 GB**, 3,789 `*.RAW.gz`.
- `journalctl -u sleepypod-biometrics-pruner`: `sort: write failed: 'standard output': Broken pipe` → `status=2/INVALIDARGUMENT` every 15 min.

## Test plan
- [x] Repro under `set -o pipefail`: `seq 1 100000 | sort -n | head -1 | awk '{print $1}'` exits **141**; `sort -n | awk 'NR==1{print $1}'` exits **0**.
- [x] `bash -n` clean.
- [ ] Deploy to .88, run `systemctl start sleepypod-biometrics-pruner`, confirm it prunes oldest `.RAW.gz` until `/persistent` < 80% and logs `pruned=N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a premature-pruning failure in the biometrics archive pruner caused by pipeline breakage under strict error handling. The script now reliably identifies and prunes the oldest eligible files, preventing it from aborting early and helping keep archive size properly managed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/biometrics-pruner-sigpipe
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/biometrics-pruner-sigpipe/scripts/install \
  | sudo bash -s -- --branch fix/biometrics-pruner-sigpipe
```

🎯 **Pin to this exact build** ([run 27520832687](https://github.com/sleepypod/core/actions/runs/27520832687) · `412c906`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/412c90698d429015f8b045f8173d4f337ed66477/scripts/install \
  | sudo bash -s -- \
      --branch fix/biometrics-pruner-sigpipe \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27520832687/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27520832687/artifacts/7627998221) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

