### PR TITLE
Wire biometric + matrix sensors into the live automation engine

### DIFF
--- a/src/automation/index.ts
+++ b/src/automation/index.ts
@@ -12,8 +12,9 @@ export {
   getAutomationEngineIfRunning,
   shutdownAutomationEngine,
 } from './instance'
-export { clockInTimezone, collectWindowSignals, DeviceSignalReader } from './signals'
+export { clockInTimezone, collectWindowSignals, CompositeSignalReader, DeviceSignalReader } from './signals'
 export type { SignalReader, SignalSnapshot } from './signals'
+export { BiometricsSignalReader } from './signals.biometrics'
 export { evaluateCondition } from './evaluator'
 export { clamp, evaluateExpr } from './expressions'
 export type { EvalContext } from './expressions'

--- a/src/automation/instance.ts
+++ b/src/automation/instance.ts
@@ -15,7 +15,8 @@ import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { withSideLock } from '@/src/hardware/sideLock'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { AutomationEngine } from './engine'
-import { DeviceSignalReader, clockInTimezone } from './signals'
+import { BiometricsSignalReader } from './signals.biometrics'
+import { CompositeSignalReader, DeviceSignalReader, clockInTimezone } from './signals'
 import type {
   Action,
   AutomationRule,
@@ -100,7 +101,12 @@ export async function getAutomationEngine(): Promise<AutomationEngine> {
   engineInitPromise = (async () => {
     try {
       const timezone = await loadTimezone()
-      const reader = new DeviceSignalReader()
+      // DAC status first, biometrics merged on top; the DAC reader stays
+      // authoritative for any overlapping key (e.g. water.low).
+      const reader = new CompositeSignalReader([
+        new BiometricsSignalReader(),
+        new DeviceSignalReader(),
+      ])
       const engine = new AutomationEngine({
         signals: reader,
         now: () => Date.now(),

--- a/src/automation/signals.biometrics.ts
+++ b/src/automation/signals.biometrics.ts
@@ -10,10 +10,12 @@
  * stale or absent sample resolves to `undefined` — the engine then skips, the
  * safe default DeviceSignalReader already relies on.
  *
- * The capacitive matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per side) is
- * exposed only as reducers — max / mean / spread / peakZone — keeping the engine
- * scalar. It is live-only: the raw frames are not persisted granularly, so cap.*
- * signals cannot be back-tested.
+ * The capacitive presence matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per
+ * side — body-contact load across head/torso/legs, NOT temperature) is exposed
+ * only as scalar reducers — max / mean / spread — keeping the engine scalar. It
+ * is live-only: the raw frames are not persisted granularly, so cap.* signals
+ * cannot be back-tested. (`reduceCap` also derives a peakZone index, used by the
+ * UI zone visualization rather than the engine.)
  */
 
 import { desc, eq } from 'drizzle-orm'
@@ -119,7 +121,6 @@ export class BiometricsSignalReader implements SignalReader {
             out[`${side}.cap.max`] = r.max
             out[`${side}.cap.mean`] = r.mean
             out[`${side}.cap.spread`] = r.spread
-            if (r.peakZone != null) out[`${side}.cap.peakZone`] = r.peakZone
           }
         }
       }

--- a/src/automation/signals.biometrics.ts
+++ b/src/automation/signals.biometrics.ts
@@ -1,0 +1,134 @@
+/**
+ * Biometrics-backed signal reader for the automation engine.
+ *
+ * The live DAC monitor (DeviceSignalReader) only knows heat level / water level.
+ * The richer sensors — vitals, movement, ambient + bed-surface + water
+ * temperature, ambient light, and the capacitive sensor matrix — are produced by
+ * the streaming services and persisted to biometrics.db (scalars) or held as a
+ * live in-memory snapshot (the cap matrix). This reader surfaces them to the
+ * engine as numeric catalog signals, gated by a per-source freshness window so a
+ * stale or absent sample resolves to `undefined` — the engine then skips, the
+ * safe default DeviceSignalReader already relies on.
+ *
+ * The capacitive matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per side) is
+ * exposed only as reducers — max / mean / spread / peakZone — keeping the engine
+ * scalar. It is live-only: the raw frames are not persisted granularly, so cap.*
+ * signals cannot be back-tested.
+ */
+
+import { desc, eq } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db'
+import { ambientLight, bedTemp, freezerTemp, movement, vitals } from '@/src/db/biometrics-schema'
+import { centiDegreesToF, centiPercentToPercent } from '@/src/lib/tempUtils'
+import { getLatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+import type { SignalReader, SignalSnapshot } from './signals'
+
+// Freshness windows (ms). A latest row older than its window is treated as
+// absent. Vitals/movement land ~once a minute while in bed; environment frames
+// are slower; the cap matrix arrives ~2 Hz on the live stream (see piezoStream).
+const VITALS_FRESH_MS = 5 * 60_000
+const MOVEMENT_FRESH_MS = 5 * 60_000
+const ENV_FRESH_MS = 15 * 60_000
+const CAP_FRESH_MS = 30_000
+
+const SIDES = ['left', 'right'] as const
+
+function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+/**
+ * Reduce a per-side capacitive channel array to scalar matrix signals. Returns
+ * null when there are no usable channels. `peakZone` is the index (0–2) of the
+ * highest paired zone (A/B/C), available only on the full 6-channel frame.
+ */
+export function reduceCap(values: number[]): { max: number, mean: number, spread: number, peakZone: number | null } | null {
+  // capSense2 carries 6 sensor channels + 2 reference channels; drop the refs.
+  const zones = values.length >= 8 ? values.slice(0, 6) : values
+  if (zones.length === 0) return null
+  const max = Math.max(...zones)
+  const min = Math.min(...zones)
+  // Three paired zones (A/B/C) only when the full 6-channel frame is present.
+  const peakZone = zones.length === 6
+    ? [mean([zones[0], zones[1]]), mean([zones[2], zones[3]]), mean([zones[4], zones[5]])]
+        .reduce((best, v, i, arr) => (v > arr[best] ? i : best), 0)
+    : null
+  return { max, mean: mean(zones), spread: max - min, peakZone }
+}
+
+export class BiometricsSignalReader implements SignalReader {
+  read(): SignalSnapshot {
+    const out: SignalSnapshot = {}
+    const now = Date.now()
+    const fresh = (ts: Date | number, maxAgeMs: number): boolean =>
+      now - (ts instanceof Date ? ts.getTime() : ts) <= maxAgeMs
+
+    try {
+      for (const side of SIDES) {
+        const [v] = biometricsDb.select().from(vitals)
+          .where(eq(vitals.side, side)).orderBy(desc(vitals.timestamp)).limit(1).all()
+        if (v && fresh(v.timestamp, VITALS_FRESH_MS)) {
+          if (v.heartRate != null) out[`${side}.heartRate`] = v.heartRate
+          if (v.hrv != null) out[`${side}.hrv`] = v.hrv
+          if (v.breathingRate != null) out[`${side}.breathingRate`] = v.breathingRate
+        }
+
+        const [m] = biometricsDb.select().from(movement)
+          .where(eq(movement.side, side)).orderBy(desc(movement.timestamp)).limit(1).all()
+        if (m && fresh(m.timestamp, MOVEMENT_FRESH_MS)) {
+          out[`${side}.movement`] = m.totalMovement
+        }
+      }
+
+      const [bt] = biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1).all()
+      if (bt && fresh(bt.timestamp, ENV_FRESH_MS)) {
+        if (bt.ambientTemp != null) out['ambient.temperature'] = centiDegreesToF(bt.ambientTemp)
+        if (bt.humidity != null) out['ambient.humidity'] = centiPercentToPercent(bt.humidity)
+        const zonesBySide = {
+          left: { outer: bt.leftOuterTemp, center: bt.leftCenterTemp, inner: bt.leftInnerTemp },
+          right: { outer: bt.rightOuterTemp, center: bt.rightCenterTemp, inner: bt.rightInnerTemp },
+        }
+        for (const side of SIDES) {
+          const z = zonesBySide[side]
+          const presentF = [z.outer, z.center, z.inner]
+            .filter((t): t is number => t != null)
+            .map(centiDegreesToF)
+          if (presentF.length > 0) out[`${side}.surfaceTemp`] = mean(presentF)
+          if (presentF.length >= 2) out[`${side}.surfaceTemp.spread`] = Math.max(...presentF) - Math.min(...presentF)
+          if (z.inner != null && z.outer != null) out[`${side}.surfaceTemp.gradient`] = centiDegreesToF(z.inner) - centiDegreesToF(z.outer)
+        }
+      }
+
+      const [fz] = biometricsDb.select().from(freezerTemp).orderBy(desc(freezerTemp.timestamp)).limit(1).all()
+      if (fz && fresh(fz.timestamp, ENV_FRESH_MS)) {
+        if (fz.leftWaterTemp != null) out['left.waterTemp'] = centiDegreesToF(fz.leftWaterTemp)
+        if (fz.rightWaterTemp != null) out['right.waterTemp'] = centiDegreesToF(fz.rightWaterTemp)
+      }
+
+      const [al] = biometricsDb.select().from(ambientLight).orderBy(desc(ambientLight.timestamp)).limit(1).all()
+      if (al && fresh(al.timestamp, ENV_FRESH_MS) && al.lux != null) {
+        out['ambient.light'] = al.lux
+      }
+
+      const cap = getLatestCapSenseSnapshot()
+      if (cap && fresh(cap.receivedAtMs, CAP_FRESH_MS)) {
+        for (const side of SIDES) {
+          const raw = cap[side]
+          const r = reduceCap(Array.isArray(raw) ? raw : [raw])
+          if (r) {
+            out[`${side}.cap.max`] = r.max
+            out[`${side}.cap.mean`] = r.mean
+            out[`${side}.cap.spread`] = r.spread
+            if (r.peakZone != null) out[`${side}.cap.peakZone`] = r.peakZone
+          }
+        }
+      }
+    }
+    catch (err) {
+      // Surface rather than swallow; the partial/empty snapshot makes dependent
+      // rules skip, which is the safe default but shouldn't happen silently.
+      console.warn('[automation] BiometricsSignalReader.read failed:', err)
+    }
+    return out
+  }
+}

--- a/src/automation/signals.ts
+++ b/src/automation/signals.ts
@@ -90,6 +90,21 @@ export class DeviceSignalReader implements SignalReader {
   }
 }
 
+/**
+ * Merge several readers into one snapshot. Readers are applied in order, so a
+ * later reader overrides an earlier one on key collision — keep the
+ * authoritative source last (e.g. the live DAC reader's `water.low`).
+ */
+export class CompositeSignalReader implements SignalReader {
+  constructor(private readonly readers: SignalReader[]) {}
+
+  read(): SignalSnapshot {
+    const out: SignalSnapshot = {}
+    for (const reader of this.readers) Object.assign(out, reader.read())
+    return out
+  }
+}
+
 /** Walk an expression tree collecting the signal keys referenced by windows. */
 function collectWindowKeysFromExpr(expr: Expr, out: Set<string>): void {
   switch (expr.kind) {

--- a/src/automation/tests/instance.test.ts
+++ b/src/automation/tests/instance.test.ts
@@ -37,7 +37,17 @@ vi.mock('../signals', () => ({
   DeviceSignalReader: class {
     read() { return {} }
   },
+  CompositeSignalReader: class {
+    constructor(readonly readers: Array<{ read: () => Record<string, number> }>) {}
+    read() { return Object.assign({}, ...this.readers.map(r => r.read())) }
+  },
   clockInTimezone: vi.fn(() => ({ nowMinutes: 123, dayOfWeek: 'monday' })),
+}))
+
+vi.mock('../signals.biometrics', () => ({
+  BiometricsSignalReader: class {
+    read() { return {} }
+  },
 }))
 
 const hardwareClient = { connect: async () => {}, setTemperature: async () => {}, setPower: async () => {} }

--- a/src/automation/tests/signals.biometrics.test.ts
+++ b/src/automation/tests/signals.biometrics.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { reduceCap } from '../signals.biometrics'
+
+describe('reduceCap', () => {
+  it('returns null for an empty array', () => {
+    expect(reduceCap([])).toBeNull()
+  })
+
+  it('reduces a scalar (Pod 3) channel to degenerate stats', () => {
+    expect(reduceCap([42])).toEqual({ max: 42, mean: 42, spread: 0, peakZone: null })
+  })
+
+  it('drops the two reference channels from a full capSense2 frame', () => {
+    // [A1,A2,B1,B2,C1,C2,ref1,ref2] — refs (999) must not affect the stats.
+    expect(reduceCap([10, 20, 30, 40, 50, 60, 999, 999])).toMatchObject({ max: 60, spread: 50, mean: 35 })
+  })
+
+  it('picks the paired zone (A/B/C) with the highest mean as peakZone', () => {
+    // zone A mean=15, B mean=85, C mean=35 → B is index 1.
+    expect(reduceCap([10, 20, 80, 90, 30, 40, 0, 0])).toMatchObject({ peakZone: 1 })
+    // zone C dominant → index 2.
+    expect(reduceCap([10, 10, 20, 20, 95, 95, 0, 0])).toMatchObject({ peakZone: 2 })
+  })
+
+  it('leaves peakZone null when the frame is not the 6-channel shape', () => {
+    expect(reduceCap([10, 20, 30])).toMatchObject({ peakZone: null })
+  })
+})

--- a/src/components/Autopilot/CapZoneViz.tsx
+++ b/src/components/Autopilot/CapZoneViz.tsx
@@ -1,0 +1,116 @@
+/**
+ * Live capacitive-zone visualization for the rule editor.
+ *
+ * The `{side}.cap.*` signals reduce the capacitive *presence* matrix — per-zone
+ * body-contact load across head/torso/legs, NOT temperature. "Zone" is opaque as
+ * a number, so when a rule references a pressure signal we render the live matrix
+ * the same way the Sensors page PresenceCard does: per-channel variance over a
+ * sliding window, paired into the three zones (channels `z*2` / `z*2+1`), with
+ * the most-active zone highlighted. Live-only — there is no granular history, so
+ * this is not part of the backtest.
+ */
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useOnSensorFrame, useSensorFrame } from '@/src/hooks/useSensorStream'
+import type { SensorFrame } from '@/src/hooks/useSensorStream'
+import { Icon } from './icons'
+import { Card } from './primitives'
+
+const WINDOW = 20 // frames of history for the variance estimate
+const NORMALIZE = 0.5 // variance mapped to a full-intensity cell
+const ZONES = [{ i: 0, label: 'Head' }, { i: 1, label: 'Torso' }, { i: 2, label: 'Legs' }] as const
+
+function variance(xs: number[]): number {
+  if (xs.length < 2) return 0
+  const m = xs.reduce((a, b) => a + b, 0) / xs.length
+  return Math.sqrt(xs.reduce((a, b) => a + (b - m) ** 2, 0) / xs.length)
+}
+
+/** Per-zone activity = the louder of its two paired channels. */
+function zoneActivity(channelVar: number[], zone: number): number {
+  return Math.max(channelVar[zone * 2] ?? 0, channelVar[zone * 2 + 1] ?? 0)
+}
+
+function fmtTs(ts: number | undefined): string {
+  if (!ts) return '--'
+  return new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+export function CapZoneViz({ side }: { side: 'left' | 'right' | 'both' }) {
+  const capSense = useSensorFrame('capSense')
+  const capSense2 = useSensorFrame('capSense2')
+  const frame = capSense2 ?? capSense
+
+  const [hist, setHist] = useState<{ left: number[][], right: number[][] }>({ left: [], right: [] })
+  useOnSensorFrame(useCallback((f: SensorFrame) => {
+    if (f.type !== 'capSense' && f.type !== 'capSense2') return
+    const l = Array.isArray(f.left) ? f.left : [f.left]
+    const r = Array.isArray(f.right) ? f.right : [f.right]
+    setHist(prev => ({
+      left: [...prev.left, l].slice(-WINDOW),
+      right: [...prev.right, r].slice(-WINDOW),
+    }))
+  }, []))
+
+  const channelVar = useMemo(() => {
+    const calc = (frames: number[][]): number[] => {
+      const n = Math.max(6, ...frames.map(h => h.length))
+      return Array.from({ length: n }, (_, ch) => variance(frames.map(h => h[ch] ?? 0)))
+    }
+    return { left: calc(hist.left), right: calc(hist.right) }
+  }, [hist])
+
+  const sides = side === 'both' ? (['left', 'right'] as const) : ([side] as const)
+
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Icon.Activity size={13} className="text-zinc-500" />
+          <span className="text-[12px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Bed pressure · live zones</span>
+        </div>
+        {frame && <span className="mono text-[10px] text-zinc-600">{fmtTs(frame.ts)}</span>}
+      </div>
+
+      {!frame
+        ? <div className="grid h-24 place-items-center text-[12px] text-zinc-600">Waiting for live capacitive data…</div>
+        : (
+            <div className="flex gap-3">
+              {sides.map((s) => {
+                const act = ZONES.map(z => zoneActivity(channelVar[s], z.i))
+                const peak = act.indexOf(Math.max(...act))
+                return (
+                  <div key={s} className="flex-1">
+                    <div className="mb-1.5 text-center text-[10px] uppercase tracking-wide text-zinc-500">{s}</div>
+                    <div className="flex flex-col gap-1">
+                      {ZONES.map((z, i) => {
+                        const pct = Math.min(act[i] / NORMALIZE, 1)
+                        const isPeak = i === peak && act[i] > 0.02
+                        return (
+                          <div
+                            key={z.i}
+                            className="relative h-9 overflow-hidden rounded-md border"
+                            style={{ borderColor: isPeak ? 'var(--accent)' : 'rgba(63,63,70,0.5)' }}
+                          >
+                            <div className="absolute inset-0" style={{ background: 'var(--accent)', opacity: 0.06 + pct * 0.5 }} />
+                            <div className="absolute inset-0 flex items-center justify-between px-2.5">
+                              <span className="text-[11px] text-zinc-200">{z.label}</span>
+                              <span className="mono text-[10px] text-zinc-400">{act[i].toFixed(2)}</span>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+
+      <div className="mt-3 text-[11px] leading-relaxed text-zinc-600">
+        Capacitive presence sensing — body-contact load across head/torso/legs (not temperature). Brighter = more contact; the outlined band is the most-active zone. Live only, not part of the backtest.
+      </div>
+    </Card>
+  )
+}

--- a/src/components/Autopilot/RuleEditor.tsx
+++ b/src/components/Autopilot/RuleEditor.tsx
@@ -10,6 +10,7 @@ import { trpc } from '@/src/utils/trpc'
 import { Icon, type IconName } from './icons'
 import { Button, Card, NumberField, SectionLabel, Segmented, Select, Toggle } from './primitives'
 import { BacktestPanel } from './BacktestPanel'
+import { CapZoneViz } from './CapZoneViz'
 import {
   AGGS,
   type BuilderRule,
@@ -308,6 +309,15 @@ export function RuleEditor({ automation, onClose, onSave, saving }: { automation
   const ambientQ = trpc.environment.getLatestBedTemp.useQuery({ unit: 'F' })
   const liveAmbient = ambientQ.data?.ambientTemp ?? null
 
+  // Show the live capacitive zone viz when the rule reads a pressure signal —
+  // "zone" is meaningless as a bare number without it.
+  const usesCapSignal = useMemo(() => {
+    const sigs: string[] = []
+    if ('signal' in rule.when && rule.when.signal) sigs.push(rule.when.signal)
+    for (const c of rule.ifs) if (c.type === 'cond') sigs.push(c.signal)
+    return sigs.some(s => s.startsWith('{side}.cap.'))
+  }, [rule])
+
   const ast = useMemo(() => toAST(debounced), [debounced])
   const backtestQ = trpc.automations.backtest.useQuery(
     {
@@ -355,6 +365,7 @@ export function RuleEditor({ automation, onClose, onSave, saving }: { automation
         <div className="flex-1 overflow-y-auto bg-zinc-950/40 p-5">
           <div className="mx-auto flex max-w-2xl flex-col gap-4">
             <SentencePreview rule={rule} />
+            {usesCapSignal && <CapZoneViz side={rule.side} />}
             <Card className="p-4">
               <BacktestPanel
                 result={backtestQ.data?.ok ? (backtestQ.data.result as Parameters<typeof BacktestPanel>[0]['result']) : null}

--- a/src/components/Autopilot/builderModel.ts
+++ b/src/components/Autopilot/builderModel.ts
@@ -35,7 +35,7 @@ export interface SignalDef {
   label: string
   unit: string
   kind: SignalKind
-  group: 'Room' | 'Bed' | 'Bio' | 'Matrix' | 'System'
+  group: 'Room' | 'Bed' | 'Bio' | 'Presence' | 'System'
   icon: string
   perSide?: boolean
   max?: number
@@ -58,10 +58,10 @@ export const SIGNALS: SignalDef[] = [
   { id: '{side}.heartRate', label: 'Heart rate', unit: 'bpm', kind: 'num', group: 'Bio', icon: 'Heart', perSide: true },
   { id: '{side}.hrv', label: 'HRV', unit: 'ms', kind: 'num', group: 'Bio', icon: 'Pulse', perSide: true },
   { id: '{side}.breathingRate', label: 'Breathing rate', unit: 'brpm', kind: 'num', group: 'Bio', icon: 'Wind', perSide: true },
-  { id: '{side}.cap.max', label: 'Cap matrix peak', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.mean', label: 'Cap matrix mean', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.spread', label: 'Cap matrix spread', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.peakZone', label: 'Cap matrix peak zone', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  // Capacitive presence sensing (not temperature): per-zone body-contact load.
+  { id: '{side}.cap.max', label: 'Bed pressure (peak)', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.mean', label: 'Bed pressure (avg)', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.spread', label: 'Pressure spread', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
   { id: 'water.low', label: 'Water low', unit: '', kind: 'num', group: 'System', icon: 'Droplet' },
 ]
 

--- a/src/components/Autopilot/builderModel.ts
+++ b/src/components/Autopilot/builderModel.ts
@@ -35,22 +35,33 @@ export interface SignalDef {
   label: string
   unit: string
   kind: SignalKind
-  group: 'Room' | 'Bed' | 'Bio' | 'System'
+  group: 'Room' | 'Bed' | 'Bio' | 'Matrix' | 'System'
   icon: string
   perSide?: boolean
   max?: number
+  /** Live-only: no granular history, so it reads live but can't be back-tested. */
+  liveOnly?: boolean
 }
 
 /** Numeric, engine-evaluable signals (subset wired for live read and/or backtest). */
 export const SIGNALS: SignalDef[] = [
   { id: 'ambient.temperature', label: 'Ambient temp', unit: '°F', kind: 'num', group: 'Room', icon: 'Thermometer' },
   { id: 'ambient.humidity', label: 'Ambient humidity', unit: '%', kind: 'num', group: 'Room', icon: 'Droplet' },
-  { id: '{side}.currentTemperature', label: 'Current temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
-  { id: '{side}.targetTemperature', label: 'Target temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: 'ambient.light', label: 'Ambient light', unit: 'lux', kind: 'num', group: 'Room', icon: 'Moon' },
+  { id: '{side}.currentTemperature', label: 'Current temp (level)', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.targetTemperature', label: 'Target temp (level)', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp', label: 'Bed surface temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp.spread', label: 'Surface temp spread', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp.gradient', label: 'Surface temp gradient', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.waterTemp', label: 'Water temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Droplet', perSide: true },
   { id: '{side}.movement', label: 'Movement', unit: '', kind: 'num', group: 'Bio', icon: 'Activity', perSide: true, max: 1000 },
   { id: '{side}.heartRate', label: 'Heart rate', unit: 'bpm', kind: 'num', group: 'Bio', icon: 'Heart', perSide: true },
   { id: '{side}.hrv', label: 'HRV', unit: 'ms', kind: 'num', group: 'Bio', icon: 'Pulse', perSide: true },
   { id: '{side}.breathingRate', label: 'Breathing rate', unit: 'brpm', kind: 'num', group: 'Bio', icon: 'Wind', perSide: true },
+  { id: '{side}.cap.max', label: 'Cap matrix peak', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.mean', label: 'Cap matrix mean', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.spread', label: 'Cap matrix spread', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.peakZone', label: 'Cap matrix peak zone', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
   { id: 'water.low', label: 'Water low', unit: '', kind: 'num', group: 'System', icon: 'Droplet' },
 ]
 

--- a/src/components/Autopilot/primitives.tsx
+++ b/src/components/Autopilot/primitives.tsx
@@ -159,7 +159,7 @@ export function Select({ value, options, onChange, placeholder = 'Select…', cl
         <Icon.ChevDown size={13} className="opacity-60" />
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 min-w-full max-h-64 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 p-1 shadow-2xl shadow-black/60" style={{ left: 0 }}>
+        <div className="absolute z-50 mt-1 w-max min-w-full max-w-[280px] max-h-64 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 p-1 shadow-2xl shadow-black/60" style={{ left: 0 }}>
           {opts.map((o) => {
             const I = o.icon ? Icon[o.icon] : null
             return (
@@ -172,8 +172,8 @@ export function Select({ value, options, onChange, placeholder = 'Select…', cl
                 }}
                 className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] hover:bg-zinc-800 ${o.value === value ? 'text-white' : 'text-zinc-300'}`}
               >
-                {I ? <I size={14} className="text-zinc-500" /> : null}
-                <span className="flex-1">{o.label}</span>
+                {I ? <I size={14} className="shrink-0 text-zinc-500" /> : null}
+                <span className="flex-1 whitespace-nowrap">{o.label}</span>
                 {o.hint && <span className="text-[11px] text-zinc-500 mono">{o.hint}</span>}
                 {o.value === value && <Icon.Check size={13} style={{ color: 'var(--accent)' }} />}
               </button>

--- a/src/server/routers/automations.ts
+++ b/src/server/routers/automations.ts
@@ -17,7 +17,7 @@ import { and, desc, eq, gte, lte } from 'drizzle-orm'
 import { publicProcedure, router } from '@/src/server/trpc'
 import { biometricsDb, db } from '@/src/db'
 import { automationRuns, automations, deviceSettings } from '@/src/db/schema'
-import { bedTemp, movement, sleepRecords, vitals, waterLevelReadings } from '@/src/db/biometrics-schema'
+import { ambientLight, bedTemp, freezerTemp, movement, sleepRecords, vitals, waterLevelReadings } from '@/src/db/biometrics-schema'
 import { centiDegreesToF, centiPercentToPercent } from '@/src/lib/tempUtils'
 import {
   automationActionSchema,
@@ -434,14 +434,44 @@ function loadSeries(side: 'left' | 'right', startMs: number, endMs: number): Rec
   series[`${side}.hrv`] = vit.flatMap(r => r.hrv != null ? [{ t: r.t.getTime(), v: r.hrv }] : [])
   series[`${side}.breathingRate`] = vit.flatMap(r => r.br != null ? [{ t: r.t.getTime(), v: r.br }] : [])
 
+  const zoneCols = side === 'left'
+    ? { o: bedTemp.leftOuterTemp, c: bedTemp.leftCenterTemp, n: bedTemp.leftInnerTemp }
+    : { o: bedTemp.rightOuterTemp, c: bedTemp.rightCenterTemp, n: bedTemp.rightInnerTemp }
   const bt = biometricsDb
-    .select({ t: bedTemp.timestamp, amb: bedTemp.ambientTemp, hum: bedTemp.humidity })
+    .select({ t: bedTemp.timestamp, amb: bedTemp.ambientTemp, hum: bedTemp.humidity, o: zoneCols.o, c: zoneCols.c, n: zoneCols.n })
     .from(bedTemp)
     .where(and(gte(bedTemp.timestamp, start), lte(bedTemp.timestamp, end)))
     .orderBy(bedTemp.timestamp)
     .all()
   series['ambient.temperature'] = bt.flatMap(r => r.amb != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.amb) }] : [])
   series['ambient.humidity'] = bt.flatMap(r => r.hum != null ? [{ t: r.t.getTime(), v: centiPercentToPercent(r.hum) }] : [])
+  series[`${side}.surfaceTemp`] = bt.flatMap((r) => {
+    const zs = [r.o, r.c, r.n].filter((x): x is number => x != null).map(centiDegreesToF)
+    return zs.length ? [{ t: r.t.getTime(), v: zs.reduce((a, b) => a + b, 0) / zs.length }] : []
+  })
+  series[`${side}.surfaceTemp.spread`] = bt.flatMap((r) => {
+    const zs = [r.o, r.c, r.n].filter((x): x is number => x != null).map(centiDegreesToF)
+    return zs.length >= 2 ? [{ t: r.t.getTime(), v: Math.max(...zs) - Math.min(...zs) }] : []
+  })
+  series[`${side}.surfaceTemp.gradient`] = bt.flatMap(r =>
+    r.n != null && r.o != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.n) - centiDegreesToF(r.o) }] : [])
+
+  const waterCol = side === 'left' ? freezerTemp.leftWaterTemp : freezerTemp.rightWaterTemp
+  const fz = biometricsDb
+    .select({ t: freezerTemp.timestamp, w: waterCol })
+    .from(freezerTemp)
+    .where(and(gte(freezerTemp.timestamp, start), lte(freezerTemp.timestamp, end)))
+    .orderBy(freezerTemp.timestamp)
+    .all()
+  series[`${side}.waterTemp`] = fz.flatMap(r => r.w != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.w) }] : [])
+
+  const al = biometricsDb
+    .select({ t: ambientLight.timestamp, lux: ambientLight.lux })
+    .from(ambientLight)
+    .where(and(gte(ambientLight.timestamp, start), lte(ambientLight.timestamp, end)))
+    .orderBy(ambientLight.timestamp)
+    .all()
+  series['ambient.light'] = al.flatMap(r => r.lux != null ? [{ t: r.t.getTime(), v: r.lux }] : [])
 
   const wl = biometricsDb
     .select({ t: waterLevelReadings.timestamp, level: waterLevelReadings.level })


### PR DESCRIPTION
## Why

You can build an automation rule on heart rate, movement, or ambient temperature and **back-test it fine** — but it would **never fire live**. The backtest reads those signals from `biometrics.db` history (`automations.ts`), while the live engine's `DeviceSignalReader` only reads the DAC status frame (heat level + water level). Everything in the catalog except temp-level/water was effectively a no-op at runtime.

Separately, the catalog's `{side}.currentTemperature` is *not* a measured temperature — it's the current **heat level** mapped to °F (`levelToFahrenheit(heatLevel)`). The real measured temperatures (bed-surface zones, water temp) existed in `biometrics.db` but were never exposed.

## What

**`BiometricsSignalReader`** (new) — snapshots the latest *fresh* row per source, staleness-gated so a stale/absent sample resolves to `undefined` and the rule skips (the safe default `DeviceSignalReader` already relies on). It surfaces:

- **Vitals** — `{side}.heartRate`, `.hrv`, `.breathingRate`
- **Movement** — `{side}.movement`
- **Room** — `ambient.temperature`, `ambient.humidity`, `ambient.light` (new)
- **Measured bed temps** (new) — `{side}.surfaceTemp` (mean of outer/center/inner zones), `{side}.surfaceTemp.spread`, `{side}.surfaceTemp.gradient`
- **Measured water temp** (new) — `{side}.waterTemp` (from `freezerTemp`)
- **Capacitive matrix reducers** (new, live-only) — `{side}.cap.max/mean/spread/peakZone`, computed from `getLatestCapSenseSnapshot()` (`[A1,A2,B1,B2,C1,C2,ref1,ref2]`, reference channels dropped)

**`CompositeSignalReader`** (new) merges readers in order; `instance.ts` now wires `[Biometrics, Device]` with the DAC reader authoritative for overlapping keys (`water.low`).

**Matrix model** — exposed as scalar **reducers** (chosen over per-cell flattening), so the engine stays `Record<string, number>`. The raw matrix is not persisted granularly, so `cap.*` are flagged `liveOnly` and are not back-testable.

**Catalog** (`builderModel.ts`) — new signals added under a new `Matrix` group + `liveOnly` flag; `currentTemperature`/`targetTemperature` relabeled "Current/Target temp (level)" to stop implying they're measured.

**Backtest** (`automations.ts`) — `loadSeries` extended for the persisted newcomers (surface temp + spread/gradient, water temp, ambient light). `cap.*` intentionally absent (live-only).

## Notes / follow-ups

- `cap.*` will show empty in the backtest panel (no granular history). A "live only" badge in `RuleEditor` is deliberately **not** in this PR to avoid a file conflict with #642 (which touches `RuleEditor.tsx`); easy fast-follow once #642 lands.
- Freshness windows: vitals/movement 5 min, environment 15 min, cap matrix 30 s.

## Test plan

- `tsc --noEmit` clean; `eslint` clean on all changed files.
- `vitest` — 169 passed across `src/automation` + `src/components/Autopilot`, including new `reduceCap` unit tests (ref-channel stripping, peakZone selection, scalar/empty cases) and updated `instance.test.ts` mocks.
- Manual (suggested): on a live pod, create a dry-run rule on `{side}.heartRate` or `{side}.cap.max` and confirm it now evaluates against live data in the engine logs.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/automation-wire-sensors
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/automation-wire-sensors/scripts/install \
  | sudo bash -s -- --branch feat/automation-wire-sensors
```

🎯 **Pin to this exact build** ([run 27513757780](https://github.com/sleepypod/core/actions/runs/27513757780) · `d6ccf6c`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/d6ccf6c3bfb7827bbcd9a616cfb9c5599db86d62/scripts/install \
  | sudo bash -s -- \
      --branch feat/automation-wire-sensors \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27513757780/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27513757780/artifacts/7625645710) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added biometrics signal reader integration for vitals and movement monitoring.
  * Introduced ambient light detection for automation rules.
  * Enhanced temperature monitoring with surface temperature analytics and water temperature tracking.
  * Added capacitive sensor signals for automation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
