### PR TITLE
Persist downsampled capacitive frames for historical replay

### DIFF
--- a/src/automation/capReduce.ts
+++ b/src/automation/capReduce.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure reducers over a capacitive presence channel array.
+ *
+ * capSense2 carries `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per side — body-contact load
+ * across head/torso/legs (NOT temperature) plus two reference channels. capSense
+ * (Pod 3) carries a single scalar. These helpers collapse either shape to scalar
+ * stats (for the automation engine) or a three-zone triple (for the UI/replay).
+ *
+ * Kept dependency-free so both the engine (`signals.biometrics`) and the
+ * streaming persistence writer (`streaming/capFramePersistence`) can import it
+ * without pulling in a module cycle.
+ */
+
+export function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+/**
+ * Reduce a per-side capacitive channel array to scalar matrix signals. Returns
+ * null when there are no usable channels. `peakZone` is the index (0–2) of the
+ * highest paired zone (A/B/C), available only on the full 6-channel frame.
+ */
+export function reduceCap(values: number[]): { max: number, mean: number, spread: number, peakZone: number | null } | null {
+  // capSense2 carries 6 sensor channels + 2 reference channels; drop the refs.
+  const zones = values.length >= 8 ? values.slice(0, 6) : values
+  if (zones.length === 0) return null
+  const max = Math.max(...zones)
+  const min = Math.min(...zones)
+  // Three paired zones (A/B/C) only when the full 6-channel frame is present.
+  const peakZone = zones.length === 6
+    ? [mean([zones[0], zones[1]]), mean([zones[2], zones[3]]), mean([zones[4], zones[5]])]
+        .reduce((best, v, i, arr) => (v > arr[best] ? i : best), 0)
+    : null
+  return { max, mean: mean(zones), spread: max - min, peakZone }
+}
+
+/**
+ * Collapse a channel array to the three paired-zone (head/torso/legs) means used
+ * by the spatial replay. Returns null unless the full 6 sensor channels are
+ * present — a Pod 3 scalar frame has no spatial resolution to replay.
+ */
+export function zoneTriple(values: number[]): [number, number, number] | null {
+  const zones = values.length >= 8 ? values.slice(0, 6) : values
+  if (zones.length < 6) return null
+  return [
+    mean([zones[0], zones[1]]),
+    mean([zones[2], zones[3]]),
+    mean([zones[4], zones[5]]),
+  ]
+}

--- a/src/automation/capReduce.ts
+++ b/src/automation/capReduce.ts
@@ -41,7 +41,9 @@ export function reduceCap(values: number[]): { max: number, mean: number, spread
  */
 export function zoneTriple(values: number[]): [number, number, number] | null {
   const zones = values.length >= 8 ? values.slice(0, 6) : values
-  if (zones.length < 6) return null
+  // Exactly 6 sensor channels — matches reduceCap's peakZone gating so a
+  // persisted frame never carries zones without a corresponding peak vote.
+  if (zones.length !== 6) return null
   return [
     mean([zones[0], zones[1]]),
     mean([zones[2], zones[3]]),

--- a/src/automation/index.ts
+++ b/src/automation/index.ts
@@ -12,8 +12,9 @@ export {
   getAutomationEngineIfRunning,
   shutdownAutomationEngine,
 } from './instance'
-export { clockInTimezone, collectWindowSignals, DeviceSignalReader } from './signals'
+export { clockInTimezone, collectWindowSignals, CompositeSignalReader, DeviceSignalReader } from './signals'
 export type { SignalReader, SignalSnapshot } from './signals'
+export { BiometricsSignalReader } from './signals.biometrics'
 export { evaluateCondition } from './evaluator'
 export { clamp, evaluateExpr } from './expressions'
 export type { EvalContext } from './expressions'

--- a/src/automation/instance.ts
+++ b/src/automation/instance.ts
@@ -15,7 +15,8 @@ import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { withSideLock } from '@/src/hardware/sideLock'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { AutomationEngine } from './engine'
-import { DeviceSignalReader, clockInTimezone } from './signals'
+import { BiometricsSignalReader } from './signals.biometrics'
+import { CompositeSignalReader, DeviceSignalReader, clockInTimezone } from './signals'
 import type {
   Action,
   AutomationRule,
@@ -100,7 +101,12 @@ export async function getAutomationEngine(): Promise<AutomationEngine> {
   engineInitPromise = (async () => {
     try {
       const timezone = await loadTimezone()
-      const reader = new DeviceSignalReader()
+      // DAC status first, biometrics merged on top; the DAC reader stays
+      // authoritative for any overlapping key (e.g. water.low).
+      const reader = new CompositeSignalReader([
+        new BiometricsSignalReader(),
+        new DeviceSignalReader(),
+      ])
       const engine = new AutomationEngine({
         signals: reader,
         now: () => Date.now(),

--- a/src/automation/signals.biometrics.ts
+++ b/src/automation/signals.biometrics.ts
@@ -10,10 +10,12 @@
  * stale or absent sample resolves to `undefined` — the engine then skips, the
  * safe default DeviceSignalReader already relies on.
  *
- * The capacitive matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per side) is
- * exposed only as reducers — max / mean / spread / peakZone — keeping the engine
- * scalar. It is live-only: the raw frames are not persisted granularly, so cap.*
- * signals cannot be back-tested.
+ * The capacitive presence matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per
+ * side — body-contact load across head/torso/legs, NOT temperature) is exposed
+ * only as scalar reducers — max / mean / spread — keeping the engine scalar. It
+ * is live-only: the raw frames are not persisted granularly, so cap.* signals
+ * cannot be back-tested. (`reduceCap` also derives a peakZone index, used by the
+ * UI zone visualization rather than the engine.)
  */
 
 import { desc, eq } from 'drizzle-orm'
@@ -119,7 +121,6 @@ export class BiometricsSignalReader implements SignalReader {
             out[`${side}.cap.max`] = r.max
             out[`${side}.cap.mean`] = r.mean
             out[`${side}.cap.spread`] = r.spread
-            if (r.peakZone != null) out[`${side}.cap.peakZone`] = r.peakZone
           }
         }
       }

--- a/src/automation/signals.biometrics.ts
+++ b/src/automation/signals.biometrics.ts
@@ -12,10 +12,11 @@
  *
  * The capacitive presence matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per
  * side — body-contact load across head/torso/legs, NOT temperature) is exposed
- * only as scalar reducers — max / mean / spread — keeping the engine scalar. It
- * is live-only: the raw frames are not persisted granularly, so cap.* signals
- * cannot be back-tested. (`reduceCap` also derives a peakZone index, used by the
- * UI zone visualization rather than the engine.)
+ * to the engine only as scalar reducers — max / mean / spread — keeping the
+ * engine scalar. This reader resolves them from the live in-memory snapshot; a
+ * downsampled copy is persisted separately for historical replay (see
+ * `streaming/capFramePersistence`). (`reduceCap` also derives a peakZone index,
+ * used by the UI zone visualization rather than the engine.)
  */
 
 import { desc, eq } from 'drizzle-orm'
@@ -23,6 +24,7 @@ import { biometricsDb } from '@/src/db'
 import { ambientLight, bedTemp, freezerTemp, movement, vitals } from '@/src/db/biometrics-schema'
 import { centiDegreesToF, centiPercentToPercent } from '@/src/lib/tempUtils'
 import { getLatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+import { mean, reduceCap } from './capReduce'
 import type { SignalReader, SignalSnapshot } from './signals'
 
 // Freshness windows (ms). A latest row older than its window is treated as
@@ -34,29 +36,6 @@ const ENV_FRESH_MS = 15 * 60_000
 const CAP_FRESH_MS = 30_000
 
 const SIDES = ['left', 'right'] as const
-
-function mean(xs: number[]): number {
-  return xs.reduce((a, b) => a + b, 0) / xs.length
-}
-
-/**
- * Reduce a per-side capacitive channel array to scalar matrix signals. Returns
- * null when there are no usable channels. `peakZone` is the index (0–2) of the
- * highest paired zone (A/B/C), available only on the full 6-channel frame.
- */
-export function reduceCap(values: number[]): { max: number, mean: number, spread: number, peakZone: number | null } | null {
-  // capSense2 carries 6 sensor channels + 2 reference channels; drop the refs.
-  const zones = values.length >= 8 ? values.slice(0, 6) : values
-  if (zones.length === 0) return null
-  const max = Math.max(...zones)
-  const min = Math.min(...zones)
-  // Three paired zones (A/B/C) only when the full 6-channel frame is present.
-  const peakZone = zones.length === 6
-    ? [mean([zones[0], zones[1]]), mean([zones[2], zones[3]]), mean([zones[4], zones[5]])]
-        .reduce((best, v, i, arr) => (v > arr[best] ? i : best), 0)
-    : null
-  return { max, mean: mean(zones), spread: max - min, peakZone }
-}
 
 export class BiometricsSignalReader implements SignalReader {
   read(): SignalSnapshot {

--- a/src/automation/signals.biometrics.ts
+++ b/src/automation/signals.biometrics.ts
@@ -1,0 +1,134 @@
+/**
+ * Biometrics-backed signal reader for the automation engine.
+ *
+ * The live DAC monitor (DeviceSignalReader) only knows heat level / water level.
+ * The richer sensors — vitals, movement, ambient + bed-surface + water
+ * temperature, ambient light, and the capacitive sensor matrix — are produced by
+ * the streaming services and persisted to biometrics.db (scalars) or held as a
+ * live in-memory snapshot (the cap matrix). This reader surfaces them to the
+ * engine as numeric catalog signals, gated by a per-source freshness window so a
+ * stale or absent sample resolves to `undefined` — the engine then skips, the
+ * safe default DeviceSignalReader already relies on.
+ *
+ * The capacitive matrix (capSense2: `[A1,A2,B1,B2,C1,C2,ref1,ref2]` per side) is
+ * exposed only as reducers — max / mean / spread / peakZone — keeping the engine
+ * scalar. It is live-only: the raw frames are not persisted granularly, so cap.*
+ * signals cannot be back-tested.
+ */
+
+import { desc, eq } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db'
+import { ambientLight, bedTemp, freezerTemp, movement, vitals } from '@/src/db/biometrics-schema'
+import { centiDegreesToF, centiPercentToPercent } from '@/src/lib/tempUtils'
+import { getLatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+import type { SignalReader, SignalSnapshot } from './signals'
+
+// Freshness windows (ms). A latest row older than its window is treated as
+// absent. Vitals/movement land ~once a minute while in bed; environment frames
+// are slower; the cap matrix arrives ~2 Hz on the live stream (see piezoStream).
+const VITALS_FRESH_MS = 5 * 60_000
+const MOVEMENT_FRESH_MS = 5 * 60_000
+const ENV_FRESH_MS = 15 * 60_000
+const CAP_FRESH_MS = 30_000
+
+const SIDES = ['left', 'right'] as const
+
+function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+/**
+ * Reduce a per-side capacitive channel array to scalar matrix signals. Returns
+ * null when there are no usable channels. `peakZone` is the index (0–2) of the
+ * highest paired zone (A/B/C), available only on the full 6-channel frame.
+ */
+export function reduceCap(values: number[]): { max: number, mean: number, spread: number, peakZone: number | null } | null {
+  // capSense2 carries 6 sensor channels + 2 reference channels; drop the refs.
+  const zones = values.length >= 8 ? values.slice(0, 6) : values
+  if (zones.length === 0) return null
+  const max = Math.max(...zones)
+  const min = Math.min(...zones)
+  // Three paired zones (A/B/C) only when the full 6-channel frame is present.
+  const peakZone = zones.length === 6
+    ? [mean([zones[0], zones[1]]), mean([zones[2], zones[3]]), mean([zones[4], zones[5]])]
+        .reduce((best, v, i, arr) => (v > arr[best] ? i : best), 0)
+    : null
+  return { max, mean: mean(zones), spread: max - min, peakZone }
+}
+
+export class BiometricsSignalReader implements SignalReader {
+  read(): SignalSnapshot {
+    const out: SignalSnapshot = {}
+    const now = Date.now()
+    const fresh = (ts: Date | number, maxAgeMs: number): boolean =>
+      now - (ts instanceof Date ? ts.getTime() : ts) <= maxAgeMs
+
+    try {
+      for (const side of SIDES) {
+        const [v] = biometricsDb.select().from(vitals)
+          .where(eq(vitals.side, side)).orderBy(desc(vitals.timestamp)).limit(1).all()
+        if (v && fresh(v.timestamp, VITALS_FRESH_MS)) {
+          if (v.heartRate != null) out[`${side}.heartRate`] = v.heartRate
+          if (v.hrv != null) out[`${side}.hrv`] = v.hrv
+          if (v.breathingRate != null) out[`${side}.breathingRate`] = v.breathingRate
+        }
+
+        const [m] = biometricsDb.select().from(movement)
+          .where(eq(movement.side, side)).orderBy(desc(movement.timestamp)).limit(1).all()
+        if (m && fresh(m.timestamp, MOVEMENT_FRESH_MS)) {
+          out[`${side}.movement`] = m.totalMovement
+        }
+      }
+
+      const [bt] = biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1).all()
+      if (bt && fresh(bt.timestamp, ENV_FRESH_MS)) {
+        if (bt.ambientTemp != null) out['ambient.temperature'] = centiDegreesToF(bt.ambientTemp)
+        if (bt.humidity != null) out['ambient.humidity'] = centiPercentToPercent(bt.humidity)
+        const zonesBySide = {
+          left: { outer: bt.leftOuterTemp, center: bt.leftCenterTemp, inner: bt.leftInnerTemp },
+          right: { outer: bt.rightOuterTemp, center: bt.rightCenterTemp, inner: bt.rightInnerTemp },
+        }
+        for (const side of SIDES) {
+          const z = zonesBySide[side]
+          const presentF = [z.outer, z.center, z.inner]
+            .filter((t): t is number => t != null)
+            .map(centiDegreesToF)
+          if (presentF.length > 0) out[`${side}.surfaceTemp`] = mean(presentF)
+          if (presentF.length >= 2) out[`${side}.surfaceTemp.spread`] = Math.max(...presentF) - Math.min(...presentF)
+          if (z.inner != null && z.outer != null) out[`${side}.surfaceTemp.gradient`] = centiDegreesToF(z.inner) - centiDegreesToF(z.outer)
+        }
+      }
+
+      const [fz] = biometricsDb.select().from(freezerTemp).orderBy(desc(freezerTemp.timestamp)).limit(1).all()
+      if (fz && fresh(fz.timestamp, ENV_FRESH_MS)) {
+        if (fz.leftWaterTemp != null) out['left.waterTemp'] = centiDegreesToF(fz.leftWaterTemp)
+        if (fz.rightWaterTemp != null) out['right.waterTemp'] = centiDegreesToF(fz.rightWaterTemp)
+      }
+
+      const [al] = biometricsDb.select().from(ambientLight).orderBy(desc(ambientLight.timestamp)).limit(1).all()
+      if (al && fresh(al.timestamp, ENV_FRESH_MS) && al.lux != null) {
+        out['ambient.light'] = al.lux
+      }
+
+      const cap = getLatestCapSenseSnapshot()
+      if (cap && fresh(cap.receivedAtMs, CAP_FRESH_MS)) {
+        for (const side of SIDES) {
+          const raw = cap[side]
+          const r = reduceCap(Array.isArray(raw) ? raw : [raw])
+          if (r) {
+            out[`${side}.cap.max`] = r.max
+            out[`${side}.cap.mean`] = r.mean
+            out[`${side}.cap.spread`] = r.spread
+            if (r.peakZone != null) out[`${side}.cap.peakZone`] = r.peakZone
+          }
+        }
+      }
+    }
+    catch (err) {
+      // Surface rather than swallow; the partial/empty snapshot makes dependent
+      // rules skip, which is the safe default but shouldn't happen silently.
+      console.warn('[automation] BiometricsSignalReader.read failed:', err)
+    }
+    return out
+  }
+}

--- a/src/automation/signals.ts
+++ b/src/automation/signals.ts
@@ -90,6 +90,21 @@ export class DeviceSignalReader implements SignalReader {
   }
 }
 
+/**
+ * Merge several readers into one snapshot. Readers are applied in order, so a
+ * later reader overrides an earlier one on key collision — keep the
+ * authoritative source last (e.g. the live DAC reader's `water.low`).
+ */
+export class CompositeSignalReader implements SignalReader {
+  constructor(private readonly readers: SignalReader[]) {}
+
+  read(): SignalSnapshot {
+    const out: SignalSnapshot = {}
+    for (const reader of this.readers) Object.assign(out, reader.read())
+    return out
+  }
+}
+
 /** Walk an expression tree collecting the signal keys referenced by windows. */
 function collectWindowKeysFromExpr(expr: Expr, out: Set<string>): void {
   switch (expr.kind) {

--- a/src/automation/tests/capReduce.test.ts
+++ b/src/automation/tests/capReduce.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { zoneTriple } from '../capReduce'
+
+describe('zoneTriple', () => {
+  it('returns null for a scalar (Pod 3) frame', () => {
+    expect(zoneTriple([42])).toBeNull()
+  })
+
+  it('returns null below six sensor channels', () => {
+    expect(zoneTriple([10, 20, 30])).toBeNull()
+  })
+
+  it('pairs six channels into head/torso/legs means', () => {
+    expect(zoneTriple([10, 20, 30, 40, 50, 60])).toEqual([15, 35, 55])
+  })
+
+  it('drops the two reference channels on a full capSense2 frame', () => {
+    expect(zoneTriple([10, 20, 30, 40, 50, 60, 999, 999])).toEqual([15, 35, 55])
+  })
+})

--- a/src/automation/tests/instance.test.ts
+++ b/src/automation/tests/instance.test.ts
@@ -37,7 +37,17 @@ vi.mock('../signals', () => ({
   DeviceSignalReader: class {
     read() { return {} }
   },
+  CompositeSignalReader: class {
+    constructor(readonly readers: Array<{ read: () => Record<string, number> }>) {}
+    read() { return Object.assign({}, ...this.readers.map(r => r.read())) }
+  },
   clockInTimezone: vi.fn(() => ({ nowMinutes: 123, dayOfWeek: 'monday' })),
+}))
+
+vi.mock('../signals.biometrics', () => ({
+  BiometricsSignalReader: class {
+    read() { return {} }
+  },
 }))
 
 const hardwareClient = { connect: async () => {}, setTemperature: async () => {}, setPower: async () => {} }

--- a/src/automation/tests/signals.biometrics.test.ts
+++ b/src/automation/tests/signals.biometrics.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { reduceCap } from '../signals.biometrics'
+
+describe('reduceCap', () => {
+  it('returns null for an empty array', () => {
+    expect(reduceCap([])).toBeNull()
+  })
+
+  it('reduces a scalar (Pod 3) channel to degenerate stats', () => {
+    expect(reduceCap([42])).toEqual({ max: 42, mean: 42, spread: 0, peakZone: null })
+  })
+
+  it('drops the two reference channels from a full capSense2 frame', () => {
+    // [A1,A2,B1,B2,C1,C2,ref1,ref2] — refs (999) must not affect the stats.
+    expect(reduceCap([10, 20, 30, 40, 50, 60, 999, 999])).toMatchObject({ max: 60, spread: 50, mean: 35 })
+  })
+
+  it('picks the paired zone (A/B/C) with the highest mean as peakZone', () => {
+    // zone A mean=15, B mean=85, C mean=35 → B is index 1.
+    expect(reduceCap([10, 20, 80, 90, 30, 40, 0, 0])).toMatchObject({ peakZone: 1 })
+    // zone C dominant → index 2.
+    expect(reduceCap([10, 10, 20, 20, 95, 95, 0, 0])).toMatchObject({ peakZone: 2 })
+  })
+
+  it('leaves peakZone null when the frame is not the 6-channel shape', () => {
+    expect(reduceCap([10, 20, 30])).toMatchObject({ peakZone: null })
+  })
+})

--- a/src/automation/tests/signals.biometrics.test.ts
+++ b/src/automation/tests/signals.biometrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { reduceCap } from '../signals.biometrics'
+import { reduceCap } from '../capReduce'
 
 describe('reduceCap', () => {
   it('returns null for an empty array', () => {

--- a/src/components/Autopilot/CapZoneViz.tsx
+++ b/src/components/Autopilot/CapZoneViz.tsx
@@ -1,0 +1,116 @@
+/**
+ * Live capacitive-zone visualization for the rule editor.
+ *
+ * The `{side}.cap.*` signals reduce the capacitive *presence* matrix — per-zone
+ * body-contact load across head/torso/legs, NOT temperature. "Zone" is opaque as
+ * a number, so when a rule references a pressure signal we render the live matrix
+ * the same way the Sensors page PresenceCard does: per-channel variance over a
+ * sliding window, paired into the three zones (channels `z*2` / `z*2+1`), with
+ * the most-active zone highlighted. Live-only — there is no granular history, so
+ * this is not part of the backtest.
+ */
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useOnSensorFrame, useSensorFrame } from '@/src/hooks/useSensorStream'
+import type { SensorFrame } from '@/src/hooks/useSensorStream'
+import { Icon } from './icons'
+import { Card } from './primitives'
+
+const WINDOW = 20 // frames of history for the variance estimate
+const NORMALIZE = 0.5 // variance mapped to a full-intensity cell
+const ZONES = [{ i: 0, label: 'Head' }, { i: 1, label: 'Torso' }, { i: 2, label: 'Legs' }] as const
+
+function variance(xs: number[]): number {
+  if (xs.length < 2) return 0
+  const m = xs.reduce((a, b) => a + b, 0) / xs.length
+  return Math.sqrt(xs.reduce((a, b) => a + (b - m) ** 2, 0) / xs.length)
+}
+
+/** Per-zone activity = the louder of its two paired channels. */
+function zoneActivity(channelVar: number[], zone: number): number {
+  return Math.max(channelVar[zone * 2] ?? 0, channelVar[zone * 2 + 1] ?? 0)
+}
+
+function fmtTs(ts: number | undefined): string {
+  if (!ts) return '--'
+  return new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+export function CapZoneViz({ side }: { side: 'left' | 'right' | 'both' }) {
+  const capSense = useSensorFrame('capSense')
+  const capSense2 = useSensorFrame('capSense2')
+  const frame = capSense2 ?? capSense
+
+  const [hist, setHist] = useState<{ left: number[][], right: number[][] }>({ left: [], right: [] })
+  useOnSensorFrame(useCallback((f: SensorFrame) => {
+    if (f.type !== 'capSense' && f.type !== 'capSense2') return
+    const l = Array.isArray(f.left) ? f.left : [f.left]
+    const r = Array.isArray(f.right) ? f.right : [f.right]
+    setHist(prev => ({
+      left: [...prev.left, l].slice(-WINDOW),
+      right: [...prev.right, r].slice(-WINDOW),
+    }))
+  }, []))
+
+  const channelVar = useMemo(() => {
+    const calc = (frames: number[][]): number[] => {
+      const n = Math.max(6, ...frames.map(h => h.length))
+      return Array.from({ length: n }, (_, ch) => variance(frames.map(h => h[ch] ?? 0)))
+    }
+    return { left: calc(hist.left), right: calc(hist.right) }
+  }, [hist])
+
+  const sides = side === 'both' ? (['left', 'right'] as const) : ([side] as const)
+
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Icon.Activity size={13} className="text-zinc-500" />
+          <span className="text-[12px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Bed pressure · live zones</span>
+        </div>
+        {frame && <span className="mono text-[10px] text-zinc-600">{fmtTs(frame.ts)}</span>}
+      </div>
+
+      {!frame
+        ? <div className="grid h-24 place-items-center text-[12px] text-zinc-600">Waiting for live capacitive data…</div>
+        : (
+            <div className="flex gap-3">
+              {sides.map((s) => {
+                const act = ZONES.map(z => zoneActivity(channelVar[s], z.i))
+                const peak = act.indexOf(Math.max(...act))
+                return (
+                  <div key={s} className="flex-1">
+                    <div className="mb-1.5 text-center text-[10px] uppercase tracking-wide text-zinc-500">{s}</div>
+                    <div className="flex flex-col gap-1">
+                      {ZONES.map((z, i) => {
+                        const pct = Math.min(act[i] / NORMALIZE, 1)
+                        const isPeak = i === peak && act[i] > 0.02
+                        return (
+                          <div
+                            key={z.i}
+                            className="relative h-9 overflow-hidden rounded-md border"
+                            style={{ borderColor: isPeak ? 'var(--accent)' : 'rgba(63,63,70,0.5)' }}
+                          >
+                            <div className="absolute inset-0" style={{ background: 'var(--accent)', opacity: 0.06 + pct * 0.5 }} />
+                            <div className="absolute inset-0 flex items-center justify-between px-2.5">
+                              <span className="text-[11px] text-zinc-200">{z.label}</span>
+                              <span className="mono text-[10px] text-zinc-400">{act[i].toFixed(2)}</span>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+
+      <div className="mt-3 text-[11px] leading-relaxed text-zinc-600">
+        Capacitive presence sensing — body-contact load across head/torso/legs (not temperature). Brighter = more contact; the outlined band is the most-active zone. Live only, not part of the backtest.
+      </div>
+    </Card>
+  )
+}

--- a/src/components/Autopilot/RuleEditor.tsx
+++ b/src/components/Autopilot/RuleEditor.tsx
@@ -10,6 +10,7 @@ import { trpc } from '@/src/utils/trpc'
 import { Icon, type IconName } from './icons'
 import { Button, Card, NumberField, SectionLabel, Segmented, Select, Toggle } from './primitives'
 import { BacktestPanel } from './BacktestPanel'
+import { CapZoneViz } from './CapZoneViz'
 import {
   AGGS,
   type BuilderRule,
@@ -308,6 +309,15 @@ export function RuleEditor({ automation, onClose, onSave, saving }: { automation
   const ambientQ = trpc.environment.getLatestBedTemp.useQuery({ unit: 'F' })
   const liveAmbient = ambientQ.data?.ambientTemp ?? null
 
+  // Show the live capacitive zone viz when the rule reads a pressure signal —
+  // "zone" is meaningless as a bare number without it.
+  const usesCapSignal = useMemo(() => {
+    const sigs: string[] = []
+    if ('signal' in rule.when && rule.when.signal) sigs.push(rule.when.signal)
+    for (const c of rule.ifs) if (c.type === 'cond') sigs.push(c.signal)
+    return sigs.some(s => s.startsWith('{side}.cap.'))
+  }, [rule])
+
   const ast = useMemo(() => toAST(debounced), [debounced])
   const backtestQ = trpc.automations.backtest.useQuery(
     {
@@ -355,6 +365,7 @@ export function RuleEditor({ automation, onClose, onSave, saving }: { automation
         <div className="flex-1 overflow-y-auto bg-zinc-950/40 p-5">
           <div className="mx-auto flex max-w-2xl flex-col gap-4">
             <SentencePreview rule={rule} />
+            {usesCapSignal && <CapZoneViz side={rule.side} />}
             <Card className="p-4">
               <BacktestPanel
                 result={backtestQ.data?.ok ? (backtestQ.data.result as Parameters<typeof BacktestPanel>[0]['result']) : null}

--- a/src/components/Autopilot/builderModel.ts
+++ b/src/components/Autopilot/builderModel.ts
@@ -35,7 +35,7 @@ export interface SignalDef {
   label: string
   unit: string
   kind: SignalKind
-  group: 'Room' | 'Bed' | 'Bio' | 'Matrix' | 'System'
+  group: 'Room' | 'Bed' | 'Bio' | 'Presence' | 'System'
   icon: string
   perSide?: boolean
   max?: number
@@ -58,10 +58,10 @@ export const SIGNALS: SignalDef[] = [
   { id: '{side}.heartRate', label: 'Heart rate', unit: 'bpm', kind: 'num', group: 'Bio', icon: 'Heart', perSide: true },
   { id: '{side}.hrv', label: 'HRV', unit: 'ms', kind: 'num', group: 'Bio', icon: 'Pulse', perSide: true },
   { id: '{side}.breathingRate', label: 'Breathing rate', unit: 'brpm', kind: 'num', group: 'Bio', icon: 'Wind', perSide: true },
-  { id: '{side}.cap.max', label: 'Cap matrix peak', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.mean', label: 'Cap matrix mean', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.spread', label: 'Cap matrix spread', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
-  { id: '{side}.cap.peakZone', label: 'Cap matrix peak zone', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  // Capacitive presence sensing (not temperature): per-zone body-contact load.
+  { id: '{side}.cap.max', label: 'Bed pressure (peak)', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.mean', label: 'Bed pressure (avg)', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.spread', label: 'Pressure spread', unit: '', kind: 'num', group: 'Presence', icon: 'Activity', perSide: true, liveOnly: true },
   { id: 'water.low', label: 'Water low', unit: '', kind: 'num', group: 'System', icon: 'Droplet' },
 ]
 

--- a/src/components/Autopilot/builderModel.ts
+++ b/src/components/Autopilot/builderModel.ts
@@ -35,22 +35,33 @@ export interface SignalDef {
   label: string
   unit: string
   kind: SignalKind
-  group: 'Room' | 'Bed' | 'Bio' | 'System'
+  group: 'Room' | 'Bed' | 'Bio' | 'Matrix' | 'System'
   icon: string
   perSide?: boolean
   max?: number
+  /** Live-only: no granular history, so it reads live but can't be back-tested. */
+  liveOnly?: boolean
 }
 
 /** Numeric, engine-evaluable signals (subset wired for live read and/or backtest). */
 export const SIGNALS: SignalDef[] = [
   { id: 'ambient.temperature', label: 'Ambient temp', unit: '°F', kind: 'num', group: 'Room', icon: 'Thermometer' },
   { id: 'ambient.humidity', label: 'Ambient humidity', unit: '%', kind: 'num', group: 'Room', icon: 'Droplet' },
-  { id: '{side}.currentTemperature', label: 'Current temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
-  { id: '{side}.targetTemperature', label: 'Target temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: 'ambient.light', label: 'Ambient light', unit: 'lux', kind: 'num', group: 'Room', icon: 'Moon' },
+  { id: '{side}.currentTemperature', label: 'Current temp (level)', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.targetTemperature', label: 'Target temp (level)', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp', label: 'Bed surface temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp.spread', label: 'Surface temp spread', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.surfaceTemp.gradient', label: 'Surface temp gradient', unit: '°F', kind: 'num', group: 'Bed', icon: 'Thermometer', perSide: true },
+  { id: '{side}.waterTemp', label: 'Water temp', unit: '°F', kind: 'num', group: 'Bed', icon: 'Droplet', perSide: true },
   { id: '{side}.movement', label: 'Movement', unit: '', kind: 'num', group: 'Bio', icon: 'Activity', perSide: true, max: 1000 },
   { id: '{side}.heartRate', label: 'Heart rate', unit: 'bpm', kind: 'num', group: 'Bio', icon: 'Heart', perSide: true },
   { id: '{side}.hrv', label: 'HRV', unit: 'ms', kind: 'num', group: 'Bio', icon: 'Pulse', perSide: true },
   { id: '{side}.breathingRate', label: 'Breathing rate', unit: 'brpm', kind: 'num', group: 'Bio', icon: 'Wind', perSide: true },
+  { id: '{side}.cap.max', label: 'Cap matrix peak', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.mean', label: 'Cap matrix mean', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.spread', label: 'Cap matrix spread', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
+  { id: '{side}.cap.peakZone', label: 'Cap matrix peak zone', unit: '', kind: 'num', group: 'Matrix', icon: 'Activity', perSide: true, liveOnly: true },
   { id: 'water.low', label: 'Water low', unit: '', kind: 'num', group: 'System', icon: 'Droplet' },
 ]
 

--- a/src/components/Autopilot/primitives.tsx
+++ b/src/components/Autopilot/primitives.tsx
@@ -159,7 +159,7 @@ export function Select({ value, options, onChange, placeholder = 'Select…', cl
         <Icon.ChevDown size={13} className="opacity-60" />
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 min-w-full max-h-64 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 p-1 shadow-2xl shadow-black/60" style={{ left: 0 }}>
+        <div className="absolute z-50 mt-1 w-max min-w-full max-w-[280px] max-h-64 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 p-1 shadow-2xl shadow-black/60" style={{ left: 0 }}>
           {opts.map((o) => {
             const I = o.icon ? Icon[o.icon] : null
             return (
@@ -172,8 +172,8 @@ export function Select({ value, options, onChange, placeholder = 'Select…', cl
                 }}
                 className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] hover:bg-zinc-800 ${o.value === value ? 'text-white' : 'text-zinc-300'}`}
               >
-                {I ? <I size={14} className="text-zinc-500" /> : null}
-                <span className="flex-1">{o.label}</span>
+                {I ? <I size={14} className="shrink-0 text-zinc-500" /> : null}
+                <span className="flex-1 whitespace-nowrap">{o.label}</span>
                 {o.hint && <span className="text-[11px] text-zinc-500 mono">{o.hint}</span>}
                 {o.value === value && <Icon.Check size={13} style={{ color: 'var(--accent)' }} />}
               </button>

--- a/src/db/biometrics-migrations/0010_fixed_silvermane.sql
+++ b/src/db/biometrics-migrations/0010_fixed_silvermane.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `cap_sense_frames` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`side` text NOT NULL,
+	`timestamp` integer NOT NULL,
+	`zones` text,
+	`max` real NOT NULL,
+	`mean` real NOT NULL,
+	`spread` real NOT NULL,
+	`peak_zone` integer,
+	`frame_count` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_cap_sense_frames_side_ts` ON `cap_sense_frames` (`side`,`timestamp`);

--- a/src/db/biometrics-migrations/0010_tidy_senator_kelly.sql
+++ b/src/db/biometrics-migrations/0010_tidy_senator_kelly.sql
@@ -10,4 +10,4 @@ CREATE TABLE `cap_sense_frames` (
 	`frame_count` integer NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX `idx_cap_sense_frames_side_ts` ON `cap_sense_frames` (`side`,`timestamp`);
+CREATE UNIQUE INDEX `uq_cap_sense_frames_side_ts` ON `cap_sense_frames` (`side`,`timestamp`);

--- a/src/db/biometrics-migrations/meta/0010_snapshot.json
+++ b/src/db/biometrics-migrations/meta/0010_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "82d7d72a-4151-46cc-9c7b-0c66c5a4d786",
+  "id": "6d9e70b0-4c9e-4a22-9e60-55eda5b6b2ad",
   "prevId": "00d19013-c8ca-4064-92bc-42035032b07e",
   "tables": {
     "ambient_light": {
@@ -429,13 +429,13 @@
         }
       },
       "indexes": {
-        "idx_cap_sense_frames_side_ts": {
-          "name": "idx_cap_sense_frames_side_ts",
+        "uq_cap_sense_frames_side_ts": {
+          "name": "uq_cap_sense_frames_side_ts",
           "columns": [
             "side",
             "timestamp"
           ],
-          "isUnique": false
+          "isUnique": true
         }
       },
       "foreignKeys": {},

--- a/src/db/biometrics-migrations/meta/0010_snapshot.json
+++ b/src/db/biometrics-migrations/meta/0010_snapshot.json
@@ -1,0 +1,1080 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "82d7d72a-4151-46cc-9c7b-0c66c5a4d786",
+  "prevId": "00d19013-c8ca-4064-92bc-42035032b07e",
+  "tables": {
+    "ambient_light": {
+      "name": "ambient_light",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lux": {
+          "name": "lux",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ambient_light_timestamp": {
+          "name": "idx_ambient_light_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bed_temp": {
+      "name": "bed_temp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ambient_temp": {
+          "name": "ambient_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcu_temp": {
+          "name": "mcu_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "humidity": {
+          "name": "humidity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "left_outer_temp": {
+          "name": "left_outer_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "left_center_temp": {
+          "name": "left_center_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "left_inner_temp": {
+          "name": "left_inner_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_outer_temp": {
+          "name": "right_outer_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_center_temp": {
+          "name": "right_center_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_inner_temp": {
+          "name": "right_inner_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_bed_temp_timestamp": {
+          "name": "idx_bed_temp_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "calibration_profiles": {
+      "name": "calibration_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sensor_type": {
+          "name": "sensor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_window_start": {
+          "name": "source_window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_window_end": {
+          "name": "source_window_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "samples_used": {
+          "name": "samples_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cal_type_status": {
+          "name": "idx_cal_type_status",
+          "columns": [
+            "sensor_type",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "uq_cal_side_type_active": {
+          "name": "uq_cal_side_type_active",
+          "columns": [
+            "side",
+            "sensor_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "calibration_runs": {
+      "name": "calibration_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sensor_type": {
+          "name": "sensor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_window_start": {
+          "name": "source_window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_window_end": {
+          "name": "source_window_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "samples_used": {
+          "name": "samples_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cal_runs_side_type": {
+          "name": "idx_cal_runs_side_type",
+          "columns": [
+            "side",
+            "sensor_type",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cap_sense_frames": {
+      "name": "cap_sense_frames",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zones": {
+          "name": "zones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max": {
+          "name": "max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mean": {
+          "name": "mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spread": {
+          "name": "spread",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peak_zone": {
+          "name": "peak_zone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frame_count": {
+          "name": "frame_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cap_sense_frames_side_ts": {
+          "name": "idx_cap_sense_frames_side_ts",
+          "columns": [
+            "side",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "flow_readings": {
+      "name": "flow_readings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "left_flowrate_cd": {
+          "name": "left_flowrate_cd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_flowrate_cd": {
+          "name": "right_flowrate_cd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "left_pump_rpm": {
+          "name": "left_pump_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_pump_rpm": {
+          "name": "right_pump_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_flow_readings_timestamp": {
+          "name": "idx_flow_readings_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "freezer_temp": {
+      "name": "freezer_temp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ambient_temp": {
+          "name": "ambient_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heatsink_temp": {
+          "name": "heatsink_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "left_water_temp": {
+          "name": "left_water_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "right_water_temp": {
+          "name": "right_water_temp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_freezer_temp_timestamp": {
+          "name": "idx_freezer_temp_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movement": {
+      "name": "movement",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_movement": {
+          "name": "total_movement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movement_side_timestamp": {
+          "name": "idx_movement_side_timestamp",
+          "columns": [
+            "side",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pump_alerts": {
+      "name": "pump_alerts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flowrate_cd": {
+          "name": "flowrate_cd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "restore_target_temperature": {
+          "name": "restore_target_temperature",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restore_duration_seconds": {
+          "name": "restore_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pump_alerts_timestamp": {
+          "name": "idx_pump_alerts_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_pump_alerts_acknowledged": {
+          "name": "idx_pump_alerts_acknowledged",
+          "columns": [
+            "acknowledged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sleep_records": {
+      "name": "sleep_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entered_bed_at": {
+          "name": "entered_bed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "left_bed_at": {
+          "name": "left_bed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sleep_duration_seconds": {
+          "name": "sleep_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "times_exited_bed": {
+          "name": "times_exited_bed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "present_intervals": {
+          "name": "present_intervals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "not_present_intervals": {
+          "name": "not_present_intervals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sleep_records_side_entered": {
+          "name": "idx_sleep_records_side_entered",
+          "columns": [
+            "side",
+            "entered_bed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vitals": {
+      "name": "vitals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hrv": {
+          "name": "hrv",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "breathing_rate": {
+          "name": "breathing_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_vitals_side_timestamp": {
+          "name": "uq_vitals_side_timestamp",
+          "columns": [
+            "side",
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vitals_quality": {
+      "name": "vitals_quality",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "vitals_id": {
+          "name": "vitals_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hr_raw": {
+          "name": "hr_raw",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_vq_vitals_id": {
+          "name": "idx_vq_vitals_id",
+          "columns": [
+            "vitals_id"
+          ],
+          "isUnique": false
+        },
+        "idx_vq_side_ts": {
+          "name": "idx_vq_side_ts",
+          "columns": [
+            "side",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "water_level_alerts": {
+      "name": "water_level_alerts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_water_level_alerts_dismissed": {
+          "name": "idx_water_level_alerts_dismissed",
+          "columns": [
+            "dismissed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "water_level_readings": {
+      "name": "water_level_readings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calibrated_empty": {
+          "name": "calibrated_empty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calibrated_full": {
+          "name": "calibrated_full",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_water_level_timestamp": {
+          "name": "idx_water_level_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/biometrics-migrations/meta/_journal.json
+++ b/src/db/biometrics-migrations/meta/_journal.json
@@ -75,8 +75,8 @@
     {
       "idx": 10,
       "version": "6",
-      "when": 1781477768520,
-      "tag": "0010_fixed_silvermane",
+      "when": 1781480384713,
+      "tag": "0010_tidy_senator_kelly",
       "breakpoints": true
     }
   ]

--- a/src/db/biometrics-migrations/meta/_journal.json
+++ b/src/db/biometrics-migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779761660310,
       "tag": "0009_robust_the_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1781477768520,
+      "tag": "0010_fixed_silvermane",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/biometrics-schema.ts
+++ b/src/db/biometrics-schema.ts
@@ -106,6 +106,27 @@ export const ambientLight = sqliteTable('ambient_light', {
   uniqueIndex('idx_ambient_light_timestamp').on(t.timestamp),
 ])
 
+// Downsampled capacitive presence frames for historical replay. The live
+// capSense matrix arrives ~2 Hz and is never persisted raw; this table holds one
+// windowed row per side (~5s) so the spatial zone replay and cap.* backtest can
+// reach recent nights. Pruned aggressively (~48h) — it is the bulkiest sensor
+// stream and only the last night or two is ever replayed.
+export const capSenseFrames = sqliteTable('cap_sense_frames', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  side: text('side', { enum: ['left', 'right'] }).notNull(),
+  timestamp: integer('timestamp', { mode: 'timestamp' }).notNull(),
+  // [head, torso, legs] windowed-mean zone loads, or null for a scalar (Pod 3)
+  // sensor with no spatial resolution.
+  zones: text('zones', { mode: 'json' }),
+  max: real('max').notNull(),
+  mean: real('mean').notNull(),
+  spread: real('spread').notNull(),
+  peakZone: integer('peak_zone'), // 0–2 modal zone over the window, or null
+  frameCount: integer('frame_count').notNull(), // raw frames aggregated into this row
+}, t => [
+  index('idx_cap_sense_frames_side_ts').on(t.side, t.timestamp),
+])
+
 export const pumpAlerts = sqliteTable('pump_alerts', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   timestamp: integer('timestamp', { mode: 'timestamp' }).notNull(),

--- a/src/db/biometrics-schema.ts
+++ b/src/db/biometrics-schema.ts
@@ -124,7 +124,9 @@ export const capSenseFrames = sqliteTable('cap_sense_frames', {
   peakZone: integer('peak_zone'), // 0–2 modal zone over the window, or null
   frameCount: integer('frame_count').notNull(), // raw frames aggregated into this row
 }, t => [
-  index('idx_cap_sense_frames_side_ts').on(t.side, t.timestamp),
+  // One row per side/window — guards against duplicates if a restart re-reads
+  // the active RAW file from the start (insert is conflict-tolerant).
+  uniqueIndex('uq_cap_sense_frames_side_ts').on(t.side, t.timestamp),
 ])
 
 export const pumpAlerts = sqliteTable('pump_alerts', {

--- a/src/server/routers/automations.ts
+++ b/src/server/routers/automations.ts
@@ -17,7 +17,7 @@ import { and, desc, eq, gte, lte } from 'drizzle-orm'
 import { publicProcedure, router } from '@/src/server/trpc'
 import { biometricsDb, db } from '@/src/db'
 import { automationRuns, automations, deviceSettings } from '@/src/db/schema'
-import { bedTemp, movement, sleepRecords, vitals, waterLevelReadings } from '@/src/db/biometrics-schema'
+import { ambientLight, bedTemp, freezerTemp, movement, sleepRecords, vitals, waterLevelReadings } from '@/src/db/biometrics-schema'
 import { centiDegreesToF, centiPercentToPercent } from '@/src/lib/tempUtils'
 import {
   automationActionSchema,
@@ -434,14 +434,44 @@ function loadSeries(side: 'left' | 'right', startMs: number, endMs: number): Rec
   series[`${side}.hrv`] = vit.flatMap(r => r.hrv != null ? [{ t: r.t.getTime(), v: r.hrv }] : [])
   series[`${side}.breathingRate`] = vit.flatMap(r => r.br != null ? [{ t: r.t.getTime(), v: r.br }] : [])
 
+  const zoneCols = side === 'left'
+    ? { o: bedTemp.leftOuterTemp, c: bedTemp.leftCenterTemp, n: bedTemp.leftInnerTemp }
+    : { o: bedTemp.rightOuterTemp, c: bedTemp.rightCenterTemp, n: bedTemp.rightInnerTemp }
   const bt = biometricsDb
-    .select({ t: bedTemp.timestamp, amb: bedTemp.ambientTemp, hum: bedTemp.humidity })
+    .select({ t: bedTemp.timestamp, amb: bedTemp.ambientTemp, hum: bedTemp.humidity, o: zoneCols.o, c: zoneCols.c, n: zoneCols.n })
     .from(bedTemp)
     .where(and(gte(bedTemp.timestamp, start), lte(bedTemp.timestamp, end)))
     .orderBy(bedTemp.timestamp)
     .all()
   series['ambient.temperature'] = bt.flatMap(r => r.amb != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.amb) }] : [])
   series['ambient.humidity'] = bt.flatMap(r => r.hum != null ? [{ t: r.t.getTime(), v: centiPercentToPercent(r.hum) }] : [])
+  series[`${side}.surfaceTemp`] = bt.flatMap((r) => {
+    const zs = [r.o, r.c, r.n].filter((x): x is number => x != null).map(centiDegreesToF)
+    return zs.length ? [{ t: r.t.getTime(), v: zs.reduce((a, b) => a + b, 0) / zs.length }] : []
+  })
+  series[`${side}.surfaceTemp.spread`] = bt.flatMap((r) => {
+    const zs = [r.o, r.c, r.n].filter((x): x is number => x != null).map(centiDegreesToF)
+    return zs.length >= 2 ? [{ t: r.t.getTime(), v: Math.max(...zs) - Math.min(...zs) }] : []
+  })
+  series[`${side}.surfaceTemp.gradient`] = bt.flatMap(r =>
+    r.n != null && r.o != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.n) - centiDegreesToF(r.o) }] : [])
+
+  const waterCol = side === 'left' ? freezerTemp.leftWaterTemp : freezerTemp.rightWaterTemp
+  const fz = biometricsDb
+    .select({ t: freezerTemp.timestamp, w: waterCol })
+    .from(freezerTemp)
+    .where(and(gte(freezerTemp.timestamp, start), lte(freezerTemp.timestamp, end)))
+    .orderBy(freezerTemp.timestamp)
+    .all()
+  series[`${side}.waterTemp`] = fz.flatMap(r => r.w != null ? [{ t: r.t.getTime(), v: centiDegreesToF(r.w) }] : [])
+
+  const al = biometricsDb
+    .select({ t: ambientLight.timestamp, lux: ambientLight.lux })
+    .from(ambientLight)
+    .where(and(gte(ambientLight.timestamp, start), lte(ambientLight.timestamp, end)))
+    .orderBy(ambientLight.timestamp)
+    .all()
+  series['ambient.light'] = al.flatMap(r => r.lux != null ? [{ t: r.t.getTime(), v: r.lux }] : [])
 
   const wl = biometricsDb
     .select({ t: waterLevelReadings.timestamp, level: waterLevelReadings.level })

--- a/src/streaming/capFramePersistence.ts
+++ b/src/streaming/capFramePersistence.ts
@@ -1,0 +1,157 @@
+/**
+ * Downsampling writer for the capacitive presence matrix.
+ *
+ * The live broadcast loop sees capSense / capSense2 frames at ~2 Hz but never
+ * persists them — `signals.biometrics` reads only the in-memory snapshot. This
+ * module accumulates those frames into a fixed time window (per side) and flushes
+ * one aggregated row to `cap_sense_frames` per window, so the spatial zone replay
+ * and `cap.*` backtest can reach recent nights without storing every raw frame.
+ *
+ * Windowing keys off the firmware frame timestamp, not wall clock, so a stream
+ * catching up after a gap downsamples correctly instead of collapsing a burst.
+ * Old rows are pruned to ~48h — this is the bulkiest sensor stream and only the
+ * last night or two is ever replayed.
+ */
+
+import { lte } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db'
+import { capSenseFrames } from '@/src/db/biometrics-schema'
+import { reduceCap, zoneTriple } from '@/src/automation/capReduce'
+
+const WINDOW_MS = 5_000
+const RETENTION_MS = 48 * 60 * 60_000
+const PRUNE_INTERVAL_MS = 10 * 60_000
+
+type Side = 'left' | 'right'
+
+interface WindowAccumulator {
+  startTsMs: number
+  lastTsMs: number
+  n: number
+  maxSum: number
+  meanSum: number
+  spreadSum: number
+  zoneSums: [number, number, number] | null
+  peakCounts: [number, number, number]
+}
+
+const windows: Record<Side, WindowAccumulator | null> = { left: null, right: null }
+let lastPruneMs = 0
+
+function freshWindow(tsMs: number): WindowAccumulator {
+  return {
+    startTsMs: tsMs,
+    lastTsMs: tsMs,
+    n: 0,
+    maxSum: 0,
+    meanSum: 0,
+    spreadSum: 0,
+    zoneSums: null,
+    peakCounts: [0, 0, 0],
+  }
+}
+
+export interface CapFrameRow {
+  timestamp: Date
+  zones: [number, number, number] | null
+  max: number
+  mean: number
+  spread: number
+  peakZone: number | null
+  frameCount: number
+}
+
+/** Collapse a filled window into the row shape written to `cap_sense_frames`. */
+export function summarizeWindow(acc: WindowAccumulator): CapFrameRow {
+  const zones: [number, number, number] | null = acc.zoneSums
+    ? [acc.zoneSums[0] / acc.n, acc.zoneSums[1] / acc.n, acc.zoneSums[2] / acc.n]
+    : null
+  // Modal peak zone across the window — only meaningful when zones were present.
+  const peakZone = acc.zoneSums
+    ? acc.peakCounts.reduce((best, c, i, arr) => (c > arr[best] ? i : best), 0)
+    : null
+  return {
+    timestamp: new Date(acc.lastTsMs),
+    zones,
+    max: acc.maxSum / acc.n,
+    mean: acc.meanSum / acc.n,
+    spread: acc.spreadSum / acc.n,
+    peakZone,
+    frameCount: acc.n,
+  }
+}
+
+function flush(side: Side, acc: WindowAccumulator): void {
+  if (acc.n === 0) return
+  try {
+    biometricsDb.insert(capSenseFrames).values({ side, ...summarizeWindow(acc) }).run()
+  }
+  catch (err) {
+    // Persistence is best-effort: a write failure must never disrupt the live
+    // stream. Surface rather than swallow silently.
+    console.warn('[capFrames] flush failed:', err)
+  }
+}
+
+function maybePrune(nowMs: number): void {
+  if (nowMs - lastPruneMs < PRUNE_INTERVAL_MS) return
+  lastPruneMs = nowMs
+  try {
+    biometricsDb.delete(capSenseFrames)
+      .where(lte(capSenseFrames.timestamp, new Date(nowMs - RETENTION_MS)))
+      .run()
+  }
+  catch (err) {
+    console.warn('[capFrames] prune failed:', err)
+  }
+}
+
+/**
+ * Feed one per-side capacitive reading from the live broadcast loop. `raw` is the
+ * frame's `left`/`right` channel value (scalar for Pod 3, the raw 8-channel array
+ * for capSense2). `tsSeconds` is the firmware frame timestamp (epoch seconds).
+ * Flushes a downsampled row whenever the window rolls over.
+ */
+export function recordCapFrame(side: Side, raw: number | number[], tsSeconds: number): void {
+  const tsMs = tsSeconds * 1000
+  const values = Array.isArray(raw) ? raw : [raw]
+  const r = reduceCap(values)
+  if (!r) return
+
+  let acc = windows[side]
+  if (!acc) {
+    acc = freshWindow(tsMs)
+    windows[side] = acc
+  }
+  else if (tsMs - acc.startTsMs >= WINDOW_MS) {
+    flush(side, acc)
+    maybePrune(Date.now())
+    acc = freshWindow(tsMs)
+    windows[side] = acc
+  }
+
+  acc.n += 1
+  acc.lastTsMs = tsMs
+  acc.maxSum += r.max
+  acc.meanSum += r.mean
+  acc.spreadSum += r.spread
+  const triple = zoneTriple(values)
+  if (triple) {
+    if (!acc.zoneSums) acc.zoneSums = [0, 0, 0]
+    acc.zoneSums[0] += triple[0]
+    acc.zoneSums[1] += triple[1]
+    acc.zoneSums[2] += triple[2]
+    if (r.peakZone != null) acc.peakCounts[r.peakZone] += 1
+  }
+}
+
+/** Reset accumulators — called when the active RAW file switches. */
+export function resetCapFrameWindows(): void {
+  windows.left = null
+  windows.right = null
+}
+
+/** Test-only accessor for the in-flight per-side window state. */
+export function _getCapFrameWindow(side: Side): WindowAccumulator | null {
+  return windows[side]
+}

--- a/src/streaming/capFramePersistence.ts
+++ b/src/streaming/capFramePersistence.ts
@@ -84,7 +84,10 @@ export function summarizeWindow(acc: WindowAccumulator): CapFrameRow {
 // Caller invariant: only ever called on rollover, when `acc` holds ≥1 frame.
 function flush(side: Side, acc: WindowAccumulator): void {
   try {
-    biometricsDb.insert(capSenseFrames).values({ side, ...summarizeWindow(acc) }).run()
+    biometricsDb.insert(capSenseFrames)
+      .values({ side, ...summarizeWindow(acc) })
+      .onConflictDoNothing()
+      .run()
   }
   catch (err) {
     // Persistence is best-effort: a write failure must never disrupt the live

--- a/src/streaming/capFramePersistence.ts
+++ b/src/streaming/capFramePersistence.ts
@@ -81,8 +81,8 @@ export function summarizeWindow(acc: WindowAccumulator): CapFrameRow {
   }
 }
 
+// Caller invariant: only ever called on rollover, when `acc` holds ≥1 frame.
 function flush(side: Side, acc: WindowAccumulator): void {
-  if (acc.n === 0) return
   try {
     biometricsDb.insert(capSenseFrames).values({ side, ...summarizeWindow(acc) }).run()
   }
@@ -154,4 +154,11 @@ export function resetCapFrameWindows(): void {
 /** Test-only accessor for the in-flight per-side window state. */
 export function _getCapFrameWindow(side: Side): WindowAccumulator | null {
   return windows[side]
+}
+
+/** Test-only reset of all module state (windows + prune throttle clock). */
+export function _resetForTest(): void {
+  windows.left = null
+  windows.right = null
+  lastPruneMs = 0
 }

--- a/src/streaming/normalizeFrame.ts
+++ b/src/streaming/normalizeFrame.ts
@@ -124,6 +124,34 @@ function cdToC(v: unknown): number | null {
   return v / 100
 }
 
+/**
+ * Unwrap a raw per-side capacitive payload into a flat channel array.
+ *
+ * Firmware shapes vary by pod: Pod 4/5 capSense2 sends `{ values: number[],
+ * status }`, Pod 3 capSense sends `{ out, cen, in }` (projected to the same
+ * 6-slot paired layout capSense2 uses), and some builds send a bare array or
+ * scalar. Returns null when nothing numeric is present so callers can skip.
+ */
+export function capSideChannels(v: unknown): number[] | null {
+  if (typeof v === 'number') return [v]
+  if (Array.isArray(v)) {
+    const nums = v.filter((x): x is number => typeof x === 'number')
+    return nums.length > 0 ? nums : null
+  }
+  if (v && typeof v === 'object') {
+    const o = v as Record<string, unknown>
+    if (Array.isArray(o.values)) {
+      const nums = (o.values as unknown[]).filter((x): x is number => typeof x === 'number')
+      return nums.length > 0 ? nums : null
+    }
+    if (typeof o.out === 'number' || typeof o.cen === 'number' || typeof o.in === 'number') {
+      const n = (x: unknown): number => (typeof x === 'number' ? x : 0)
+      return [n(o.out), n(o.out), n(o.cen), n(o.cen), n(o.in), n(o.in)]
+    }
+  }
+  return null
+}
+
 // ---------------------------------------------------------------------------
 // Normalizer
 // ---------------------------------------------------------------------------

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -37,6 +37,7 @@ import { WebSocketServer, WebSocket } from 'ws'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Decoder } from 'cbor-x'
+import { recordCapFrame, resetCapFrameWindows } from './capFramePersistence'
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -680,6 +681,8 @@ export function startPiezoStreamServer(): WebSocketServer {
       // Drop the cached capSense snapshot — old file's last frame doesn't
       // describe the current sensor state.
       latestCapSenseSnapshot = null
+      // Drop any in-flight downsample windows; the new file restarts the stream.
+      resetCapFrameWindows()
     }
 
     // Read any new bytes appended since last read
@@ -773,6 +776,9 @@ export function startPiezoStreamServer(): WebSocketServer {
                   left: left as number | number[],
                   right: right as number | number[],
                 }
+                // Downsample into biometrics.db for historical replay.
+                recordCapFrame('left', left as number | number[], ts)
+                recordCapFrame('right', right as number | number[], ts)
               }
             }
           }

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -38,6 +38,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Decoder } from 'cbor-x'
 import { recordCapFrame, resetCapFrameWindows } from './capFramePersistence'
+import { capSideChannels } from './normalizeFrame'
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -764,24 +765,24 @@ export function startPiezoStreamServer(): WebSocketServer {
             }
 
             // Update the live capSense snapshot for in-process readers (virtual
-            // occupancy sensor). Cheap O(1) copy of the small per-frame shape.
+            // occupancy sensor) and downsample into biometrics.db for replay.
+            // Firmware sends per-side channels as {values:[...]} on Pod 4/5 and
+            // {out,cen,in} on Pod 3 — unwrap to a flat array so both paths see
+            // real readings regardless of pod variant.
             if (frameType === 'capSense' || frameType === 'capSense2') {
-              const left = (frame as { left: unknown }).left
-              const right = (frame as { right: unknown }).right
               const ts = (frame as { ts: unknown }).ts
-              if (typeof ts === 'number'
-                && (typeof left === 'number' || Array.isArray(left))
-                && (typeof right === 'number' || Array.isArray(right))) {
+              const left = capSideChannels((frame as { left: unknown }).left)
+              const right = capSideChannels((frame as { right: unknown }).right)
+              if (typeof ts === 'number' && left && right) {
                 latestCapSenseSnapshot = {
                   type: frameType,
                   ts,
                   receivedAtMs: Date.now(),
-                  left: left as number | number[],
-                  right: right as number | number[],
+                  left,
+                  right,
                 }
-                // Downsample into biometrics.db for historical replay.
-                recordCapFrame('left', left as number | number[], ts)
-                recordCapFrame('right', right as number | number[], ts)
+                recordCapFrame('left', left, ts)
+                recordCapFrame('right', right, ts)
               }
             }
           }

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -661,9 +661,12 @@ export function startPiezoStreamServer(): WebSocketServer {
     })
   })
 
-  // Periodic file-tailing loop: read new data from the RAW file and broadcast
+  // Periodic file-tailing loop: read new data from the RAW file and broadcast.
+  // Runs even with no clients connected — the cap-frame downsampler must keep
+  // persisting through unattended nights so the next morning can be replayed.
+  // Broadcasting is already per-client guarded, so an idle loop does no fan-out.
   streamingInterval = setInterval(() => {
-    if (!wss || wss.clients.size === 0) return
+    if (!wss) return
 
     // Find the latest RAW file
     const latest = findLatestRaw(RAW_DATA_DIR)

--- a/src/streaming/tests/capFramePersistence.test.ts
+++ b/src/streaming/tests/capFramePersistence.test.ts
@@ -1,4 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Keep the suite hermetic: stub the DB so state-machine tests never touch the
+// real biometrics schema. The error/throttle tests re-spy these per case.
+vi.mock('@/src/db', () => {
+  const chain = {
+    values: () => chain,
+    onConflictDoNothing: () => chain,
+    where: () => chain,
+    run: () => {},
+  }
+  return { biometricsDb: { insert: () => chain, delete: () => chain } }
+})
+
 import { biometricsDb } from '@/src/db'
 import {
   _getCapFrameWindow,

--- a/src/streaming/tests/capFramePersistence.test.ts
+++ b/src/streaming/tests/capFramePersistence.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _getCapFrameWindow,
+  recordCapFrame,
+  resetCapFrameWindows,
+  summarizeWindow,
+} from '../capFramePersistence'
+
+const A = [10, 20, 30, 40, 50, 60, 999, 999] // peak zone 2
+const B = [60, 50, 40, 30, 20, 10, 0, 0] // peak zone 0
+
+function window(side: 'left' | 'right') {
+  const w = _getCapFrameWindow(side)
+  if (!w) throw new Error(`no window for ${side}`)
+  return w
+}
+
+describe('capFramePersistence', () => {
+  beforeEach(() => resetCapFrameWindows())
+
+  it('accumulates frames inside a single window without flushing', () => {
+    recordCapFrame('left', A, 1000)
+    recordCapFrame('left', B, 1002) // +2s, still inside the 5s window
+
+    const w = window('left')
+    expect(w.n).toBe(2)
+    expect(w.startTsMs).toBe(1_000_000)
+
+    const row = summarizeWindow(w)
+    expect(row.frameCount).toBe(2)
+    expect(row.max).toBe(60)
+    expect(row.spread).toBe(50)
+    expect(row.zones).toEqual([35, 35, 35]) // ([15,35,55] + [55,35,15]) / 2
+    expect(row.peakZone).toBe(0) // modal of {zone2:1, zone0:1} → first max
+    expect(row.timestamp.getTime()).toBe(1_002_000) // last frame ts
+  })
+
+  it('rolls over to a fresh window once past the 5s boundary', () => {
+    recordCapFrame('left', A, 1000)
+    recordCapFrame('left', A, 1006) // +6s ≥ window → flush + new window
+
+    const w = window('left')
+    expect(w.n).toBe(1)
+    expect(w.startTsMs).toBe(1_006_000)
+  })
+
+  it('keeps zones null for a scalar (Pod 3) sensor', () => {
+    recordCapFrame('right', 42, 1000)
+    const row = summarizeWindow(window('right'))
+    expect(row.zones).toBeNull()
+    expect(row.peakZone).toBeNull()
+    expect(row.max).toBe(42)
+    expect(row.spread).toBe(0)
+  })
+
+  it('tracks each side independently', () => {
+    recordCapFrame('left', A, 1000)
+    expect(_getCapFrameWindow('left')?.n).toBe(1)
+    expect(_getCapFrameWindow('right')).toBeNull()
+  })
+
+  it('resets windows on demand', () => {
+    recordCapFrame('left', A, 1000)
+    resetCapFrameWindows()
+    expect(_getCapFrameWindow('left')).toBeNull()
+  })
+})

--- a/src/streaming/tests/capFramePersistence.test.ts
+++ b/src/streaming/tests/capFramePersistence.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { biometricsDb } from '@/src/db'
 import {
   _getCapFrameWindow,
+  _resetForTest,
   recordCapFrame,
   resetCapFrameWindows,
   summarizeWindow,
@@ -16,7 +18,7 @@ function window(side: 'left' | 'right') {
 }
 
 describe('capFramePersistence', () => {
-  beforeEach(() => resetCapFrameWindows())
+  beforeEach(() => _resetForTest())
 
   it('accumulates frames inside a single window without flushing', () => {
     recordCapFrame('left', A, 1000)
@@ -63,5 +65,35 @@ describe('capFramePersistence', () => {
     recordCapFrame('left', A, 1000)
     resetCapFrameWindows()
     expect(_getCapFrameWindow('left')).toBeNull()
+  })
+
+  describe('best-effort persistence', () => {
+    afterEach(() => vi.restoreAllMocks())
+
+    it('keeps streaming when a flush write throws', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(biometricsDb, 'insert').mockImplementation(() => {
+        throw new Error('db down')
+      })
+
+      recordCapFrame('left', A, 1000)
+      expect(() => recordCapFrame('left', A, 1006)).not.toThrow() // rollover → flush
+      expect(warn).toHaveBeenCalled()
+      // A failed write must not stall the stream: the new window still opens.
+      expect(_getCapFrameWindow('left')?.n).toBe(1)
+    })
+
+    it('throttles pruning across rapid rollovers', () => {
+      const del = vi.spyOn(biometricsDb, 'delete')
+      vi.spyOn(biometricsDb, 'insert').mockImplementation(() => {
+        throw new Error('skip write')
+      })
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      recordCapFrame('left', A, 1000)
+      recordCapFrame('left', A, 1006) // first rollover → prune runs
+      recordCapFrame('left', A, 1012) // second rollover within 10min → throttled
+      expect(del).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/streaming/tests/normalizeFrame.test.ts
+++ b/src/streaming/tests/normalizeFrame.test.ts
@@ -7,7 +7,33 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { normalizeFrame } from '../normalizeFrame'
+import { capSideChannels, normalizeFrame } from '../normalizeFrame'
+
+describe('capSideChannels', () => {
+  it('unwraps the Pod 4/5 {values,status} object', () => {
+    expect(capSideChannels({ values: [16.2, 16.1, 22.2, 1.16], status: 'good' }))
+      .toEqual([16.2, 16.1, 22.2, 1.16])
+  })
+
+  it('projects the Pod 3 {out,cen,in} object into the 6-slot paired layout', () => {
+    expect(capSideChannels({ out: 10, cen: 20, in: 30 })).toEqual([10, 10, 20, 20, 30, 30])
+  })
+
+  it('passes a bare numeric array through, dropping non-numbers', () => {
+    expect(capSideChannels([1, 2, null, 3])).toEqual([1, 2, 3])
+  })
+
+  it('wraps a scalar (degenerate) reading', () => {
+    expect(capSideChannels(42)).toEqual([42])
+  })
+
+  it('returns null for empty/garbage payloads', () => {
+    expect(capSideChannels({ values: [] })).toBeNull()
+    expect(capSideChannels({})).toBeNull()
+    expect(capSideChannels(null)).toBeNull()
+    expect(capSideChannels('nope')).toBeNull()
+  })
+})
 
 // ---------------------------------------------------------------------------
 // Real firmware payloads (captured from pod 2026-03-22)


### PR DESCRIPTION
## Why

The Automations right pane shows the capacitive presence matrix (bed-pressure zones) only as a **live** view — the raw ~2 Hz `capSense2` frames are never persisted, so the spatial zone replay and `cap.*` backtest can't reach past nights. This is the foundation for lifting the night/date selector to pane scope and adding a standalone "Last Night" historical view (follow-up PRs).

## What

Add a downsampling writer that aggregates the live capacitive stream into **one row per side per ~5s window** in a new `cap_sense_frames` table, pruned to **~48h** (the bulkiest sensor stream — only the last night or two is ever replayed).

- New `cap_sense_frames` table (`zones` head/torso/legs means, scalar `max/mean/spread`, modal `peakZone`, `frameCount`).
- `streaming/capFramePersistence.ts`: ts-keyed windowing (correct under stream catch-up), best-effort writes (a DB failure never disrupts the live stream), throttled 48h prune.
- Wired into the `piezoStream` broadcast loop alongside the existing live snapshot; windows reset on RAW-file switch.
- Extracted `reduceCap` + new `zoneTriple` into dependency-free `automation/capReduce.ts` to avoid a `piezoStream ↔ signals.biometrics` import cycle.

Scalar (Pod 3) sensors persist `zones: null` — no spatial resolution to replay, but `cap.*` scalars still backtest.

## Scope / non-goals

This PR only **writes** the frames. Reading them into the backtest series and the UI (pane-level night picker, standalone history view) are follow-up PRs.

## Test plan

- `vitest run src/automation/tests/capReduce.test.ts src/streaming/tests/capFramePersistence.test.ts` — new unit coverage for `zoneTriple` and the window state machine (accumulate within window, rollover past the 5s boundary, scalar→null zones, per-side independence, reset).
- `vitest run src/automation/tests/signals.biometrics.test.ts src/streaming/tests/piezoStream.test.ts src/lib/tests/occupancy.test.ts` — existing suites green after the `reduceCap` extraction.
- `tsc` clean; `eslint` clean on changed files.
- `pnpm db:biometrics:generate` → migration `0010_fixed_silvermane.sql`.

Manual: on a pod, confirm `cap_sense_frames` accrues ~1 row/side/5s while occupied and that rows older than 48h are pruned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added historical storage and analysis of capacitive presence sensor readings with spatial zone tracking
  * Automatic data retention and cleanup for storage optimization

* **Refactor**
  * Reorganized internal sensor data processing utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/persist-cap-frames
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/persist-cap-frames/scripts/install \
  | sudo bash -s -- --branch feat/persist-cap-frames
```

🎯 **Pin to this exact build** ([run 27516162063](https://github.com/sleepypod/core/actions/runs/27516162063) · `34b060c`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/34b060c475e873eebcd6765f33607daae66029ae/scripts/install \
  | sudo bash -s -- \
      --branch feat/persist-cap-frames \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27516162063/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27516162063/artifacts/7626417573) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


