### PR TITLE
fix(hardware): stop pump stall guard false-tripping on firmware-commanded stops

### DIFF
--- a/docs/adr/0022-pump-stall-safety.md
+++ b/docs/adr/0022-pump-stall-safety.md
@@ -354,12 +354,16 @@ non-zero while the water equalizes). The frzHealth frame cadence
 2-sample dwell a ~20s window — far shorter than the mirror lag.
 
 Fix: `DeviceStateSync` now suppresses stall counting when the stop is
-firmware-commanded, using lag-free firmware-side signals — `pump.duty
-= 0` (a genuinely stalled pump under closed-loop control is driven at
-duty > 0 while RPM reads 0), priming active or ended within 120s, the
-firmware `targetLevel` reading neutral, or the session countdown
-(`heatTime`) within 90s of its natural end. A zero-RPM frame
-mid-session with the pump still driven trips exactly as before.
+firmware-commanded, using lag-free firmware-side signals. `pump.duty`
+is authoritative when the frame carries it: 0 means a commanded stop,
+while a driven pump (duty > 0) reading 0 RPM is the stall signature
+and is never suppressed. When duty is absent, fall back to priming
+active or ended within 120s, the firmware `targetLevel` reading
+neutral, or the session countdown (`heatTimeL/R` on the wire,
+`heatingDuration` in `DeviceStatus`) within 90s of its natural end —
+bounded to 600s past the projected end so a stale snapshot cannot
+suppress a later session's genuine stall. A zero-RPM frame mid-session
+with the pump still driven trips exactly as before.
 
 ## References
 

--- a/docs/adr/0022-pump-stall-safety.md
+++ b/docs/adr/0022-pump-stall-safety.md
@@ -341,6 +341,26 @@ the wire protocol's actual reliability.
   placeholder. Needs data from a pod with a known clog episode to
   calibrate, or a longer in-field bake before enabling by default.
 
+## Addendum (2026-07-11): false trips on firmware-initiated pump stops
+
+Field report (Pod 4): the guard tripped both sides daily, always with
+`rpm = 0`, at exactly session-duration expiry and at the end of the
+scheduled daily prime. Root cause: `expectedActive` was derived solely
+from `device_state`, which mirrors the firmware through the
+`durationExpired` heuristic and can report a side as powered for
+minutes after the firmware ends a session (`currentLevel` stays
+non-zero while the water equalizes). The frzHealth frame cadence
+(~10s, not the 60s assumed in "Alternatives considered" §7) made the
+2-sample dwell a ~20s window — far shorter than the mirror lag.
+
+Fix: `DeviceStateSync` now suppresses stall counting when the stop is
+firmware-commanded, using lag-free firmware-side signals — `pump.duty
+= 0` (a genuinely stalled pump under closed-loop control is driven at
+duty > 0 while RPM reads 0), priming active or ended within 120s, the
+firmware `targetLevel` reading neutral, or the session countdown
+(`heatTime`) within 90s of its natural end. A zero-RPM frame
+mid-session with the pump still driven trips exactly as before.
+
 ## References
 
 - Incident report: Discord, 2026-05-24, free-sleep user thread.

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -64,14 +64,17 @@ export function getAlarmState(): { left: boolean, right: boolean } {
  * Extract a well-formed pump object from a frzHealth side. Returns the pump
  * only when `side.pump.rpm` is a finite number — otherwise frzHealth-shaped
  * frames with a null/garbled pump would crash the downstream insert.
+ * `duty` (commanded PWM drive) is optional on the wire; null when absent
+ * or malformed.
  */
-function pumpOf(side: unknown): { rpm: number } | null {
+function pumpOf(side: unknown): { rpm: number, duty: number | null } | null {
   if (!side || typeof side !== 'object') return null
   const pump = (side as { pump?: unknown }).pump
   if (!pump || typeof pump !== 'object') return null
   const rpm = (pump as { rpm?: unknown }).rpm
   if (typeof rpm !== 'number' || !Number.isFinite(rpm)) return null
-  return { rpm }
+  const duty = (pump as { duty?: unknown }).duty
+  return { rpm, duty: typeof duty === 'number' && Number.isFinite(duty) ? duty : null }
 }
 
 // ── Flow anomaly detection thresholds ──
@@ -81,14 +84,33 @@ const FLOWRATE_SUDDEN_CHANGE_CD = 500 // centidegrees — large delta between co
 const ASYMMETRY_THRESHOLD_CD = 300 // centidegrees — left/right divergence threshold
 const ANOMALY_LOG_COOLDOWN_MS = 300_000 // 5 min between repeated warnings per type
 
+// ── Expected-pump-stop suppression (stall guard false-trip fix) ──
+const PRIME_GRACE_MS = 120_000 // pumps spin down at prime end; RPM 0 is expected
+const SESSION_END_GRACE_S = 90 // remaining session seconds within which a stop is natural
+
 export class DeviceStateSync {
   private lastWaterLevelWrite = 0
   private lastFlowWrite = 0
   private lastAnomalyLog: Record<string, number> = {}
   private prevFlowLeft: number | null = null
   private prevFlowRight: number | null = null
+  // Latest firmware-reported side state, kept off the DB mirror: device_state
+  // can report a side powered for minutes after the firmware ends a session
+  // (currentLevel stays non-zero while the water equalizes), which is exactly
+  // the lag that false-tripped the stall guard on every session end.
+  private lastSideStatus: Record<Side, { targetLevel: number, heatingDuration: number, at: number } | null> = { left: null, right: null }
+  private isPriming = false
+  private primeEndedAt = 0
 
   sync = async (status: DeviceStatus): Promise<void> => {
+    const now = Date.now()
+    if (this.isPriming && !status.isPriming) {
+      this.primeEndedAt = now
+    }
+    this.isPriming = status.isPriming
+    this.lastSideStatus.left = { targetLevel: status.leftSide.targetLevel, heatingDuration: status.leftSide.heatingDuration, at: now }
+    this.lastSideStatus.right = { targetLevel: status.rightSide.targetLevel, heatingDuration: status.rightSide.heatingDuration, at: now }
+
     this.recordWaterLevel(status)
     try {
       await Promise.all([
@@ -217,7 +239,7 @@ export class DeviceStateSync {
     const now = Date.now()
 
     // Run anomaly checks on every frame (not rate-limited)
-    this.checkFlowAnomalies(frzHealth, now)
+    this.checkFlowAnomalies(frzHealth, leftPump, rightPump, now)
 
     if (now - this.lastFlowWrite < 60_000) return
 
@@ -239,8 +261,40 @@ export class DeviceStateSync {
     }
   }
 
+  /**
+   * True when a zero-RPM frame is explainable by a firmware-commanded pump
+   * stop rather than a mechanical stall. Every signal here is firmware-side
+   * and lag-free — unlike device_state, which mirrors the firmware through
+   * the durationExpired heuristic and stays "powered" for minutes after a
+   * session ends on the firmware side.
+   */
+  private isExpectedPumpStop(side: Side, duty: number | null, now: number): boolean {
+    // Firmware isn't driving the pump. A genuinely stalled pump under
+    // closed-loop control shows duty > 0 while RPM reads 0.
+    if (duty === 0) return true
+
+    // Priming spins both pumps regardless of side power; the spin-down at
+    // the end of the cycle reads as RPM 0 for a few frames.
+    if (this.isPriming || (this.primeEndedAt > 0 && now - this.primeEndedAt < PRIME_GRACE_MS)) return true
+
+    const last = this.lastSideStatus[side]
+    if (!last) return false
+
+    // Firmware target is neutral — the pump is expected to stop even while
+    // device_state still mirrors the old session.
+    if (last.targetLevel === 0) return true
+
+    // Session countdown at or past its natural end. heatingDuration is the
+    // remaining seconds at poll time; project it forward so a stalled status
+    // stream can't hold suppression off after the session should have ended.
+    // The > 0 gate keeps firmware variants that report 0 during an active
+    // session (no countdown) on the plain device_state path.
+    const remaining = last.heatingDuration - (now - last.at) / 1000
+    return last.heatingDuration > 0 && remaining <= SESSION_END_GRACE_S
+  }
+
   /** Look up the side's commanded state and feed the pump stall guard. */
-  private async runStallGuard(side: Side, rpm: number): Promise<void> {
+  private async runStallGuard(side: Side, rpm: number, duty: number | null): Promise<void> {
     try {
       const [row] = db
         .select({
@@ -251,7 +305,8 @@ export class DeviceStateSync {
         .where(eq(deviceState.side, side))
         .limit(1)
         .all()
-      const expectedActive = Boolean(row?.isPowered && row.targetTemperature != null)
+      const expectedActive = !this.isExpectedPumpStop(side, duty, Date.now())
+        && Boolean(row?.isPowered && row.targetTemperature != null)
       await pumpStallOnFrame({
         side,
         rpm,
@@ -277,17 +332,17 @@ export class DeviceStateSync {
   private checkFlowAnomalies(frzHealth: {
     left: { pump: { rpm: number }, temps?: { flowrate?: number } }
     right: { pump: { rpm: number }, temps?: { flowrate?: number } }
-  }, now: number): void {
-    const leftRpm = frzHealth.left.pump.rpm
-    const rightRpm = frzHealth.right.pump.rpm
+  }, leftPump: { rpm: number, duty: number | null }, rightPump: { rpm: number, duty: number | null }, now: number): void {
+    const leftRpm = leftPump.rpm
+    const rightRpm = rightPump.rpm
     const leftFlowCd = frzHealth.left.temps?.flowrate != null ? Math.round(frzHealth.left.temps.flowrate * 100) : NaN
     const rightFlowCd = frzHealth.right.temps?.flowrate != null ? Math.round(frzHealth.right.temps.flowrate * 100) : NaN
 
     // Feed the per-side stall guard. Reads current device_state to derive
     // expectedActive — a side that's commanded off should not trip on
     // RPM = 0 since that is the correct value.
-    void this.runStallGuard('left', leftRpm)
-    void this.runStallGuard('right', rightRpm)
+    void this.runStallGuard('left', leftRpm, leftPump.duty)
+    void this.runStallGuard('right', rightRpm, rightPump.duty)
 
     // Pump running but flowrate missing — possible sensor fault
     if (leftRpm >= PUMP_FAILURE_RPM_MIN && Number.isNaN(leftFlowCd)) {

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -87,6 +87,7 @@ const ANOMALY_LOG_COOLDOWN_MS = 300_000 // 5 min between repeated warnings per t
 // ── Expected-pump-stop suppression (stall guard false-trip fix) ──
 const PRIME_GRACE_MS = 120_000 // pumps spin down at prime end; RPM 0 is expected
 const SESSION_END_GRACE_S = 90 // remaining session seconds within which a stop is natural
+const SESSION_END_STALE_S = 600 // stop trusting the projected countdown this long past its end
 
 export class DeviceStateSync {
   private lastWaterLevelWrite = 0
@@ -269,9 +270,11 @@ export class DeviceStateSync {
    * session ends on the firmware side.
    */
   private isExpectedPumpStop(side: Side, duty: number | null, now: number): boolean {
-    // Firmware isn't driving the pump. A genuinely stalled pump under
-    // closed-loop control shows duty > 0 while RPM reads 0.
-    if (duty === 0) return true
+    // Duty is authoritative when the frame carries it: 0 means the firmware
+    // isn't driving the pump (commanded stop), while a driven pump (duty > 0)
+    // reading 0 RPM is exactly the stall signature — never suppress it, even
+    // inside a prime or session-end window.
+    if (duty !== null) return duty === 0
 
     // Priming spins both pumps regardless of side power; the spin-down at
     // the end of the cycle reads as RPM 0 for a few frames.
@@ -286,11 +289,15 @@ export class DeviceStateSync {
 
     // Session countdown at or past its natural end. heatingDuration is the
     // remaining seconds at poll time; project it forward so a stalled status
-    // stream can't hold suppression off after the session should have ended.
+    // stream can't hold suppression off after the session should have ended,
+    // but only within a bounded window — a snapshot that is long past its
+    // projected end must not suppress a later session's genuine stall.
     // The > 0 gate keeps firmware variants that report 0 during an active
     // session (no countdown) on the plain device_state path.
     const remaining = last.heatingDuration - (now - last.at) / 1000
-    return last.heatingDuration > 0 && remaining <= SESSION_END_GRACE_S
+    return last.heatingDuration > 0
+      && remaining <= SESSION_END_GRACE_S
+      && remaining >= -SESSION_END_STALE_S
   }
 
   /** Look up the side's commanded state and feed the pump stall guard. */

--- a/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
+++ b/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
@@ -164,6 +164,18 @@ describe('DeviceStateSync — stall guard expected-stop suppression', () => {
     expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
   })
 
+  it('duty > 0 overrides priming — a driven-but-stopped pump is a stall even mid-prime', async () => {
+    await sync.sync(status({ isPriming: true }))
+    sync.recordFlowData(frame({ rpm: 0, duty: 65 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+
+  it('duty > 0 overrides the session-end grace window', async () => {
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 60 }))
+    sync.recordFlowData(frame({ rpm: 0, duty: 65 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+
   it('falls back to device_state when the frame omits duty', async () => {
     sync.recordFlowData(frame({ rpm: 0 }))
     expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
@@ -209,6 +221,16 @@ describe('DeviceStateSync — stall guard expected-stop suppression', () => {
     vi.setSystemTime(new Date('2026-07-11T08:04:10Z'))
     sync.recordFlowData(frame({ rpm: 0 }))
     expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('stops trusting the projected countdown long past its end (stale snapshot)', async () => {
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 300 }))
+    // 1000s later the projection is 700s past the session end — beyond the
+    // 600s staleness bound, so a genuine stall in a later session is not
+    // masked by the old snapshot.
+    vi.setSystemTime(new Date('2026-07-11T08:16:40Z'))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
   })
 
   it('does not treat heatingDuration=0 with a non-neutral target as session end', async () => {

--- a/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
+++ b/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
@@ -1,0 +1,221 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type BetterSqlite3 from 'better-sqlite3'
+import type { DeviceStatus } from '../types'
+
+vi.mock('@/src/db', async () => {
+  const BetterSqlite3 = (await import('better-sqlite3')).default
+  const { drizzle } = await import('drizzle-orm/better-sqlite3')
+  const schema = await import('@/src/db/schema')
+  const biometricsSchema = await import('@/src/db/biometrics-schema')
+  const primary = new BetterSqlite3(':memory:')
+  primary.pragma('foreign_keys = ON')
+  const bio = new BetterSqlite3(':memory:')
+  bio.pragma('foreign_keys = ON')
+  return {
+    db: drizzle(primary, { schema }),
+    biometricsDb: drizzle(bio, { schema: biometricsSchema }),
+    sqlite: primary,
+    biometricsSqlite: bio,
+    closeDatabase: vi.fn(),
+    closeBiometricsDatabase: vi.fn(),
+  }
+})
+
+vi.mock('../pumpStallGuard', () => ({
+  onFrame: vi.fn().mockResolvedValue(undefined),
+}))
+
+import * as dbModule from '@/src/db'
+import { onFrame } from '../pumpStallGuard'
+import { DeviceStateSync, _resetMutationStamps } from '../deviceStateSync'
+
+const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
+  sqlite: BetterSqlite3.Database
+  biometricsSqlite: BetterSqlite3.Database
+}
+
+function resetSchema(): void {
+  ;(sqlite as any).exec(`
+    DROP TABLE IF EXISTS device_state;
+    CREATE TABLE device_state (
+      side TEXT PRIMARY KEY,
+      current_temperature REAL,
+      target_temperature REAL,
+      is_powered INTEGER NOT NULL DEFAULT 0,
+      is_alarm_vibrating INTEGER NOT NULL DEFAULT 0,
+      water_level TEXT DEFAULT 'unknown',
+      powered_on_at INTEGER,
+      last_updated INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+  `)
+  ;(biometricsSqlite as any).exec(`
+    DROP TABLE IF EXISTS water_level_readings;
+    DROP TABLE IF EXISTS flow_readings;
+    CREATE TABLE water_level_readings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp INTEGER NOT NULL,
+      level TEXT NOT NULL,
+      raw INTEGER,
+      calibrated_empty INTEGER,
+      calibrated_full INTEGER
+    );
+    CREATE TABLE flow_readings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp INTEGER NOT NULL,
+      left_flowrate_cd INTEGER,
+      right_flowrate_cd INTEGER,
+      left_pump_rpm INTEGER NOT NULL,
+      right_pump_rpm INTEGER NOT NULL
+    );
+  `)
+}
+
+function seedSide(side: 'left' | 'right', isPowered: boolean, targetTemp: number | null = null): void {
+  ;(sqlite as any)
+    .prepare(
+      `INSERT INTO device_state (side, is_powered, target_temperature, powered_on_at, last_updated)
+       VALUES (?, ?, ?, ?, unixepoch())
+       ON CONFLICT(side) DO UPDATE SET
+         is_powered = excluded.is_powered,
+         target_temperature = excluded.target_temperature,
+         powered_on_at = excluded.powered_on_at,
+         last_updated = unixepoch()`
+    )
+    .run(side, isPowered ? 1 : 0, targetTemp, isPowered ? Math.floor(Date.now() / 1000) : null)
+}
+
+/** DeviceStatus with both sides mid-session (powered, countdown running). */
+function status(overrides: {
+  targetLevel?: number
+  heatingDuration?: number
+  isPriming?: boolean
+} = {}): DeviceStatus {
+  const side: DeviceStatus['rightSide'] = {
+    currentTemperature: 75,
+    targetTemperature: 75,
+    currentLevel: 5,
+    targetLevel: overrides.targetLevel ?? 5,
+    heatingDuration: overrides.heatingDuration ?? 7200,
+  }
+  return {
+    leftSide: { ...side },
+    rightSide: { ...side },
+    waterLevel: 'ok',
+    isPriming: overrides.isPriming ?? false,
+    podVersion: 'H00' as DeviceStatus['podVersion'],
+    sensorLabel: 'test',
+  }
+}
+
+function frame(opts: { rpm?: number, duty?: number | null } = {}): Record<string, unknown> {
+  const pump: any = { rpm: opts.rpm ?? 0 }
+  if (opts.duty !== null && opts.duty !== undefined) pump.duty = opts.duty
+  return {
+    left: { pump: { ...pump }, temps: { flowrate: 25.0 } },
+    right: { pump: { ...pump }, temps: { flowrate: 25.0 } },
+  }
+}
+
+async function lastGuardInput(side: 'left' | 'right') {
+  // runStallGuard is fire-and-forget; let its microtask settle.
+  await Promise.resolve()
+  await Promise.resolve()
+  const calls = vi.mocked(onFrame).mock.calls
+    .map(([input]) => input)
+    .filter(input => input.side === side)
+  return calls[calls.length - 1]
+}
+
+describe('DeviceStateSync — stall guard expected-stop suppression', () => {
+  let sync: DeviceStateSync
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    vi.mocked(onFrame).mockClear()
+    sync = new DeviceStateSync()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-11T08:00:00Z'))
+    // DB says both sides are commanded active — the pre-fix code would
+    // derive expectedActive=true from this alone.
+    seedSide('left', true, 75)
+    seedSide('right', true, 75)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('mid-session zero RPM still reaches the guard as expectedActive=true (real stall)', async () => {
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 7200 }))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+    expect((await lastGuardInput('right'))?.expectedActive).toBe(true)
+  })
+
+  it('suppresses when firmware pump duty is 0 (commanded stop, not a stall)', async () => {
+    sync.recordFlowData(frame({ rpm: 0, duty: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('does not suppress on duty alone when duty > 0 (stalled pump still driven)', async () => {
+    sync.recordFlowData(frame({ rpm: 0, duty: 65 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+
+  it('falls back to device_state when the frame omits duty', async () => {
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+
+  it('suppresses while priming', async () => {
+    await sync.sync(status({ isPriming: true }))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('suppresses within the grace window after priming ends, then resumes', async () => {
+    await sync.sync(status({ isPriming: true }))
+    await sync.sync(status({ isPriming: false }))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+
+    vi.setSystemTime(new Date('2026-07-11T08:02:01Z')) // 121s after prime end
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+
+  it('suppresses when firmware targetLevel is 0 while device_state still says powered', async () => {
+    // The field-observed failure: firmware commanded neutral, but
+    // device_state.isPowered stays true because durationExpired requires
+    // heatingDuration=0 too and currentLevel is still non-zero.
+    await sync.sync(status({ targetLevel: 0, heatingDuration: 600 }))
+    seedSide('left', true, 75) // sync's upsert may have flipped it; force the lagging-DB state
+    seedSide('right', true, 75)
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('suppresses inside the session-end grace window (countdown nearly elapsed)', async () => {
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 60 }))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('projects the countdown forward from the last poll', async () => {
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 300 }))
+    // No further polls; 250s later the projected remaining is ~50s ≤ grace.
+    vi.setSystemTime(new Date('2026-07-11T08:04:10Z'))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(false)
+  })
+
+  it('does not treat heatingDuration=0 with a non-neutral target as session end', async () => {
+    // A firmware variant reporting no countdown during an active session
+    // must stay on the plain device_state path, not be suppressed forever.
+    await sync.sync(status({ targetLevel: 5, heatingDuration: 0 }))
+    sync.recordFlowData(frame({ rpm: 0 }))
+    expect((await lastGuardInput('left'))?.expectedActive).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

Field report (Pod 4, 2026-07-11): `stall_left`/`stall_right` alerts fired daily on both sides within seconds of each other, always with `rpm = 0`; the two most recent ended in `power_off`, leaving the bed guard-blocked. The pumps are healthy — 3,477 of 5,881 flow readings in the last 7 days show normal running RPM, and the daily prime ran fine at ~3,000 RPM *after* the trip.

Every alert lines up with a **firmware-commanded pump stop**, not a stall:

- Jul 7 + Jul 8 alerts both at exactly **12:10:21 UTC** — the end of the scheduled daily prime (flow data shows the prime running 12:01:02 → 12:10:33).
- Jul 11 alerts at 08:48:39/49 — exactly **28,800s (the 8h session duration) after the 00:48:02 power-on**, with sides tripping in the same order they powered on.

## Root cause

`runStallGuard` derived `expectedActive` solely from `device_state`, which mirrors firmware through the `durationExpired` heuristic (`targetLevel === 0 && heatingDuration === 0`, else `currentLevel !== 0`). After the firmware ends a session, `currentLevel` stays non-zero while the water equalizes, so the mirror reports the side as powered for minutes while the pump correctly reads 0 RPM. With frzHealth frames arriving ~every 10s (not the 60s cadence ADR 0022 assumed) and `dwellSamples = 2`, the guard tripped ~20s after every natural session end.

## Fix

`DeviceStateSync` now suppresses stall counting when the stop is explainable by lag-free firmware-side signals (`isExpectedPumpStop`):

1. **`pump.duty === 0`** — firmware isn't driving the pump. A genuinely stalled pump under closed-loop control shows duty > 0 while RPM reads 0, so real stalls are unaffected. Falls back cleanly when the frame omits `duty`.
2. **Priming active, or ended within 120s** — the prime cycle spins both pumps regardless of side power and stops them at the end.
3. **Firmware `targetLevel === 0`** — commanded neutral, pump stop expected even while `device_state` lags.
4. **Session countdown (`heatTime`) within 90s of its natural end**, projected forward from the last poll. Gated on `heatingDuration > 0` so firmware variants that report no countdown during an active session keep the previous behavior.

A zero-RPM frame mid-session with the pump still driven reaches the guard as `expectedActive = true` exactly as before. `pumpStallGuard.ts` itself is unchanged. Also documents the failure mode as an addendum in ADR 0022.

## Test plan

- `vitest run src/hardware/tests/` — 71 tests pass, including a new suite (`deviceStateSync.stallSuppression.test.ts`) covering: duty=0 suppression, duty>0 non-suppression, missing-duty fallback, priming + post-prime grace expiry, firmware-neutral-while-DB-powered (the field-observed case), session-end grace, countdown projection across a stalled status stream, indefinite-session (heatingDuration=0) non-suppression, and mid-session zero-RPM still tripping.
- `tsc --noEmit` and `eslint` clean.
- Manual verification once merged: on the affected pod, re-enable stall protection, let an 8h session expire and the 12:01 daily prime complete — no `pump_alerts` rows should appear; then verify a real stall still trips by unplugging a pump mid-session.

Refs: ygg `sleepypod-core-1`, ADR 0022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pump-stall-false-trip
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pump-stall-false-trip/scripts/install \
  | sudo bash -s -- --branch fix/pump-stall-false-trip
```

🎯 **Pin to this exact build** ([run 29172327550](https://github.com/sleepypod/core/actions/runs/29172327550) · `a45903d`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a45903d711b0ca342330e04b0a493fd4ddba8e21/scripts/install \
  | sudo bash -s -- \
      --branch fix/pump-stall-false-trip \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/29172327550/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/29172327550/artifacts/8253876739) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false pump-stall alerts when pumps stop normally due to firmware commands, priming completion, neutral settings, or session end.
  * Continued detecting genuine mid-session zero-RPM stalls while the pump is still expected to run.
  * Improved handling of pump status and session timing to prevent premature alerts.

* **Documentation**
  * Added an architecture decision record addendum explaining stall-detection behavior and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
