### PR TITLE
fix(install): grant service user journal read so log viewer works on all pods

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -1270,12 +1270,25 @@ echo "Creating systemd service..."
 # the runtime's checkAndRepairIptables() writes /etc/iptables/rules.v4).
 mkdir -p /etc/iptables
 
-# Only emit SupplementaryGroups=dac when the dac group exists — otherwise
-# systemd refuses to start the unit with "Failed to determine supplementary
-# group: No such file or directory".
-SUPP_GROUPS_LINE=""
+# Only emit groups that exist — otherwise systemd refuses to start the
+# unit with "Failed to determine supplementary group: No such file or
+# directory". systemd-journal (adm on images without it) lets the
+# next-server's /system/logs endpoint run journalctl as User=sleepypod;
+# without it the log viewer fails with "No journal files were opened due
+# to insufficient permissions" on pods where the journal isn't
+# world-readable.
+SUPP_GROUPS=()
 if getent group dac &>/dev/null; then
-  SUPP_GROUPS_LINE="SupplementaryGroups=dac"
+  SUPP_GROUPS+=(dac)
+fi
+if getent group systemd-journal &>/dev/null; then
+  SUPP_GROUPS+=(systemd-journal)
+elif getent group adm &>/dev/null; then
+  SUPP_GROUPS+=(adm)
+fi
+SUPP_GROUPS_LINE=""
+if [ ${#SUPP_GROUPS[@]} -gt 0 ]; then
+  SUPP_GROUPS_LINE="SupplementaryGroups=${SUPP_GROUPS[*]}"
 fi
 
 cat > /etc/systemd/system/sleepypod.service << EOF


### PR DESCRIPTION
## Problem

Field report (trinity): the log viewer fails with

```
Failed to read logs: Command failed: journalctl -u sleepypod.service -n 201 --no-pager --output short-iso --show-cursor
No journal files were opened due to insufficient permissions.
```

`system.getLogs` shells out to `journalctl` from the next-server, which runs as `User=sleepypod`. The installer only granted `SupplementaryGroups=dac`, and journal files are readable only by `adm` / `systemd-journal` / `wheel` — so on pods where the journal directory isn't world-readable, journalctl opens zero files and every log read fails.

## Fix

Build the unit's supplementary-groups list dynamically in `scripts/install`: `dac` plus `systemd-journal` (falling back to `adm` where `systemd-journal` doesn't exist), keeping the existing getent guard so systemd never sees a nonexistent group. The installer rewrites the unit on every run, so existing pods pick this up on their next `sp-update`.

## Test plan

- [x] `bash -n scripts/install` passes
- [x] Simulated the group-line rendering under `set -euo pipefail` for all three cases (dac+journal, dac only, neither) — emits `SupplementaryGroups=dac systemd-journal`, `SupplementaryGroups=dac`, and omits the line respectively
- [ ] On an affected pod: run installer, `systemctl show sleepypod -p SupplementaryGroups` shows `systemd-journal`, and `/debug` log viewer loads entries

## Immediate workaround for affected pods

```bash
sudo mkdir -p /etc/systemd/system/sleepypod.service.d
printf '[Service]\nSupplementaryGroups=systemd-journal\n' | sudo tee /etc/systemd/system/sleepypod.service.d/journal.conf
sudo systemctl daemon-reload && sudo systemctl restart sleepypod
```

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/install-journal-group
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/install-journal-group/scripts/install \
  | sudo bash -s -- --branch fix/install-journal-group
```

🎯 **Pin to this exact build** ([run 28831409722](https://github.com/sleepypod/core/actions/runs/28831409722) · `e47243b`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/e47243b63fefe6f3afd0849b45bfe56280ea8561/scripts/install \
  | sudo bash -s -- \
      --branch fix/install-journal-group \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/28831409722/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/28831409722/artifacts/8124541929) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
