### PR TITLE
fix(server): acknowledge restart-orphaned pump alerts by falling back to the newest active row

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -306,6 +306,20 @@ export async function initializeScheduler(): Promise<void> {
     // Start DAC monitor (non-blocking — waits for frankenfirmware to connect)
     initializeDacMonitor()
 
+    // Rehydrate the pump stall guard from persisted un-acknowledged alerts
+    // before anything that consults shouldBlock (keepalives, scheduler jobs)
+    // can re-energize a side whose fault predates this boot.
+    try {
+      const { rehydrate } = await import('@/src/hardware/pumpStallGuard')
+      rehydrate()
+    }
+    catch (error) {
+      console.warn(
+        '[pumpStallGuard] rehydration failed:',
+        error instanceof Error ? error.message : error
+      )
+    }
+
     // Initialize temperature keepalive timers for sides with alwaysOn enabled
     initializeKeepalives()
 

--- a/src/components/TempScreen/PumpStallNotification.tsx
+++ b/src/components/TempScreen/PumpStallNotification.tsx
@@ -25,7 +25,9 @@ const formatTime = (unixSeconds: number): string => {
  *   Re-enable — restores the pre-stall setpoint via the normal command
  *     path. If the pump is still bad, the guard re-trips on the next
  *     frame; the banner returns.
- *   Dismiss — clears the notification only. Side stays off.
+ *   Dismiss — clears the notification and re-arms stall protection; the
+ *     side stays off until the user powers it back on, and any command
+ *     path re-triggers the guard if the pump is still bad.
  */
 export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction }: PumpStallNotificationProps) => {
   const acknowledge = trpc.pumpAlerts.acknowledgeAndRestore.useMutation()
@@ -34,8 +36,12 @@ export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction 
   // stamps exactly this row even across a restart. 0 means "no row".
   const alertRef = alertId || undefined
 
+  // While either mutation is in flight, both actions stay disabled — the
+  // two paths race for the same guard state and alert row.
+  const busy = acknowledge.isPending || dismiss.isPending
+
   return (
-    <div className="flex items-center gap-2 rounded-2xl border border-red-500/20 bg-red-950/30 p-3 sm:p-4">
+    <div role="alert" className="flex items-center gap-2 rounded-2xl border border-red-500/20 bg-red-950/30 p-3 sm:p-4">
       <AlertTriangle size={18} className="shrink-0 text-red-400" />
       <div className="flex-1 text-sm text-red-200">
         <p className="font-medium">
@@ -56,14 +62,15 @@ export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction 
       </div>
       <button
         onClick={() => acknowledge.mutate({ side, alertId: alertRef }, { onSettled: onAction })}
-        disabled={acknowledge.isPending}
+        disabled={busy}
         className="rounded-full bg-red-500/20 px-3 py-2 text-xs text-red-100 transition-all hover:bg-red-500/30 active:scale-95 disabled:opacity-50"
       >
         Re-enable
       </button>
       <button
         onClick={() => dismiss.mutate({ side, alertId: alertRef }, { onSettled: onAction })}
-        disabled={dismiss.isPending}
+        disabled={busy}
+        aria-label="Dismiss pump stall notification"
         className="flex h-11 w-11 items-center justify-center rounded-full text-red-400/60 transition-all hover:text-red-300 active:scale-90 disabled:opacity-50"
       >
         <X size={16} />

--- a/src/components/TempScreen/PumpStallNotification.tsx
+++ b/src/components/TempScreen/PumpStallNotification.tsx
@@ -8,6 +8,8 @@ interface PumpStallNotificationProps {
   rpm: number
   /** unix seconds */
   trippedAt: number
+  /** pump_alerts row id from the notice; 0 when the trip-time insert failed. */
+  alertId?: number
   /** Called after either re-enable or dismiss settles so the parent can refetch. */
   onAction?: () => void
 }
@@ -25,9 +27,12 @@ const formatTime = (unixSeconds: number): string => {
  *     frame; the banner returns.
  *   Dismiss — clears the notification only. Side stays off.
  */
-export const PumpStallNotification = ({ side, rpm, trippedAt, onAction }: PumpStallNotificationProps) => {
+export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction }: PumpStallNotificationProps) => {
   const acknowledge = trpc.pumpAlerts.acknowledgeAndRestore.useMutation()
   const dismiss = trpc.pumpAlerts.dismissNotification.useMutation()
+  // Correlate the mutation with the incident shown here — the server then
+  // stamps exactly this row even across a restart. 0 means "no row".
+  const alertRef = alertId || undefined
 
   return (
     <div className="flex items-center gap-2 rounded-2xl border border-red-500/20 bg-red-950/30 p-3 sm:p-4">
@@ -50,14 +55,14 @@ export const PumpStallNotification = ({ side, rpm, trippedAt, onAction }: PumpSt
         </p>
       </div>
       <button
-        onClick={() => acknowledge.mutate({ side }, { onSettled: onAction })}
+        onClick={() => acknowledge.mutate({ side, alertId: alertRef }, { onSettled: onAction })}
         disabled={acknowledge.isPending}
         className="rounded-full bg-red-500/20 px-3 py-2 text-xs text-red-100 transition-all hover:bg-red-500/30 active:scale-95 disabled:opacity-50"
       >
         Re-enable
       </button>
       <button
-        onClick={() => dismiss.mutate({ side }, { onSettled: onAction })}
+        onClick={() => dismiss.mutate({ side, alertId: alertRef }, { onSettled: onAction })}
         disabled={dismiss.isPending}
         className="flex h-11 w-11 items-center justify-center rounded-full text-red-400/60 transition-all hover:text-red-300 active:scale-90 disabled:opacity-50"
       >

--- a/src/components/TempScreen/TempScreen.tsx
+++ b/src/components/TempScreen/TempScreen.tsx
@@ -151,6 +151,7 @@ export const TempScreen = () => {
           side="left"
           rpm={stallNotices.left.rpm}
           trippedAt={stallNotices.left.trippedAt}
+          alertId={stallNotices.left.alertId}
           onAction={() => refetch()}
         />
       )}
@@ -159,6 +160,7 @@ export const TempScreen = () => {
           side="right"
           rpm={stallNotices.right.rpm}
           trippedAt={stallNotices.right.trippedAt}
+          alertId={stallNotices.right.alertId}
           onAction={() => refetch()}
         />
       )}

--- a/src/components/TempScreen/tests/PumpStallNotification.test.tsx
+++ b/src/components/TempScreen/tests/PumpStallNotification.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for PumpStallNotification — alert-id correlation on both mutations,
+ * dual-pending button lockout (Re-enable and Dismiss race for the same
+ * guard state), and the banner's accessibility contract.
+ */
+
+import { fireEvent, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trpcMock = vi.hoisted(() => {
+  const ackMutate = vi.fn()
+  const dismissMutate = vi.fn()
+  const pending = { acknowledge: false, dismiss: false }
+  return {
+    ackMutate,
+    dismissMutate,
+    pending,
+    trpc: {
+      pumpAlerts: {
+        acknowledgeAndRestore: { useMutation: () => ({ mutate: ackMutate, isPending: pending.acknowledge }) },
+        dismissNotification: { useMutation: () => ({ mutate: dismissMutate, isPending: pending.dismiss }) },
+      },
+    },
+  }
+})
+
+vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
+
+import { PumpStallNotification } from '../PumpStallNotification'
+
+beforeEach(() => {
+  trpcMock.ackMutate.mockClear()
+  trpcMock.dismissMutate.mockClear()
+  trpcMock.pending.acknowledge = false
+  trpcMock.pending.dismiss = false
+})
+
+describe('PumpStallNotification', () => {
+  it('passes the side and alert id to acknowledgeAndRestore on Re-enable', () => {
+    const { getByText } = render(
+      <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
+    )
+    fireEvent.click(getByText('Re-enable'))
+    expect(trpcMock.ackMutate).toHaveBeenCalledTimes(1)
+    expect(trpcMock.ackMutate).toHaveBeenCalledWith({ side: 'left', alertId: 38 }, expect.anything())
+  })
+
+  it('passes the side and alert id to dismissNotification on Dismiss', () => {
+    const { getByLabelText } = render(
+      <PumpStallNotification side="right" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
+    )
+    fireEvent.click(getByLabelText('Dismiss pump stall notification'))
+    expect(trpcMock.dismissMutate).toHaveBeenCalledTimes(1)
+    expect(trpcMock.dismissMutate).toHaveBeenCalledWith({ side: 'right', alertId: 38 }, expect.anything())
+  })
+
+  it('omits the alert id when the trip-time insert failed (alertId 0)', () => {
+    const { getByText, getByLabelText } = render(
+      <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={0} />,
+    )
+    fireEvent.click(getByText('Re-enable'))
+    fireEvent.click(getByLabelText('Dismiss pump stall notification'))
+    expect(trpcMock.ackMutate).toHaveBeenCalledWith({ side: 'left', alertId: undefined }, expect.anything())
+    expect(trpcMock.dismissMutate).toHaveBeenCalledWith({ side: 'left', alertId: undefined }, expect.anything())
+  })
+
+  it('disables both buttons while the acknowledge mutation is pending', () => {
+    trpcMock.pending.acknowledge = true
+    const { getByText, getByLabelText } = render(
+      <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
+    )
+    expect((getByText('Re-enable') as HTMLButtonElement).disabled).toBe(true)
+    expect((getByLabelText('Dismiss pump stall notification') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('disables both buttons while the dismiss mutation is pending', () => {
+    trpcMock.pending.dismiss = true
+    const { getByText, getByLabelText } = render(
+      <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
+    )
+    expect((getByText('Re-enable') as HTMLButtonElement).disabled).toBe(true)
+    expect((getByLabelText('Dismiss pump stall notification') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('exposes the banner as an alert for assistive tech', () => {
+    const { getByRole } = render(
+      <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
+    )
+    expect(getByRole('alert').textContent).toContain('side powered off — pump stall detected')
+  })
+})

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -17,7 +17,7 @@
  * shouldBlock is read from API route handlers.
  */
 
-import { eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import { biometricsDb, db } from '@/src/db'
 import { pumpAlerts } from '@/src/db/biometrics-schema'
 import { deviceSettings, deviceState } from '@/src/db/schema'
@@ -198,6 +198,65 @@ export function acknowledge(side: Side): {
   getState()[side] = emptyState()
   clearPumpStallNotice(side)
   return { restore, alertId }
+}
+
+// ── Startup rehydration ────────────────────────────────────────────────────
+
+/**
+ * Restore per-side guard state from the newest still-active `power_off`
+ * row. A restart wipes the in-memory block and banner while the fault row
+ * (and possibly the stalled pump) persists — without this the side comes
+ * back unguarded and the acknowledgement path has nothing to stamp.
+ * Skipped when stall protection is disabled; DB errors warn, never throw.
+ */
+export function rehydrate(): void {
+  if (!readSettings().enabled) return
+  for (const side of ['left', 'right'] as Side[]) {
+    const state = getState()[side]
+    if (state.blocked || state.activeAlertId != null) continue
+
+    let row
+    try {
+      [row] = biometricsDb
+        .select({
+          id: pumpAlerts.id,
+          timestamp: pumpAlerts.timestamp,
+          rpm: pumpAlerts.rpm,
+          restoreTargetTemperature: pumpAlerts.restoreTargetTemperature,
+          restoreDurationSeconds: pumpAlerts.restoreDurationSeconds,
+        })
+        .from(pumpAlerts)
+        .where(and(
+          eq(pumpAlerts.side, side),
+          eq(pumpAlerts.action, 'power_off'),
+          isNull(pumpAlerts.acknowledgedAt),
+          isNull(pumpAlerts.dismissedAt),
+        ))
+        .orderBy(desc(pumpAlerts.timestamp), desc(pumpAlerts.id))
+        .limit(1)
+        .all()
+    }
+    catch (err) {
+      console.warn('[pumpStallGuard] rehydration read failed:', err instanceof Error ? err.message : err)
+      continue
+    }
+    if (!row) continue
+
+    const restore = row.restoreTargetTemperature != null && row.restoreDurationSeconds != null
+      ? { targetTemperature: row.restoreTargetTemperature, durationSeconds: row.restoreDurationSeconds }
+      : null
+    state.blocked = true
+    state.trippedAt = row.timestamp.getTime()
+    state.activeAlertId = row.id
+    state.preStall = restore
+    setPumpStallNotice(side, {
+      alertId: row.id,
+      trippedAt: Math.floor(row.timestamp.getTime() / 1000),
+      rpm: row.rpm ?? 0,
+      restore,
+    })
+    console.warn(`[pumpStallGuard] rehydrated active stall for ${side} from alert ${row.id} — blocked until acknowledged`)
+  }
 }
 
 // ── Test / runtime reset ───────────────────────────────────────────────────

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -34,6 +34,9 @@ interface GuardState {
    *  update `action` on the same row. */
   activeAlertId: number | null
   preStall: { targetTemperature: number, durationSeconds: number } | null
+  /** true when the trip-time hardware power-off never went out — retried
+   *  on every subsequent frame until it succeeds. */
+  cutoffPending: boolean
 }
 
 interface GuardSettings {
@@ -68,6 +71,7 @@ function emptyState(): GuardState {
     trippedAt: null,
     activeAlertId: null,
     preStall: null,
+    cutoffPending: false,
   }
 }
 
@@ -162,7 +166,21 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
     return
   }
 
-  // Already blocked — track healthy recovery frames if auto-recovery is on.
+  // Already blocked — if the trip-time cutoff never reached the hardware,
+  // the side may still be energized against a stalled pump. Retry until
+  // the command is confirmed sent; the alert row already says power_off.
+  if (state.cutoffPending) {
+    try {
+      const client = getSharedHardwareClient()
+      await client.setPower(input.side, false)
+      state.cutoffPending = false
+    }
+    catch (err) {
+      console.warn(`[pumpStallGuard] cutoff retry for ${input.side} failed:`, err instanceof Error ? err.message : err)
+    }
+  }
+
+  // Track healthy recovery frames if auto-recovery is on.
   if (input.rpm >= settings.recoveryRpm) {
     state.consecutiveHealthyFrames += 1
   }
@@ -310,6 +328,7 @@ async function trip(side: Side, rpm: number): Promise<void> {
     await client.setPower(side, false)
   }
   catch (err) {
+    state.cutoffPending = true
     console.error('[pumpStallGuard] hardware power-off failed:', err instanceof Error ? err.message : err)
   }
 

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -218,6 +218,37 @@ export function acknowledge(side: Side): {
   return { restore, alertId }
 }
 
+// ── Re-arm after a failed acknowledge-and-restore ──────────────────────────
+
+/**
+ * Re-block a side whose acknowledgement could not complete. acknowledge()
+ * clears the guard optimistically; when the subsequent hardware restore
+ * fails, the alert row is still active (nothing was stamped) and the block
+ * plus banner must come back with it — otherwise the protection is
+ * silently lost while the side sits in an unknown power state.
+ */
+export function rearm(side: Side, params: {
+  alertId: number | null
+  restore: { targetTemperature: number, durationSeconds: number } | null
+  /** ms epoch of the original trip; defaults to now */
+  trippedAt?: number
+  rpm?: number
+}): void {
+  const state = getState()[side]
+  state.blocked = true
+  state.trippedAt = params.trippedAt ?? Date.now()
+  state.activeAlertId = params.alertId
+  state.preStall = params.restore
+  state.consecutiveLowFrames = 0
+  state.consecutiveHealthyFrames = 0
+  setPumpStallNotice(side, {
+    alertId: params.alertId ?? 0,
+    trippedAt: Math.floor(state.trippedAt / 1000),
+    rpm: params.rpm ?? 0,
+    restore: params.restore,
+  })
+}
+
 // ── Startup rehydration ────────────────────────────────────────────────────
 
 /**

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -33,6 +33,7 @@ import {
   acknowledge,
   invalidateGuardSettingsCache,
   onFrame,
+  rehydrate,
   reset,
   shouldBlock,
 } from '../pumpStallGuard'
@@ -755,5 +756,132 @@ describe('pumpStallGuard', () => {
     expect(alert.acknowledged_at).toBeTypeOf('number')
     expect(log).toHaveBeenCalledWith('[pumpStallGuard] auto-recovered left')
     log.mockRestore()
+  })
+
+  describe('rehydrate', () => {
+    function insertAlert(row: {
+      side: 'left' | 'right'
+      timestamp?: number
+      rpm?: number | null
+      action?: string
+      restoreTarget?: number | null
+      restoreDuration?: number | null
+      acknowledgedAt?: number | null
+      dismissedAt?: number | null
+    }): number {
+      const result = (biometricsSqlite as any).prepare(`
+        INSERT INTO pump_alerts (timestamp, type, side, rpm, action, restore_target_temperature, restore_duration_seconds, acknowledged_at, dismissed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        row.timestamp ?? 1_720_000_000,
+        row.side === 'left' ? 'stall_left' : 'stall_right',
+        row.side,
+        row.rpm === undefined ? 120 : row.rpm,
+        row.action ?? 'power_off',
+        row.restoreTarget === undefined ? 78 : row.restoreTarget,
+        row.restoreDuration === undefined ? 28800 : row.restoreDuration,
+        row.acknowledgedAt ?? null,
+        row.dismissedAt ?? null,
+      )
+      return Number(result.lastInsertRowid)
+    }
+
+    it('restores blocked state, snapshot, and notice from an active power_off row', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const id = insertAlert({ side: 'left', timestamp: 1_720_000_050, rpm: 90, restoreTarget: 81, restoreDuration: 5400 })
+
+      rehydrate()
+
+      expect(shouldBlock('left')).toBe(true)
+      expect(shouldBlock('right')).toBe(false)
+      const state = __test__.getState().left
+      expect(state.activeAlertId).toBe(id)
+      expect(state.trippedAt).toBe(1_720_000_050_000)
+      expect(state.preStall).toEqual({ targetTemperature: 81, durationSeconds: 5400 })
+      expect(getPumpStallNotice('left')).toEqual({
+        alertId: id,
+        trippedAt: 1_720_000_050,
+        rpm: 90,
+        restore: { targetTemperature: 81, durationSeconds: 5400 },
+      })
+      expect(warn).toHaveBeenCalledWith(`[pumpStallGuard] rehydrated active stall for left from alert ${id} — blocked until acknowledged`)
+      // A rehydrated block behaves like a live one: acknowledge clears it
+      // and hands the persisted snapshot back for restoration.
+      const { restore, alertId } = acknowledge('left')
+      expect(alertId).toBe(id)
+      expect(restore).toEqual({ targetTemperature: 81, durationSeconds: 5400 })
+      warn.mockRestore()
+    })
+
+    it('picks the newest row by timestamp then id for same-second rows', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      insertAlert({ side: 'left', timestamp: 1_720_000_010 })
+      const sameSecondOlder = insertAlert({ side: 'left', timestamp: 1_720_000_099 })
+      const sameSecondNewer = insertAlert({ side: 'left', timestamp: 1_720_000_099 })
+      expect(sameSecondNewer).toBeGreaterThan(sameSecondOlder)
+
+      rehydrate()
+
+      expect(__test__.getState().left.activeAlertId).toBe(sameSecondNewer)
+      warn.mockRestore()
+    })
+
+    it('skips entirely when stall protection is disabled', () => {
+      insertAlert({ side: 'left' })
+      setSettings({ pump_stall_protection_enabled: 0 })
+      invalidateGuardSettingsCache()
+
+      rehydrate()
+
+      expect(shouldBlock('left')).toBe(false)
+      expect(getPumpStallNotice('left')).toBeNull()
+    })
+
+    it('ignores acknowledged, dismissed, and non-power_off rows', () => {
+      insertAlert({ side: 'left', acknowledgedAt: 1_720_000_100 })
+      insertAlert({ side: 'left', dismissedAt: 1_720_000_100 })
+      insertAlert({ side: 'left', action: 'warned' })
+
+      rehydrate()
+
+      expect(shouldBlock('left')).toBe(false)
+      expect(getPumpStallNotice('left')).toBeNull()
+    })
+
+    it('rehydrates with a null snapshot and zero rpm when the row carries none', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const id = insertAlert({ side: 'right', rpm: null, restoreTarget: null, restoreDuration: null })
+
+      rehydrate()
+
+      expect(shouldBlock('right')).toBe(true)
+      expect(__test__.getState().right.preStall).toBeNull()
+      expect(getPumpStallNotice('right')).toEqual(expect.objectContaining({ alertId: id, rpm: 0, restore: null }))
+      warn.mockRestore()
+    })
+
+    it('does not disturb a side that is already blocked in memory', async () => {
+      await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      const liveAlertId = __test__.getState().left.activeAlertId
+      insertAlert({ side: 'left', timestamp: 1_700_000_000 })
+
+      rehydrate()
+
+      expect(__test__.getState().left.activeAlertId).toBe(liveAlertId)
+    })
+
+    it('warns and continues when the rehydration read fails', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      ;(biometricsSqlite as any).exec('DROP TABLE pump_alerts')
+
+      expect(() => rehydrate()).not.toThrow()
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('rehydration read failed'),
+        expect.anything(),
+      )
+      expect(shouldBlock('left')).toBe(false)
+      warn.mockRestore()
+    })
   })
 })

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -423,6 +423,44 @@ describe('pumpStallGuard', () => {
     err.mockRestore()
   })
 
+  it('retries a failed trip-time cutoff on subsequent frames until it succeeds', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setPower.mockRejectedValueOnce(new Error('hw down'))
+
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(shouldBlock('left')).toBe(true)
+    expect(__test__.getState().left.cutoffPending).toBe(true)
+
+    // First retry also fails — warn per retry, stay pending.
+    setPower.mockRejectedValueOnce(new Error('still down'))
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(warn).toHaveBeenCalledWith('[pumpStallGuard] cutoff retry for left failed:', 'still down')
+    expect(__test__.getState().left.cutoffPending).toBe(true)
+
+    // Second retry succeeds and stops.
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(setPower).toHaveBeenCalledTimes(3)
+    expect(setPower).toHaveBeenLastCalledWith('left', false)
+    expect(__test__.getState().left.cutoffPending).toBe(false)
+
+    // No further retries once the cutoff is confirmed sent.
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(setPower).toHaveBeenCalledTimes(3)
+    err.mockRestore()
+    warn.mockRestore()
+  })
+
+  it('does not retry the cutoff when the trip-time power-off succeeded', async () => {
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(__test__.getState().left.cutoffPending).toBe(false)
+
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(setPower).toHaveBeenCalledTimes(1)
+  })
+
   it('warns when device_state update fails after a trip', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -33,6 +33,7 @@ import {
   acknowledge,
   invalidateGuardSettingsCache,
   onFrame,
+  rearm,
   rehydrate,
   reset,
   shouldBlock,
@@ -273,6 +274,42 @@ describe('pumpStallGuard', () => {
     expect(alertId).toBeGreaterThan(0)
     expect(shouldBlock('right')).toBe(false)
     expect(getPumpStallNotice('right')).toBeNull()
+  })
+
+  it('rearm restores blocked state, snapshot, and notice', () => {
+    rearm('left', {
+      alertId: 9,
+      restore: { targetTemperature: 77, durationSeconds: 3600 },
+      trippedAt: 1_720_000_111_000,
+      rpm: 42,
+    })
+
+    expect(shouldBlock('left')).toBe(true)
+    const state = __test__.getState().left
+    expect(state.activeAlertId).toBe(9)
+    expect(state.trippedAt).toBe(1_720_000_111_000)
+    expect(state.preStall).toEqual({ targetTemperature: 77, durationSeconds: 3600 })
+    expect(getPumpStallNotice('left')).toEqual({
+      alertId: 9,
+      trippedAt: 1_720_000_111,
+      rpm: 42,
+      restore: { targetTemperature: 77, durationSeconds: 3600 },
+    })
+  })
+
+  it('rearm falls back to now and zeroed notice fields when trip metadata is unknown', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_720_000_500_000)
+
+    rearm('right', { alertId: null, restore: null })
+
+    expect(shouldBlock('right')).toBe(true)
+    expect(__test__.getState().right.activeAlertId).toBeNull()
+    expect(getPumpStallNotice('right')).toEqual({
+      alertId: 0,
+      trippedAt: 1_720_000_500,
+      rpm: 0,
+      restore: null,
+    })
   })
 
   it('reset() clears guard and notification', async () => {

--- a/src/server/routers/pumpAlerts.ts
+++ b/src/server/routers/pumpAlerts.ts
@@ -122,9 +122,12 @@ export const pumpAlertsRouter = router({
       // A restart wipes the guard's in-memory state, so a trip from before
       // the restart has no activeAlertId anymore and its row would strand
       // unacknowledged in the active list forever. Fall back to the newest
-      // active power_off row for this side.
+      // active power_off row for this side — but only when the restore
+      // snapshot is gone too: a failed alert INSERT at trip time also
+      // returns a null id while the snapshot survives, and falling back
+      // there would stamp an older, unrelated row.
       let stampId = alertId
-      if (stampId == null) {
+      if (stampId == null && restore == null) {
         try {
           const [orphan] = await biometricsDb
             .select({ id: pumpAlerts.id })

--- a/src/server/routers/pumpAlerts.ts
+++ b/src/server/routers/pumpAlerts.ts
@@ -110,7 +110,7 @@ export const pumpAlertsRouter = router({
    */
   acknowledgeAndRestore: publicProcedure
     .meta({ openapi: { method: 'POST', path: '/pump-alerts/acknowledge', protect: false, tags: ['Pump Alerts'] } })
-    .input(z.object({ side: sideSchema }).strict())
+    .input(z.object({ side: sideSchema, alertId: idSchema.optional() }).strict())
     .output(z.object({
       success: z.boolean(),
       restoredTarget: z.number().nullable(),
@@ -123,15 +123,20 @@ export const pumpAlertsRouter = router({
       const priorNotice = getPumpStallNotice(input.side)
       const { restore, alertId } = guardAcknowledge(input.side)
 
-      // A restart wipes the guard's in-memory state, so a trip from before
-      // the restart has no activeAlertId anymore and its row would strand
-      // unacknowledged in the active list forever. Fall back to the newest
-      // active power_off row for this side — but only when the restore
-      // snapshot is gone too: a failed alert INSERT at trip time also
-      // returns a null id while the snapshot survives, and falling back
-      // there would stamp an older, unrelated row. The row's persisted
-      // restore columns (ADR 0022) stand in for the lost snapshot.
-      let stampId = alertId
+      // Identity correlation: a client that saw the banner passes the
+      // notice's alertId, so a stale or replayed request stamps exactly
+      // that incident's row (and never falls through to guessing).
+      //
+      // Without a client id, a restart wipes the guard's in-memory state,
+      // so a trip from before the restart has no activeAlertId anymore and
+      // its row would strand unacknowledged in the active list forever.
+      // Fall back to the newest active power_off row for this side — but
+      // only when the restore snapshot is gone too: a failed alert INSERT
+      // at trip time also returns a null id while the snapshot survives,
+      // and falling back there would stamp an older, unrelated row. The
+      // row's persisted restore columns (ADR 0022) stand in for the lost
+      // snapshot.
+      let stampId = input.alertId ?? alertId
       let orphanRecovered = false
       let orphanRestore: { targetTemperature: number, durationSeconds: number } | null = null
       if (stampId == null && restore == null) {
@@ -175,14 +180,25 @@ export const pumpAlertsRouter = router({
       }
 
       // Best-effort by design: a stamp failure only leaves the row in the
-      // active list; the guard itself is already released.
+      // active list; the guard itself is already released. The WHERE clause
+      // re-checks activity so a concurrently dismissed row is not stamped
+      // twice (mirroring dismissAlert), and a client-provided id must also
+      // prove it names this side's power_off incident.
       const stampAcknowledged = async (): Promise<void> => {
         if (stampId == null) return
+        const conditions = [
+          eq(pumpAlerts.id, stampId),
+          isNull(pumpAlerts.acknowledgedAt),
+          isNull(pumpAlerts.dismissedAt),
+        ]
+        if (input.alertId != null) {
+          conditions.push(eq(pumpAlerts.side, input.side), eq(pumpAlerts.action, 'power_off'))
+        }
         try {
           await biometricsDb
             .update(pumpAlerts)
             .set({ acknowledgedAt: new Date() })
-            .where(eq(pumpAlerts.id, stampId))
+            .where(and(...conditions))
         }
         catch (err) {
           console.warn('[pumpAlerts] failed to stamp acknowledgedAt:', err instanceof Error ? err.message : err)
@@ -277,17 +293,31 @@ export const pumpAlertsRouter = router({
    */
   dismissNotification: publicProcedure
     .meta({ openapi: { method: 'POST', path: '/pump-alerts/dismiss-notification', protect: false, tags: ['Pump Alerts'] } })
-    .input(z.object({ side: sideSchema }).strict())
+    .input(z.object({ side: sideSchema, alertId: idSchema.optional() }).strict())
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
       const { alertId } = guardAcknowledge(input.side)
       clearPumpStallNotice(input.side)
-      if (alertId != null) {
+      // A client-provided id survives a restart (the guard's is wiped) and
+      // pins the stamp to the incident the user actually dismissed; it must
+      // prove it names this side's power_off incident. There is no
+      // newest-row fallback here on purpose — without an id there is no way
+      // to tell which incident a stale request meant.
+      const stampId = input.alertId ?? alertId
+      if (stampId != null) {
+        const conditions = [eq(pumpAlerts.id, stampId), isNull(pumpAlerts.dismissedAt)]
+        if (input.alertId != null) {
+          conditions.push(
+            eq(pumpAlerts.side, input.side),
+            eq(pumpAlerts.action, 'power_off'),
+            isNull(pumpAlerts.acknowledgedAt),
+          )
+        }
         try {
           await biometricsDb
             .update(pumpAlerts)
             .set({ dismissedAt: new Date() })
-            .where(eq(pumpAlerts.id, alertId))
+            .where(and(...conditions))
         }
         catch (err) {
           console.warn('[pumpAlerts] failed to stamp dismissedAt:', err instanceof Error ? err.message : err)

--- a/src/server/routers/pumpAlerts.ts
+++ b/src/server/routers/pumpAlerts.ts
@@ -4,8 +4,8 @@ import { and, desc, eq, isNull } from 'drizzle-orm'
 import { publicProcedure, router } from '@/src/server/trpc'
 import { biometricsDb } from '@/src/db'
 import { bedTemp, pumpAlerts } from '@/src/db/biometrics-schema'
-import { acknowledge as guardAcknowledge } from '@/src/hardware/pumpStallGuard'
-import { clearPumpStallNotice } from '@/src/hardware/pumpStallNotification'
+import { acknowledge as guardAcknowledge, rearm as guardRearm } from '@/src/hardware/pumpStallGuard'
+import { clearPumpStallNotice, getPumpStallNotice } from '@/src/hardware/pumpStallNotification'
 import { idSchema, sideSchema } from '@/src/server/validation-schemas'
 
 const ALERT_TYPE = z.enum([
@@ -118,6 +118,9 @@ export const pumpAlertsRouter = router({
       orphanRecovered: z.boolean(),
     }))
     .mutation(async ({ input }) => {
+      // Snapshot the notice before acknowledge() clears it — a failed
+      // restore re-arms the guard with the original trip metadata.
+      const priorNotice = getPumpStallNotice(input.side)
       const { restore, alertId } = guardAcknowledge(input.side)
 
       // A restart wipes the guard's in-memory state, so a trip from before
@@ -171,7 +174,10 @@ export const pumpAlertsRouter = router({
         }
       }
 
-      if (stampId != null) {
+      // Best-effort by design: a stamp failure only leaves the row in the
+      // active list; the guard itself is already released.
+      const stampAcknowledged = async (): Promise<void> => {
+        if (stampId == null) return
         try {
           await biometricsDb
             .update(pumpAlerts)
@@ -184,6 +190,7 @@ export const pumpAlertsRouter = router({
       }
 
       if (restore == null && orphanRestore == null) {
+        await stampAcknowledged()
         return { success: true, restoredTarget: null, restoredDuration: null, orphanRecovered }
       }
 
@@ -212,11 +219,17 @@ export const pumpAlertsRouter = router({
         }
       }
       if (effectiveRestore == null) {
+        await stampAcknowledged()
         return { success: true, restoredTarget: null, restoredDuration: null, orphanRecovered }
       }
 
+      // Restore first, stamp after: if the hardware calls fail the row must
+      // stay in the active list and the guard must re-arm, or the fault is
+      // hidden while the side sits in an unknown power state.
+      let poweredOn = false
       try {
         await caller.device.setPower({ side: input.side, powered: true, temperature: effectiveRestore.targetTemperature })
+        poweredOn = true
         await caller.device.setTemperature({
           side: input.side,
           temperature: effectiveRestore.targetTemperature,
@@ -224,12 +237,31 @@ export const pumpAlertsRouter = router({
         })
       }
       catch (err) {
+        if (poweredOn) {
+          // Partial restore: the side energized but the setpoint didn't
+          // take. Park it again before re-arming; if that also fails the
+          // guard still re-arms below.
+          try {
+            await caller.device.setPower({ side: input.side, powered: false })
+          }
+          catch (offErr) {
+            console.warn('[pumpAlerts] failed to park side after partial restore:', offErr instanceof Error ? offErr.message : offErr)
+          }
+        }
+        guardRearm(input.side, {
+          alertId: stampId,
+          restore: effectiveRestore,
+          trippedAt: priorNotice ? priorNotice.trippedAt * 1000 : undefined,
+          rpm: priorNotice?.rpm,
+        })
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to restore side: ${err instanceof Error ? err.message : 'Unknown error'}`,
           cause: err,
         })
       }
+
+      await stampAcknowledged()
 
       return {
         success: true,

--- a/src/server/routers/pumpAlerts.ts
+++ b/src/server/routers/pumpAlerts.ts
@@ -115,6 +115,7 @@ export const pumpAlertsRouter = router({
       success: z.boolean(),
       restoredTarget: z.number().nullable(),
       restoredDuration: z.number().nullable(),
+      orphanRecovered: z.boolean(),
     }))
     .mutation(async ({ input }) => {
       const { restore, alertId } = guardAcknowledge(input.side)
@@ -125,12 +126,20 @@ export const pumpAlertsRouter = router({
       // active power_off row for this side — but only when the restore
       // snapshot is gone too: a failed alert INSERT at trip time also
       // returns a null id while the snapshot survives, and falling back
-      // there would stamp an older, unrelated row.
+      // there would stamp an older, unrelated row. The row's persisted
+      // restore columns (ADR 0022) stand in for the lost snapshot.
       let stampId = alertId
+      let orphanRecovered = false
+      let orphanRestore: { targetTemperature: number, durationSeconds: number } | null = null
       if (stampId == null && restore == null) {
+        let orphan
         try {
-          const [orphan] = await biometricsDb
-            .select({ id: pumpAlerts.id })
+          [orphan] = await biometricsDb
+            .select({
+              id: pumpAlerts.id,
+              restoreTargetTemperature: pumpAlerts.restoreTargetTemperature,
+              restoreDurationSeconds: pumpAlerts.restoreDurationSeconds,
+            })
             .from(pumpAlerts)
             .where(and(
               eq(pumpAlerts.side, input.side),
@@ -138,12 +147,27 @@ export const pumpAlertsRouter = router({
               isNull(pumpAlerts.acknowledgedAt),
               isNull(pumpAlerts.dismissedAt),
             ))
-            .orderBy(desc(pumpAlerts.timestamp))
+            .orderBy(desc(pumpAlerts.timestamp), desc(pumpAlerts.id))
             .limit(1)
-          stampId = orphan?.id ?? null
         }
         catch (err) {
-          console.warn('[pumpAlerts] orphaned-alert lookup failed:', err instanceof Error ? err.message : err)
+          // This lookup is the mutation's only route to the stranded row —
+          // when it fails the whole restart-recovery action failed.
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to look up orphaned pump alert: ${err instanceof Error ? err.message : 'Unknown error'}`,
+            cause: err,
+          })
+        }
+        if (orphan) {
+          stampId = orphan.id
+          orphanRecovered = true
+          if (orphan.restoreTargetTemperature != null && orphan.restoreDurationSeconds != null) {
+            orphanRestore = {
+              targetTemperature: orphan.restoreTargetTemperature,
+              durationSeconds: orphan.restoreDurationSeconds,
+            }
+          }
         }
       }
 
@@ -159,8 +183,8 @@ export const pumpAlertsRouter = router({
         }
       }
 
-      if (!restore) {
-        return { success: true, restoredTarget: null, restoredDuration: null }
+      if (restore == null && orphanRestore == null) {
+        return { success: true, restoredTarget: null, restoredDuration: null, orphanRecovered }
       }
 
       // Route through the device router so debounce, freshness stamping,
@@ -168,12 +192,35 @@ export const pumpAlertsRouter = router({
       // user mutation.
       const { appRouter } = await import('./app')
       const caller = appRouter.createCaller({})
+
+      let effectiveRestore = restore
+      if (effectiveRestore == null && orphanRestore != null) {
+        // Replay the persisted snapshot only when the side is still parked:
+        // after an earlier silent stamp failure the side may already be
+        // running a newer setpoint, and blind replay would clobber it. A
+        // failed status read skips the replay — leaving the side off is
+        // the conservative outcome.
+        try {
+          const status = await caller.device.getStatus({})
+          const sideStatus = input.side === 'left' ? status.leftSide : status.rightSide
+          if (sideStatus.targetLevel === 0) {
+            effectiveRestore = orphanRestore
+          }
+        }
+        catch (err) {
+          console.warn('[pumpAlerts] status read before orphan replay failed — leaving the side off:', err instanceof Error ? err.message : err)
+        }
+      }
+      if (effectiveRestore == null) {
+        return { success: true, restoredTarget: null, restoredDuration: null, orphanRecovered }
+      }
+
       try {
-        await caller.device.setPower({ side: input.side, powered: true, temperature: restore.targetTemperature })
+        await caller.device.setPower({ side: input.side, powered: true, temperature: effectiveRestore.targetTemperature })
         await caller.device.setTemperature({
           side: input.side,
-          temperature: restore.targetTemperature,
-          duration: restore.durationSeconds,
+          temperature: effectiveRestore.targetTemperature,
+          duration: effectiveRestore.durationSeconds,
         })
       }
       catch (err) {
@@ -186,8 +233,9 @@ export const pumpAlertsRouter = router({
 
       return {
         success: true,
-        restoredTarget: restore.targetTemperature,
-        restoredDuration: restore.durationSeconds,
+        restoredTarget: effectiveRestore.targetTemperature,
+        restoredDuration: effectiveRestore.durationSeconds,
+        orphanRecovered,
       }
     }),
 

--- a/src/server/routers/pumpAlerts.ts
+++ b/src/server/routers/pumpAlerts.ts
@@ -119,12 +119,37 @@ export const pumpAlertsRouter = router({
     .mutation(async ({ input }) => {
       const { restore, alertId } = guardAcknowledge(input.side)
 
-      if (alertId != null) {
+      // A restart wipes the guard's in-memory state, so a trip from before
+      // the restart has no activeAlertId anymore and its row would strand
+      // unacknowledged in the active list forever. Fall back to the newest
+      // active power_off row for this side.
+      let stampId = alertId
+      if (stampId == null) {
+        try {
+          const [orphan] = await biometricsDb
+            .select({ id: pumpAlerts.id })
+            .from(pumpAlerts)
+            .where(and(
+              eq(pumpAlerts.side, input.side),
+              eq(pumpAlerts.action, 'power_off'),
+              isNull(pumpAlerts.acknowledgedAt),
+              isNull(pumpAlerts.dismissedAt),
+            ))
+            .orderBy(desc(pumpAlerts.timestamp))
+            .limit(1)
+          stampId = orphan?.id ?? null
+        }
+        catch (err) {
+          console.warn('[pumpAlerts] orphaned-alert lookup failed:', err instanceof Error ? err.message : err)
+        }
+      }
+
+      if (stampId != null) {
         try {
           await biometricsDb
             .update(pumpAlerts)
             .set({ acknowledgedAt: new Date() })
-            .where(eq(pumpAlerts.id, alertId))
+            .where(eq(pumpAlerts.id, stampId))
         }
         catch (err) {
           console.warn('[pumpAlerts] failed to stamp acknowledgedAt:', err instanceof Error ? err.message : err)

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -355,6 +355,16 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       expect(warn).toHaveBeenCalledWith('[pumpAlerts] orphaned-alert lookup failed:', 'sqlite locked')
       expect(dbMock.update).not.toHaveBeenCalled()
     })
+
+    it('logs the raw value for a non-Error orphan lookup failure', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      rejectNext('sqlite unavailable')
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
+      expect(warn).toHaveBeenCalledWith('[pumpAlerts] orphaned-alert lookup failed:', 'sqlite unavailable')
+      expect(dbMock.update).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TRPCError } from '@trpc/server'
 import type * as DrizzleOrmModule from 'drizzle-orm'
+import { pumpAlerts } from '@/src/db/biometrics-schema'
 
 const sql = vi.hoisted(() => ({
   and: vi.fn((...conditions: unknown[]) => ({ kind: 'and', conditions })),
@@ -316,11 +317,18 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
         expect.objectContaining({ kind: 'isNull' }),
         expect.objectContaining({ kind: 'isNull' }),
       )
-      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 'left')
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.side, 'left')
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.action, 'power_off')
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.acknowledgedAt)
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
+      expect(sql.desc).toHaveBeenCalledWith(pumpAlerts.timestamp)
       expect(dbMock.chain.orderBy).toHaveBeenCalledWith(expect.objectContaining({ kind: 'desc' }))
+      expect(dbMock.chain.limit).toHaveBeenCalledWith(1)
       expect(dbMock.chain.set).toHaveBeenCalledWith({ acknowledgedAt: expect.any(Date) })
-      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 38)
-      // No in-memory snapshot survives a restart — nothing to restore.
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 38)
+      // The guard's in-memory snapshot did not survive the restart, so
+      // there is nothing to restore from memory (the row's persisted
+      // restore columns are deliberately not replayed here).
       expect(device.createCaller).not.toHaveBeenCalled()
     })
 
@@ -344,6 +352,25 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
       expect(dbMock.select).not.toHaveBeenCalled()
       expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 42)
+    })
+
+    it('skips the fallback when the guard kept its restore snapshot (failed insert, not a restart)', async () => {
+      // A failed alert INSERT at trip time leaves alertId null but keeps
+      // the snapshot — the current trip has no row of its own, so falling
+      // back would stamp an older, unrelated incident.
+      guard.acknowledge.mockReturnValue({
+        restore: { targetTemperature: 70, durationSeconds: 1800 },
+        alertId: null,
+      })
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toEqual({
+        success: true,
+        restoredTarget: 70,
+        restoredDuration: 1800,
+      })
+      expect(dbMock.select).not.toHaveBeenCalled()
+      expect(dbMock.update).not.toHaveBeenCalled()
+      expect(device.setPower).toHaveBeenCalledWith({ side: 'left', powered: true, temperature: 70 })
     })
 
     it('tolerates a failed orphan lookup and still resolves', async () => {

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -227,7 +227,7 @@ describe('pumpAlerts.getCapabilities', () => {
 })
 
 describe('pumpAlerts.acknowledgeAndRestore', () => {
-  it('acknowledges the guard without touching the DB when there is no alert snapshot', async () => {
+  it('acknowledges the guard without a restore or update when no snapshot and no orphan row exist', async () => {
     await expect(caller.acknowledgeAndRestore({ side: 'right' })).resolves.toEqual({
       success: true,
       restoredTarget: null,
@@ -293,6 +293,67 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
     await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Failed to restore side: Unknown error',
+    })
+  })
+
+  describe('restart-orphaned alerts', () => {
+    it('stamps the newest active power_off row for the side when the guard lost its alert id', async () => {
+      // Simulated restart: the guard's in-memory state is empty, but the
+      // trip's row is still active in the DB.
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      dbState.queue.push([{ id: 38 }]) // orphan lookup
+      dbState.queue.push([]) // acknowledgedAt update
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toEqual({
+        success: true,
+        restoredTarget: null,
+        restoredDuration: null,
+      })
+      expect(dbMock.select).toHaveBeenCalledOnce()
+      expect(sql.and).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'eq' }),
+        expect.objectContaining({ kind: 'eq', right: 'power_off' }),
+        expect.objectContaining({ kind: 'isNull' }),
+        expect.objectContaining({ kind: 'isNull' }),
+      )
+      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 'left')
+      expect(dbMock.chain.orderBy).toHaveBeenCalledWith(expect.objectContaining({ kind: 'desc' }))
+      expect(dbMock.chain.set).toHaveBeenCalledWith({ acknowledgedAt: expect.any(Date) })
+      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 38)
+      // No in-memory snapshot survives a restart — nothing to restore.
+      expect(device.createCaller).not.toHaveBeenCalled()
+    })
+
+    it('succeeds without an update when no active power_off row exists for the side', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      dbState.queue.push([]) // orphan lookup finds nothing
+
+      await expect(caller.acknowledgeAndRestore({ side: 'right' })).resolves.toEqual({
+        success: true,
+        restoredTarget: null,
+        restoredDuration: null,
+      })
+      expect(dbMock.select).toHaveBeenCalledOnce()
+      expect(dbMock.update).not.toHaveBeenCalled()
+    })
+
+    it('skips the orphan lookup entirely when the guard still holds the alert id', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: 42 })
+      dbState.queue.push([]) // acknowledgedAt update
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
+      expect(dbMock.select).not.toHaveBeenCalled()
+      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 42)
+    })
+
+    it('tolerates a failed orphan lookup and still resolves', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      rejectNext(new Error('sqlite locked'))
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
+      expect(warn).toHaveBeenCalledWith('[pumpAlerts] orphaned-alert lookup failed:', 'sqlite locked')
+      expect(dbMock.update).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -19,12 +19,20 @@ const dbState = vi.hoisted(() => ({
   queue: [] as unknown[],
   rejection: undefined as unknown,
   shouldReject: false,
+  exhausted: false,
   pop(): unknown {
     if (dbState.shouldReject) {
       dbState.shouldReject = false
       return Promise.reject(dbState.rejection)
     }
-    return dbState.queue.shift() ?? []
+    if (dbState.queue.length === 0) {
+      // Loud on purpose: a silently-successful unexpected query hid real
+      // DB traffic behind tolerant catch blocks. Every test enqueues every
+      // expected result; the afterEach flag check catches swallowed throws.
+      dbState.exhausted = true
+      throw new Error('dbState queue exhausted — enqueue a result for every expected DB call')
+    }
+    return dbState.queue.shift()
   },
 }))
 
@@ -95,6 +103,7 @@ beforeEach(() => {
   dbState.queue.length = 0
   dbState.shouldReject = false
   dbState.rejection = undefined
+  dbState.exhausted = false
   dbMock.select.mockClear()
   dbMock.update.mockClear()
   for (const value of Object.values(dbMock.chain)) {
@@ -124,6 +133,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  expect(dbState.exhausted, 'a DB call ran without an enqueued result').toBe(false)
 })
 
 describe('pumpAlerts OpenAPI contract', () => {

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -481,7 +481,16 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
 
       await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
       expect(dbMock.select).not.toHaveBeenCalled()
-      expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 42)
+      // The stamp re-checks activity so a concurrently dismissed row is
+      // not also acknowledged (TOCTOU with dismissAlert).
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 42)
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.acknowledgedAt)
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
+      expect(sql.and).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'eq' }),
+        expect.objectContaining({ kind: 'isNull' }),
+        expect.objectContaining({ kind: 'isNull' }),
+      )
     })
 
     it('skips the fallback when the guard kept its restore snapshot (failed insert, not a restart)', async () => {
@@ -528,6 +537,51 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       expect(dbMock.update).not.toHaveBeenCalled()
     })
   })
+
+  describe('identity correlation', () => {
+    it('stamps exactly the client-provided alert id, constrained to this side\'s active power_off row', async () => {
+      // Post-restart the guard is empty, but the client saw the banner and
+      // still knows which incident it is acknowledging.
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      dbState.queue.push([]) // acknowledgedAt update
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left', alertId: 38 })).resolves.toEqual({
+        success: true,
+        restoredTarget: null,
+        restoredDuration: null,
+        orphanRecovered: false,
+      })
+      // No newest-row heuristic when the client names the row.
+      expect(dbMock.select).not.toHaveBeenCalled()
+      expect(dbMock.chain.set).toHaveBeenCalledWith({ acknowledgedAt: expect.any(Date) })
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 38)
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.side, 'left')
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.action, 'power_off')
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.acknowledgedAt)
+      expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
+      expect(sql.and).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'eq' }),
+        expect.objectContaining({ kind: 'isNull' }),
+        expect.objectContaining({ kind: 'isNull' }),
+        expect.objectContaining({ kind: 'eq' }),
+        expect.objectContaining({ kind: 'eq', right: 'power_off' }),
+      )
+    })
+
+    it('prefers the client-provided id over the guard-held one', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: 42 })
+      dbState.queue.push([]) // acknowledgedAt update
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left', alertId: 38 })).resolves.toMatchObject({ success: true })
+      expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 38)
+      expect(sql.eq).not.toHaveBeenCalledWith(pumpAlerts.id, 42)
+    })
+
+    it('rejects a non-positive alert id', async () => {
+      await expect(caller.acknowledgeAndRestore({ side: 'left', alertId: 0 })).rejects.toThrow()
+      expect(dbMock.update).not.toHaveBeenCalled()
+    })
+  })
 })
 
 describe('pumpAlerts dismissals', () => {
@@ -545,8 +599,45 @@ describe('pumpAlerts dismissals', () => {
 
     await expect(caller.dismissNotification({ side: 'right' })).resolves.toEqual({ success: true })
     expect(dbMock.chain.set).toHaveBeenCalledWith({ dismissedAt: expect.any(Date) })
-    expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 12)
+    // Re-checks the row is not already dismissed (TOCTOU with dismissAlert).
+    expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 12)
+    expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
+    expect(sql.and).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'eq' }),
+      expect.objectContaining({ kind: 'isNull' }),
+    )
     expect(warn).toHaveBeenCalledWith('[pumpAlerts] failed to stamp dismissedAt:', 'write failed')
+  })
+
+  it('stamps the client-provided id with full identity constraints when the guard is empty', async () => {
+    // Post-restart dismissal: the guard lost the id but the client kept it.
+    guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+    dbState.queue.push([]) // dismissedAt update
+
+    await expect(caller.dismissNotification({ side: 'left', alertId: 31 })).resolves.toEqual({ success: true })
+    expect(dbMock.select).not.toHaveBeenCalled()
+    expect(dbMock.chain.set).toHaveBeenCalledWith({ dismissedAt: expect.any(Date) })
+    expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 31)
+    expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.side, 'left')
+    expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.action, 'power_off')
+    expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.acknowledgedAt)
+    expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
+    expect(sql.and).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'eq' }),
+      expect.objectContaining({ kind: 'isNull' }),
+      expect.objectContaining({ kind: 'eq' }),
+      expect.objectContaining({ kind: 'eq', right: 'power_off' }),
+      expect.objectContaining({ kind: 'isNull' }),
+    )
+  })
+
+  it('prefers the client-provided id over the guard-held one when dismissing', async () => {
+    guard.acknowledge.mockReturnValue({ restore: null, alertId: 12 })
+    dbState.queue.push([]) // dismissedAt update
+
+    await expect(caller.dismissNotification({ side: 'right', alertId: 31 })).resolves.toEqual({ success: true })
+    expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 31)
+    expect(sql.eq).not.toHaveBeenCalledWith(pumpAlerts.id, 12)
   })
 
   it('dismisses a specific active history row', async () => {

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -53,6 +53,7 @@ const notices = vi.hoisted(() => ({
 const device = vi.hoisted(() => ({
   setPower: vi.fn(),
   setTemperature: vi.fn(),
+  getStatus: vi.fn(),
   createCaller: vi.fn(),
 }))
 
@@ -104,10 +105,15 @@ beforeEach(() => {
   notices.clearPumpStallNotice.mockReset()
   device.setPower.mockReset().mockResolvedValue({ success: true })
   device.setTemperature.mockReset().mockResolvedValue({ success: true })
+  device.getStatus.mockReset().mockResolvedValue({
+    leftSide: { targetLevel: 0 },
+    rightSide: { targetLevel: 0 },
+  })
   device.createCaller.mockReset().mockReturnValue({
     device: {
       setPower: device.setPower,
       setTemperature: device.setTemperature,
+      getStatus: device.getStatus,
     },
   })
 })
@@ -229,12 +235,16 @@ describe('pumpAlerts.getCapabilities', () => {
 
 describe('pumpAlerts.acknowledgeAndRestore', () => {
   it('acknowledges the guard without a restore or update when no snapshot and no orphan row exist', async () => {
+    dbState.queue.push([]) // orphan lookup finds nothing
+
     await expect(caller.acknowledgeAndRestore({ side: 'right' })).resolves.toEqual({
       success: true,
       restoredTarget: null,
       restoredDuration: null,
+      orphanRecovered: false,
     })
     expect(guard.acknowledge).toHaveBeenCalledWith('right')
+    expect(dbMock.select).toHaveBeenCalledOnce()
     expect(dbMock.update).not.toHaveBeenCalled()
     expect(device.createCaller).not.toHaveBeenCalled()
   })
@@ -248,6 +258,7 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       success: true,
       restoredTarget: 71,
       restoredDuration: 5400,
+      orphanRecovered: false,
     })
     expect(dbMock.chain.set).toHaveBeenCalledWith({ acknowledgedAt: expect.any(Date) })
     expect(sql.eq).toHaveBeenCalledWith(expect.anything(), 42)
@@ -302,13 +313,14 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       // Simulated restart: the guard's in-memory state is empty, but the
       // trip's row is still active in the DB.
       guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
-      dbState.queue.push([{ id: 38 }]) // orphan lookup
+      dbState.queue.push([{ id: 38, restoreTargetTemperature: null, restoreDurationSeconds: null }]) // orphan lookup
       dbState.queue.push([]) // acknowledgedAt update
 
       await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toEqual({
         success: true,
         restoredTarget: null,
         restoredDuration: null,
+        orphanRecovered: true,
       })
       expect(dbMock.select).toHaveBeenCalledOnce()
       expect(sql.and).toHaveBeenCalledWith(
@@ -322,27 +334,67 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.acknowledgedAt)
       expect(sql.isNull).toHaveBeenCalledWith(pumpAlerts.dismissedAt)
       expect(sql.desc).toHaveBeenCalledWith(pumpAlerts.timestamp)
-      expect(dbMock.chain.orderBy).toHaveBeenCalledWith(expect.objectContaining({ kind: 'desc' }))
+      expect(sql.desc).toHaveBeenCalledWith(pumpAlerts.id)
+      expect(dbMock.chain.orderBy).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'desc', column: pumpAlerts.timestamp }),
+        expect.objectContaining({ kind: 'desc', column: pumpAlerts.id }),
+      )
       expect(dbMock.chain.limit).toHaveBeenCalledWith(1)
       expect(dbMock.chain.set).toHaveBeenCalledWith({ acknowledgedAt: expect.any(Date) })
       expect(sql.eq).toHaveBeenCalledWith(pumpAlerts.id, 38)
-      // The guard's in-memory snapshot did not survive the restart, so
-      // there is nothing to restore from memory (the row's persisted
-      // restore columns are deliberately not replayed here).
+      // This row persisted no restore columns, so there is nothing to
+      // replay — the side stays off.
       expect(device.createCaller).not.toHaveBeenCalled()
     })
 
-    it('succeeds without an update when no active power_off row exists for the side', async () => {
+    it('replays the persisted restore columns when the side is still parked', async () => {
       guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
-      dbState.queue.push([]) // orphan lookup finds nothing
+      dbState.queue.push([{ id: 44, restoreTargetTemperature: 74, restoreDurationSeconds: 7200 }]) // orphan lookup
+      dbState.queue.push([]) // acknowledgedAt update
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toEqual({
+        success: true,
+        restoredTarget: 74,
+        restoredDuration: 7200,
+        orphanRecovered: true,
+      })
+      expect(device.getStatus).toHaveBeenCalledWith({})
+      expect(device.setPower).toHaveBeenCalledWith({ side: 'left', powered: true, temperature: 74 })
+      expect(device.setTemperature).toHaveBeenCalledWith({ side: 'left', temperature: 74, duration: 7200 })
+      expect(device.getStatus.mock.invocationCallOrder[0]).toBeLessThan(device.setPower.mock.invocationCallOrder[0] ?? 0)
+    })
+
+    it('skips the replay when the side is already powered', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      device.getStatus.mockResolvedValue({ leftSide: { targetLevel: 0 }, rightSide: { targetLevel: 2 } })
+      dbState.queue.push([{ id: 45, restoreTargetTemperature: 74, restoreDurationSeconds: 7200 }]) // orphan lookup
+      dbState.queue.push([]) // acknowledgedAt update
 
       await expect(caller.acknowledgeAndRestore({ side: 'right' })).resolves.toEqual({
         success: true,
         restoredTarget: null,
         restoredDuration: null,
+        orphanRecovered: true,
       })
-      expect(dbMock.select).toHaveBeenCalledOnce()
-      expect(dbMock.update).not.toHaveBeenCalled()
+      expect(device.setPower).not.toHaveBeenCalled()
+      expect(device.setTemperature).not.toHaveBeenCalled()
+    })
+
+    it('skips the replay and warns when the pre-replay status read fails', async () => {
+      guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
+      device.getStatus.mockRejectedValueOnce(new Error('status offline'))
+      dbState.queue.push([{ id: 46, restoreTargetTemperature: 74, restoreDurationSeconds: 7200 }]) // orphan lookup
+      dbState.queue.push([]) // acknowledgedAt update
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toEqual({
+        success: true,
+        restoredTarget: null,
+        restoredDuration: null,
+        orphanRecovered: true,
+      })
+      expect(warn).toHaveBeenCalledWith('[pumpAlerts] status read before orphan replay failed — leaving the side off:', 'status offline')
+      expect(device.setPower).not.toHaveBeenCalled()
     })
 
     it('skips the orphan lookup entirely when the guard still holds the alert id', async () => {
@@ -367,29 +419,34 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
         success: true,
         restoredTarget: 70,
         restoredDuration: 1800,
+        orphanRecovered: false,
       })
       expect(dbMock.select).not.toHaveBeenCalled()
       expect(dbMock.update).not.toHaveBeenCalled()
       expect(device.setPower).toHaveBeenCalledWith({ side: 'left', powered: true, temperature: 70 })
     })
 
-    it('tolerates a failed orphan lookup and still resolves', async () => {
+    it('propagates a failed orphan lookup as INTERNAL_SERVER_ERROR', async () => {
+      // The lookup is the mutation's only route to the stranded row —
+      // swallowing the failure would report success with nothing stamped.
       guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
       rejectNext(new Error('sqlite locked'))
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
-      expect(warn).toHaveBeenCalledWith('[pumpAlerts] orphaned-alert lookup failed:', 'sqlite locked')
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to look up orphaned pump alert: sqlite locked',
+      })
       expect(dbMock.update).not.toHaveBeenCalled()
     })
 
-    it('logs the raw value for a non-Error orphan lookup failure', async () => {
+    it('uses Unknown error for a non-Error orphan lookup failure', async () => {
       guard.acknowledge.mockReturnValue({ restore: null, alertId: null })
       rejectNext('sqlite unavailable')
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-      await expect(caller.acknowledgeAndRestore({ side: 'left' })).resolves.toMatchObject({ success: true })
-      expect(warn).toHaveBeenCalledWith('[pumpAlerts] orphaned-alert lookup failed:', 'sqlite unavailable')
+      await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to look up orphaned pump alert: Unknown error',
+      })
       expect(dbMock.update).not.toHaveBeenCalled()
     })
   })

--- a/src/server/routers/tests/pumpAlerts.test.ts
+++ b/src/server/routers/tests/pumpAlerts.test.ts
@@ -44,10 +44,12 @@ const dbMock = vi.hoisted(() => {
 
 const guard = vi.hoisted(() => ({
   acknowledge: vi.fn(),
+  rearm: vi.fn(),
 }))
 
 const notices = vi.hoisted(() => ({
   clearPumpStallNotice: vi.fn(),
+  getPumpStallNotice: vi.fn(),
 }))
 
 const device = vi.hoisted(() => ({
@@ -58,7 +60,7 @@ const device = vi.hoisted(() => ({
 }))
 
 vi.mock('@/src/db', () => ({ biometricsDb: dbMock }))
-vi.mock('@/src/hardware/pumpStallGuard', () => ({ acknowledge: guard.acknowledge }))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({ acknowledge: guard.acknowledge, rearm: guard.rearm }))
 vi.mock('@/src/hardware/pumpStallNotification', () => notices)
 vi.mock('@/src/server/routers/app', () => ({
   appRouter: {
@@ -102,7 +104,9 @@ beforeEach(() => {
   }
   Object.values(sql).forEach(mock => mock.mockClear())
   guard.acknowledge.mockReset().mockReturnValue({ restore: null, alertId: null })
+  guard.rearm.mockReset()
   notices.clearPumpStallNotice.mockReset()
+  notices.getPumpStallNotice.mockReset().mockReturnValue(null)
   device.setPower.mockReset().mockResolvedValue({ success: true })
   device.setTemperature.mockReset().mockResolvedValue({ success: true })
   device.getStatus.mockReset().mockResolvedValue({
@@ -266,6 +270,8 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
     expect(device.setPower).toHaveBeenCalledWith({ side: 'left', powered: true, temperature: 71 })
     expect(device.setTemperature).toHaveBeenCalledWith({ side: 'left', temperature: 71, duration: 5400 })
     expect(device.setPower.mock.invocationCallOrder[0]).toBeLessThan(device.setTemperature.mock.invocationCallOrder[0] ?? 0)
+    // acknowledgedAt is stamped only after both restore calls succeed.
+    expect(dbMock.update.mock.invocationCallOrder[0]).toBeGreaterThan(device.setTemperature.mock.invocationCallOrder[0] ?? Infinity)
   })
 
   it('logs an acknowledgement stamp failure but still restores the side', async () => {
@@ -281,7 +287,7 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
     expect(device.setPower).toHaveBeenCalledOnce()
   })
 
-  it('wraps an Error from the device restore path', async () => {
+  it('wraps an Error from the device restore path and re-arms without trip metadata', async () => {
     guard.acknowledge.mockReturnValue({
       restore: { targetTemperature: 69, durationSeconds: 1200 },
       alertId: null,
@@ -293,6 +299,15 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       message: 'Failed to restore side: hardware offline',
     })
     expect(device.setTemperature).not.toHaveBeenCalled()
+    // Power-on itself failed, so there is nothing to park again.
+    expect(device.setPower).toHaveBeenCalledTimes(1)
+    expect(guard.rearm).toHaveBeenCalledWith('left', {
+      alertId: null,
+      restore: { targetTemperature: 69, durationSeconds: 1200 },
+      trippedAt: undefined,
+      rpm: undefined,
+    })
+    expect(dbMock.update).not.toHaveBeenCalled()
   })
 
   it('uses Unknown error for a non-Error device restore rejection', async () => {
@@ -306,6 +321,69 @@ describe('pumpAlerts.acknowledgeAndRestore', () => {
       code: 'INTERNAL_SERVER_ERROR',
       message: 'Failed to restore side: Unknown error',
     })
+  })
+
+  it('does not stamp and re-arms with the prior notice metadata when the restore fails', async () => {
+    notices.getPumpStallNotice.mockReturnValue({
+      alertId: 7,
+      trippedAt: 1_720_000_000,
+      rpm: 55,
+      restore: { targetTemperature: 69, durationSeconds: 1200 },
+    })
+    guard.acknowledge.mockReturnValue({
+      restore: { targetTemperature: 69, durationSeconds: 1200 },
+      alertId: 7,
+    })
+    device.setPower.mockRejectedValueOnce(new Error('hardware offline'))
+
+    await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    })
+    expect(notices.getPumpStallNotice).toHaveBeenCalledWith('left')
+    expect(guard.rearm).toHaveBeenCalledWith('left', {
+      alertId: 7,
+      restore: { targetTemperature: 69, durationSeconds: 1200 },
+      trippedAt: 1_720_000_000_000,
+      rpm: 55,
+    })
+    expect(dbMock.update).not.toHaveBeenCalled()
+  })
+
+  it('parks the side again when the setpoint fails after a successful power-on', async () => {
+    guard.acknowledge.mockReturnValue({
+      restore: { targetTemperature: 71, durationSeconds: 5400 },
+      alertId: 42,
+    })
+    device.setTemperature.mockRejectedValueOnce(new Error('setpoint refused'))
+
+    await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to restore side: setpoint refused',
+    })
+    expect(device.setPower).toHaveBeenCalledTimes(2)
+    expect(device.setPower).toHaveBeenLastCalledWith({ side: 'left', powered: false })
+    expect(guard.rearm).toHaveBeenCalledWith('left', expect.objectContaining({ alertId: 42 }))
+    expect(dbMock.update).not.toHaveBeenCalled()
+  })
+
+  it('still re-arms and warns when the post-failure park also fails', async () => {
+    guard.acknowledge.mockReturnValue({
+      restore: { targetTemperature: 71, durationSeconds: 5400 },
+      alertId: 42,
+    })
+    device.setTemperature.mockRejectedValueOnce(new Error('setpoint refused'))
+    device.setPower
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('park failed'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(caller.acknowledgeAndRestore({ side: 'left' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to restore side: setpoint refused',
+    })
+    expect(warn).toHaveBeenCalledWith('[pumpAlerts] failed to park side after partial restore:', 'park failed')
+    expect(guard.rearm).toHaveBeenCalledWith('left', expect.objectContaining({ alertId: 42 }))
+    expect(dbMock.update).not.toHaveBeenCalled()
   })
 
   describe('restart-orphaned alerts', () => {

--- a/tests/instrumentation.initialize.test.ts
+++ b/tests/instrumentation.initialize.test.ts
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   runMigrations: vi.fn(async () => undefined),
   seedDefaultData: vi.fn(async () => undefined),
   checkAndRepairIptables: vi.fn(() => ({ ok: true, repaired: [] })),
+  rehydratePumpStallGuard: vi.fn(),
 }))
 
 vi.mock('@/src/scheduler', () => ({
@@ -85,6 +86,9 @@ vi.mock('@/src/db/migrate', () => ({
 }))
 vi.mock('@/src/hardware/iptablesCheck', () => ({
   checkAndRepairIptables: mocks.checkAndRepairIptables,
+}))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  rehydrate: mocks.rehydratePumpStallGuard,
 }))
 
 const scheduler = {
@@ -142,7 +146,11 @@ describe('initializeScheduler — happy path', () => {
     expect(mocks.getJobManager).toHaveBeenCalled()
     expect(mocks.startDacServer).toHaveBeenCalled()
     expect(mocks.getDacMonitor).toHaveBeenCalled()
+    expect(mocks.rehydratePumpStallGuard).toHaveBeenCalled()
     expect(mocks.initializeKeepalives).toHaveBeenCalled()
+    // The guard must be re-armed before keepalives can consult shouldBlock.
+    expect(mocks.rehydratePumpStallGuard.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.initializeKeepalives.mock.invocationCallOrder[0] ?? 0)
     expect(mocks.startPiezoStreamServer).toHaveBeenCalled()
     expect(mocks.startMqttBridge).toHaveBeenCalled()
     expect(mocks.startAutoOffWatcher).toHaveBeenCalled()
@@ -203,6 +211,19 @@ describe('initializeScheduler — error swallowing', () => {
     const { initializeScheduler } = await fresh()
     await initializeScheduler()
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/Piezo stream server failed/), expect.anything())
+    warnSpy.mockRestore()
+  })
+
+  it('logs and swallows when pump stall guard rehydration throws', async () => {
+    mocks.rehydratePumpStallGuard.mockImplementationOnce((): never => {
+      throw new Error('bio db locked')
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+    expect(warnSpy).toHaveBeenCalledWith('[pumpStallGuard] rehydration failed:', 'bio db locked')
+    expect(mocks.initializeKeepalives).toHaveBeenCalled()
     warnSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Problem

Field report (eight-pod bundle, 2026-07-21): pump alerts 38/39 (`stall_left`/`stall_right`, `ack=null`) became permanently unacknowledgeable after an sp-update restarted the server. The guard's `activeAlertId` lives on `globalThis`, so `acknowledgeAndRestore` got `alertId=null` back, stamped nothing, and the rows sat in the `/api/pump-alerts` active list forever. The only remaining cleanup path was per-row `dismissAlert` by id from the diagnostics console.

## Fix

Root cause first: the guard now **rehydrates at startup**. For each side, the newest un-acknowledged, un-dismissed `power_off` row re-arms the in-memory block, restore snapshot, and banner notice (skipped when `pumpStallProtectionEnabled` is off), so after a restart the banner reappears and acknowledge/dismiss work through the normal in-memory path. Wired in `instrumentation.ts` before keepalives start; DB errors warn instead of crashing startup.

The acknowledge path was then hardened around it, following the adversarial-review findings:

- The orphan fallback now also selects the row's persisted `restoreTargetTemperature`/`restoreDurationSeconds` (ADR 0022) and replays them through the device router — but only when a status read shows the side still parked; a failed status read skips the replay conservatively. A failed orphan lookup now surfaces as `INTERNAL_SERVER_ERROR` instead of a silent success, the lookup orders by `desc(timestamp), desc(id)` for same-second determinism, and the response gained `orphanRecovered` so clients can tell a restart recovery from a plain no-op.
- `acknowledgedAt` is stamped only **after** both restore calls succeed. On restore failure the row stays active and the guard re-arms (new `pumpStallGuard.rearm`) with the original trip metadata, so the banner returns; a partial failure (power-on succeeded, setpoint failed) parks the side again before re-arming.
- `acknowledgeAndRestore` and `dismissNotification` accept an optional `alertId` (OpenAPI backward compatible); the banner passes the notice's id through both mutations, so a stale or replayed request stamps exactly the incident the user saw — including across restarts — instead of a newest-row guess. All stamp UPDATEs re-check `isNull(acknowledgedAt)`/`isNull(dismissedAt)` in the WHERE clause, mirroring `dismissAlert`'s guard against a concurrent dismiss.
- `trip()` no longer swallows a failed hardware power-off: cutoff-pending is tracked per side and retried on every subsequent frame until the command is confirmed sent.
- Banner: both actions disable while either mutation is pending, the container is `role="alert"`, the X button has an accessible name, and the dismiss comment now says what dismiss actually does (clears the notification and re-arms stall protection; the side stays off until the user powers it back on).

## Test plan

- `vitest run src/server/routers/tests/pumpAlerts.test.ts` — 41 pass: orphan replay (parked / already-powered / status-read-failure), stamp-after-restore ordering, re-arm on failure including the partial-restore park, client-id correlation for ack and dismiss, TOCTOU where-clauses, `desc(timestamp), desc(id)` ordering, lookup failure → 500. The DB mock now throws on any un-enqueued call.
- `vitest run src/hardware/tests/pumpStallGuard.test.ts` — 40 pass: rehydration (restores state+notice, skips when protection disabled, ignores acknowledged/dismissed/non-power_off rows, same-second id tiebreak, tolerates read failure), `rearm`, cutoff retry.
- New `PumpStallNotification.test.tsx` (6 pass) pins alert-id pass-through, dual-pending lockout, and the `role="alert"` contract; instrumentation tests pin rehydration running before keepalives and boot surviving a rehydration throw.
- Full suite: 3227 pass / 1 skipped. `pnpm tsc` and `pnpm lint` clean.
- Manual: on a pod with a stranded active alert, restart the server — the banner reappears; Re-enable restores the pre-stall setpoint and the row leaves the active list.

Refs: ygg `sleepypod-core-8`, PR #663.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pump-alert-ack-restart
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pump-alert-ack-restart/scripts/install \
  | sudo bash -s -- --branch fix/pump-alert-ack-restart
```

🎯 **Pin to this exact build** ([run 29812820241](https://github.com/sleepypod/core/actions/runs/29812820241) · `0649261`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/064926121a902b987431a8b12e371885609aee8f/scripts/install \
  | sudo bash -s -- \
      --branch fix/pump-alert-ack-restart \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/29812820241/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/29812820241/artifacts/8488141864) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alert acknowledgment after a guard restart when the in-memory alert reference is lost.
  - When appropriate, the app now locates and acknowledges the newest matching unresolved power-off alert for the affected side.
  - Recovery succeeds even if no matching alert is found or if the lookup fails, without blocking the operation.
- **Tests**
  - Expanded automated coverage for restart and orphaned-alert acknowledgment scenarios, including error-tolerant behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

