### PR TITLE
fix(hardware): pump-stall guard hardening — HomeKit gate, twitchy-trip, active recovery, scheduled reboot

### DIFF
--- a/docs/adr/0022-pump-stall-safety.md
+++ b/docs/adr/0022-pump-stall-safety.md
@@ -143,11 +143,41 @@ remains stall-driven; cross-check is for sensor sanity.
 
 ### Control intervention
 
-`pumpStallGuard.shouldBlock(side)` is consulted at three points:
+`pumpStallGuard.shouldBlock(side)` is consulted at every energizing
+ingress (inventory refreshed 2026-07-22; the original text listed only
+the first three device-router/keepalive points and went stale as new
+write surfaces landed — treat this list as the authoritative one and
+update it when adding an ingress):
 
-- `device.setTemperature` (`src/server/routers/device.ts:232`),
-- `device.setPower` when raising a side,
-- `temperatureKeepalive` re-issue path (`src/services/temperatureKeepalive.ts`).
+- **tRPC/REST** (via `assertPumpStallNotBlocked`, `src/server/helpers.ts`):
+  - `device.setTemperature` — pre-debounce ingress + re-check inside the
+    side lock (`src/server/routers/device.ts`),
+  - `device.setPower` when raising a side — ingress + in-lock re-check,
+  - `device.execute` — raw opcodes that energize a side, ingress +
+    in-lock re-check (left-before-right when SET_TEMP spans both sides),
+  - `runOnce.start` — before cancelling the prior session + re-check at
+    the write (`src/server/routers/runOnce.ts`).
+- **Scheduler** (`src/scheduler/jobManager.ts`, all inside the side lock):
+  recurring temperature jobs, recurring power-on jobs, away-return power
+  restore, and run-once set-point jobs skip a blocked side; alarm jobs
+  suppress the temperature push but still fire vibration (waking the
+  user is the alarm's purpose and moves no water).
+- **HomeKit** (`src/homekit/accessories/sideController.ts`):
+  `setSidePowerOn` — ingress + in-lock re-check; `setTargetTemperature`
+  — in-lock gate on the firmware push (staging a target on an off side
+  is not gated). Denials throw `NOT_ALLOWED_IN_CURRENT_STATE` so iOS
+  shows a refusal, not a bridge outage.
+- **Gestures** (`src/hardware/gestureActionHandler.ts`, in-lock):
+  temperature gestures and power-raising alarm-inactive toggles.
+- **Automation engine** (`src/automation/engine.ts`, injected via
+  `src/automation/instance.ts`): energizing rule actions are skipped on
+  a blocked side.
+- **Keepalive** (`src/services/temperatureKeepalive.ts`): the re-issue
+  path skips blocked sides.
+
+Read-only exposure (not a gate): the `health` router reports
+`guardBlocked` per side. Power-off writes are never gated anywhere — off
+is the safe direction and the guard's own trip path uses it.
 
 On a confirmed stall, the guard:
 

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -124,7 +124,19 @@ export function isEffectivelyPowered(monitor: DacMonitor, side: Side): boolean {
 export function reconcileIntendedPower(status: DeviceStatus, side: Side): void {
   const intended = intendedPower[side]
   if (intended === null) return
-  if (isPoweredFromStatus(status, side) === intended) {
+  const observed = isPoweredFromStatus(status, side)
+  if (observed === intended) {
+    intendedPower[side] = null
+    return
+  }
+  // A stall trip can land after a power-on was accepted but before any
+  // status frame confirms it: firmware keeps reporting OFF, so the ON latch
+  // would survive forever ("write in flight" never resolves). Once the guard
+  // clears, a mere slider drag would then compute powered=true from the
+  // stale latch and re-energize the side. Drop the latch only when the
+  // guard blocks the side AND firmware observes OFF — a normal in-flight
+  // ON (guard healthy) must keep its latch.
+  if (intended && !observed && pumpStallShouldBlock(side)) {
     intendedPower[side] = null
   }
 }

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -17,6 +17,8 @@
  * across off-cycles.
  */
 
+import { HapStatusError } from 'hap-nodejs'
+import type { HAPStatus } from 'hap-nodejs'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
 import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL } from '@/src/hardware/types'
@@ -24,6 +26,25 @@ import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getAutomationEngineIfRunning } from '@/src/automation'
 import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { withSideLock } from '@/src/hardware/sideLock'
+
+/**
+ * Guard denials surface as NOT_ALLOWED_IN_CURRENT_STATE (-70412): hap-nodejs
+ * maps any plain Error to SERVICE_COMMUNICATION_FAILURE (-70402), which iOS
+ * renders as a bridge outage rather than an intentional refusal. Message
+ * wording mirrors the REST path (server/helpers.ts) — the UI action is
+ * literally "Re-enable".
+ */
+// HAPStatus is an ambient const enum in hap-nodejs typings — inaccessible as
+// a value under isolatedModules, so pin the wire constant directly (asserted
+// numerically in sideController.test.ts).
+const NOT_ALLOWED_IN_CURRENT_STATE = -70412 as HAPStatus
+
+class GuardBlockedError extends HapStatusError {
+  constructor() {
+    super(NOT_ALLOWED_IN_CURRENT_STATE)
+    this.message = 'Pump stall protection active — re-enable the side first'
+  }
+}
 
 /**
  * HomeKit must honor the pump stall guard like every other write surface
@@ -35,7 +56,7 @@ import { withSideLock } from '@/src/hardware/sideLock'
 function assertNotGuardBlocked(side: Side, label: string): void {
   if (!pumpStallShouldBlock(side)) return
   console.warn(`[homekit] refused ${label} — pump stall protection active on ${side}`)
-  throw new Error('Pump stall protection active — acknowledge the alert first')
+  throw new GuardBlockedError()
 }
 
 const lastTargetF: Record<Side, number | null> = { left: null, right: null }
@@ -169,12 +190,10 @@ export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<v
   intendedPower[side] = true
   try {
     await withSideLock(side, async () => {
-      // Throw rather than silently skip: the catch below rolls intendedPower
-      // back so iOS Home reverts the toggle instead of showing a phantom ON.
-      if (pumpStallShouldBlock(side)) {
-        console.warn(`[homekit] skipped setPower(${side}, true): pump stall guard blocks ${side}`)
-        throw new Error(`pump stall protection active on ${side}`)
-      }
+      // Re-check inside the lock: a trip can land while this call is queued.
+      // Throw rather than silently skip: the catch below resets intendedPower
+      // so iOS Home reverts the toggle instead of showing a phantom ON.
+      assertNotGuardBlocked(side, `setPower(${side}, true)`)
       const target = clampF(getStagedTargetF(monitor, side))
       lastTargetF[side] = target
       registerManualOverride(side)

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -42,6 +42,10 @@ const NOT_ALLOWED_IN_CURRENT_STATE = -70412 as HAPStatus
 class GuardBlockedError extends HapStatusError {
   constructor() {
     super(NOT_ALLOWED_IN_CURRENT_STATE)
+    // The parent constructor pins the prototype to HapStatusError.prototype
+    // (its Error-subclass workaround), which breaks instanceof for further
+    // subclasses — restore ours so the rollback catch can identify us.
+    Object.setPrototypeOf(this, GuardBlockedError.prototype)
     this.message = 'Pump stall protection active — re-enable the side first'
   }
 }
@@ -204,7 +208,12 @@ export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<v
     })
   }
   catch (e) {
-    intendedPower[side] = prev
+    // A guard rejection means the side is definitively de-energized (the
+    // trip path forces power off), so latch false rather than restoring
+    // `prev`: with two blocked power-ons in flight, `prev` can be the other
+    // call's transient ON, and restoring it would resurrect a phantom ON
+    // with zero hardware writes.
+    intendedPower[side] = e instanceof GuardBlockedError ? false : prev
     throw e
   }
 }

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -165,6 +165,16 @@ export function getStagedTargetF(monitor: DacMonitor, side: Side): number {
  *   matches iOS Home thermostat-tile semantics. Power resumes through
  *   TargetHeatingCoolingState or the dedicated Power switch.
  *
+ * Requested-intent contract (PR #670 review, F1 — decided 2026-07-22): the
+ * cache retains the requested value even when the pump-stall gate rejects
+ * the firmware push. iOS Home shows the slider reverting (HAP keeps the
+ * characteristic at oldValue on rejection) while the staged value survives
+ * and applies on the next explicit power-on. This is deliberate: lastTargetF
+ * records what the user asked for, not what firmware confirmed, and heating
+ * to it requires a separate deliberate power-on after the side is re-enabled.
+ * The web UI's pump-stall alert card — the only surface that can re-enable
+ * the side — is where the staged/visible mismatch gets surfaced.
+ *
  * f is captured in closure so back-to-back drags of the slider each push
  * their own value, even though the cache only retains the latest.
  */

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -23,6 +23,20 @@ import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL } from '@/src/hardware/types'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getAutomationEngineIfRunning } from '@/src/automation'
 import { withSideLock } from '@/src/hardware/sideLock'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
+
+/**
+ * HomeKit must honor the pump stall guard like every other write surface
+ * (device router, keepalive). Without this gate a guard-blocked side could
+ * be silently re-powered from the Home app — re-heating a side with zero
+ * flow and defeating the fail-safe. Powering OFF is never gated: it is the
+ * safe direction and the guard's own trip path uses it.
+ */
+function assertNotGuardBlocked(side: Side, label: string): void {
+  if (!pumpStallShouldBlock(side)) return
+  console.warn(`[homekit] refused ${label} — pump stall protection active on ${side}`)
+  throw new Error('Pump stall protection active — acknowledge the alert first')
+}
 
 const lastTargetF: Record<Side, number | null> = { left: null, right: null }
 
@@ -128,6 +142,10 @@ export async function setTargetTemperature(
     const intended = intendedPower[side]
     const powered = intended !== null ? intended : isCurrentlyPowered(monitor, side)
     if (!powered) return
+    // Gate only the firmware push: staging a target on an off side is
+    // harmless, and the guard trip leaves the intent latch stuck ON
+    // (firmware never confirms), so `powered` alone can't be trusted here.
+    assertNotGuardBlocked(side, `setTemperature(${side}, ${f})`)
     registerManualOverride(side)
     await logged(
       `setTemperature(${side}, ${f})`,
@@ -146,6 +164,7 @@ export async function setTargetTemperature(
  * that the failed power-on left in an unknown state.
  */
 export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<void> {
+  assertNotGuardBlocked(side, `setPower(${side}, true)`)
   const prev = intendedPower[side]
   intendedPower[side] = true
   try {

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -443,6 +443,40 @@ describe('sideController', () => {
       warn.mockRestore()
     })
 
+    it('concurrent power-ons rejected in-lock cannot resurrect the ON intent latch', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let release: () => void = () => {}
+      const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await Promise.resolve()
+
+      try {
+        // Both calls pass the ingress assert while the guard is healthy and
+        // queue behind the held lock; the second snapshots the first call's
+        // transient ON as its rollback value. The trip lands strictly after.
+        const first = setSidePowerOn(monitor(offStatus), 'left')
+        const second = setSidePowerOn(monitor(offStatus), 'left')
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        shouldBlock.mockReturnValue(true)
+        release()
+        await holder
+        await expect(first).rejects.toThrow('Pump stall protection active')
+        await expect(second).rejects.toThrow('Pump stall protection active')
+
+        expect(setPower).not.toHaveBeenCalled()
+        // Neither rollback may restore the other call's transient true —
+        // iOS Home must read OFF, not a phantom ON with zero hardware writes.
+        expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+      }
+      finally {
+        release()
+        warn.mockRestore()
+      }
+    })
+
     it('setTargetTemperature refuses the firmware push on a blocked powered side but still caches the target', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       shouldBlock.mockReturnValue(true)

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -360,6 +360,25 @@ describe('sideController', () => {
       expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(true)
     })
 
+    it('drops a stale ON latch when the guard tripped before firmware ever confirmed the power-on', async () => {
+      // Power-on accepted while healthy; the trip lands before any status
+      // frame reports ON, so firmware keeps saying OFF and the ON intent
+      // would otherwise read as "write in flight" forever.
+      await setSidePowerOn(monitor(offStatus), 'left')
+      shouldBlock.mockReturnValue(true)
+
+      reconcileIntendedPower(offStatus, 'left')
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+
+      // Guard clears (user acknowledged). A slider drag on the still-off
+      // side must stage only — the stale latch must not re-energize it.
+      shouldBlock.mockReturnValue(false)
+      setTemperature.mockClear()
+      await setTargetTemperature(monitor(offStatus), 'left', 72)
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(getStagedTargetF(monitor(offStatus), 'left')).toBe(72)
+    })
+
     it('after reconciliation, setTargetTemperature no longer re-heats a scheduler-stopped side', async () => {
       await setSidePowerOn(monitor(offStatus), 'left')
       reconcileIntendedPower(onStatus, 'left') // firmware confirmed ON
@@ -489,9 +508,10 @@ describe('sideController', () => {
 
     it('setTargetTemperature refuses when the trip left the intent latch stuck ON', async () => {
       // Real-stall scenario: HomeKit powered the side on, the guard tripped
-      // (firmware now off, side blocked). reconcileIntendedPower never clears
-      // the latch because firmware never confirms ON — so the push path
-      // computes powered=true from the latch and must be stopped by the gate.
+      // (firmware now off, side blocked). reconcileIntendedPower only drops
+      // the stale latch on the next status frame — until one arrives, the
+      // push path computes powered=true from the latch and must be stopped
+      // by the gate.
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       await setSidePowerOn(monitor(offStatus), 'left')
       setTemperature.mockClear()

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -414,7 +414,13 @@ describe('sideController', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       shouldBlock.mockReturnValue(true)
 
-      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
+      // hapStatus -70412 (NOT_ALLOWED_IN_CURRENT_STATE): hap-nodejs surfaces
+      // it to iOS as a refusal instead of mapping a plain Error to the
+      // generic SERVICE_COMMUNICATION_FAILURE (-70402) bridge-outage status.
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toMatchObject({
+        message: 'Pump stall protection active — re-enable the side first',
+        hapStatus: -70412,
+      })
       expect(setPower).not.toHaveBeenCalled()
       expect(registerManualOverride).not.toHaveBeenCalled()
       // Latch must stay untouched so onGet keeps reporting the true (off) state.
@@ -428,10 +434,10 @@ describe('sideController', () => {
       // section runs — the in-lock re-check must still refuse the write.
       shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
 
-      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('pump stall protection active on left')
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
 
       expect(setPower).not.toHaveBeenCalled()
-      expect(warn).toHaveBeenCalledWith('[homekit] skipped setPower(left, true): pump stall guard blocks left')
+      expect(warn).toHaveBeenCalledWith('[homekit] refused setPower(left, true) — pump stall protection active on left')
       // Intent rolled back — iOS Home reads OFF again instead of a phantom ON.
       expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
       warn.mockRestore()

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -433,10 +433,15 @@ describe('sideController', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       shouldBlock.mockReturnValue(true)
 
+      const pending = setSidePowerOn(monitor(offStatus), 'left')
+      // Latch must stay untouched even while the refused call is still
+      // pending — a transient ON here would leak through a concurrent onGet.
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+
       // hapStatus -70412 (NOT_ALLOWED_IN_CURRENT_STATE): hap-nodejs surfaces
       // it to iOS as a refusal instead of mapping a plain Error to the
       // generic SERVICE_COMMUNICATION_FAILURE (-70402) bridge-outage status.
-      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toMatchObject({
+      await expect(pending).rejects.toMatchObject({
         message: 'Pump stall protection active — re-enable the side first',
         hapStatus: -70412,
       })
@@ -449,17 +454,65 @@ describe('sideController', () => {
 
     it('setSidePowerOn re-checks inside the lock and rolls back intent when a trip lands while queued', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      // Guard is clear at the ingress assert, then trips before the locked
-      // section runs — the in-lock re-check must still refuse the write.
-      shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+      let release: () => void = () => {}
+      const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await Promise.resolve()
 
-      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
+      try {
+        // The call passes the ingress assert while the guard is healthy and
+        // queues behind the held lock — the trip below lands strictly after,
+        // so only the in-lock re-check can refuse the write.
+        const pending = setSidePowerOn(monitor(offStatus), 'left')
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        shouldBlock.mockReturnValue(true)
+        release()
+        await holder
+        await expect(pending).rejects.toThrow('Pump stall protection active')
 
-      expect(setPower).not.toHaveBeenCalled()
-      expect(warn).toHaveBeenCalledWith('[homekit] refused setPower(left, true) — pump stall protection active on left')
-      // Intent rolled back — iOS Home reads OFF again instead of a phantom ON.
-      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
-      warn.mockRestore()
+        expect(setPower).not.toHaveBeenCalled()
+        expect(registerManualOverride).not.toHaveBeenCalled()
+        expect(warn).toHaveBeenCalledWith('[homekit] refused setPower(left, true) — pump stall protection active on left')
+        // Intent rolled back — iOS Home reads OFF again instead of a phantom ON.
+        expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+      }
+      finally {
+        release()
+        warn.mockRestore()
+      }
+    })
+
+    it('setTargetTemperature refuses when a trip lands while the push is queued on the side lock', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let release: () => void = () => {}
+      const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await Promise.resolve()
+
+      try {
+        // Side is powered and the guard is healthy at submission; the trip
+        // lands while the push waits on the lock. The in-lock gate is the
+        // only check on this path and must refuse the write.
+        const pending = setTargetTemperature(monitor(onStatus), 'left', 68)
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        shouldBlock.mockReturnValue(true)
+        release()
+        await holder
+        await expect(pending).rejects.toThrow('Pump stall protection active')
+
+        expect(setTemperature).not.toHaveBeenCalled()
+        expect(registerManualOverride).not.toHaveBeenCalled()
+      }
+      finally {
+        release()
+        warn.mockRestore()
+      }
     })
 
     it('concurrent power-ons rejected in-lock cannot resurrect the ON intent latch', async () => {
@@ -502,6 +555,9 @@ describe('sideController', () => {
 
       await expect(setTargetTemperature(monitor(onStatus), 'left', 68)).rejects.toThrow('Pump stall protection active')
       expect(setTemperature).not.toHaveBeenCalled()
+      // A rejected write must not suspend autopilot (same ordering contract
+      // as the REST path: the override registers only after the gate passes).
+      expect(registerManualOverride).not.toHaveBeenCalled()
       expect(getStagedTargetF(monitor(onStatus), 'left')).toBe(68)
       warn.mockRestore()
     })
@@ -538,11 +594,13 @@ describe('sideController', () => {
     })
 
     it('consults the guard for the specific side being written', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       shouldBlock.mockImplementation((side: 'left' | 'right') => side === 'left')
 
       await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
       await setSidePowerOn(monitor(offStatus), 'right')
       expect(setPower).toHaveBeenCalledWith('right', true, expect.any(Number))
+      warn.mockRestore()
     })
   })
 })

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -3,12 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const setTemperature = vi.fn()
 const setPower = vi.fn()
 const registerManualOverride = vi.fn()
+const shouldBlock = vi.fn<(side: 'left' | 'right') => boolean>()
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: () => ({ setTemperature, setPower }),
 }))
 vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
+}))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: (side: 'left' | 'right') => shouldBlock(side),
 }))
 
 import {
@@ -50,8 +54,10 @@ describe('sideController', () => {
     setTemperature.mockReset()
     setPower.mockReset()
     registerManualOverride.mockReset()
+    shouldBlock.mockReset()
     setTemperature.mockResolvedValue(undefined)
     setPower.mockResolvedValue(undefined)
+    shouldBlock.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -400,6 +406,68 @@ describe('sideController', () => {
       await setTargetTemperature(monitor(onStatus), 'left', 72)
       expect(setTemperature).toHaveBeenCalledWith('left', 72)
       warn.mockRestore()
+    })
+  })
+
+  describe('pump stall guard gate', () => {
+    it('setSidePowerOn refuses a guard-blocked side without touching hardware or the intent latch', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      shouldBlock.mockReturnValue(true)
+
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
+      expect(setPower).not.toHaveBeenCalled()
+      expect(registerManualOverride).not.toHaveBeenCalled()
+      // Latch must stay untouched so onGet keeps reporting the true (off) state.
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+      warn.mockRestore()
+    })
+
+    it('setTargetTemperature refuses the firmware push on a blocked powered side but still caches the target', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      shouldBlock.mockReturnValue(true)
+
+      await expect(setTargetTemperature(monitor(onStatus), 'left', 68)).rejects.toThrow('Pump stall protection active')
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(getStagedTargetF(monitor(onStatus), 'left')).toBe(68)
+      warn.mockRestore()
+    })
+
+    it('setTargetTemperature refuses when the trip left the intent latch stuck ON', async () => {
+      // Real-stall scenario: HomeKit powered the side on, the guard tripped
+      // (firmware now off, side blocked). reconcileIntendedPower never clears
+      // the latch because firmware never confirms ON — so the push path
+      // computes powered=true from the latch and must be stopped by the gate.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      await setSidePowerOn(monitor(offStatus), 'left')
+      setTemperature.mockClear()
+
+      shouldBlock.mockReturnValue(true)
+      await expect(setTargetTemperature(monitor(offStatus), 'left', 72)).rejects.toThrow('Pump stall protection active')
+      expect(setTemperature).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('setTargetTemperature still stages silently on a blocked side that is off with no latch', async () => {
+      shouldBlock.mockReturnValue(true)
+
+      await expect(setTargetTemperature(monitor(offStatus), 'left', 66)).resolves.toBeUndefined()
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(getStagedTargetF(monitor(offStatus), 'left')).toBe(66)
+    })
+
+    it('setSidePowerOff is never gated', async () => {
+      shouldBlock.mockReturnValue(true)
+
+      await setSidePowerOff(monitor(onStatus), 'left')
+      expect(setPower).toHaveBeenCalledWith('left', false)
+    })
+
+    it('consults the guard for the specific side being written', async () => {
+      shouldBlock.mockImplementation((side: 'left' | 'right') => side === 'left')
+
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
+      await setSidePowerOn(monitor(offStatus), 'right')
+      expect(setPower).toHaveBeenCalledWith('right', true, expect.any(Number))
     })
   })
 })

--- a/src/homekit/tests/thermostat.test.ts
+++ b/src/homekit/tests/thermostat.test.ts
@@ -4,6 +4,7 @@ import { Characteristic } from 'hap-nodejs'
 const setTemperature = vi.fn().mockResolvedValue(undefined)
 const setPower = vi.fn().mockResolvedValue(undefined)
 const registerManualOverride = vi.fn()
+const shouldBlock = vi.fn<() => boolean>().mockReturnValue(false)
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: () => ({ setTemperature, setPower }),
@@ -12,7 +13,7 @@ vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
 }))
 vi.mock('@/src/hardware/pumpStallGuard', () => ({
-  shouldBlock: () => false,
+  shouldBlock: () => shouldBlock(),
 }))
 
 import { buildThermostatService } from '../accessories/thermostat'
@@ -43,6 +44,8 @@ describe('thermostat accessory', () => {
     setTemperature.mockClear()
     setPower.mockClear()
     registerManualOverride.mockClear()
+    shouldBlock.mockReset()
+    shouldBlock.mockReturnValue(false)
   })
 
   it.each(['left', 'right'] as const)('uses stable metadata for the %s side', (side) => {
@@ -149,6 +152,37 @@ describe('thermostat accessory', () => {
     const [, f] = setTemperature.mock.calls[0]
     expect(f).toBeGreaterThan(64)
     expect(f).toBeLessThan(66)
+  })
+
+  it('a guard-rejected TargetTemperature keeps HAP at oldValue but retains the requested intent for the next power-on', async () => {
+    // Requested-intent contract (PR #670 review F1, decided 2026-07-22):
+    // hap-nodejs assigns Characteristic.value only when onSet resolves, so a
+    // gated rejection leaves the visible slider at its old value while the
+    // staged cache advances. The staged value must survive the rejection and
+    // apply on the next explicit power-on after the side is re-enabled.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { service } = buildThermostatService('left', fakeMonitor as DacMonitor)
+    const target = service.getCharacteristic(Characteristic.TargetTemperature)
+    // Seed the visible value the way a live bridge would (status push): 77°F.
+    target.updateValue(f2c(77))
+
+    shouldBlock.mockReturnValue(true)
+    // Left fixture is powered (targetLevel -45), so the push is gated. At the
+    // HAP boundary handleSetRequest rejects with the raw status number: -70412
+    // (NOT_ALLOWED_IN_CURRENT_STATE), not a generic communication failure.
+    await expect(target.handleSetRequest(f2c(95))).rejects.toBe(-70412)
+
+    // Visible characteristic froze at oldValue (tolerance covers hap-nodejs's
+    // minStep grid rounding); nothing reached hardware.
+    expect(Math.abs((target.value as number) - f2c(77))).toBeLessThan(0.5)
+    expect(setTemperature).not.toHaveBeenCalled()
+
+    // Side re-enabled; an explicit power-on heats to the retained 95°F —
+    // the requested intent, not the 77°F the slider visibly reverted to.
+    shouldBlock.mockReturnValue(false)
+    await service.getCharacteristic(Characteristic.TargetHeatingCoolingState).handleSetRequest(3)
+    expect(setPower).toHaveBeenCalledWith('left', true, 95)
+    warn.mockRestore()
   })
 
   it('CurrentHeatingCoolingState reflects targetLevel sign', async () => {


### PR DESCRIPTION
> **This PR bundles four pump-stall guard changes.** The original HomeKit gate (§1), plus three fixes from a 2026-07-29 field report: the daily reboot never ran, the guard tripped on ~2s glitches, and auto-recovery could never fire overnight.

---

## 1. HomeKit gate (original)

Field report (eight-pod bundle, 2026-07-21): with both sides guard-blocked, the web UI correctly refused power/temp commands (PRECONDITION_FAILED at `device.ts:325/437`), but adjusting the thermostat in the Home app silently re-powered the side — `sideController` wrote straight to the shared hardware client with no `shouldBlock` consultation. With a genuine stall this bypass lets a user keep re-heating a side with zero flow, defeating the fail-safe.

`setSidePowerOn` and `setTargetTemperature`'s firmware-push path now refuse when `pumpStallGuard.shouldBlock(side)` is true, matching the device router and keepalive. `setSidePowerOn` refuses before touching the intent latch (onGet keeps reporting the true off state); `setTargetTemperature` still caches the requested target (staging on an off side stays allowed) but gates the hardware push, covering the stuck-latch case where `reconcileIntendedPower` never clears a latched ON after a trip; `setSidePowerOff` is never gated (safe direction, used by the guard's own trip path). The thrown error rejects the HAP onSet so Home surfaces the failed write. A follow-up commit surfaces the guard-blocked staged target on the alert card.

## 2. Scheduled reboot runs as the `sleepypod` user

The daily / pre-prime reboot jobs shelled `systemctl reboot`, but next-server runs as `User=sleepypod`, which can't reboot directly — the command failed interactive-auth and the pod never rebooted on schedule (observed: 5-day uptime with `reboot_daily` on; `pre-prime-calibration` and `daily-prime` ran fine). `executeReboot` now shells `sudo -n systemctl reboot` via a NOPASSWD rule the installer adds to `/etc/sudoers.d/sleepypod-update`, scoped to exactly `systemctl reboot` and mirroring `system.triggerUpdate`.

`sp-maintenance` re-applies the sudoers rule (idempotently, best-effort) on every service start, and `sp-update` installs the new `sp-maintenance` before it restarts the service — so **`sp-update <branch>` is enough** for already-installed pods; no full reinstall needed.

## 3. Twitchy trip hardening

The guard powered a side off (and, without recovery, kept it off all night) on ~2 seconds of bad readings — e.g. a single frame where **both** sides read exactly 0 RPM while flow/loop-temp kept moving, both healthy again a minute later. Two independent fixes:

- **Bilateral-zero de-glitch** (`deviceStateSync`): both pumps dropping from clearly running to exactly 0 RPM in one frame is the dropped/garbled-frame signature, not a real dual stall — which hits one side. That single frame is suppressed so neither dwell counter advances; a sustained dual-stall still trips one frame later.
- **Time-based dwell floor** (`pumpStallGuard`): a trip now requires the pump to stay sub-threshold for both `dwellSamples` frames **and** `DWELL_MIN_MS` (10s) of wall clock, so a brief low burst can't end a night. Frame time is threaded through `onFrame` so the floor is driven by frame arrival and stays deterministic under test.

## 4. Active-probe auto-recovery

`pumpStallAutoRecoveryEnabled` was inert for the case that matters. A trip powers the pump off, so RPM sits at 0 forever and the "recoverySamples consecutive healthy frames" watcher never advances — nothing re-energizes the pump to let it prove itself. Daytime trips only recovered because the daily prime or a manual restart happened to spin the pump up; overnight trips stayed `power_off` until morning (field trace: trip 02:16 → 0 RPM for 11.7 h → 14:00 prime).

The guard now **actively probes**: a blocked side with auto-recovery enabled is re-energized after a backoff (5 m → 15 m → 30 m); sustained healthy RPM restores it via the existing `autoRecover` path, otherwise the probe is powered back off and the next backoff applies, staying off after the last attempt until acknowledged. Probe energize / de-energize serialize through `withSideLock`. ADR 0022 gains a Revisions section for §3–§4.

## Test plan

- **Full unit suite: 3330 pass / 0 fail.** `tsc` and `eslint` clean.
- `vitest run src/hardware/tests/pumpStallGuard.test.ts` — 59 pass, incl. 4 time-dwell-floor cases and 6 active-probe cases (backoff timing, restore on spin-up, power-off + give-up after 3 attempts, no-snapshot, energize-failure, side-lock serialization).
- `vitest run src/hardware/tests/deviceStateSync.stallSuppression.test.ts` — 4 new bilateral-zero cases (drop after both-running, feed sustained zero, single-side not suppressed, cold-start not suppressed).
- `vitest run src/scheduler/tests/` — reboot command pinned to `sudo -n systemctl reboot`.
- Manual (§1): trip the guard and try powering the side on from Home — write fails, pump stays off; acknowledge, control returns.

Refs: ygg `sleepypod-core-7`, PR #663; field report Discord 2026-07-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/homekit-stall-guard-gate
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/homekit-stall-guard-gate/scripts/install \
  | sudo bash -s -- --branch fix/homekit-stall-guard-gate
```

🎯 **Pin to this exact build** ([run 29962457341](https://github.com/sleepypod/core/actions/runs/29962457341) · `c20e7ec`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/c20e7ec520996395150cbf69c571f0e6048afb70/scripts/install \
  | sudo bash -s -- \
      --branch fix/homekit-stall-guard-gate \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/29962457341/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/29962457341/artifacts/8546532306) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->




