### PR TITLE
chore: pin pod runtime to Node 24 (match .node-version)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -853,8 +853,8 @@ fi
 # ============================================================================
 # Install Node.js via binary download (works on any Linux, no apt required)
 # ============================================================================
-NODE_WANTED=22
-NODE_FULL="22.17.0"
+NODE_WANTED=24
+NODE_FULL="24.16.0"
 NODE_DIR="/usr/local/lib/nodejs"
 
 # Detect architecture


### PR DESCRIPTION
## Why

PR #416 bumped `.node-version` `22` → `24`, but that file only drives **dev/CI** (`actions/setup-node` reads `node-version-file: '.node-version'`). The **pod runtime** version is pinned independently in `scripts/install` (`NODE_WANTED` / `NODE_FULL`), so fresh pods would still install Node 22 — leaving dev/CI and production out of lockstep.

## What

Bump the pod's Node pin to `24.16.0` (current v24 LTS, 'Krypton') so freshly-installed pods match the toolchain.

## Safety

`better-sqlite3` (the only native dep) ships **N-API prebuilds** (`prebuilds/linux-<arch>/node.napi.node`) and is `pnpm install`-ed **on the pod**, not bundled from CI. N-API is ABI-stable across Node majors, so the 22 → 24 move carries no native-module ABI risk. The install script's existing SHA-256 verification covers the new tarball.

The `CURRENT_NODE_MAJOR -lt NODE_WANTED` guard means pods already on Node ≥ 24 are left untouched; pods on 22 get upgraded on next install run.

## Test plan

- `bash -n scripts/install` — syntax clean ✅
- Verified `https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-arm64.tar.gz` returns HTTP 200 ✅
- Manual: run installer on a clean pod, confirm `node -v` reports v24.16.0 and the app's better-sqlite3 module loads

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update chore/install-node-24
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/chore/install-node-24/scripts/install \
  | sudo bash -s -- --branch chore/install-node-24
```

🎯 **Pin to this exact build** ([run 27525355981](https://github.com/sleepypod/core/actions/runs/27525355981) · `f1338bb`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/f1338bb773b7c850ef61950cc71f7de5df5fddb9/scripts/install \
  | sudo bash -s -- \
      --branch chore/install-node-24 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/27525355981/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/27525355981/artifacts/7629546769) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
