### PR TITLE
Move dry-run notice above the editor's right-column cards

### DIFF
--- a/src/components/Autopilot/RuleEditor.tsx
+++ b/src/components/Autopilot/RuleEditor.tsx
@@ -343,17 +343,17 @@ export function RuleEditor({ automation, onClose, onSave, saving }: { automation
             <IfEditor rule={rule} set={setRule} />
             <div className="flex justify-center"><Icon.ArrowDown size={16} className="text-zinc-700" /></div>
             <ThenEditor rule={rule} set={setRule} liveAmbient={liveAmbient} />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto bg-zinc-950/40 p-5">
+          <div className="mx-auto flex max-w-2xl flex-col gap-4">
             {rule.mode === 'dryrun' && (
               <div className="flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/5 px-3 py-2 text-[12px] text-amber-400">
                 <Icon.Flask size={14} />
                 Dry-run: Autopilot logs what it would do but never touches hardware.
               </div>
             )}
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-y-auto bg-zinc-950/40 p-5">
-          <div className="mx-auto flex max-w-2xl flex-col gap-4">
             <SentencePreview rule={rule} />
             <Card className="p-4">
               <BacktestPanel


### PR DESCRIPTION
## Why

In the Autopilot rule editor, the dry-run notice was tucked at the bottom of the left-hand form column, below the THEN card — easy to miss, and far from the preview/backtest the user is actually reading while in dry-run.

Per the Autopilot.html design handoff, the notice should sit above the right column's cards so it caps the live preview and reads as context for "here's what this rule *would* do."

## What

Move the `rule.mode === 'dryrun'` notice from the bottom of the left form column to the top of the right column, above SentencePreview and the BacktestPanel card. No styling or logic change — same condition, same markup, new position.

## Test plan

- `tsc` clean
- `eslint src/components/Autopilot/RuleEditor.tsx` clean
- Manual: open a rule editor, toggle Dry-run — notice now appears at the top of the right pane above the "Reads as" card; toggle to Active — notice disappears.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/autopilot-design
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/autopilot-design/scripts/install \
  | sudo bash -s -- --branch feat/autopilot-design
```

🎯 **Pin to this exact build** ([run 27516922675](https://github.com/sleepypod/core/actions/runs/27516922675) · `fcf0a90`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fcf0a906b5e54285c4c594de6d29de08770316b5/scripts/install \
  | sudo bash -s -- \
      --branch feat/autopilot-design \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27516922675/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27516922675/artifacts/7626634849) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting and layout adjustments with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->