### PR TITLE
fix(streaming): include pump-stall notices in WebSocket status frames

### DIFF
--- a/src/hardware/dacMonitor.instance.ts
+++ b/src/hardware/dacMonitor.instance.ts
@@ -23,6 +23,7 @@ import { GestureActionHandler } from './gestureActionHandler'
 import { defaultGestureActionDeps } from './gestureActionHandler.deps'
 import { DeviceStateSync, getAlarmState } from './deviceStateSync'
 import { trackPrimingState, resetPrimingState, getPrimeCompletedAt } from './primeNotification'
+import { getAllPumpStallNotices } from './pumpStallNotification'
 import { cancelSnooze, getSnoozeStatus } from './snoozeManager'
 import { clearSharedHardwareClient, getSharedHardwareClient } from './sharedClient'
 
@@ -98,6 +99,7 @@ export const getDacMonitor = async (): Promise<DacMonitor> => {
         import('../streaming/piezoStream').then(({ broadcastFrame }) => {
           const primeCompletedAt = getPrimeCompletedAt()
           const alarmState = getAlarmState()
+          const stallNotices = getAllPumpStallNotices()
           broadcastFrame({
             type: 'deviceStatus',
             ts: Date.now(),
@@ -106,6 +108,7 @@ export const getDacMonitor = async (): Promise<DacMonitor> => {
             waterLevel: status.waterLevel,
             isPriming: status.isPriming,
             ...(primeCompletedAt && { primeCompletedNotification: { timestamp: primeCompletedAt } }),
+            ...((stallNotices.left || stallNotices.right) && { pumpStallNotifications: stallNotices }),
             snooze: {
               left: getSnoozeStatus('left'),
               right: getSnoozeStatus('right'),

--- a/src/hardware/dacMonitor.ts
+++ b/src/hardware/dacMonitor.ts
@@ -39,7 +39,8 @@ const IDLE_POLL_INTERVAL_MS = 5000
 const TAP_TYPES = ['doubleTap', 'tripleTap', 'quadTap'] as const
 
 /**
- * Polls the hardware daemon at a fixed interval and emits typed events.
+ * Polls the hardware daemon on an adaptive interval — 1s active / 2s default /
+ * 5s idle, switched via setActive/setIdle — and emits typed events.
  * No database access. No action execution. Observe and publish only.
  *
  * Lifecycle: stopped → starting → running ↔ degraded

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -102,6 +102,8 @@ export class DeviceStateSync {
   private lastSideStatus: Record<Side, { targetLevel: number, heatingDuration: number, at: number } | null> = { left: null, right: null }
   private isPriming = false
   private primeEndedAt = 0
+  private stallGuardInFlight: Record<Side, boolean> = { left: false, right: false }
+  private stallGuardPending: Record<Side, { rpm: number, duty: number | null } | null> = { left: null, right: null }
 
   sync = async (status: DeviceStatus): Promise<void> => {
     const now = Date.now()
@@ -300,6 +302,33 @@ export class DeviceStateSync {
       && remaining >= -SESSION_END_STALE_S
   }
 
+  /**
+   * Feed the stall guard, coalesced to one in-flight call per side. A guard
+   * pass can hold the side lock for a full DAC timeout (cutoff / retry /
+   * recovery); frames keep arriving during that window, and running them
+   * concurrently would stack duplicate transitions on the sequential
+   * transport. Only the newest frame received while busy is kept.
+   */
+  private queueStallGuard(side: Side, rpm: number, duty: number | null): void {
+    if (this.stallGuardInFlight[side]) {
+      this.stallGuardPending[side] = { rpm, duty }
+      return
+    }
+    this.stallGuardInFlight[side] = true
+    void (async () => {
+      // runStallGuard never throws (it catches internally), so this chain
+      // always releases the in-flight flag.
+      await this.runStallGuard(side, rpm, duty)
+      let next = this.stallGuardPending[side]
+      while (next) {
+        this.stallGuardPending[side] = null
+        await this.runStallGuard(side, next.rpm, next.duty)
+        next = this.stallGuardPending[side]
+      }
+      this.stallGuardInFlight[side] = false
+    })()
+  }
+
   /** Look up the side's commanded state and feed the pump stall guard. */
   private async runStallGuard(side: Side, rpm: number, duty: number | null): Promise<void> {
     try {
@@ -348,8 +377,8 @@ export class DeviceStateSync {
     // Feed the per-side stall guard. Reads current device_state to derive
     // expectedActive — a side that's commanded off should not trip on
     // RPM = 0 since that is the correct value.
-    void this.runStallGuard('left', leftRpm, leftPump.duty)
-    void this.runStallGuard('right', rightRpm, rightPump.duty)
+    this.queueStallGuard('left', leftRpm, leftPump.duty)
+    this.queueStallGuard('right', rightRpm, rightPump.duty)
 
     // Pump running but flowrate missing — possible sensor fault
     if (leftRpm >= PUMP_FAILURE_RPM_MIN && Number.isNaN(leftFlowCd)) {

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -316,16 +316,21 @@ export class DeviceStateSync {
     }
     this.stallGuardInFlight[side] = true
     void (async () => {
-      // runStallGuard never throws (it catches internally), so this chain
-      // always releases the in-flight flag.
-      await this.runStallGuard(side, rpm, duty)
-      let next = this.stallGuardPending[side]
-      while (next) {
-        this.stallGuardPending[side] = null
-        await this.runStallGuard(side, next.rpm, next.duty)
-        next = this.stallGuardPending[side]
+      // runStallGuard catches internally today; finally guarantees the
+      // in-flight flag is released even if that ever changes — a leaked
+      // flag would silently stop feeding the guard for this side.
+      try {
+        await this.runStallGuard(side, rpm, duty)
+        let next = this.stallGuardPending[side]
+        while (next) {
+          this.stallGuardPending[side] = null
+          await this.runStallGuard(side, next.rpm, next.duty)
+          next = this.stallGuardPending[side]
+        }
       }
-      this.stallGuardInFlight[side] = false
+      finally {
+        this.stallGuardInFlight[side] = false
+      }
     })()
   }
 

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -23,6 +23,7 @@ import { pumpAlerts } from '@/src/db/biometrics-schema'
 import { deviceSettings, deviceState } from '@/src/db/schema'
 import { getSharedHardwareClient } from '@/src/hardware/sharedClient'
 import { clearPumpStallNotice, setPumpStallNotice } from './pumpStallNotification'
+import { withSideLock } from './sideLock'
 import type { Side } from './types'
 
 interface GuardState {
@@ -174,8 +175,10 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
   // the command is confirmed sent; the alert row already says power_off.
   if (state.cutoffPending) {
     try {
-      const client = getSharedHardwareClient()
-      await client.setPower(input.side, false)
+      await withSideLock(input.side, async () => {
+        const client = getSharedHardwareClient()
+        await client.setPower(input.side, false)
+      })
       state.cutoffPending = false
     }
     catch (err) {
@@ -355,18 +358,10 @@ async function trip(side: Side, rpm: number): Promise<void> {
     }
   }
 
-  // Power-off via the shared hardware client, bypassing the router gate
-  // (the gate consults shouldBlock(side), which is already true).
-  try {
-    const client = getSharedHardwareClient()
-    await client.setPower(side, false)
-  }
-  catch (err) {
-    state.cutoffPending = true
-    console.error('[pumpStallGuard] hardware power-off failed:', err instanceof Error ? err.message : err)
-  }
-
-  // Mirror the database state so getStatus / UI reflect the fail-safe.
+  // Mirror the database state before the hardware write — same ordering as
+  // the router power-off path (see sideLock.ts): a queued same-side writer
+  // that acquires the lock after the cutoff observes isPowered=false and
+  // skips.
   try {
     db
       .update(deviceState)
@@ -406,6 +401,10 @@ async function trip(side: Side, rpm: number): Promise<void> {
 
   state.activeAlertId = alertId || null
 
+  // Publish the banner before any await: against unresponsive firmware the
+  // cutoff below can block for the full DAC timeout, and commands rejected
+  // during that window need the notice to explain why. An acknowledge()
+  // racing the cutoff clears the notice after this point, so it always wins.
   setPumpStallNotice(side, {
     alertId,
     trippedAt: Math.floor(state.trippedAt / 1000),
@@ -414,6 +413,23 @@ async function trip(side: Side, rpm: number): Promise<void> {
   })
 
   console.warn(`[pumpStallGuard] tripped ${side} at ${rpm} rpm — powering off until acknowledged`)
+
+  // Power-off via the shared hardware client, bypassing the router gate
+  // (the gate consults shouldBlock(side), which is already true). Serialized
+  // through withSideLock so the cutoff cannot interleave with a queued
+  // same-side writer's command sequence. Deadlock analysis: trip() is only
+  // reachable from the frame path (deviceStateSync.runStallGuard → onFrame),
+  // never from a caller already holding the same-side lock.
+  try {
+    await withSideLock(side, async () => {
+      const client = getSharedHardwareClient()
+      await client.setPower(side, false)
+    })
+  }
+  catch (err) {
+    state.cutoffPending = true
+    console.error('[pumpStallGuard] hardware power-off failed:', err instanceof Error ? err.message : err)
+  }
 }
 
 async function autoRecover(side: Side): Promise<void> {
@@ -426,10 +442,15 @@ async function autoRecover(side: Side): Promise<void> {
     return
   }
 
+  // Same lock + deadlock rationale as the trip() cutoff: only reachable from
+  // the frame path, and the restore sequence must not interleave with a
+  // queued same-side writer.
   try {
-    const client = getSharedHardwareClient()
-    await client.setPower(side, true, restore.targetTemperature)
-    await client.setTemperature(side, restore.targetTemperature, restore.durationSeconds)
+    await withSideLock(side, async () => {
+      const client = getSharedHardwareClient()
+      await client.setPower(side, true, restore.targetTemperature)
+      await client.setTemperature(side, restore.targetTemperature, restore.durationSeconds)
+    })
   }
   catch (err) {
     console.error('[pumpStallGuard] auto-recover hardware call failed:', err instanceof Error ? err.message : err)

--- a/src/hardware/tests/dacMonitor.instance.test.ts
+++ b/src/hardware/tests/dacMonitor.instance.test.ts
@@ -90,6 +90,7 @@ const cancelSnoozeMock = vi.fn<(side: 'left' | 'right') => void>()
 const resetPrimingStateMock = vi.fn()
 const trackPrimingStateMock = vi.fn<(priming: boolean) => void>()
 const getPrimeCompletedAtMock = vi.fn(() => null as number | null)
+const getAllPumpStallNoticesMock = vi.fn<() => { left: unknown, right: unknown }>(() => ({ left: null, right: null }))
 const getAlarmStateMock = vi.fn(() => ({ left: false, right: false }))
 const getSnoozeStatusMock = vi.fn<(side: 'left' | 'right') => { active: boolean, snoozeUntil: number | null }>(
   () => ({ active: false, snoozeUntil: null }),
@@ -128,6 +129,10 @@ vi.mock('../primeNotification', () => ({
   trackPrimingState: (priming: boolean) => trackPrimingStateMock(priming),
   resetPrimingState: () => resetPrimingStateMock(),
   getPrimeCompletedAt: () => getPrimeCompletedAtMock(),
+}))
+
+vi.mock('../pumpStallNotification', () => ({
+  getAllPumpStallNotices: () => getAllPumpStallNoticesMock(),
 }))
 
 vi.mock('../snoozeManager', () => ({
@@ -197,6 +202,7 @@ describe('hardware/dacMonitor.instance', () => {
     resetPrimingStateMock.mockClear()
     trackPrimingStateMock.mockClear()
     getPrimeCompletedAtMock.mockReset().mockReturnValue(null)
+    getAllPumpStallNoticesMock.mockReset().mockReturnValue({ left: null, right: null })
     getAlarmStateMock.mockReset().mockReturnValue({ left: false, right: false })
     getSnoozeStatusMock.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
     broadcastFrameMock.mockClear()
@@ -592,6 +598,38 @@ describe('hardware/dacMonitor.instance', () => {
       const lastFrame = broadcastFrameMock.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
       expect(lastFrame).toBeDefined()
       expect(lastFrame?.primeCompletedNotification).toEqual({ timestamp: 123_456 })
+    })
+
+    it('status:updated includes pumpStallNotifications when one side has an active notice', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+      const notice = { alertId: 42, trippedAt: 1_700_000_000, rpm: 0, restore: null }
+      getAllPumpStallNoticesMock.mockReturnValue({ left: null, right: notice })
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw')
+      monitor.emit('status:updated', status)
+      await flushMicrotasks()
+
+      const lastFrame = broadcastFrameMock.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+      expect(lastFrame).toBeDefined()
+      expect(lastFrame?.pumpStallNotifications).toEqual({ left: null, right: notice })
+    })
+
+    it('status:updated omits pumpStallNotifications when both sides are null', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw')
+      monitor.emit('status:updated', status)
+      await flushMicrotasks()
+
+      const lastFrame = broadcastFrameMock.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+      expect(lastFrame).toBeDefined()
+      expect(lastFrame && 'pumpStallNotifications' in lastFrame).toBe(false)
     })
 
     it('status:updated does NOT crash when trackPrimingState throws', async () => {

--- a/src/hardware/tests/dacMonitor.instance.test.ts
+++ b/src/hardware/tests/dacMonitor.instance.test.ts
@@ -617,6 +617,23 @@ describe('hardware/dacMonitor.instance', () => {
       expect(lastFrame?.pumpStallNotifications).toEqual({ left: null, right: notice })
     })
 
+    it('status:updated includes pumpStallNotifications when only the left side has an active notice', async () => {
+      const mod = await freshModule()
+      await mod.getDacMonitor()
+      await flushMicrotasks()
+      const monitor = monitorInstances[0]
+      const notice = { alertId: 43, trippedAt: 1_700_000_000, rpm: 0, restore: null }
+      getAllPumpStallNoticesMock.mockReturnValue({ left: notice, right: null })
+
+      const status: DeviceStatus = parseDeviceStatusMock('raw')
+      monitor.emit('status:updated', status)
+      await flushMicrotasks()
+
+      const lastFrame = broadcastFrameMock.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+      expect(lastFrame).toBeDefined()
+      expect(lastFrame?.pumpStallNotifications).toEqual({ left: notice, right: null })
+    })
+
     it('status:updated omits pumpStallNotifications when both sides are null', async () => {
       const mod = await freshModule()
       await mod.getDacMonitor()

--- a/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
+++ b/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
@@ -296,3 +296,60 @@ describe('DeviceStateSync — stall guard expected-stop suppression', () => {
     }))
   })
 })
+
+describe('DeviceStateSync — stall guard coalescing', () => {
+  let sync: DeviceStateSync
+
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 5; i += 1) await Promise.resolve()
+  }
+
+  const leftInputs = () => vi.mocked(onFrame).mock.calls
+    .map(([input]) => input)
+    .filter(input => input.side === 'left')
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    vi.mocked(onFrame).mockClear()
+    vi.mocked(onFrame).mockResolvedValue(undefined)
+    sync = new DeviceStateSync()
+    seedSide('left', true, 75)
+    seedSide('right', true, 75)
+  })
+
+  it('keeps only the newest frame while a guard pass is in flight', async () => {
+    let resolveFirst!: () => void
+    vi.mocked(onFrame).mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resolveFirst = resolve
+      }),
+    )
+
+    sync.recordFlowData(frame({ rpm: 100 }))
+    await flush()
+    expect(leftInputs()).toHaveLength(1)
+    expect(leftInputs()[0]?.rpm).toBe(100)
+
+    // Two more frames land while the first pass awaits hardware — the
+    // intermediate one must be dropped, not queued.
+    sync.recordFlowData(frame({ rpm: 200 }))
+    sync.recordFlowData(frame({ rpm: 300 }))
+    await flush()
+    expect(leftInputs()).toHaveLength(1)
+
+    resolveFirst()
+    await flush()
+    expect(leftInputs()).toHaveLength(2)
+    expect(leftInputs()[1]?.rpm).toBe(300)
+  })
+
+  it('releases the in-flight slot so later frames run immediately', async () => {
+    sync.recordFlowData(frame({ rpm: 100 }))
+    await flush()
+    sync.recordFlowData(frame({ rpm: 200 }))
+    await flush()
+    expect(leftInputs()).toHaveLength(2)
+    expect(leftInputs()[1]?.rpm).toBe(200)
+  })
+})

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -39,6 +39,7 @@ import {
   shouldBlock,
 } from '../pumpStallGuard'
 import { getPumpStallNotice } from '../pumpStallNotification'
+import { withSideLock } from '../sideLock'
 
 const { sqlite, biometricsSqlite } = dbModule as typeof dbModule & {
   sqlite: BetterSqlite3.Database
@@ -992,5 +993,178 @@ describe('pumpStallGuard', () => {
       expect(shouldBlock('left')).toBe(false)
       warn.mockRestore()
     })
+  })
+})
+
+describe('pumpStallGuard — side-lock serialization and notice timing', () => {
+  const lowFrame = (side: 'left' | 'right') => ({
+    side,
+    rpm: 100,
+    expectedActive: true,
+    preStallTarget: 78,
+    preStallDurationSeconds: 28800,
+  })
+
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 5; i += 1) await Promise.resolve()
+  }
+
+  beforeEach(() => {
+    resetSchema()
+    invalidateGuardSettingsCache()
+    reset()
+    setPower.mockClear()
+    setTemperature.mockClear()
+  })
+  afterEach(() => {
+    reset()
+    vi.restoreAllMocks()
+  })
+
+  it('queues the trip cutoff behind a same-side writer already holding the lock', async () => {
+    const order: string[] = []
+    let releaseWriter!: () => void
+    const writerGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    const writerDone = withSideLock('left', async () => {
+      await writerGate
+      order.push('writer:on')
+    })
+
+    await onFrame(lowFrame('left'))
+    const tripping = onFrame(lowFrame('left'))
+    await flush()
+
+    // Trip already latched (block + banner) but the cutoff is still queued
+    // behind the writer — nothing has reached the hardware client yet.
+    expect(shouldBlock('left')).toBe(true)
+    expect(getPumpStallNotice('left')).not.toBeNull()
+    expect(setPower).not.toHaveBeenCalled()
+
+    setPower.mockImplementation(async () => {
+      order.push('guard:cutoff')
+    })
+    releaseWriter()
+    await writerDone
+    await tripping
+
+    // The energizing write landed first, the cutoff after it — never the
+    // reverse — so the side ends up OFF.
+    expect(order).toEqual(['writer:on', 'guard:cutoff'])
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('serializes the cutoff retry through the side lock', async () => {
+    setPower.mockRejectedValueOnce(new Error('socket gone'))
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await onFrame(lowFrame('left'))
+    await onFrame(lowFrame('left'))
+    expect(shouldBlock('left')).toBe(true)
+    err.mockRestore()
+
+    const order: string[] = []
+    let releaseWriter!: () => void
+    const writerGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    const writerDone = withSideLock('left', async () => {
+      await writerGate
+      order.push('writer:on')
+    })
+
+    setPower.mockImplementation(async () => {
+      order.push('guard:retry')
+    })
+    const retrying = onFrame(lowFrame('left'))
+    await flush()
+    expect(order).toEqual([])
+
+    releaseWriter()
+    await writerDone
+    await retrying
+    expect(order).toEqual(['writer:on', 'guard:retry'])
+  })
+
+  it('serializes the auto-recovery restore through the side lock', async () => {
+    setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 1 })
+    invalidateGuardSettingsCache()
+    await onFrame(lowFrame('left'))
+    await onFrame(lowFrame('left'))
+    expect(shouldBlock('left')).toBe(true)
+    setPower.mockClear()
+
+    const order: string[] = []
+    let releaseWriter!: () => void
+    const writerGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    const writerDone = withSideLock('left', async () => {
+      await writerGate
+      order.push('writer')
+    })
+
+    setPower.mockImplementation(async () => {
+      order.push('guard:restore-power')
+    })
+    const healthy = { side: 'left' as const, rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 }
+    const recovering = onFrame(healthy)
+    await flush()
+    expect(order).toEqual([])
+
+    releaseWriter()
+    await writerDone
+    await recovering
+    expect(order).toEqual(['writer', 'guard:restore-power'])
+    expect(setTemperature).toHaveBeenCalledWith('left', 78, 28800)
+    expect(shouldBlock('left')).toBe(false)
+  })
+
+  it('publishes the notice, alert row, and DB mirror before the cutoff resolves', async () => {
+    let resolveCutoff!: () => void
+    setPower.mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resolveCutoff = resolve
+      }),
+    )
+
+    await onFrame(lowFrame('left'))
+    const tripping = onFrame(lowFrame('left'))
+    await flush()
+
+    // Cutoff still awaiting hardware — banner, alert row, and device_state
+    // mirror must already be visible so the trip is explained during a slow
+    // or unresponsive firmware window.
+    const notice = getPumpStallNotice('left')
+    expect(notice?.alertId).toBeGreaterThan(0)
+    expect((biometricsSqlite as any).prepare('SELECT action FROM pump_alerts WHERE id = ?').get(notice?.alertId)).toEqual({ action: 'power_off' })
+    expect((sqlite as any).prepare('SELECT is_powered FROM device_state WHERE side = \'left\'').get()).toEqual({ is_powered: 0 })
+
+    resolveCutoff()
+    await tripping
+    expect(setPower).toHaveBeenCalledWith('left', false)
+  })
+
+  it('an acknowledge during a pending cutoff clears the notice for good', async () => {
+    let resolveCutoff!: () => void
+    setPower.mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        resolveCutoff = resolve
+      }),
+    )
+
+    await onFrame(lowFrame('left'))
+    const tripping = onFrame(lowFrame('left'))
+    await flush()
+    expect(getPumpStallNotice('left')).not.toBeNull()
+
+    acknowledge('left')
+    expect(getPumpStallNotice('left')).toBeNull()
+
+    resolveCutoff()
+    await tripping
+    // The completed cutoff must not resurrect the banner or the block.
+    expect(getPumpStallNotice('left')).toBeNull()
+    expect(shouldBlock('left')).toBe(false)
   })
 })

--- a/src/hooks/useDeviceStatus.ts
+++ b/src/hooks/useDeviceStatus.ts
@@ -17,8 +17,9 @@ const HTTP_IDLE_POLL_MS = 60_000
 /**
  * Device status via WebSocket with tRPC HTTP fallback.
  *
- * Primary: `deviceStatus` frames pushed by dacMonitor every ~2s over the
- * existing piezoStream WebSocket (port 3001).
+ * Primary: `deviceStatus` frames pushed by dacMonitor on its adaptive poll
+ * (1–5s), plus immediate mutation overlays, over the existing piezoStream
+ * WebSocket (port 3001).
  *
  * Fallback: `device.getStatus` tRPC query for initial load and whenever the
  * WS stream is disconnected or has stopped delivering frames. (An earlier

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, useSyncExternalStore } from 'react'
 import { normalizeFrame } from '@/src/streaming/normalizeFrame'
+import type { SideStatus } from '@/src/hardware/types'
 
 // ---------------------------------------------------------------------------
 // Sensor frame types (matching piezoStream.ts server output)
@@ -116,24 +117,15 @@ export interface GestureFrame {
   tapType: string
 }
 
-/** Device status frame — pushed by dacMonitor every 2s. */
+/** Device status frame — pushed on DacMonitor's adaptive poll (1s active /
+ * 2s default / 5s idle) and immediately after mutations via
+ * broadcastMutationStatus. Sides carry the full SideStatus payload the
+ * producers spread (nullable temps when a side is off/neutral). */
 export interface DeviceStatusFrame {
   type: 'deviceStatus'
   ts: number
-  leftSide: {
-    currentTemperature: number
-    targetTemperature: number
-    currentLevel: number
-    targetLevel: number
-    isAlarmVibrating: boolean
-  }
-  rightSide: {
-    currentTemperature: number
-    targetTemperature: number
-    currentLevel: number
-    targetLevel: number
-    isAlarmVibrating: boolean
-  }
+  leftSide: SideStatus & { isAlarmVibrating: boolean }
+  rightSide: SideStatus & { isAlarmVibrating: boolean }
   waterLevel: 'low' | 'ok'
   isPriming: boolean
   primeCompletedNotification?: { timestamp: number }

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -253,6 +253,16 @@ describe('device.getStatus', () => {
     expect(result.pumpStallNotifications?.left).toBeNull()
   })
 
+  it('exposes pumpStallNotifications when only the left side has an active notice', async () => {
+    pumpStallNotificationMock.getAllPumpStallNotices.mockReturnValueOnce({
+      left: { alertId: 43, trippedAt: 1700000000, rpm: 50, restore: null },
+      right: null,
+    })
+    const result = await caller.getStatus({})
+    expect(result.pumpStallNotifications?.left?.alertId).toBe(43)
+    expect(result.pumpStallNotifications?.right).toBeNull()
+  })
+
   it('omits pumpStallNotifications when both sides are null', async () => {
     pumpStallNotificationMock.getAllPumpStallNotices.mockReturnValueOnce({ left: null, right: null })
     const result = await caller.getStatus({})

--- a/src/streaming/broadcastMutationStatus.ts
+++ b/src/streaming/broadcastMutationStatus.ts
@@ -3,10 +3,12 @@
  *
  * Overlays the mutation onto the last polled status from DacMonitor so all
  * WS clients see the change immediately. Fire-and-forget — never blocks the
- * caller. DacMonitor's 2s poll remains the authoritative consistency backstop.
+ * caller. DacMonitor's adaptive poll (1–5s) remains the authoritative
+ * consistency backstop.
  *
- * Used by both the device router (user-initiated mutations) and the scheduler
- * (automated jobs) so all writers go through the same broadcast path.
+ * Called by the device/runOnce routers, scheduler jobs, snooze manager,
+ * automation engine, and auto-off watcher. Not every writer broadcasts —
+ * HomeKit and gesture writes rely on the poll to surface their changes.
  */
 
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'

--- a/src/streaming/broadcastMutationStatus.ts
+++ b/src/streaming/broadcastMutationStatus.ts
@@ -12,6 +12,7 @@
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 import { broadcastFrame } from './piezoStream'
 import { getPrimeCompletedAt } from '@/src/hardware/primeNotification'
+import { getAllPumpStallNotices } from '@/src/hardware/pumpStallNotification'
 import { getAlarmState } from '@/src/hardware/deviceStateSync'
 import { getSnoozeStatus } from '@/src/hardware/snoozeManager'
 
@@ -26,6 +27,7 @@ export function broadcastMutationStatus(
 
     const primeCompletedAt = getPrimeCompletedAt()
     const alarmState = getAlarmState()
+    const stallNotices = getAllPumpStallNotices()
     const leftSide = { ...lastStatus.leftSide, isAlarmVibrating: alarmState.left }
     const rightSide = { ...lastStatus.rightSide, isAlarmVibrating: alarmState.right }
 
@@ -42,6 +44,7 @@ export function broadcastMutationStatus(
       waterLevel: lastStatus.waterLevel,
       isPriming: lastStatus.isPriming,
       ...(primeCompletedAt && { primeCompletedNotification: { timestamp: primeCompletedAt } }),
+      ...((stallNotices.left || stallNotices.right) && { pumpStallNotifications: stallNotices }),
       snooze: {
         left: getSnoozeStatus('left'),
         right: getSnoozeStatus('right'),

--- a/src/streaming/tests/broadcastMutationStatus.test.ts
+++ b/src/streaming/tests/broadcastMutationStatus.test.ts
@@ -3,7 +3,7 @@
  *
  * All hardware/streaming dependencies are mocked. We assert payload shape,
  * overlay merging, the no-status / no-monitor guards, the prime-completed
- * conditional spread, and the error guard.
+ * and pump-stall conditional spreads, and the error guard.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -31,6 +31,12 @@ const alarmMock = vi.hoisted(() => {
   return { state, getAlarmState }
 })
 
+const stallMock = vi.hoisted(() => {
+  const state: { left: unknown, right: unknown } = { left: null, right: null }
+  const getAllPumpStallNotices = vi.fn(() => ({ left: state.left, right: state.right }))
+  return { state, getAllPumpStallNotices }
+})
+
 const snoozeMock = vi.hoisted(() => {
   const calls: Array<'left' | 'right'> = []
   const getSnoozeStatus = vi.fn((side: 'left' | 'right') => {
@@ -54,6 +60,10 @@ vi.mock('@/src/hardware/primeNotification', () => ({
 
 vi.mock('@/src/hardware/deviceStateSync', () => ({
   getAlarmState: alarmMock.getAlarmState,
+}))
+
+vi.mock('@/src/hardware/pumpStallNotification', () => ({
+  getAllPumpStallNotices: stallMock.getAllPumpStallNotices,
 }))
 
 vi.mock('@/src/hardware/snoozeManager', () => ({
@@ -82,11 +92,14 @@ beforeEach(() => {
   primeMock.state.primeCompletedAt = null
   alarmMock.state.left = false
   alarmMock.state.right = false
+  stallMock.state.left = null
+  stallMock.state.right = null
   snoozeMock.calls.length = 0
   dacMock.getDacMonitorIfRunning.mockClear()
   piezoMock.broadcastFrame.mockClear()
   primeMock.getPrimeCompletedAt.mockClear()
   alarmMock.getAlarmState.mockClear()
+  stallMock.getAllPumpStallNotices.mockClear()
   snoozeMock.getSnoozeStatus.mockClear()
   warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 })
@@ -209,6 +222,28 @@ describe('broadcastMutationStatus', () => {
 
     const frame = piezoMock.broadcastFrame.mock.calls[0]?.[0] as Record<string, any>
     expect(frame.primeCompletedNotification).toEqual({ timestamp: 1_700_000_000_000 })
+  })
+
+  it('includes pumpStallNotifications when one side has an active notice', () => {
+    setLastStatus(baseStatus)
+    stallMock.state.right = { alertId: 42, trippedAt: 1_700_000_000, rpm: 0, restore: null }
+
+    broadcastMutationStatus()
+
+    const frame = piezoMock.broadcastFrame.mock.calls[0]?.[0] as Record<string, any>
+    expect(frame.pumpStallNotifications).toEqual({
+      left: null,
+      right: { alertId: 42, trippedAt: 1_700_000_000, rpm: 0, restore: null },
+    })
+  })
+
+  it('omits pumpStallNotifications when both sides are null', () => {
+    setLastStatus(baseStatus)
+
+    broadcastMutationStatus()
+
+    const frame = piezoMock.broadcastFrame.mock.calls[0]?.[0] as Record<string, unknown>
+    expect('pumpStallNotifications' in frame).toBe(false)
   })
 
   it('catches and logs errors thrown by downstream dependencies', () => {

--- a/src/streaming/tests/broadcastMutationStatus.test.ts
+++ b/src/streaming/tests/broadcastMutationStatus.test.ts
@@ -256,7 +256,8 @@ describe('broadcastMutationStatus', () => {
     broadcastMutationStatus()
 
     const frame = piezoMock.broadcastFrame.mock.calls[0]?.[0] as Record<string, unknown>
-    expect('pumpStallNotifications' in frame).toBe(false)
+    expect(frame).toBeDefined()
+    expect(frame && 'pumpStallNotifications' in frame).toBe(false)
   })
 
   it('catches and logs errors thrown by downstream dependencies', () => {

--- a/src/streaming/tests/broadcastMutationStatus.test.ts
+++ b/src/streaming/tests/broadcastMutationStatus.test.ts
@@ -237,6 +237,19 @@ describe('broadcastMutationStatus', () => {
     })
   })
 
+  it('includes pumpStallNotifications when only the left side has an active notice', () => {
+    setLastStatus(baseStatus)
+    stallMock.state.left = { alertId: 43, trippedAt: 1_700_000_000, rpm: 0, restore: null }
+
+    broadcastMutationStatus()
+
+    const frame = piezoMock.broadcastFrame.mock.calls[0]?.[0] as Record<string, any>
+    expect(frame.pumpStallNotifications).toEqual({
+      left: { alertId: 43, trippedAt: 1_700_000_000, rpm: 0, restore: null },
+      right: null,
+    })
+  })
+
   it('omits pumpStallNotifications when both sides are null', () => {
     setLastStatus(baseStatus)
 


### PR DESCRIPTION
## Problem

Adversarial review of PR #669, finding S3: the pump-stall banner is driven by `pumpStallNotifications` in device status, but only the tRPC HTTP path (`device.getStatus` in `src/server/routers/device.ts`) includes it via `getAllPumpStallNotices()`. The WebSocket `deviceStatus` producers omit the field, and `useDeviceStatus` prefers live WS frames over HTTP wholesale — so while the WS stream is healthy the stall banner never renders even though the guard tripped.

## Fix

Include `pumpStallNotifications` in every WS `deviceStatus` frame, mirroring the HTTP path's conditional-inclusion semantics (key present only when at least one side has an active notice, so the wire shape stays zod-compatible):

- `src/hardware/dacMonitor.instance.ts` — the `status:updated` broadcast (2s poll path)
- `src/streaming/broadcastMutationStatus.ts` — the mutation-overlay broadcast

No hook change needed: `useDeviceStatus` already maps `frame.pumpStallNotifications` and `DeviceStatusFrame` already declares the optional field.

## Test plan

- Pinning tests for both producers (Stryker): field present when a side has a notice, absent when both sides are null — `src/hardware/tests/dacMonitor.instance.test.ts`, `src/streaming/tests/broadcastMutationStatus.test.ts`
- `pnpm tsc && pnpm lint && pnpm test` clean (3197 passed; pre-push hook re-ran gates)
- Manual: trip the pump-stall guard on a pod with the WS stream connected; the stall banner should render from the next frame without waiting for an HTTP poll

## Review follow-ups (adversarial review)

- **Heads-up:** the MQTT/Home Assistant bridge mirrors WS `deviceStatus` frames verbatim to the retained `device-status` topic, so `pumpStallNotifications` now appears there during a stall — new field for HA consumers, intended.
- Applied from the review (5 commits): stall-guard hardware writes (trip cutoff, retry, auto-recovery) serialized through `withSideLock` with the notice/alert/DB mirror published before the cutoff await; per-side stall-guard frame processing coalesced to one in-flight pass; left-side notice inclusion pinned in all three status producers; `DeviceStatusFrame` sides now typed as `SideStatus & { isAlarmVibrating }`; stale status-stream JSDoc corrected.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pump-stall-ws-notices
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pump-stall-ws-notices/scripts/install \
  | sudo bash -s -- --branch fix/pump-stall-ws-notices
```

🎯 **Pin to this exact build** ([run 29959976457](https://github.com/sleepypod/core/actions/runs/29959976457) · `a69ca26`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a69ca26985b1f7bd43e8b0f32d22fa7b881936a4/scripts/install \
  | sudo bash -s -- \
      --branch fix/pump-stall-ws-notices \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/29959976457/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/29959976457/artifacts/8545601539) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device status broadcasts now include pump-stall notifications only when active, with the affected side populated.
  * The status API now exposes pump-stall notification details when present.

* **Bug Fixes**
  * Improved pump-stall guard handling to avoid overlapping operations per side and ensure cutoff/restore actions run in order.

* **Tests**
  * Added coverage for left-only, right-only, and no-notice broadcast payloads, plus concurrency/queuing scenarios and router status behavior.

* **Documentation**
  * Refreshed inline documentation to reflect adaptive device-status polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



