### PR TITLE
fix(biometrics-pruner): use POSIX df/ls so busybox pods actually prune

### DIFF
--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner
@@ -9,20 +9,32 @@ TARGET_USED_PCT="${TARGET_USED_PCT:-80}"
 
 mkdir -p "$ARCHIVE_DIR"
 
+# Portable disk-usage read. `df --output=pcent` (and `df -h`) are GNU-only;
+# pods can ship busybox df (see the sha256sum/busybox fallback in
+# scripts/install), where `--output` is rejected → empty stdout → used_pct
+# defaults to 0 → the loop never prunes and the archive grows unbounded. `df -P`
+# is POSIX (busybox + GNU) and always prints one data row whose 5th field is
+# the capacity percent.
+disk_used_pct() {
+  local pct
+  pct=$(df -P /persistent | awk 'NR==2 {gsub(/%/,"",$5); print $5}')
+  echo "${pct:-0}"
+}
+
 pruned=0
 while :; do
-  used_pct=$(df --output=pcent /persistent | tail -1 | tr -dc '0-9')
-  used_pct=${used_pct:-0}
+  used_pct=$(disk_used_pct)
   if [ "$used_pct" -le "$TARGET_USED_PCT" ]; then
     break
   fi
 
-  # awk takes the first line and consumes the rest of the stream; piping to
-  # `head -1` instead closes the pipe early and, under `set -o pipefail`,
-  # makes `sort` fail with SIGPIPE/"Broken pipe" → the whole script aborts
-  # and never prunes (archive grows unbounded, /persistent fills past target).
-  oldest=$(find "$ARCHIVE_DIR" -maxdepth 1 -type f -name '*.RAW.gz' -printf '%T@ %p\n' 2>/dev/null \
-    | sort -n | awk 'NR==1{print $2}')
+  # Oldest archive by mtime. `ls -tr` (mtime order, oldest first) is
+  # busybox-safe; the old `find -printf` is GNU-only and silently no-ops on
+  # busybox find. `awk NR==1` rather than `head -1` consumes the whole stream —
+  # `head` closes the pipe early and, under `set -o pipefail`, aborts the
+  # script on SIGPIPE so it never prunes (archive grows unbounded, /persistent
+  # fills past target).
+  oldest=$(ls -1tr "$ARCHIVE_DIR"/*.RAW.gz 2>/dev/null | awk 'NR==1')
   if [ -z "$oldest" ]; then
     echo "pruner: $used_pct% used but archive is empty — nothing to prune" >&2
     break
@@ -32,5 +44,4 @@ while :; do
   pruned=$((pruned + 1))
 done
 
-used_pct=$(df --output=pcent /persistent | tail -1 | tr -dc '0-9')
-echo "pruner: pruned=$pruned used_pct=$used_pct%"
+echo "pruner: pruned=$pruned used_pct=$(disk_used_pct)%"


### PR DESCRIPTION
## Why

A pod owner (trinity) reported their pod stopped working — `/persistent` was full, and `sp-update` failed with:

```
cp: error copying '/persistent/sleepypod-data/sleepypod.db' to '…sleepypod.db.bak…': No space left on device
```

Their `/persistent/biometrics-archive` had grown to ~13 GB of 15 GB. The gzip archiver had been running fine, but the **pruner never deleted anything** — the archive grew unbounded.

## Root cause

`sleepypod-biometrics-pruner` used two GNU-only constructs:

- `df --output=pcent /persistent` — read current disk usage
- `find … -printf '%T@ %p\n'` — pick the oldest archive

Pods can ship **busybox** coreutils/findutils (the install script already accounts for this — see the `sha256sum` → `shasum` busybox fallback, and every other disk check uses the portable `df -m … | awk` form). On busybox:

- `df --output=pcent` is rejected → empty stdout → `used_pct` defaults to `0` → `0 ≤ 80` → loop breaks immediately → **nothing is ever pruned**.
- `find -printf` isn't supported either, so even past the df check no file would be selected.

Result: archiver keeps adding gzips, pruner silently no-ops, disk fills, pod dies. (A separate `head -1` SIGPIPE stall was already fixed on `dev`; this is the remaining latent failure mode.)

## Change

- `df -P /persistent | awk 'NR==2 {gsub(/%/,"",$5); print $5}'` — POSIX capacity %, works on busybox **and** GNU.
- `ls -1tr "$ARCHIVE_DIR"/*.RAW.gz | awk 'NR==1'` — busybox-safe oldest-by-mtime, keeping the pipefail-safe `awk NR==1` (not `head -1`) that the prior fix established.
- Factored the read into a `disk_used_pct()` helper used in both the loop and the final log line.

No behavior change on GNU pods; fixes the silent stall on busybox pods.

## Test plan

- `bash -n` clean.
- `df -P … | awk` parse verified against a real mount (`used_pct=26`).
- `ls -1tr | awk NR==1` verified to select the oldest of three files by mtime, and to return empty (no crash under `set -euo pipefail`) on an empty archive dir.
- Manual on-pod verification pending: install on a busybox pod with a >80%-full `/persistent` and confirm `pruner: pruned=N used_pct=<target>` in `journalctl -u sleepypod-biometrics-pruner`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive cleanup on devices with limited shell tools, making it more reliable across environments.
  * Fixed disk usage reporting so the final status message is more consistent and less likely to fail when system output is empty.
  * Updated selection of the oldest archived file to work more broadly while preserving the same cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/biometrics-pruner-busybox
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/biometrics-pruner-busybox/scripts/install \
  | sudo bash -s -- --branch fix/biometrics-pruner-busybox
```

🎯 **Pin to this exact build** ([run 28749897785](https://github.com/sleepypod/core/actions/runs/28749897785) · `83dae7e`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/83dae7ec58bbe72d1c6a2f18506f6599d80d8042/scripts/install \
  | sudo bash -s -- \
      --branch fix/biometrics-pruner-busybox \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/28749897785/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/28749897785/artifacts/8094350378) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
