### PR TITLE
chore(sp-bundle-logs): capture streamer attach log and archive/disk pressure

### DIFF
--- a/scripts/bin/sp-bundle-logs
+++ b/scripts/bin/sp-bundle-logs
@@ -165,6 +165,19 @@ for svc in sleepypod sleepypod-piezo-processor sleepypod-sleep-detector \
     'systemctl show -p Environment "$1.service" | sed "s/^Environment=//" | tr " " "\n" | grep -E "^RAW_DATA_DIR=" || true' _ "$svc"
 done
 
+# Which RAW file the WebSocket streamer actually attached to. It only tails
+# while a Sensors/debug client is connected. "Switched to RAW file: SEQNO.RAW"
+# followed by "Resync:" spam is the classic wrong-file symptom (attaching to
+# the 16-byte counter instead of a real capture) — only DEV shows in the tab.
+capture "raw/ws-3001.txt"          bash -c 'ss -ltn 2>/dev/null | grep -q ":3001 " && echo "port 3001 listening" || echo "port 3001 NOT listening"'
+capture "raw/sensorstream-log.txt" bash -c 'journalctl -u sleepypod.service -b --no-pager 2>/dev/null | grep -iE "\[sensorStream\]" | tail -40'
+
+# Retention: gzip cold-archive size vs disk. A large archive next to a
+# near-full /persistent means the pruner has stalled — the usual cause of
+# "No space left on device" on update. Pruner/archiver journals are captured
+# above under journals/.
+capture "raw/archive-size.txt" bash -c 'du -sh /persistent/biometrics-archive 2>/dev/null; echo "gz files: $(find /persistent/biometrics-archive -maxdepth 1 -type f -name "*.gz" 2>/dev/null | wc -l)"; df -h /persistent 2>/dev/null'
+
 # --- install log ---------------------------------------------------------
 if [ -f "$INSTALL_LOG" ]; then
   cp "$INSTALL_LOG" "$STAGE/sleepypod-install.log"


### PR DESCRIPTION
## Why

`sp-bundle-logs` already captures the RAW *routing* (where frames land, where each reader looks, tmpfs state), but two live field reports needed signals it didn't collect:

1. **"Only DEV shows in the Sensors tab"** (#608) — caused by the streamer tailing `SEQNO.RAW` (the 16-byte counter) instead of a real capture. The tell is in `sleepypod.service`'s log: `[sensorStream] Switched to RAW file: SEQNO.RAW` followed by `Resync:` spam. Not previously in the bundle.
2. **"Pod stopped working, `/persistent` full, update fails with No space left on device"** — a stalled biometrics pruner letting the gzip archive grow unbounded. The bundle recorded the pruner's journal but not the archive size vs. disk free, so the smoking gun wasn't obvious.

## Change

Two probes appended to the existing `raw/` section:

- `raw/ws-3001.txt` + `raw/sensorstream-log.txt` — is the streamer WS server up, and what did it last attach to (+ any resync spam).
- `raw/archive-size.txt` — `du -sh` of the cold archive, gz file count, and `df -h /persistent` side by side.

No new dependencies; all best-effort under the existing `capture` helper. Pruner/archiver journals continue to come from the `journals/` section.

## Test plan

- `bash -n` clean.
- Nested-quote `bash -c` snippets smoke-tested locally (archive-size probe emits count + df; sensorStream grep is a no-op on a non-pod).
- On-pod: run `sp-bundle-logs`, confirm `raw/ws-3001.txt`, `raw/sensorstream-log.txt`, and `raw/archive-size.txt` are populated.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update chore/sp-bundle-logs-streamer-retention
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/chore/sp-bundle-logs-streamer-retention/scripts/install \
  | sudo bash -s -- --branch chore/sp-bundle-logs-streamer-retention
```

🎯 **Pin to this exact build** ([run 28831420964](https://github.com/sleepypod/core/actions/runs/28831420964) · `71859db`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/71859db98d8fdfd0f64cdf49f8a00b089fe418c0/scripts/install \
  | sudo bash -s -- \
      --branch chore/sp-bundle-logs-streamer-retention \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/28831420964/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/28831420964/artifacts/8124547044) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more diagnostic and storage details to the bundled logs, including network, service journal, disk usage, and archive size information.

* **Bug Fixes**
  * Improved service setup so it only uses available system groups, reducing startup failures on systems where expected groups are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

