### PR TITLE
Automation builder: legible backtest chart + editable number fields

### DIFF
--- a/src/components/Autopilot/BacktestPanel.tsx
+++ b/src/components/Autopilot/BacktestPanel.tsx
@@ -56,12 +56,23 @@ function Chart({ r }: { r: BacktestResult }) {
   const N = r.clockMin.length
   if (N < 2) return <div className="text-[12px] text-zinc-500 px-2 py-8 text-center">Not enough data in this window to replay.</div>
 
-  const W = 660, H = 188, mL = 38, mR = 42, mT = 14, mB = 22
-  const iw = W - mL - mR, ih = H - mT - mB
-  const x = (i: number) => mL + (i / (N - 1)) * iw
-
   // Policy overlays ambient + setpoint on one shared temperature scale.
   const policy = r.mode === 'policy'
+
+  const W = 660, mL = 38, mR = 42, mT = 14
+  const iw = W - mL - mR
+  // Edge mode reserves a dedicated event rail beneath the plot so the plot
+  // itself stays clean at any event density; policy keeps the original layout.
+  const plotH = 152
+  const ih = policy ? plotH : plotH - 2
+  const railGap = 8
+  const railH = 14
+  const railTop = mT + ih + railGap
+  const railBottom = railTop + railH
+  const labelY = policy ? mT + ih + 16 : railBottom + 11
+  const H = policy ? mT + ih + 22 : labelY + 5
+  const x = (i: number) => mL + (i / (N - 1)) * iw
+  const stepX = iw / (N - 1)
   const primA = r.primaryAxis
   const tempA = r.tempAxis ?? { min: 60, max: 80 }
   const sharedMin = policy ? Math.min(primA?.min ?? tempA.min, tempA.min) : tempA.min
@@ -110,6 +121,28 @@ function Chart({ r }: { r: BacktestResult }) {
   // time ticks at ~6 even index positions
   const tickIdx = Array.from({ length: 6 }, (_, k) => Math.round((k / 5) * (N - 1)))
 
+  // Collapse consecutive suppressed indices into cooldown runs so a dense
+  // burst reads as a single band rather than N stacked marks (edge only).
+  const cooldownBands: Array<[number, number]> = (() => {
+    if (policy || r.suppressed.length === 0) return []
+    const sorted = [...r.suppressed].sort((a, b) => a - b)
+    const runs: Array<[number, number]> = []
+    let s = sorted[0]
+    let p = sorted[0]
+    for (let k = 1; k < sorted.length; k++) {
+      const i = sorted[k]
+      if (i === p + 1) {
+        p = i
+        continue
+      }
+      runs.push([s, p])
+      s = i
+      p = i
+    }
+    runs.push([s, p])
+    return runs
+  })()
+
   return (
     <div className="rounded-lg border border-zinc-800/80 bg-zinc-950/60 p-2">
       <svg width="100%" viewBox={`0 0 ${W} ${H}`} style={{ display: 'block' }}>
@@ -119,7 +152,7 @@ function Chart({ r }: { r: BacktestResult }) {
         {tickIdx.map((idx, i) => (
           <g key={i}>
             <line x1={x(idx)} x2={x(idx)} y1={mT} y2={mT + ih} stroke="#18181b" strokeWidth="1" />
-            <text x={x(idx)} y={H - 6} textAnchor="middle" className="mono" style={{ fontSize: 9, fill: '#71717a' }}>{minToClock(r.clockMin[idx])}</text>
+            <text x={x(idx)} y={labelY} textAnchor="middle" className="mono" style={{ fontSize: 9, fill: '#71717a' }}>{minToClock(r.clockMin[idx])}</text>
           </g>
         ))}
 
@@ -144,6 +177,13 @@ function Chart({ r }: { r: BacktestResult }) {
           ))
         })()}
 
+        {/* cooldown bands — one rect per suppressed run, padded half a step */}
+        {cooldownBands.map(([a, b], k) => {
+          const x0 = Math.max(mL, x(a) - stepX / 2)
+          const x1 = Math.min(W - mR, x(b) + stepX / 2)
+          return <rect key={`cb${k}`} x={x0} y={mT} width={Math.max(1, x1 - x0)} height={ih} fill="#71717a" opacity="0.07" />
+        })}
+
         {/* policy clamp band */}
         {policy && r.clamp && (
           <>
@@ -153,44 +193,49 @@ function Chart({ r }: { r: BacktestResult }) {
           </>
         )}
 
+        {/* fire zone — faint red tint above the threshold (edge) */}
+        {!policy && r.threshold != null && r.primaryAxis && (
+          <rect x={mL} y={mT} width={iw} height={Math.max(0, yPrimary(r.threshold) - mT)} fill="#ef4444" opacity="0.05" />
+        )}
+
         {/* threshold (edge) */}
         {!policy && r.threshold != null && r.primaryAxis && (
           <>
-            <line x1={mL} x2={W - mR} y1={yPrimary(r.threshold)} y2={yPrimary(r.threshold)} stroke="#ef4444" strokeWidth="1.2" strokeDasharray="4 3" opacity="0.8" />
+            <line x1={mL} x2={W - mR} y1={yPrimary(r.threshold)} y2={yPrimary(r.threshold)} stroke="#ef4444" strokeWidth="1.2" strokeDasharray="4 3" opacity="0.6" />
             <text x={W - mR + 3} y={yPrimary(r.threshold) + 3} className="mono" style={{ fontSize: 9, fill: '#ef4444' }}>{r.threshold}</text>
           </>
         )}
 
-        {/* primary raw trace */}
-        {r.primary && <path d={linePath(r.primary.values, yPrimary)} fill="none" stroke="#3f3f46" strokeWidth="1.3" />}
+        {/* primary raw trace — soft hairline behind the avg (edge) */}
+        {r.primary && <path d={linePath(r.primary.values, yPrimary)} fill="none" stroke="#3f3f46" strokeWidth={policy ? 1.3 : 1} opacity={policy ? 1 : 0.5} />}
         {/* policy raw (pre-clamp) ghost */}
         {policy && r.setpointRaw && <path d={linePath(r.setpointRaw, yTemp)} fill="none" stroke="#52525b" strokeWidth="1" strokeDasharray="3 3" />}
-        {/* windowed avg (edge) */}
-        {r.avg && <path d={linePath(r.avg.values, yPrimary)} fill="none" stroke="#d4d4d8" strokeWidth="1.8" />}
+        {/* windowed avg — brightest, heaviest trace (edge) */}
+        {r.avg && <path d={linePath(r.avg.values, yPrimary)} fill="none" stroke={policy ? '#d4d4d8' : '#fafafa'} strokeWidth={policy ? 1.8 : 2} />}
 
         {/* setpoint */}
         <path d={policy ? linePath(r.setpoint, yTemp) : stepPath} fill="none" stroke="var(--accent)" strokeWidth="2.1" />
 
-        {/* suppressed markers */}
-        {!policy && r.suppressed.map((i, k) => {
-          const av = r.avg?.values[i]
-          return (
-            <g key={`s${k}`}>
-              <line x1={x(i)} x2={x(i)} y1={mT} y2={mT + ih} stroke="#52525b" strokeWidth="1" strokeDasharray="2 3" opacity="0.5" />
-              {av != null && <circle cx={x(i)} cy={yPrimary(av)} r="2.5" fill="#52525b" />}
-            </g>
-          )
-        })}
-        {/* fire markers */}
+        {/* fire dots on the avg curve (edge) */}
         {!policy && r.fires.map((i, k) => {
           const yv = r.avg?.values[i] ?? r.primary?.values[i] ?? null
-          return (
-            <g key={`f${k}`}>
-              <line x1={x(i)} x2={x(i)} y1={mT} y2={mT + ih} stroke="#ef4444" strokeWidth="1" opacity="0.45" />
-              {yv != null && <circle cx={x(i)} cy={yPrimary(yv)} r="4" fill="#ef4444" stroke="#0a0a0b" strokeWidth="1.5" />}
-            </g>
-          )
+          return yv == null
+            ? null
+            : <circle key={`f${k}`} cx={x(i)} cy={yPrimary(yv)} r="4" fill="#ef4444" stroke="#0a0a0b" strokeWidth="1.5" />
         })}
+
+        {/* event rail — carries all event density so the plot stays clean (edge) */}
+        {!policy && (
+          <g>
+            <rect x={mL} y={railTop} width={iw} height={railH} rx={3} fill="#141417" stroke="#26262b" strokeWidth="1" />
+            {r.suppressed.map((i, k) => (
+              <line key={`rs${k}`} x1={x(i)} x2={x(i)} y1={railTop + 3.5} y2={railBottom - 3.5} stroke="#52525b" strokeWidth="1" opacity="0.8" />
+            ))}
+            {r.fires.map((i, k) => (
+              <line key={`rf${k}`} x1={x(i)} x2={x(i)} y1={railTop + 1.5} y2={railBottom - 1.5} stroke="#ef4444" strokeWidth="1.8" />
+            ))}
+          </g>
+        )}
 
         {/* axes labels */}
         {!policy && r.primaryAxis && (
@@ -248,7 +293,7 @@ export function BacktestPanel({
         <>
           <Chart r={r} />
           <div className="mt-3 flex items-center gap-3 flex-wrap text-[11px] text-zinc-400">
-            {r.avg && <Legend swatch="#d4d4d8">{r.avg.label}</Legend>}
+            {r.avg && <Legend swatch={r.mode === 'edge' ? '#fafafa' : '#d4d4d8'}>{r.avg.label}</Legend>}
             {r.primary && <Legend swatch="#3f3f46">{r.mode === 'policy' ? r.primary.label.toLowerCase() : `raw ${r.primary.label.toLowerCase()}`}</Legend>}
             {r.mode === 'policy' && r.setpointRaw && <Legend dashed swatch="#52525b">pre-clamp</Legend>}
             {r.mode === 'edge' && r.threshold != null && <Legend dashed swatch="#ef4444">threshold</Legend>}
@@ -256,7 +301,8 @@ export function BacktestPanel({
             {r.mode === 'edge' && (
               <>
                 <Dot color="#ef4444">fired</Dot>
-                <Dot color="#52525b">suppressed</Dot>
+                <Tick color="#52525b">suppressed</Tick>
+                <Block color="#71717a">cooldown</Block>
               </>
             )}
           </div>
@@ -295,6 +341,22 @@ function Dot({ color, children }: { color: string, children: React.ReactNode }) 
   return (
     <span className="inline-flex items-center gap-1.5">
       <span className="h-2 w-2 rounded-full" style={{ background: color }} />
+      {children}
+    </span>
+  )
+}
+function Tick({ color, children }: { color: string, children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="h-2.5 w-0.5" style={{ background: color }} />
+      {children}
+    </span>
+  )
+}
+function Block({ color, children }: { color: string, children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="h-2.5 w-3 rounded-sm" style={{ background: color, opacity: 0.18 }} />
       {children}
     </span>
   )

--- a/src/components/Autopilot/RuleEditor.tsx
+++ b/src/components/Autopilot/RuleEditor.tsx
@@ -87,7 +87,7 @@ function WhenEditor({ rule, set }: { rule: BuilderRule, set: (r: BuilderRule) =>
             <Select chip value={w.op} options={['>', '≥', '<', '≤']} onChange={v => setW({ op: v as UiOp })} />
             <NumberField value={w.value} step={10} onChange={v => setW({ value: v })} width={92} />
             <span>over the last</span>
-            <NumberField value={w.window} step={5} suffix="m" onChange={v => setW({ window: Math.max(1, v) })} width={84} />
+            <NumberField value={w.window} step={5} suffix="minutes" onChange={v => setW({ window: Math.max(1, v) })} width={84} />
           </>
         )}
         {w.type === 'cond' && (
@@ -218,7 +218,7 @@ function ThenEditor({ rule, set, liveAmbient }: { rule: BuilderRule, set: (r: Bu
                 <Toggle size="sm" checked={!!a.revert} onChange={v => setA({ revert: v ? 20 : undefined })} />
                 revert after
               </label>
-              {a.revert ? <NumberField value={a.revert} step={5} suffix="m" onChange={v => setA({ revert: Math.max(1, v) })} width={78} /> : null}
+              {a.revert ? <NumberField value={a.revert} step={5} suffix="minutes" onChange={v => setA({ revert: Math.max(1, v) })} width={78} /> : null}
             </div>
           )}
 
@@ -278,7 +278,7 @@ function ThenEditor({ rule, set, liveAmbient }: { rule: BuilderRule, set: (r: Bu
         <label className="inline-flex items-center gap-2">
           <Icon.Clock size={13} className="text-zinc-500" />
           cooldown
-          <NumberField value={rule.cooldown} step={5} suffix="m" onChange={v => set({ ...rule, cooldown: Math.max(0, v) })} width={80} />
+          <NumberField value={rule.cooldown} step={5} suffix="minutes" onChange={v => set({ ...rule, cooldown: Math.max(0, v) })} width={80} />
         </label>
       </div>
     </Card>

--- a/src/components/Autopilot/primitives.tsx
+++ b/src/components/Autopilot/primitives.tsx
@@ -186,15 +186,37 @@ export function Select({ value, options, onChange, placeholder = 'Select…', cl
 }
 
 export function NumberField({ value, onChange, step = 1, suffix = '', width = 84 }: { value: number, onChange: (v: number) => void, step?: number, suffix?: string, width?: number }) {
+  // Draft string keeps the field freely typeable (empty/partial entries) while
+  // the numeric value flows up only once it parses; the +/- buttons reuse it.
+  // Re-sync the draft during render whenever the external value changes.
+  const [draft, setDraft] = useState(String(value))
+  const [syncedValue, setSyncedValue] = useState(value)
+  if (value !== syncedValue) {
+    setSyncedValue(value)
+    setDraft(String(value))
+  }
+
   return (
-    <div className="inline-flex items-stretch rounded-lg border border-zinc-700/70 bg-zinc-900/70 overflow-hidden" style={{ width }}>
-      <button type="button" onClick={() => onChange(value - step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Minus size={13} /></button>
-      <div className="flex-1 flex items-center justify-center mono text-[13px] text-zinc-100 tabular-nums">
-        {value}
-        {suffix}
-      </div>
-      <button type="button" onClick={() => onChange(value + step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Plus size={13} /></button>
-    </div>
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-flex items-stretch rounded-lg border border-zinc-700/70 bg-zinc-900/70 overflow-hidden" style={{ width }}>
+        <button type="button" onClick={() => onChange(value - step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Minus size={13} /></button>
+        <input
+          type="text"
+          inputMode="numeric"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            const n = Number(e.target.value)
+            if (e.target.value.trim() !== '' && Number.isFinite(n)) onChange(n)
+          }}
+          onBlur={() => setDraft(String(value))}
+          onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur() }}
+          className="min-w-0 flex-1 bg-transparent px-1 text-center mono text-[13px] text-zinc-100 tabular-nums focus:outline-none"
+        />
+        <button type="button" onClick={() => onChange(value + step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Plus size={13} /></button>
+      </span>
+      {suffix && <span className="text-[12px] text-zinc-500">{suffix}</span>}
+    </span>
   )
 }
 

--- a/src/components/Autopilot/primitives.tsx
+++ b/src/components/Autopilot/primitives.tsx
@@ -196,10 +196,17 @@ export function NumberField({ value, onChange, step = 1, suffix = '', width = 84
     setDraft(String(value))
   }
 
+  // Reset the draft when stepping so stale text can't survive a parent that
+  // clamps back to the same numeric value (no render-time re-sync fires then).
+  const applyStep = (delta: number) => {
+    setDraft(String(value))
+    onChange(value + delta)
+  }
+
   return (
     <span className="inline-flex items-center gap-1.5">
       <span className="inline-flex items-stretch rounded-lg border border-zinc-700/70 bg-zinc-900/70 overflow-hidden" style={{ width }}>
-        <button type="button" onClick={() => onChange(value - step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Minus size={13} /></button>
+        <button type="button" onClick={() => applyStep(-step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Minus size={13} /></button>
         <input
           type="text"
           inputMode="numeric"
@@ -213,7 +220,7 @@ export function NumberField({ value, onChange, step = 1, suffix = '', width = 84
           onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur() }}
           className="min-w-0 flex-1 bg-transparent px-1 text-center mono text-[13px] text-zinc-100 tabular-nums focus:outline-none"
         />
-        <button type="button" onClick={() => onChange(value + step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Plus size={13} /></button>
+        <button type="button" onClick={() => applyStep(step)} className="px-1.5 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"><Icon.Plus size={13} /></button>
       </span>
       {suffix && <span className="text-[12px] text-zinc-500">{suffix}</span>}
     </span>


### PR DESCRIPTION
## Why

Two UX problems in the Autopilot/Automations builder:

1. The edge-triggered **backtest chart** became unreadable at high event density (e.g. 7 fires + 70 suppressed). Every fired and suppressed sample drew a full-height vertical line across the plot, hatching a "curtain" that buried the actual traces.
2. The builder's **number inputs** were +/- steppers only — you couldn't click in and type a value. The minute fields also crammed the unit into the value ("5m") inside the box.

## What

All changes are scoped to the **edge-triggered** path of `Chart` and the shared `NumberField`. Continuous-policy mode renders identically to before (guarded by `policy ?`), and the `simulate`/server backtest logic and the summary Stat cards are untouched.

### Backtest chart (`BacktestPanel.tsx`)
- **Removed** all per-sample full-height vertical lines (both suppressed and fired); suppressed no longer marks the main plot at all, fires remain as dots on the avg curve.
- **Cooldown bands**: consecutive suppressed indices collapse into a single low-opacity grey rect per run (padded half a sample-step each side) instead of N marks.
- **Event rail**: new ~14px dark rounded lane beneath the plot carries all event density — one grey tick per suppressed sample, one heavier red tick per fire on top. Time-axis labels moved below the rail; viewBox height recomputed from the new geometry.
- **Hierarchy fix**: windowed-avg is now the brightest/heaviest trace (white `#fafafa`, 2px); raw movement dropped to a 1px hairline at 0.5 opacity behind it.
- **Red does one job**: faint red fire-zone tint above the threshold, threshold dashed line softened to 0.6 opacity, saturated red reserved for fires (curve dots + rail ticks).
- **Legend** updated to match: white avg swatch, suppressed shown as a vertical tick, new translucent "cooldown" block.

### Number inputs (`primitives.tsx`, `RuleEditor.tsx`)
- `NumberField` center is now a typeable `<input>` (click in and type) alongside the +/- buttons, via a draft string that commits only when it parses.
- The unit renders **outside** the box (matching the existing number-then-unit pattern); minute fields now read `[5] minutes` instead of `5m`. Applies to every builder field (threshold, comparison value, delta, clamp min/max, window, revert, cooldown).

## Test plan

- `eslint` + `tsc --noEmit` clean on all three files.
- Deployed to Pod 5 (`192.168.1.88`); `sleepypod.service` active, app serving.
- Manual: open the Automations builder backtest panel on a high-density night and confirm the plot stays clean with events on the rail; click into each number field and type a value; confirm continuous-policy mode chart is visually unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Backtest chart now features edge mode with a dedicated event rail to better visualize event density
- Cooldown bands now display suppressed event information more clearly
- Number input fields now support direct text entry

**Style**
- Time durations now display as "minutes" for improved clarity
- Updated chart legend to reflect new visualization elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/automation-builder-ui
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/automation-builder-ui/scripts/install \
  | sudo bash -s -- --branch feat/automation-builder-ui
```

🎯 **Pin to this exact build** ([run 27520854239](https://github.com/sleepypod/core/actions/runs/27520854239) · `5cb380c`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/5cb380c75f60169ba951bafe9ce647d5c3067a65/scripts/install \
  | sudo bash -s -- \
      --branch feat/automation-builder-ui \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27520854239/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27520854239/artifacts/7628004076) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

