### PR TITLE
fix(hardware): enforce pump-stall guard at every energizing ingress

### DIFF
--- a/docs/adr/0016-raw-command-execution.md
+++ b/docs/adr/0016-raw-command-execution.md
@@ -25,6 +25,16 @@ Add a `POST /device/execute` endpoint that accepts a hardware command name and o
 - Can cause unexpected hardware state if misused
 - Not covered by the standard safety/debounce mechanisms
 
+## Amendment (2026-07-21)
+
+Energizing opcodes (`SET_TEMP`, `LEFT_TEMP_DURATION`, `RIGHT_TEMP_DURATION`,
+`TEMP_LEVEL_LEFT`, `TEMP_LEVEL_RIGHT` — by name or numeric opcode) are now
+gated on the pump-stall guard (ADR 0022) and serialized through the side
+lock. A level/duration write of `0` (the power-off direction) is never
+blocked, and unknown opcodes still pass through unguarded for probing. To
+deliberately re-energize a tripped side, acknowledge the alert first
+(`pumpAlerts.acknowledge`).
+
 ## Disclaimer
 
 This is a power user feature. It is unsupported, undocumented beyond this ADR, and carries no guarantees. Misuse can lead to unexpected hardware behavior. The sleepypod project assumes no liability for issues arising from raw command execution.

--- a/src/automation/engine.ts
+++ b/src/automation/engine.ts
@@ -61,6 +61,9 @@ export interface AutomationEngineDeps {
   clock: () => { nowMinutes: number, dayOfWeek: DayOfWeek, dateKey?: string }
   getHardware: () => HardwareWriter
   withSideLock: <T>(side: Side, fn: () => Promise<T>) => Promise<T>
+  /** Pump stall guard gate — energizing writes are skipped while it blocks
+   * the side (ADR 0022: a tripped side stays parked until acknowledged). */
+  pumpStallShouldBlock: (side: Side) => boolean
   broadcast: (side: Side, overlay: Record<string, unknown>) => void
   markMutated: (side: Side) => void
   loadRules: () => Promise<AutomationRule[]>
@@ -406,8 +409,16 @@ export class AutomationEngine {
       return { kind: action.kind, side, dryRun: true, raw, temp, clamped, on: action.kind === 'setPower' ? action.on : undefined }
     }
 
-    // Real write through the shared, serialized hardware path.
+    // Real write through the shared, serialized hardware path. The stall-guard
+    // check runs inside the lock so a trip while this write is queued still
+    // blocks it; power-off is the safe direction and is never blocked.
+    const energizing = action.kind === 'setTemperature' || action.on
+    let stallBlocked = false
     await this.deps.withSideLock(side, async () => {
+      if (energizing && this.deps.pumpStallShouldBlock(side)) {
+        stallBlocked = true
+        return
+      }
       const hw = this.deps.getHardware()
       await hw.connect()
       if (action.kind === 'setTemperature') {
@@ -427,6 +438,10 @@ export class AutomationEngine {
         else if (!action.on) this.lastAsserted[side] = undefined
       }
     })
+    if (stallBlocked) {
+      console.warn(`[automation] skipped ${action.kind}: pump stall guard blocks ${side}`)
+      return { kind: action.kind, side, skipped: 'pump-stall', raw, temp, clamped }
+    }
     rt.actionTimes.push(now)
     return { kind: action.kind, side, sent: true, raw, temp, clamped, on: action.kind === 'setPower' ? action.on : undefined }
   }

--- a/src/automation/engine.ts
+++ b/src/automation/engine.ts
@@ -62,7 +62,8 @@ export interface AutomationEngineDeps {
   getHardware: () => HardwareWriter
   withSideLock: <T>(side: Side, fn: () => Promise<T>) => Promise<T>
   /** Pump stall guard gate — energizing writes are skipped while it blocks
-   * the side (ADR 0022: a tripped side stays parked until acknowledged). */
+   * the side (ADR 0022: a tripped side stays parked until acknowledgment
+   * or successful opt-in auto-recovery). */
   pumpStallShouldBlock: (side: Side) => boolean
   broadcast: (side: Side, overlay: Record<string, unknown>) => void
   markMutated: (side: Side) => void
@@ -163,6 +164,10 @@ export class AutomationEngine {
    */
   registerManualOverride(side: Side): void {
     this.manualOverrideUntil[side] = this.deps.now() + AUTOMATION_MANUAL_OVERRIDE_MS
+    // The user changed the setpoint out from under us — the anti-thrash
+    // baseline no longer reflects hardware, and keeping it would suppress
+    // the first re-assertion after the override window expires.
+    this.lastAsserted[side] = undefined
   }
 
   /** Flip the global kill-switch. `false` suspends all evaluation immediately. */

--- a/src/automation/instance.ts
+++ b/src/automation/instance.ts
@@ -12,6 +12,7 @@ import { db } from '@/src/db'
 import { automationRuns, automations, deviceSettings, runOnceSessions } from '@/src/db/schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { withSideLock } from '@/src/hardware/sideLock'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { AutomationEngine } from './engine'
@@ -117,6 +118,7 @@ export async function getAutomationEngine(): Promise<AutomationEngine> {
         clock: () => clockInTimezone(activeTimezone, new Date()),
         getHardware: () => getSharedHardwareClient(),
         withSideLock,
+        pumpStallShouldBlock,
         broadcast: (side, overlay) => broadcastMutationStatus(side, overlay),
         markMutated: markSideMutated,
         loadRules,

--- a/src/automation/tests/engine.test.ts
+++ b/src/automation/tests/engine.test.ts
@@ -33,6 +33,7 @@ interface Harness {
   setSignal: (key: string, value: number | undefined) => void
   setClock: (nowMinutes: number, dayOfWeek?: DayOfWeek, dateKey?: string) => void
   setRunOnce: (active: boolean) => void
+  setStallBlocked: (side: Side, blocked: boolean) => void
   runs: { id: number, outcome: RunOutcome, detail: RunDetail }[]
   notifies: { id: number, message: string }[]
   hwCalls: HwCall[]
@@ -44,6 +45,7 @@ function makeHarness(rules: AutomationRule[]): Harness {
   // due (production `now` is always >> any everyMin window from epoch 0).
   let nowMs = 1_700_000_000_000
   let runOnce = false
+  const stallBlocked: Record<Side, boolean> = { left: false, right: false }
   let nowMinutes = 0
   let dayOfWeek: DayOfWeek = 'monday'
   let dateKey = '2026-07-01'
@@ -63,6 +65,7 @@ function makeHarness(rules: AutomationRule[]): Harness {
       setPower: async (side, on, temp) => { hwCalls.push({ op: 'power', side, on, temp }) },
     }),
     withSideLock: async (_side, fn) => fn(),
+    pumpStallShouldBlock: side => stallBlocked[side],
     broadcast: () => {},
     markMutated: () => {},
     loadRules: async () => rules,
@@ -84,6 +87,7 @@ function makeHarness(rules: AutomationRule[]): Harness {
       if (date) dateKey = date
     },
     setRunOnce: (a) => { runOnce = a },
+    setStallBlocked: (side, blocked) => { stallBlocked[side] = blocked },
     runs,
     notifies,
     hwCalls,
@@ -548,6 +552,7 @@ describe('AutomationEngine — action error', () => {
         setPower: async () => {},
       }),
       withSideLock: async (_side, fn) => fn(),
+      pumpStallShouldBlock: () => false,
       broadcast: () => {},
       markMutated: () => {},
       loadRules: async () => [rule({ actions: [{ kind: 'setTemperature', temp: lit(72) }] })],
@@ -571,6 +576,7 @@ describe('AutomationEngine — action error', () => {
       clock: () => ({ nowMinutes: 0, dayOfWeek: 'monday' }),
       getHardware: () => ({ connect: async () => {}, setTemperature: async () => {}, setPower: async () => {} }),
       withSideLock: async (_side, fn) => fn(),
+      pumpStallShouldBlock: () => false,
       broadcast: () => {},
       markMutated: () => {},
       loadRules: async () => [rule({ actions: [{ kind: 'setTemperature', temp: lit(72) }] })],
@@ -644,6 +650,7 @@ describe('AutomationEngine — branch coverage corners', () => {
       clock: () => ({ nowMinutes: 0, dayOfWeek: 'monday' }),
       getHardware: () => ({ connect: async () => {}, setTemperature: async () => {}, setPower: async () => {} }),
       withSideLock: async (_side, fn) => fn(),
+      pumpStallShouldBlock: () => false,
       broadcast: () => {},
       markMutated: () => {},
       loadRules: async () => [],
@@ -726,5 +733,65 @@ describe('AutomationEngine — branch coverage corners', () => {
     await h.engine.tick()
     expect(h.runs[1].detail.actions?.[0]?.antiThrash).toBe(true)
     expect(h.runs[1].outcome).toBe('clamped')
+  })
+})
+
+describe('AutomationEngine — pump stall guard gate', () => {
+  it('skips a setTemperature action while the guard blocks the side', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const h = makeHarness([rule({ actions: [{ kind: 'setTemperature', temp: lit(72) }] })])
+      h.setStallBlocked('left', true)
+      await h.engine.reload()
+      await h.engine.tick()
+      expect(h.hwCalls).toHaveLength(0)
+      expect(h.runs[0].outcome).toBe('skipped')
+      expect(h.runs[0].detail.actions?.[0]?.skipped).toBe('pump-stall')
+      expect(warn).toHaveBeenCalledWith('[automation] skipped setTemperature: pump stall guard blocks left')
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('skips a setPower(on) action while the guard blocks the side', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const h = makeHarness([rule({ actions: [{ kind: 'setPower', on: true, temp: lit(70) }] })])
+      h.setStallBlocked('left', true)
+      await h.engine.reload()
+      await h.engine.tick()
+      expect(h.hwCalls).toHaveLength(0)
+      expect(h.runs[0].detail.actions?.[0]?.skipped).toBe('pump-stall')
+      expect(warn).toHaveBeenCalledWith('[automation] skipped setPower: pump stall guard blocks left')
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('still sends setPower(off) while the guard blocks the side', async () => {
+    const h = makeHarness([rule({ actions: [{ kind: 'setPower', on: false }] })])
+    h.setStallBlocked('left', true)
+    await h.engine.reload()
+    await h.engine.tick()
+    expect(h.hwCalls[0]).toMatchObject({ op: 'power', side: 'left', on: false })
+    expect(h.runs[0].outcome).toBe('fired')
+  })
+
+  it('only skips the blocked side when a rule fans out to both', async () => {
+    const h = makeHarness([rule({ side: null, actions: [{ kind: 'setTemperature', temp: lit(72) }] })])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      h.setStallBlocked('left', true)
+      await h.engine.reload()
+      await h.engine.tick()
+      expect(h.hwCalls).toHaveLength(1)
+      expect(h.hwCalls[0]).toMatchObject({ op: 'temp', side: 'right', temp: 72 })
+      expect(h.runs[0].detail.actions?.[0]?.skipped).toBe('pump-stall')
+    }
+    finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/src/automation/tests/engine.test.ts
+++ b/src/automation/tests/engine.test.ts
@@ -722,6 +722,27 @@ describe('AutomationEngine — branch coverage corners', () => {
     expect(h.runs[0].outcome).toBe('fired')
   })
 
+  it('re-asserts after a manual override expires even when the target is unchanged', async () => {
+    const h = makeHarness([rule({ actions: [{ kind: 'setTemperature', temp: lit(72) }] })])
+    await h.engine.reload()
+    await h.engine.tick()
+    expect(h.hwCalls).toHaveLength(1)
+
+    // The user dials the side directly: the override suspends autopilot AND
+    // invalidates the anti-thrash baseline — hardware is no longer at 72.
+    h.engine.registerManualOverride('left')
+    h.advance(60_000)
+    await h.engine.tick()
+    expect(h.hwCalls).toHaveLength(1) // suspended inside the override window
+
+    h.advance(2 * 60 * 60_000) // override expired
+    await h.engine.tick()
+    // With a stale baseline this would be anti-thrash-skipped (|72−72| < 0.5)
+    // and the user's manual setpoint would silently stick forever.
+    expect(h.hwCalls).toHaveLength(2)
+    expect(h.hwCalls[1]).toMatchObject({ op: 'temp', side: 'left', temp: 72 })
+  })
+
   it('reports clamped when an anti-thrash re-assertion is still out of band', async () => {
     const h = makeHarness([rule({ actions: [{ kind: 'setTemperature', temp: sig('target'), clamp: { min: 60, max: 75 } }] })])
     h.setSignal('target', 200) // clamps to 75, sent + clamped
@@ -777,6 +798,59 @@ describe('AutomationEngine — pump stall guard gate', () => {
     await h.engine.tick()
     expect(h.hwCalls[0]).toMatchObject({ op: 'power', side: 'left', on: false })
     expect(h.runs[0].outcome).toBe('fired')
+  })
+
+  it('blocks a write whose trip lands while it is queued on the side lock', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const runs: { id: number, outcome: RunOutcome, detail: RunDetail }[] = []
+      const hwCalls: HwCall[] = []
+      let blocked = false
+      let release: () => void = () => {}
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const deps: AutomationEngineDeps = {
+        signals: { read: () => ({}) },
+        now: () => 1_700_000_000_000,
+        clock: () => ({ nowMinutes: 0, dayOfWeek: 'monday' }),
+        getHardware: () => ({
+          connect: async () => {},
+          setTemperature: async (side, temp, duration) => { hwCalls.push({ op: 'temp', side, temp, duration }) },
+          setPower: async (side, on, temp) => { hwCalls.push({ op: 'power', side, on, temp }) },
+        }),
+        // Simulates queueing behind another writer: the locked callback only
+        // runs once release() fires — the trip lands during that wait, so
+        // only a check inside the lock body can observe it.
+        withSideLock: async (_side, fn) => {
+          await gate
+          return fn()
+        },
+        pumpStallShouldBlock: () => blocked,
+        broadcast: () => {},
+        markMutated: () => {},
+        loadRules: async () => [rule({ actions: [{ kind: 'setTemperature', temp: lit(72) }] })],
+        recordRun: async (id, outcome, detail) => { runs.push({ id, outcome, detail: detail as RunDetail }) },
+        disableRule: async () => {},
+        hasActiveRunOnceSession: async () => false,
+        notify: () => {},
+      }
+      const engine = new AutomationEngine(deps)
+      await engine.reload()
+      const tick = engine.tick()
+      // Let the tick reach withSideLock and park on the gate while healthy.
+      await new Promise((resolve) => {
+        setImmediate(resolve)
+      })
+      blocked = true
+      release()
+      await tick
+      expect(hwCalls).toHaveLength(0)
+      expect(runs[0].detail.actions?.[0]?.skipped).toBe('pump-stall')
+    }
+    finally {
+      warn.mockRestore()
+    }
   })
 
   it('only skips the blocked side when a rule fans out to both', async () => {

--- a/src/automation/tests/instance.test.ts
+++ b/src/automation/tests/instance.test.ts
@@ -56,6 +56,7 @@ const broadcastMock = vi.fn()
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({ getSharedHardwareClient: () => hardwareClient }))
 vi.mock('@/src/hardware/deviceStateSync', () => ({ markSideMutated: markSideMutatedMock }))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({ shouldBlock: () => false }))
 vi.mock('@/src/hardware/sideLock', () => ({ withSideLock: async (_side: any, fn: () => Promise<any>) => fn() }))
 vi.mock('@/src/streaming/broadcastMutationStatus', () => ({ broadcastMutationStatus: broadcastMock }))
 vi.mock('drizzle-orm', () => ({ and: (...a: any[]) => ({ a }), eq: (...a: any[]) => ({ a }), gt: (...a: any[]) => ({ a }) }))

--- a/src/hardware/gestureActionHandler.ts
+++ b/src/hardware/gestureActionHandler.ts
@@ -2,6 +2,7 @@ import type { HardwareClient } from './client'
 import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL, type Side } from './types'
 import type { GestureEvent } from './dacMonitor'
 import { getAutomationEngineIfRunning } from '@/src/automation'
+import { shouldBlock as pumpStallShouldBlock } from './pumpStallGuard'
 import { withSideLock } from '@/src/hardware/sideLock'
 
 // Re-export for callers that need to build deps
@@ -102,6 +103,10 @@ export class GestureActionHandler {
     const newTemp = Math.min(MAX_TEMP, Math.max(MIN_TEMP, currentTemp + delta))
 
     await withSideLock(event.side, async () => {
+      if (pumpStallShouldBlock(event.side)) {
+        console.warn(`[gestureActionHandler] skipped setTemperature: pump stall guard blocks ${event.side}`)
+        return
+      }
       const client = this.deps.newHardwareClient(this.socketPath)
       try {
         getAutomationEngineIfRunning()?.registerManualOverride(event.side)
@@ -168,6 +173,10 @@ export class GestureActionHandler {
         // fallback in DacHardwareClient.setPower.
         const target = state?.targetTemperature ?? TEMP_NEUTRAL
         await withSideLock(event.side, async () => {
+          if (nextPowered && pumpStallShouldBlock(event.side)) {
+            console.warn(`[gestureActionHandler] skipped power-on: pump stall guard blocks ${event.side}`)
+            return
+          }
           const client = this.deps.newHardwareClient(this.socketPath)
           try {
             getAutomationEngineIfRunning()?.registerManualOverride(event.side)

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -137,8 +137,11 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
     return
   }
 
-  if (!input.expectedActive) {
+  if (!input.expectedActive && !state.blocked) {
     // Side commanded off — RPM of zero is the correct state, don't penalize.
+    // A blocked side falls through: trip() mirrors isPowered=false, so
+    // expectedActive is false for every post-trip frame and returning here
+    // would make the cutoff retry and recovery tracking below unreachable.
     state.consecutiveLowFrames = 0
     return
   }

--- a/src/hardware/tests/gestureActionHandler.test.ts
+++ b/src/hardware/tests/gestureActionHandler.test.ts
@@ -466,5 +466,68 @@ describe('GestureActionHandler', () => {
 
       expect(client.setPower).toHaveBeenCalledWith('right', false, undefined)
     })
+
+    test('blocks a temperature gesture whose trip lands while queued on the side lock', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let release: () => void = () => {}
+      const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await Promise.resolve()
+
+      try {
+        const gesture = { actionType: 'temperature', temperatureChange: 'increment', temperatureAmount: 5 }
+        const { deps, client } = makeDeps(gesture, { targetTemperature: 70 })
+        const pending = new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('left', 'doubleTap'))
+        // The gesture queues behind the held lock while the guard is still
+        // healthy — the trip below lands strictly after.
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        pumpStallShouldBlock.mockReturnValue(true)
+        release()
+        await holder
+        await pending
+
+        expect(client.setTemperature).not.toHaveBeenCalled()
+        expect(registerManualOverride).not.toHaveBeenCalled()
+        expect(warn).toHaveBeenCalledWith('[gestureActionHandler] skipped setTemperature: pump stall guard blocks left')
+      }
+      finally {
+        release()
+        warn.mockRestore()
+      }
+    })
+
+    test('blocks a power-on toggle whose trip lands while queued on the side lock', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let release: () => void = () => {}
+      const holder = withSideLock('right', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await Promise.resolve()
+
+      try {
+        const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
+        const state = { isAlarmVibrating: false, isPowered: false, targetTemperature: 70 }
+        const { deps, client } = makeDeps(gesture, state)
+        const pending = new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('right', 'quadTap'))
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0)
+        })
+        pumpStallShouldBlock.mockReturnValue(true)
+        release()
+        await holder
+        await pending
+
+        expect(client.setPower).not.toHaveBeenCalled()
+        expect(registerManualOverride).not.toHaveBeenCalled()
+        expect(warn).toHaveBeenCalledWith('[gestureActionHandler] skipped power-on: pump stall guard blocks right')
+      }
+      finally {
+        release()
+        warn.mockRestore()
+      }
+    })
   })
 })

--- a/src/hardware/tests/gestureActionHandler.test.ts
+++ b/src/hardware/tests/gestureActionHandler.test.ts
@@ -5,9 +5,13 @@ import type { HardwareClient } from '../client'
 import { TEMP_NEUTRAL } from '../types'
 
 const registerManualOverride = vi.fn()
+const pumpStallShouldBlock = vi.fn<(side: 'left' | 'right') => boolean>(() => false)
 
 vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
+}))
+vi.mock('../pumpStallGuard', () => ({
+  shouldBlock: (side: 'left' | 'right') => pumpStallShouldBlock(side),
 }))
 
 const { GestureActionHandler } = await import('../gestureActionHandler')
@@ -57,6 +61,7 @@ describe('GestureActionHandler', () => {
   afterEach(() => {
     vi.clearAllTimers()
     registerManualOverride.mockClear()
+    pumpStallShouldBlock.mockReset().mockReturnValue(false)
     vi.useRealTimers()
   })
 
@@ -418,5 +423,48 @@ describe('GestureActionHandler', () => {
     )
     expect(client.disconnect).toHaveBeenCalledOnce()
     error.mockRestore()
+  })
+
+  describe('pump stall guard', () => {
+    test('skips a temperature gesture while the guard blocks the side', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      pumpStallShouldBlock.mockReturnValue(true)
+      const gesture = { actionType: 'temperature', temperatureChange: 'increment', temperatureAmount: 5 }
+      const { deps, client } = makeDeps(gesture, { targetTemperature: 70 })
+
+      await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('left', 'doubleTap'))
+
+      expect(deps.newHardwareClient).not.toHaveBeenCalled()
+      expect(client.setTemperature).not.toHaveBeenCalled()
+      expect(registerManualOverride).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledWith('[gestureActionHandler] skipped setTemperature: pump stall guard blocks left')
+      warn.mockRestore()
+    })
+
+    test('skips a power-on toggle while the guard blocks the side', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      pumpStallShouldBlock.mockReturnValue(true)
+      const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
+      const state = { isAlarmVibrating: false, isPowered: false, targetTemperature: 70 }
+      const { deps, client } = makeDeps(gesture, state)
+
+      await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('right', 'quadTap'))
+
+      expect(deps.newHardwareClient).not.toHaveBeenCalled()
+      expect(client.setPower).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledWith('[gestureActionHandler] skipped power-on: pump stall guard blocks right')
+      warn.mockRestore()
+    })
+
+    test('still allows a power-off toggle while the guard blocks the side', async () => {
+      pumpStallShouldBlock.mockReturnValue(true)
+      const gesture = { actionType: 'alarm', alarmBehavior: 'dismiss', alarmInactiveBehavior: 'power' }
+      const state = { isAlarmVibrating: false, isPowered: true, targetTemperature: 72 }
+      const { deps, client } = makeDeps(gesture, state)
+
+      await new GestureActionHandler(SOCKET_PATH, deps).handle(makeEvent('right', 'quadTap'))
+
+      expect(client.setPower).toHaveBeenCalledWith('right', false, undefined)
+    })
   })
 })

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -489,6 +489,40 @@ describe('pumpStallGuard', () => {
     warn.mockRestore()
   })
 
+  it('retries the cutoff on post-trip frames where the DB mirror makes expectedActive false', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setPower.mockRejectedValueOnce(new Error('hw down'))
+
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(__test__.getState().left.cutoffPending).toBe(true)
+
+    // trip() mirrors isPowered=false, so every real post-trip frame arrives
+    // with expectedActive=false — the pending cutoff must still be retried.
+    await onFrame({ side: 'left', rpm: 100, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    expect(setPower).toHaveBeenLastCalledWith('left', false)
+    expect(__test__.getState().left.cutoffPending).toBe(false)
+    err.mockRestore()
+  })
+
+  it('auto-recovers from post-trip frames where expectedActive is false', async () => {
+    setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 2 })
+    invalidateGuardSettingsCache()
+
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    expect(shouldBlock('left')).toBe(true)
+
+    // Same DB-mirror reality as above: recovery tracking must keep running
+    // on expectedActive=false frames or auto-recovery is unreachable.
+    await onFrame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    expect(shouldBlock('left')).toBe(true)
+    await onFrame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    expect(shouldBlock('left')).toBe(false)
+    expect(setPower).toHaveBeenLastCalledWith('left', true, 78)
+    expect(setTemperature).toHaveBeenCalledWith('left', 78, 28800)
+  })
+
   it('does not retry the cutoff when the trip-time power-off succeeded', async () => {
     await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -22,6 +22,7 @@ import type { DeviceStatus, Side } from '@/src/hardware/types'
 import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL } from '@/src/hardware/types'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getAutomationEngineIfRunning } from '@/src/automation'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { withSideLock } from '@/src/hardware/sideLock'
 
 const lastTargetF: Record<Side, number | null> = { left: null, right: null }
@@ -128,6 +129,12 @@ export async function setTargetTemperature(
     const intended = intendedPower[side]
     const powered = intended !== null ? intended : isCurrentlyPowered(monitor, side)
     if (!powered) return
+    if (pumpStallShouldBlock(side)) {
+      // Keep the staged target (same semantics as adjusting while OFF) but
+      // never push a write that would re-energize a parked side.
+      console.warn(`[homekit] skipped setTemperature(${side}): pump stall guard blocks ${side}`)
+      return
+    }
     registerManualOverride(side)
     await logged(
       `setTemperature(${side}, ${f})`,
@@ -150,6 +157,12 @@ export async function setSidePowerOn(monitor: DacMonitor, side: Side): Promise<v
   intendedPower[side] = true
   try {
     await withSideLock(side, async () => {
+      // Throw rather than silently skip: the catch below rolls intendedPower
+      // back so iOS Home reverts the toggle instead of showing a phantom ON.
+      if (pumpStallShouldBlock(side)) {
+        console.warn(`[homekit] skipped setPower(${side}, true): pump stall guard blocks ${side}`)
+        throw new Error(`pump stall protection active on ${side}`)
+      }
       const target = clampF(getStagedTargetF(monitor, side))
       lastTargetF[side] = target
       registerManualOverride(side)

--- a/src/homekit/tests/powerSwitch.test.ts
+++ b/src/homekit/tests/powerSwitch.test.ts
@@ -10,6 +10,9 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
 vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
 }))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: () => false,
+}))
 
 import { buildPowerSwitch } from '../accessories/powerSwitch'
 import { __resetSideController } from '../accessories/sideController'

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -3,12 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const setTemperature = vi.fn()
 const setPower = vi.fn()
 const registerManualOverride = vi.fn()
+const pumpStallShouldBlock = vi.fn<(side: 'left' | 'right') => boolean>(() => false)
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: () => ({ setTemperature, setPower }),
 }))
 vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
+}))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: (side: 'left' | 'right') => pumpStallShouldBlock(side),
 }))
 
 import {
@@ -50,6 +54,7 @@ describe('sideController', () => {
     setTemperature.mockReset()
     setPower.mockReset()
     registerManualOverride.mockReset()
+    pumpStallShouldBlock.mockReset().mockReturnValue(false)
     setTemperature.mockResolvedValue(undefined)
     setPower.mockResolvedValue(undefined)
   })
@@ -400,6 +405,43 @@ describe('sideController', () => {
       await setTargetTemperature(monitor(onStatus), 'left', 72)
       expect(setTemperature).toHaveBeenCalledWith('left', 72)
       warn.mockRestore()
+    })
+  })
+
+  describe('pump stall guard', () => {
+    it('stages but never pushes a target while the guard blocks the side', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      pumpStallShouldBlock.mockReturnValue(true)
+
+      await setTargetTemperature(monitor(onStatus), 'left', 78)
+
+      expect(setTemperature).not.toHaveBeenCalled()
+      expect(registerManualOverride).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledWith('[homekit] skipped setTemperature(left): pump stall guard blocks left')
+      // The staged value survives so an eventual re-enable powers on to it.
+      expect(getStagedTargetF(monitor(onStatus), 'left')).toBe(78)
+      warn.mockRestore()
+    })
+
+    it('rejects setSidePowerOn and rolls back intent while the guard blocks the side', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      pumpStallShouldBlock.mockReturnValue(true)
+
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('pump stall protection active on left')
+
+      expect(setPower).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledWith('[homekit] skipped setPower(left, true): pump stall guard blocks left')
+      // Intent rolled back — iOS Home reads OFF again instead of a phantom ON.
+      expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
+      warn.mockRestore()
+    })
+
+    it('still allows setSidePowerOff while the guard blocks the side', async () => {
+      pumpStallShouldBlock.mockReturnValue(true)
+
+      await setSidePowerOff(monitor(onStatus), 'left')
+
+      expect(setPower).toHaveBeenCalledWith('left', false)
     })
   })
 })

--- a/src/homekit/tests/thermostat.test.ts
+++ b/src/homekit/tests/thermostat.test.ts
@@ -11,6 +11,9 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
 vi.mock('@/src/automation', () => ({
   getAutomationEngineIfRunning: () => ({ registerManualOverride }),
 }))
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: () => false,
+}))
 
 import { buildThermostatService } from '../accessories/thermostat'
 import { __resetSideController } from '../accessories/sideController'

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -646,16 +646,21 @@ export class JobManager {
                 .where(eq(sideSettings.side, side))
                 .run()
             })
-            // Power off the side
-            try {
-              const client = getSharedHardwareClient()
-              await client.connect()
-              await client.setPower(side, false)
-              broadcastMutationStatus(side, { targetLevel: 0 })
-            }
-            catch (e) {
-              console.warn(`[awayMode] Failed to power off ${side}:`, e)
-            }
+            // Power off the side — under the side lock, marking it off in
+            // the DB first so temp/alarm jobs queued behind this one observe
+            // isPowered=false and skip (same protocol as runPowerOffJob).
+            await withSideLock(side, async () => {
+              await this.markSideOff(side)
+              try {
+                const client = getSharedHardwareClient()
+                await client.connect()
+                await client.setPower(side, false)
+                broadcastMutationStatus(side, { targetLevel: 0 })
+              }
+              catch (e) {
+                console.warn(`[awayMode] Failed to power off ${side}:`, e)
+              }
+            })
           },
           { side },
         )

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -17,6 +17,7 @@ import { fahrenheitToLevel, HardwareCommand } from '@/src/hardware/types'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { cancelAutoOffTimer } from '@/src/services/autoOffWatcher'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { withSideLock } from '@/src/hardware/sideLock'
 import { timeToDate, nowInTimezone } from './timeUtils'
 
@@ -326,6 +327,10 @@ export class JobManager {
         console.log(`Skipping temp job temp-${sched.id} — ${sched.side} is not powered`)
         return
       }
+      if (pumpStallShouldBlock(sched.side)) {
+        console.warn(`[jobManager] skipped temp job temp-${sched.id}: pump stall guard blocks ${sched.side}`)
+        return
+      }
       markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
@@ -359,6 +364,10 @@ export class JobManager {
       return
     }
     await withSideLock(sched.side, async () => {
+      if (pumpStallShouldBlock(sched.side)) {
+        console.warn(`[jobManager] skipped power-on power-on-${sched.id}: pump stall guard blocks ${sched.side}`)
+        return
+      }
       markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
@@ -430,11 +439,15 @@ export class JobManager {
       // explicit power-off and would re-arm the same race the temperature
       // path's gate was added to prevent (see withSideLock comment).
       const powered = await this.isSidePowered(sched.side)
+      const stallBlocked = pumpStallShouldBlock(sched.side)
       markSideMutated(sched.side)
       const client = getSharedHardwareClient()
       await client.connect()
-      if (powered) {
+      if (powered && !stallBlocked) {
         await client.setTemperature(sched.side, sched.alarmTemperature)
+      }
+      else if (powered) {
+        console.warn(`[jobManager] skipped alarm temperature alarm-${sched.id}: pump stall guard blocks ${sched.side}; firing vibration only`)
       }
       else {
         console.log(`Alarm job alarm-${sched.id} — ${sched.side} not powered; skipping temperature, firing vibration only`)
@@ -445,7 +458,7 @@ export class JobManager {
         duration: sched.duration,
       })
       broadcastMutationStatus(sched.side, {
-        ...(powered && {
+        ...(powered && !stallBlocked && {
           targetTemperature: sched.alarmTemperature,
           targetLevel: fahrenheitToLevel(sched.alarmTemperature),
         }),
@@ -664,6 +677,10 @@ export class JobManager {
                 .where(eq(sideSettings.side, side))
                 .run()
             })
+            if (pumpStallShouldBlock(side)) {
+              console.warn(`[jobManager] skipped away-return power-on: pump stall guard blocks ${side}`)
+              return
+            }
             // Restore power for the side
             try {
               const client = getSharedHardwareClient()
@@ -1062,6 +1079,10 @@ export class JobManager {
         fireDate,
         async () => {
           await withSideLock(side, async () => {
+            if (pumpStallShouldBlock(side)) {
+              console.warn(`[jobManager] skipped run-once set point: pump stall guard blocks ${side}`)
+              return
+            }
             markSideMutated(side)
             const client = getSharedHardwareClient()
             await client.connect()

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -677,21 +677,25 @@ export class JobManager {
                 .where(eq(sideSettings.side, side))
                 .run()
             })
-            if (pumpStallShouldBlock(side)) {
-              console.warn(`[jobManager] skipped away-return power-on: pump stall guard blocks ${side}`)
-              return
-            }
-            // Restore power for the side
-            try {
-              const client = getSharedHardwareClient()
-              await client.connect()
-              await client.setPower(side, true)
-              cancelAutoOffTimer(side)
-              broadcastMutationStatus(side, {})
-            }
-            catch (e) {
-              console.warn(`[awayMode] Failed to power on ${side}:`, e)
-            }
+            // Restore power for the side — inside the side lock, with the
+            // guard checked there, so a stall trip while this job is queued
+            // still blocks the power-on (ADR 0022).
+            await withSideLock(side, async () => {
+              if (pumpStallShouldBlock(side)) {
+                console.warn(`[jobManager] skipped away-return power-on: pump stall guard blocks ${side}`)
+                return
+              }
+              try {
+                const client = getSharedHardwareClient()
+                await client.connect()
+                await client.setPower(side, true)
+                cancelAutoOffTimer(side)
+                broadcastMutationStatus(side, {})
+              }
+              catch (e) {
+                console.warn(`[awayMode] Failed to power on ${side}:`, e)
+              }
+            })
           },
           { side },
         )

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -1537,6 +1537,114 @@ describe('JobManager residual mutation contracts', () => {
     expect(warn).toHaveBeenCalledWith('[jobManager] skipped away-return power-on: pump stall guard blocks left')
   })
 
+  it('away-start powers off under the side lock, marking the side off in the DB first', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'))
+    const captured = captureOneTimeJobs()
+    vi.spyOn(db, 'transaction').mockImplementation(((callback: any) => callback({
+      update: () => ({ set: () => ({ where: () => ({ run: vi.fn() }) }) }),
+    })) as any)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const order: string[] = []
+    const stateSets: Array<Record<string, unknown>> = []
+    vi.spyOn(db, 'update').mockImplementation((() => ({
+      set: (values: Record<string, unknown>) => {
+        order.push('db-off')
+        stateSets.push(values)
+        return { where: () => ({ run: () => undefined }) }
+      },
+    })) as any)
+    hardwareClient.setPower.mockImplementation(async () => {
+      order.push('hw-off')
+    })
+
+    ;(manager as any).scheduleAwayMode('left', new Date(Date.now() + 60_000).toISOString(), null)
+
+    // Hold the real side lock: the power-off AND its DB mark must queue
+    // behind it rather than running unlocked.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const lockHeld = withSideLock('left', () => gate)
+    const jobRun = required(captured.get('away-start-left'), 'away-start-left').handler()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(order).toHaveLength(0)
+    release()
+    await lockHeld
+    await jobRun
+
+    // Same protocol as runPowerOffJob: DB marked off before the hardware
+    // command so temp/alarm jobs queued behind observe isPowered=false.
+    expect(order).toEqual(['db-off', 'hw-off'])
+    expect(stateSets[0]).toMatchObject({ isPowered: false, poweredOnAt: null, targetTemperature: null })
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+  })
+
+  it('blocks a power-on job whose trip lands while it is queued on the side lock', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(manager, 'hasActiveRunOnceSession').mockResolvedValue(false)
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const lockHeld = withSideLock('right', () => gate)
+    const jobRun = manager.runPowerOnJob({
+      ...row,
+      id: 44,
+      side: 'right',
+      dayOfWeek: 'monday',
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+    })
+    // Let the job pass its gates and queue on the held lock while the guard
+    // is still healthy — only an in-lock check can observe the flip below.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+    release()
+    await lockHeld
+    await jobRun
+
+    expect(hardwareClient.setPower).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped power-on power-on-44: pump stall guard blocks right')
+  })
+
+  it('blocks a temperature job whose trip lands while it is queued on the side lock', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(manager, 'hasActiveRunOnceSession').mockResolvedValue(false)
+    vi.spyOn(manager as any, 'isSidePowered').mockResolvedValue(true)
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const lockHeld = withSideLock('left', () => gate)
+    const jobRun = manager.runTemperatureJob({
+      ...row,
+      id: 45,
+      side: 'left',
+      dayOfWeek: 'monday',
+      time: '08:00',
+      temperature: 78,
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+    release()
+    await lockHeld
+    await jobRun
+
+    expect(hardwareClient.setTemperature).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped temp job temp-45: pump stall guard blocks left')
+  })
+
   it('skips a run-once set point while the guard blocks the side', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'))

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -99,6 +99,7 @@ import { db } from '@/src/db'
 import { sendCommand } from '@/src/hardware/dacTransport'
 import { fahrenheitToLevel, HardwareCommand } from '@/src/hardware/types'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
+import { withSideLock } from '@/src/hardware/sideLock'
 import { JobManager } from '../jobManager'
 import { JobType } from '../types'
 
@@ -1502,6 +1503,36 @@ describe('JobManager residual mutation contracts', () => {
     await required(captured.get('away-return-left'), 'away-return-left').handler()
 
     expect(updates[0]).toMatchObject({ awayMode: false })
+    expect(hardwareClient.setPower).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped away-return power-on: pump stall guard blocks left')
+  })
+
+  it('re-checks the guard inside the side lock — a trip while away-return is queued blocks the power-on', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'))
+    const captured = captureOneTimeJobs()
+    vi.spyOn(db, 'transaction').mockImplementation(((callback: any) => callback({
+      update: () => ({ set: () => ({ where: () => ({ run: vi.fn() }) }) }),
+    })) as any)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    pumpStallMock.shouldBlock.mockReturnValue(false)
+
+    ;(manager as any).scheduleAwayMode('left', null, new Date(Date.now() + 60_000).toISOString())
+
+    // Hold the real side lock, start the job so its power-on queues behind us,
+    // trip the guard, then release: the queued write must observe the trip.
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const lockHeld = withSideLock('left', () => gate)
+    const jobRun = required(captured.get('away-return-left'), 'away-return-left').handler()
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+    release()
+    await lockHeld
+    await jobRun
+
     expect(hardwareClient.setPower).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith('[jobManager] skipped away-return power-on: pump stall guard blocks left')
   })

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -9,6 +9,9 @@ const hardwareClient = vi.hoisted(() => ({
   startPriming: vi.fn(async () => {}),
   sendRaw: vi.fn<(command: string, arg?: string) => Promise<string>>(),
 }))
+const pumpStallMock = vi.hoisted(() => ({
+  shouldBlock: vi.fn<(side: 'left' | 'right') => boolean>(() => false),
+}))
 const writeFileMock = vi.hoisted(() => vi.fn<(path: string, data: string) => Promise<void>>(async () => {}))
 const renameMock = vi.hoisted(() => vi.fn<(from: string, to: string) => Promise<void>>(async () => {}))
 const execMock = vi.hoisted(() => vi.fn())
@@ -77,6 +80,8 @@ vi.mock('@/src/hardware/dacMonitor.instance', async () => {
 vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
   broadcastMutationStatus: vi.fn(),
 }))
+
+vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
 
 vi.mock('@/src/services/autoOffWatcher', () => ({
   cancelAutoOffTimer: vi.fn(),
@@ -1334,6 +1339,7 @@ describe('JobManager residual mutation contracts', () => {
     hardwareClient.setTemperature.mockResolvedValue(undefined)
     hardwareClient.setPower.mockResolvedValue(undefined)
     vi.mocked(broadcastMutationStatus).mockClear()
+    pumpStallMock.shouldBlock.mockReset().mockReturnValue(false)
     writeFileMock.mockClear()
     renameMock.mockClear()
     execMock.mockReset()
@@ -1413,6 +1419,106 @@ describe('JobManager residual mutation contracts', () => {
     expect(log).toHaveBeenCalledWith(
       'Alarm job alarm-15 — right not powered; skipping temperature, firing vibration only',
     )
+  })
+
+  it('skips energizing temp and power-on jobs while the pump stall guard blocks the side', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(manager, 'hasActiveRunOnceSession').mockResolvedValue(false)
+    vi.spyOn(manager as any, 'isSidePowered').mockResolvedValue(true)
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+
+    await manager.runTemperatureJob({
+      ...row,
+      id: 41,
+      side: 'left',
+      dayOfWeek: 'monday',
+      time: '08:00',
+      temperature: 78,
+    })
+    await manager.runPowerOnJob({
+      ...row,
+      id: 42,
+      side: 'right',
+      dayOfWeek: 'monday',
+      onTime: '22:00',
+      offTime: '07:00',
+      onTemperature: 80,
+    })
+
+    expect(hardwareClient.setTemperature).not.toHaveBeenCalled()
+    expect(hardwareClient.setPower).not.toHaveBeenCalled()
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped temp job temp-41: pump stall guard blocks left')
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped power-on power-on-42: pump stall guard blocks right')
+  })
+
+  it('fires alarm vibration but skips its temperature while the guard blocks the side', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(manager as any, 'isSidePowered').mockResolvedValue(true)
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+
+    await manager.runAlarmJob({
+      ...row,
+      id: 43,
+      side: 'right',
+      dayOfWeek: 'monday',
+      time: '06:30',
+      alarmTemperature: 88,
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 30,
+    })
+
+    expect(hardwareClient.setTemperature).not.toHaveBeenCalled()
+    expect(hardwareClient.setAlarm).toHaveBeenCalledWith('right', {
+      vibrationIntensity: 50,
+      vibrationPattern: 'rise',
+      duration: 30,
+    })
+    expect(warn).toHaveBeenCalledWith(
+      '[jobManager] skipped alarm temperature alarm-43: pump stall guard blocks right; firing vibration only',
+    )
+    expect(broadcastMutationStatus).toHaveBeenCalledWith('right', { isAlarmVibrating: true })
+  })
+
+  it('skips away-return power-on while the guard blocks the side but still clears awayMode', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'))
+    const captured = captureOneTimeJobs()
+    const updates: Array<Record<string, unknown>> = []
+    vi.spyOn(db, 'transaction').mockImplementation(((callback: any) => callback({
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updates.push(values)
+          return { where: () => ({ run: vi.fn() }) }
+        },
+      }),
+    })) as any)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+
+    ;(manager as any).scheduleAwayMode('left', null, new Date(Date.now() + 60_000).toISOString())
+    await required(captured.get('away-return-left'), 'away-return-left').handler()
+
+    expect(updates[0]).toMatchObject({ awayMode: false })
+    expect(hardwareClient.setPower).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped away-return power-on: pump stall guard blocks left')
+  })
+
+  it('skips a run-once set point while the guard blocks the side', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'))
+    const captured = captureOneTimeJobs()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+
+    manager.scheduleRunOnceSession(78, 'left', [{ time: '12:10', temperature: 78 }], '13:00', 'UTC')
+    await required(captured.get('runonce-78-0'), 'runonce-78-0').handler()
+
+    expect(hardwareClient.setTemperature).not.toHaveBeenCalled()
+    expect(broadcastMutationStatus).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith('[jobManager] skipped run-once set point: pump stall guard blocks left')
   })
 
   it('pins away-mode state writes, payloads, metadata, logs, and failure warnings', async () => {

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -41,6 +41,10 @@ vi.mock('@/src/services/autoOffWatcher', () => ({
   cancelAutoOffTimer: (side: 'left' | 'right') => cancelAutoOffTimer(side),
 }))
 
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: () => false,
+}))
+
 // Mock child_process.exec so executeReboot tests never spawn systemctl.
 const execMock = vi.fn<(cmd: string, cb: (err: Error | null) => void) => void>()
 execMock.mockImplementation((_cmd, cb) => cb(null))

--- a/src/server/helpers.ts
+++ b/src/server/helpers.ts
@@ -4,6 +4,22 @@
 import { TRPCError } from '@trpc/server'
 import type { HardwareClient } from '@/src/hardware/client'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
+import type { Side } from '@/src/hardware/types'
+
+/**
+ * Throw PRECONDITION_FAILED when the pump stall guard is holding the side
+ * off. Callers gate every energizing write on this (ADR 0022); powering
+ * off is never blocked.
+ */
+export function assertPumpStallNotBlocked(side: Side): void {
+  if (pumpStallShouldBlock(side)) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Pump stall protection active — re-enable the side first',
+    })
+  }
+}
 
 /**
  * Execute a callback with the shared hardware client.
@@ -42,6 +58,12 @@ export async function withHardwareClient<T>(
         return await callback(client)
       }
       catch (retryError) {
+        // A TRPCError from the retried callback (e.g. the pump-stall guard's
+        // PRECONDITION_FAILED) is an intentional rejection, not a hardware
+        // failure — surface it instead of masking it as a 500.
+        if (retryError instanceof TRPCError) {
+          throw retryError
+        }
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: `${errorMessage}: ${retryError instanceof Error ? retryError.message : 'Reconnect failed'}`,

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -372,6 +372,15 @@ export const deviceRouter = router({
           pendingTemps.delete(input.side)
           try {
             await withSideLock(input.side, () => withHardwareClient(async (client) => {
+              // Re-check inside the lock: the guard can trip during the
+              // debounce window or while queued behind the side lock, and a
+              // stale queued command must not re-energize a parked side.
+              if (pumpStallShouldBlock(input.side)) {
+                throw new TRPCError({
+                  code: 'PRECONDITION_FAILED',
+                  message: 'Pump stall protection active — re-enable the side first',
+                })
+              }
               await client.setTemperature(input.side, input.temperature, input.duration)
               return { success: true }
             }, 'Failed to set temperature'))
@@ -443,6 +452,14 @@ export const deviceRouter = router({
 
       registerManualOverride(input.side)
       return withSideLock(input.side, () => withHardwareClient(async (client) => {
+        // Re-check inside the lock (see setTemperature): a trip while this
+        // command queued must not let it re-energize the side.
+        if (input.powered && pumpStallShouldBlock(input.side)) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'Pump stall protection active — re-enable the side first',
+          })
+        }
         await client.setPower(input.side, input.powered, input.temperature)
 
         // Best-effort DB sync — next getStatus() call will re-sync if this fails

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -5,10 +5,9 @@ import { db, biometricsDb } from '@/src/db'
 import { deviceState } from '@/src/db/schema'
 import { bedTemp, waterLevelReadings } from '@/src/db/biometrics-schema'
 import { eq, desc } from 'drizzle-orm'
-import { withHardwareClient } from '@/src/server/helpers'
+import { assertPumpStallNotBlocked, withHardwareClient } from '@/src/server/helpers'
 import { getPrimeCompletedAt, dismissPrimeNotification } from '@/src/hardware/primeNotification'
 import { getAllPumpStallNotices } from '@/src/hardware/pumpStallNotification'
-import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { snoozeAlarm, cancelSnooze, getSnoozeStatus } from '@/src/hardware/snoozeManager'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { HardwareCommand, fahrenheitToLevel } from '@/src/hardware/types'
@@ -322,12 +321,7 @@ export const deviceRouter = router({
     )
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input }) => {
-      if (pumpStallShouldBlock(input.side)) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Pump stall protection active — re-enable the side first',
-        })
-      }
+      assertPumpStallNotBlocked(input.side)
 
       // Server-side debounce: collapse rapid dial-drag calls into one hardware command.
       // Cancel any pending hardware call for this side BEFORE the first await
@@ -338,7 +332,6 @@ export const deviceRouter = router({
         existing.resolve({ success: true }) // resolve the earlier promise immediately
       }
 
-      registerManualOverride(input.side)
       markSideMutated(input.side)
 
       // The DB is updated optimistically on every call for responsive UI.
@@ -375,12 +368,10 @@ export const deviceRouter = router({
               // Re-check inside the lock: the guard can trip during the
               // debounce window or while queued behind the side lock, and a
               // stale queued command must not re-energize a parked side.
-              if (pumpStallShouldBlock(input.side)) {
-                throw new TRPCError({
-                  code: 'PRECONDITION_FAILED',
-                  message: 'Pump stall protection active — re-enable the side first',
-                })
-              }
+              // The manual override registers only after the check passes —
+              // a rejected command must not suspend autopilot.
+              assertPumpStallNotBlocked(input.side)
+              registerManualOverride(input.side)
               await client.setTemperature(input.side, input.temperature, input.duration)
               return { success: true }
             }, 'Failed to set temperature'))
@@ -391,6 +382,28 @@ export const deviceRouter = router({
             resolve({ success: true })
           }
           catch (error) {
+            // A late guard rejection means the optimistic isPowered=true
+            // write above contradicts the parked hardware — restore the
+            // off-state mirror trip() wrote so the UI doesn't keep showing
+            // an energized target until the next status poll.
+            if (error instanceof TRPCError && error.code === 'PRECONDITION_FAILED') {
+              try {
+                markSideMutated(input.side)
+                await db
+                  .update(deviceState)
+                  .set({
+                    isPowered: false,
+                    poweredOnAt: null,
+                    targetTemperature: null,
+                    lastUpdated: new Date(),
+                  })
+                  .where(eq(deviceState.side, input.side))
+              }
+              catch (dbError) {
+                console.error('Failed to restore parked state after guard rejection:', dbError)
+              }
+              broadcastMutationStatus(input.side, { targetLevel: 0 })
+            }
             reject(error)
           }
         }, TEMP_DEBOUNCE_MS)
@@ -443,23 +456,19 @@ export const deviceRouter = router({
     .mutation(async ({ input }) => {
       // Only block when raising power. Powering off is always allowed —
       // it's the safe direction, and the guard's own trip uses this path.
-      if (input.powered && pumpStallShouldBlock(input.side)) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Pump stall protection active — re-enable the side first',
-        })
+      if (input.powered) {
+        assertPumpStallNotBlocked(input.side)
       }
 
-      registerManualOverride(input.side)
       return withSideLock(input.side, () => withHardwareClient(async (client) => {
         // Re-check inside the lock (see setTemperature): a trip while this
-        // command queued must not let it re-energize the side.
-        if (input.powered && pumpStallShouldBlock(input.side)) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'Pump stall protection active — re-enable the side first',
-          })
+        // command queued must not let it re-energize the side. The manual
+        // override registers only after the check passes — a rejected
+        // command must not suspend autopilot.
+        if (input.powered) {
+          assertPumpStallNotBlocked(input.side)
         }
+        registerManualOverride(input.side)
         await client.setPower(input.side, input.powered, input.temperature)
 
         // Best-effort DB sync — next getStatus() call will re-sync if this fails

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -11,6 +11,7 @@ import { getAllPumpStallNotices } from '@/src/hardware/pumpStallNotification'
 import { snoozeAlarm, cancelSnooze, getSnoozeStatus } from '@/src/hardware/snoozeManager'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { HardwareCommand, fahrenheitToLevel } from '@/src/hardware/types'
+import type { Side } from '@/src/hardware/types'
 import { getSharedHardwareClient } from '@/src/hardware/sharedClient'
 import { markSideMutated } from '@/src/hardware/deviceStateSync'
 import { withSideLock } from '@/src/hardware/sideLock'
@@ -43,6 +44,37 @@ const COMMAND_MAP: Record<string, HardwareCommand> = {
   DEVICE_STATUS: HardwareCommand.DEVICE_STATUS,
   ALARM_CLEAR: HardwareCommand.ALARM_CLEAR,
   ALARM_SOLO: HardwareCommand.ALARM_SOLO,
+}
+
+// Opcodes that energize a side's pump loop. Raw execution of these respects
+// the pump-stall guard (ADR 0022) whether spelled by name or as a numeric
+// opcode — probing unknown opcodes stays unguarded, but a known energizing
+// write is a known energizing write. Keyed by parsed opcode so '09' can't
+// slip past as a string alias.
+const ENERGIZING_OPCODES: Record<number, Side[]> = {
+  1: ['left', 'right'], // SET_TEMP — legacy, arg format undocumented, so no per-side/off exemption
+  9: ['left'], // LEFT_TEMP_DURATION
+  10: ['right'], // RIGHT_TEMP_DURATION
+  11: ['left'], // TEMP_LEVEL_LEFT
+  12: ['right'], // TEMP_LEVEL_RIGHT
+}
+
+/**
+ * Sides a raw command would energize, or [] when it is free to pass. A
+ * level/duration write of exactly 0 is the power-off direction and is never
+ * blocked (ADR 0022) — firmware atoi() semantics make parseFloat the right
+ * reading of the arg.
+ */
+function energizedSides(opcode: string, args: string | undefined): Side[] {
+  const code = Number.parseInt(opcode, 10)
+  const sides = ENERGIZING_OPCODES[code]
+  if (!sides) {
+    return []
+  }
+  if (code !== Number(HardwareCommand.SET_TEMP) && args !== undefined && Number.parseFloat(args) === 0) {
+    return []
+  }
+  return sides
 }
 
 // ---------------------------------------------------------------------------
@@ -735,9 +767,14 @@ export const deviceRouter = router({
   // POWER USER / DEBUG FEATURE — Raw Hardware Command Execution
   //
   // This endpoint is a passthrough to the hardware command protocol. It does
-  // NOT validate arguments, does NOT apply safety/debounce mechanisms, and
-  // does NOT sync state to the database. Misuse can damage hardware or cause
-  // unexpected behavior. Use at your own risk.
+  // NOT validate arguments, does NOT apply debounce, and does NOT sync state
+  // to the database. Misuse can damage hardware or cause unexpected behavior.
+  // Use at your own risk.
+  //
+  // One exception: energizing opcodes respect the pump-stall guard
+  // (ADR 0022). A tripped side must be re-enabled via pumpAlerts.acknowledge
+  // before raw temp/duration writes go through — the guard exists precisely
+  // to stop a faulted pump from being re-engaged, debug tooling included.
   //
   // See ADR 0016 for rationale and consequences.
   // ---------------------------------------------------------------------------
@@ -745,8 +782,10 @@ export const deviceRouter = router({
   /**
    * Execute a raw hardware command by name.
    *
-   * Bypasses all high-level validation, debounce, and DB sync. The command
-   * name is allowlisted but the args string is passed through verbatim.
+   * Bypasses high-level validation, debounce, and DB sync. The command name
+   * is allowlisted but the args string is passed through verbatim. Energizing
+   * opcodes are gated on the pump-stall guard and serialized through the
+   * side lock like every other energizing ingress.
    */
   execute: publicProcedure
     .meta({ openapi: { method: 'POST', path: '/device/execute', protect: false, tags: ['Device'] } })
@@ -772,29 +811,60 @@ export const deviceRouter = router({
         ? COMMAND_MAP[input.command]
         : input.command
 
-      try {
-        // Route through the singleton client so the call binds to the same
-        // `dacTransport` module instance that owns the live transport.
-        // Importing sendCommand directly into the route handler can hit a
-        // separate Next.js bundle whose `transport` is undefined — that
-        // path stomps on dac.sock by spinning up a second listener.
-        const client = getSharedHardwareClient() as unknown as { sendRaw(command: string, args?: string): Promise<string> }
-        const response = await client.sendRaw(opcode, input.args)
+      const guardedSides = energizedSides(opcode, input.args)
+      for (const side of guardedSides) {
+        assertPumpStallNotBlocked(side)
+      }
 
-        return {
-          command: input.command,
-          opcode,
-          args: input.args ?? null,
-          response,
-          disclaimer: 'WARNING: Raw command execution. No validation, no safety checks. Misuse can damage hardware or cause unexpected behavior. Use at your own risk. This feature is unsupported.',
+      const send = async () => {
+        try {
+          // Route through the singleton client so the call binds to the same
+          // `dacTransport` module instance that owns the live transport.
+          // Importing sendCommand directly into the route handler can hit a
+          // separate Next.js bundle whose `transport` is undefined — that
+          // path stomps on dac.sock by spinning up a second listener.
+          const client = getSharedHardwareClient() as unknown as { sendRaw(command: string, args?: string): Promise<string> }
+          const response = await client.sendRaw(opcode, input.args)
+
+          return {
+            command: input.command,
+            opcode,
+            args: input.args ?? null,
+            response,
+            disclaimer: 'WARNING: Raw command execution. No validation, minimal safety checks (pump-stall guard only). Misuse can damage hardware or cause unexpected behavior. Use at your own risk. This feature is unsupported.',
+          }
+        }
+        catch (error) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: `Failed to execute raw command: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            cause: error,
+          })
         }
       }
-      catch (error) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: `Failed to execute raw command: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          cause: error,
+
+      if (guardedSides.length === 0) {
+        return send()
+      }
+
+      // Energizing raw writes queue on the side lock like every other
+      // ingress, with the guard re-checked inside so a trip landing while
+      // queued can't re-energize the side.
+      if (guardedSides.length === 1) {
+        const side = guardedSides[0]
+        return withSideLock(side, async () => {
+          assertPumpStallNotBlocked(side)
+          return send()
         })
       }
+
+      // SET_TEMP spans both sides — the only nested lock acquisition in the
+      // codebase. Keep the left-before-right order if another ever appears.
+      return withSideLock('left', () => withSideLock('right', async () => {
+        for (const side of guardedSides) {
+          assertPumpStallNotBlocked(side)
+        }
+        return send()
+      }))
     }),
 })

--- a/src/server/routers/runOnce.ts
+++ b/src/server/routers/runOnce.ts
@@ -5,6 +5,7 @@ import { db } from '@/src/db'
 import { runOnceSessions, deviceSettings } from '@/src/db/schema'
 import { eq, and, gt } from 'drizzle-orm'
 import { getJobManager } from '@/src/scheduler'
+import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
 import { withHardwareClient } from '@/src/server/helpers'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { fahrenheitToLevel } from '@/src/hardware/types'
@@ -35,6 +36,15 @@ export const runOnceRouter = router({
       expiresAt: z.number(),
     }))
     .mutation(async ({ input }) => {
+      // Fail fast before cancelling the existing session — starting a session
+      // powers the side on, which a tripped pump stall guard must block.
+      if (pumpStallShouldBlock(input.side)) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Pump stall protection active — re-enable the side first',
+        })
+      }
+
       const jobManager = await getJobManager()
 
       // Cancel any existing active session for this side

--- a/src/server/routers/runOnce.ts
+++ b/src/server/routers/runOnce.ts
@@ -5,8 +5,7 @@ import { db } from '@/src/db'
 import { runOnceSessions, deviceSettings } from '@/src/db/schema'
 import { eq, and, gt } from 'drizzle-orm'
 import { getJobManager } from '@/src/scheduler'
-import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
-import { withHardwareClient } from '@/src/server/helpers'
+import { assertPumpStallNotBlocked, withHardwareClient } from '@/src/server/helpers'
 import { broadcastMutationStatus } from '@/src/streaming/broadcastMutationStatus'
 import { fahrenheitToLevel } from '@/src/hardware/types'
 import { sideSchema, temperatureSchema, timeStringSchema } from '@/src/server/validation-schemas'
@@ -16,6 +15,24 @@ const setPointSchema = z.object({
   time: timeStringSchema,
   temperature: temperatureSchema,
 })
+
+/**
+ * Best-effort power-off after a start that already energized the side fails.
+ * Powering off is the safe direction and is never guard-blocked; failures
+ * here only log — the caller surfaces the original error.
+ */
+async function powerOffAfterFailedStart(side: 'left' | 'right'): Promise<void> {
+  try {
+    await withHardwareClient(async (client) => {
+      await client.setPower(side, false)
+      return { success: true }
+    }, 'Failed to power off after run-once start failure')
+    broadcastMutationStatus(side, { targetLevel: 0 })
+  }
+  catch (err) {
+    console.error(`Failed to power off ${side} after run-once start failure:`, err)
+  }
+}
 
 export const runOnceRouter = router({
   /**
@@ -38,14 +55,25 @@ export const runOnceRouter = router({
     .mutation(async ({ input }) => {
       // Fail fast before cancelling the existing session — starting a session
       // powers the side on, which a tripped pump stall guard must block.
-      if (pumpStallShouldBlock(input.side)) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'Pump stall protection active — re-enable the side first',
-        })
-      }
+      assertPumpStallNotBlocked(input.side)
 
       const jobManager = await getJobManager()
+
+      // Compute expiry from wake time and validate it BEFORE cancelling the
+      // existing session — a rejected start must leave that session running.
+      const [settings] = await db.select().from(deviceSettings).limit(1)
+      const timezone = settings?.timezone ?? 'America/Los_Angeles'
+      const now = new Date()
+      const expiresAt = timeToDate(input.wakeTime, timezone, now)
+
+      // Reject sessions longer than 14 hours (guards against wake time = now wrapping to 24h)
+      const MAX_SESSION_MS = 14 * 60 * 60 * 1000
+      if (expiresAt.getTime() - now.getTime() > MAX_SESSION_MS) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Session too long (${Math.round((expiresAt.getTime() - now.getTime()) / 3600000)}h). Wake time may have already passed.`,
+        })
+      }
 
       // Cancel any existing active session for this side
       // (synchronous transaction — better-sqlite3 is sync)
@@ -68,21 +96,6 @@ export const runOnceRouter = router({
       })
       jobManager.cancelRunOnceSession(input.side)
 
-      // Compute expiry from wake time
-      const [settings] = await db.select().from(deviceSettings).limit(1)
-      const timezone = settings?.timezone ?? 'America/Los_Angeles'
-      const now = new Date()
-      const expiresAt = timeToDate(input.wakeTime, timezone, now)
-
-      // Reject sessions longer than 14 hours (guards against wake time = now wrapping to 24h)
-      const MAX_SESSION_MS = 14 * 60 * 60 * 1000
-      if (expiresAt.getTime() - now.getTime() > MAX_SESSION_MS) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: `Session too long (${Math.round((expiresAt.getTime() - now.getTime()) / 3600000)}h). Wake time may have already passed.`,
-        })
-      }
-
       // Power on + fire first set point immediately (before inserting session,
       // so a hardware failure doesn't leave an orphaned active session)
       const firstTemp = input.setPoints[0].temperature
@@ -90,12 +103,7 @@ export const runOnceRouter = router({
         // Re-check at the write: the guard can trip during the awaited session
         // cancellation and settings lookup above, and a stale start must not
         // re-energize a parked side.
-        if (pumpStallShouldBlock(input.side)) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'Pump stall protection active — re-enable the side first',
-          })
-        }
+        assertPumpStallNotBlocked(input.side)
         await client.setPower(input.side, true, firstTemp)
         return { success: true }
       }, 'Failed to start run-once session')
@@ -105,19 +113,34 @@ export const runOnceRouter = router({
         targetLevel: fahrenheitToLevel(firstTemp),
       })
 
-      // Create session in DB (after hardware success)
-      const [session] = await db
-        .insert(runOnceSessions)
-        .values({
-          side: input.side,
-          setPoints: JSON.stringify(input.setPoints),
-          wakeTime: input.wakeTime,
-          expiresAt,
-          status: 'active',
+      // Create session in DB (after hardware success). If the insert fails,
+      // power the side back off — otherwise it stays energized with no
+      // session to run the curve or expire it.
+      let session: { id: number } | undefined
+      try {
+        [session] = await db
+          .insert(runOnceSessions)
+          .values({
+            side: input.side,
+            setPoints: JSON.stringify(input.setPoints),
+            wakeTime: input.wakeTime,
+            expiresAt,
+            status: 'active',
+          })
+          .returning({ id: runOnceSessions.id })
+      }
+      catch (insertError) {
+        console.error('Run-once session insert failed, powering side back off:', insertError)
+        await powerOffAfterFailedStart(input.side)
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create run-once session',
+          cause: insertError,
         })
-        .returning({ id: runOnceSessions.id })
+      }
 
       if (!session) {
+        await powerOffAfterFailedStart(input.side)
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create run-once session' })
       }
 

--- a/src/server/routers/runOnce.ts
+++ b/src/server/routers/runOnce.ts
@@ -87,6 +87,15 @@ export const runOnceRouter = router({
       // so a hardware failure doesn't leave an orphaned active session)
       const firstTemp = input.setPoints[0].temperature
       await withHardwareClient(async (client) => {
+        // Re-check at the write: the guard can trip during the awaited session
+        // cancellation and settings lookup above, and a stale start must not
+        // re-energize a parked side.
+        if (pumpStallShouldBlock(input.side)) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'Pump stall protection active — re-enable the side first',
+          })
+        }
         await client.setPower(input.side, true, firstTemp)
         return { success: true }
       }, 'Failed to start run-once session')

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -514,6 +514,22 @@ describe('device.setTemperature', () => {
     expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
   })
 
+  it('re-checks the guard inside the side lock — a trip during the debounce window blocks the queued command', async () => {
+    vi.useFakeTimers()
+    try {
+      // Early check passes, then the guard trips while the command is debounced.
+      pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+      const pending = caller.setTemperature({ side: 'left', temperature: 70 })
+      const assertion = expect(pending).rejects.toThrow(/Pump stall protection active/)
+      await vi.advanceTimersByTimeAsync(250)
+      await assertion
+      expect(helpersMock.client.setTemperature).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('swallows DB sync errors so the timer still fires', async () => {
     vi.useFakeTimers()
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -686,6 +702,13 @@ describe('device.setPower', () => {
     await expect(caller.setPower({ side: 'left', powered: true, temperature: 72 })).rejects.toThrow(/Pump stall protection active/)
     expect(helpersMock.client.setPower).not.toHaveBeenCalled()
     expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
+  })
+
+  it('re-checks the guard inside the side lock before sending power-on', async () => {
+    // Early check passes; the trip lands while the command queues on the lock.
+    pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+    await expect(caller.setPower({ side: 'left', powered: true, temperature: 72 })).rejects.toThrow(/Pump stall protection active/)
+    expect(helpersMock.client.setPower).not.toHaveBeenCalled()
   })
 
   it('allows powering off even when pump stall guard is active', async () => {

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -953,6 +953,74 @@ describe('device.execute (raw command)', () => {
     sharedClientMock.sendRaw.mockRejectedValue({ disconnected: true })
     await expect(caller.execute({ command: '14' })).rejects.toThrow('Failed to execute raw command: Unknown error')
   })
+
+  it.each([
+    ['TEMP_LEVEL_LEFT', 'left'],
+    ['TEMP_LEVEL_RIGHT', 'right'],
+    ['LEFT_TEMP_DURATION', 'left'],
+    ['RIGHT_TEMP_DURATION', 'right'],
+  ] as const)('blocks energizing %s when the %s guard is tripped', async (command, side) => {
+    pumpStallMock.shouldBlock.mockImplementation(s => s === side)
+    await expect(caller.execute({ command, args: '50' })).rejects.toThrow(/Pump stall protection active/)
+    expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+  })
+
+  it('blocks the numeric alias of an energizing opcode', async () => {
+    pumpStallMock.shouldBlock.mockImplementation(s => s === 'left')
+    await expect(caller.execute({ command: '11', args: '50' })).rejects.toThrow(/Pump stall protection active/)
+    expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+  })
+
+  it('blocks SET_TEMP when either side is tripped — legacy arg format claims no exemption', async () => {
+    pumpStallMock.shouldBlock.mockImplementation(s => s === 'right')
+    await expect(caller.execute({ command: 'SET_TEMP', args: '0' })).rejects.toThrow(/Pump stall protection active/)
+    expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+  })
+
+  it('lets a level-0 write through on a tripped side — powering off is never blocked', async () => {
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+    sharedClientMock.sendRaw.mockResolvedValue('ok')
+    await caller.execute({ command: 'TEMP_LEVEL_LEFT', args: '0' })
+    expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('11', '0')
+  })
+
+  it('leaves non-energizing and unknown commands unguarded while tripped', async () => {
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+    sharedClientMock.sendRaw.mockResolvedValue('ok')
+    await caller.execute({ command: 'DEVICE_STATUS' })
+    await caller.execute({ command: 'ALARM_LEFT', args: '50,double,30,0' })
+    await caller.execute({ command: '99', args: 'probe' })
+    expect(sharedClientMock.sendRaw).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-checks the guard inside the side lock before an energizing raw write', async () => {
+    // Pre-flight check passes; the trip lands while the command queues.
+    pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+    await expect(caller.execute({ command: 'TEMP_LEVEL_LEFT', args: '50' })).rejects.toThrow(/Pump stall protection active/)
+    expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+  })
+
+  it('queues an energizing raw write behind a held side lock', async () => {
+    let releaseLeft!: () => void
+    const holder = withSideLock('left', () => new Promise<void>((resolve) => {
+      releaseLeft = resolve
+    }))
+    try {
+      sharedClientMock.sendRaw.mockResolvedValue('ok')
+      const pending = caller.execute({ command: 'TEMP_LEVEL_LEFT', args: '50' })
+      await Promise.resolve()
+      expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+
+      releaseLeft()
+      await holder
+      await pending
+      expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('11', '50')
+    }
+    finally {
+      releaseLeft()
+      await holder.catch(() => {})
+    }
+  })
 })
 
 describe('device best-effort DB sync swallows errors', () => {

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -128,7 +128,22 @@ const wifiMock = vi.hoisted(() => ({
   getWifiInfo: vi.fn<() => { wifiStrength: number, wifiSSID: string }>(() => ({ wifiStrength: -1, wifiSSID: 'unknown' })),
 }))
 
-vi.mock('@/src/server/helpers', () => ({ withHardwareClient: helpersMock.withHardwareClient }))
+vi.mock('@/src/server/helpers', async () => {
+  const { TRPCError } = await import('@trpc/server')
+  return {
+    withHardwareClient: helpersMock.withHardwareClient,
+    // Mirrors the real helper but consults this file's pumpStallMock so
+    // tests keep driving the guard through shouldBlock.
+    assertPumpStallNotBlocked: (side: 'left' | 'right') => {
+      if (pumpStallMock.shouldBlock(side)) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Pump stall protection active — re-enable the side first',
+        })
+      }
+    },
+  }
+})
 vi.mock('@/src/hardware/primeNotification', () => primeMock)
 vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
@@ -524,6 +539,61 @@ describe('device.setTemperature', () => {
       await vi.advanceTimersByTimeAsync(250)
       await assertion
       expect(helpersMock.client.setTemperature).not.toHaveBeenCalled()
+      // A rejected command must not suspend autopilot.
+      expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('restores the parked DB mirror and broadcasts off when the in-lock recheck rejects', async () => {
+    vi.useFakeTimers()
+    try {
+      pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+      dbState.rowsQueue.push([{ isPowered: true, poweredOnAt: new Date() }])
+      const pending = caller.setTemperature({ side: 'left', temperature: 70 })
+      const assertion = expect(pending).rejects.toThrow(/Pump stall protection active/)
+      await vi.advanceTimersByTimeAsync(250)
+      await assertion
+      // update #0 is the optimistic energized write; update #1 must put the
+      // parked mirror back so the UI doesn't keep an energized target.
+      expect(dbChain('update', 1).set).toHaveBeenCalledWith({
+        isPowered: false,
+        poweredOnAt: null,
+        targetTemperature: null,
+        lastUpdated: expect.any(Date),
+      })
+      expect(broadcastMock.broadcastMutationStatus).toHaveBeenCalledWith('left', { targetLevel: 0 })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('blocks a debounced command queued behind a held side lock when the trip lands while queued', async () => {
+    vi.useFakeTimers()
+    try {
+      let tripped = false
+      pumpStallMock.shouldBlock.mockImplementation(() => tripped)
+      let release: () => void = () => {}
+      const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+        release = resolve
+      }))
+      await vi.advanceTimersByTimeAsync(0)
+
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+      const pending = caller.setTemperature({ side: 'left', temperature: 70 })
+      const assertion = expect(pending).rejects.toThrow(/Pump stall protection active/)
+      // Debounce fires and the write queues behind the held lock, all while
+      // the guard is still healthy — the flip below happens strictly after.
+      await vi.advanceTimersByTimeAsync(250)
+      tripped = true
+      release()
+      await holder
+      await assertion
+      expect(helpersMock.client.setTemperature).not.toHaveBeenCalled()
+      expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
     }
     finally {
       vi.useRealTimers()
@@ -568,6 +638,10 @@ describe('device.setTemperature', () => {
       const err = await caught
       expect(err).toBeInstanceOf(Error)
       expect((err as Error).message).toMatch(/hw down/)
+      // Only guard rejections compensate the optimistic write — a hardware
+      // failure leaves the single optimistic update in place.
+      expect(dbMock.update).toHaveBeenCalledTimes(1)
+      expect(broadcastMock.broadcastMutationStatus).not.toHaveBeenCalledWith('left', { targetLevel: 0 })
     }
     finally {
       vi.useRealTimers()
@@ -593,7 +667,9 @@ describe('device.setTemperature', () => {
       // Only the second call's value reaches hardware
       expect(helpersMock.client.setTemperature).toHaveBeenCalledTimes(1)
       expect(helpersMock.client.setTemperature).toHaveBeenCalledWith('left', 75, undefined)
-      expect(automationMock.registerManualOverride).toHaveBeenCalledTimes(2)
+      // One executed hardware write → one override registration; the
+      // coalesced first call must not register a second one.
+      expect(automationMock.registerManualOverride).toHaveBeenCalledTimes(1)
       expect(automationMock.registerManualOverride).toHaveBeenLastCalledWith('left')
     }
     finally {
@@ -709,6 +785,35 @@ describe('device.setPower', () => {
     pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
     await expect(caller.setPower({ side: 'left', powered: true, temperature: 72 })).rejects.toThrow(/Pump stall protection active/)
     expect(helpersMock.client.setPower).not.toHaveBeenCalled()
+    // A rejected command must not suspend autopilot.
+    expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
+  })
+
+  it('blocks a power-on queued behind a held side lock when the trip lands while queued', async () => {
+    let tripped = false
+    pumpStallMock.shouldBlock.mockImplementation(() => tripped)
+    let release: () => void = () => {}
+    const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+      release = resolve
+    }))
+    await Promise.resolve()
+
+    dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+    const pending = caller.setPower({ side: 'left', powered: true, temperature: 72 })
+    const assertion = expect(pending).rejects.toThrow(/Pump stall protection active/)
+    // Let the mutation pass its entry check and queue on the held lock
+    // while the guard is still healthy — the flip below happens strictly
+    // after, so only an in-lock recheck can observe it.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
+    expect(pumpStallMock.shouldBlock).toHaveBeenCalled()
+    tripped = true
+    release()
+    await holder
+    await assertion
+    expect(helpersMock.client.setPower).not.toHaveBeenCalled()
+    expect(automationMock.registerManualOverride).not.toHaveBeenCalled()
   })
 
   it('allows powering off even when pump stall guard is active', async () => {

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -27,6 +27,10 @@ const broadcastMock = vi.hoisted(() => ({
   broadcastMutationStatus: vi.fn(),
 }))
 
+const pumpStallMock = vi.hoisted(() => ({
+  shouldBlock: vi.fn<(side: 'left' | 'right') => boolean>(() => false),
+}))
+
 const timeUtilsMock = vi.hoisted(() => ({
   // Default: wake time 1 hour from now
   timeToDate: vi.fn((_t: string, _tz: string, now: Date) => new Date(now.getTime() + 60 * 60 * 1000)),
@@ -83,6 +87,7 @@ const dbMock = vi.hoisted(() => {
 })
 
 vi.mock('@/src/scheduler', () => schedulerMock)
+vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
 vi.mock('@/src/server/helpers', () => helpersMock)
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
 vi.mock('@/src/scheduler/timeUtils', () => timeUtilsMock)
@@ -106,6 +111,7 @@ beforeEach(() => {
   helpersMock.withHardwareClient.mockImplementation(async (cb: (client: unknown) => Promise<unknown>) => cb(helpersMock.client))
   helpersMock.client.setPower.mockReset().mockResolvedValue(undefined)
   broadcastMock.broadcastMutationStatus.mockReset()
+  pumpStallMock.shouldBlock.mockReset().mockReturnValue(false)
   timeUtilsMock.timeToDate.mockReset().mockImplementation(
     (_t, _tz, now) => new Date(now.getTime() + 60 * 60 * 1000),
   )
@@ -124,6 +130,23 @@ beforeEach(() => {
 })
 
 describe('runOnce.start', () => {
+  it('throws PRECONDITION_FAILED before touching sessions while pump stall guard blocks the side', async () => {
+    pumpStallMock.shouldBlock.mockReturnValue(true)
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Pump stall protection active/)
+
+    // Fails fast: the existing session is not cancelled, no hardware write,
+    // no session row inserted.
+    expect(dbMock.transactionFn).not.toHaveBeenCalled()
+    expect(jobManagerMock.cancelRunOnceSession).not.toHaveBeenCalled()
+    expect(helpersMock.client.setPower).not.toHaveBeenCalled()
+    expect(dbMock.insert).not.toHaveBeenCalled()
+  })
+
   it('powers on the side with the first set-point temperature, persists session, and schedules the rest', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     const expiresAt = new Date(Date.now() + 3_600_123)

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -88,7 +88,22 @@ const dbMock = vi.hoisted(() => {
 
 vi.mock('@/src/scheduler', () => schedulerMock)
 vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
-vi.mock('@/src/server/helpers', () => helpersMock)
+vi.mock('@/src/server/helpers', async () => {
+  const { TRPCError } = await import('@trpc/server')
+  return {
+    ...helpersMock,
+    // Mirrors the real helper but consults this file's pumpStallMock so
+    // tests keep driving the guard through shouldBlock.
+    assertPumpStallNotBlocked: (side: 'left' | 'right') => {
+      if (pumpStallMock.shouldBlock(side)) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Pump stall protection active — re-enable the side first',
+        })
+      }
+    },
+  }
+})
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
 vi.mock('@/src/scheduler/timeUtils', () => timeUtilsMock)
 vi.mock('@/src/db', () => ({
@@ -251,6 +266,10 @@ describe('runOnce.start', () => {
     // Hardware must NOT be touched if validation rejects
     expect(helpersMock.withHardwareClient).not.toHaveBeenCalled()
     expect(jobManagerMock.scheduleRunOnceSession).not.toHaveBeenCalled()
+    // And the existing active session must survive a rejected start —
+    // validation runs before any cancellation.
+    expect(dbMock.transactionFn).not.toHaveBeenCalled()
+    expect(jobManagerMock.cancelRunOnceSession).not.toHaveBeenCalled()
   })
 
   it('accepts a session exactly 14 hours long', async () => {
@@ -279,7 +298,7 @@ describe('runOnce.start', () => {
     })
   })
 
-  it('throws when DB insert returns no row (e.g. constraint violation)', async () => {
+  it('throws when DB insert returns no row and powers the side back off', async () => {
     dbMock.setNextInsertId(null)
 
     await expect(caller.start({
@@ -287,6 +306,52 @@ describe('runOnce.start', () => {
       setPoints: [{ time: '23:00', temperature: 70 }],
       wakeTime: '07:00',
     })).rejects.toThrow(/Failed to create run-once session/)
+
+    // The side was already energized — a failed insert must not leave it
+    // running with no session to drive or expire it.
+    expect(helpersMock.client.setPower).toHaveBeenNthCalledWith(1, 'left', true, 70)
+    expect(helpersMock.client.setPower).toHaveBeenNthCalledWith(2, 'left', false)
+    expect(broadcastMock.broadcastMutationStatus).toHaveBeenLastCalledWith('left', { targetLevel: 0 })
+  })
+
+  it('powers the side back off when the session insert throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    dbMock.insert.mockImplementationOnce(() => {
+      throw new Error('db down')
+    })
+
+    await expect(caller.start({
+      side: 'right',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to create run-once session',
+    })
+
+    expect(helpersMock.client.setPower).toHaveBeenNthCalledWith(2, 'right', false)
+    expect(jobManagerMock.scheduleRunOnceSession).not.toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+
+  it('surfaces the insert failure even when the compensating power-off also fails', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    dbMock.setNextInsertId(null)
+    helpersMock.client.setPower
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('off failed'))
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toThrow(/Failed to create run-once session/)
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to power off left after run-once start failure'),
+      expect.anything(),
+    )
+    errSpy.mockRestore()
   })
 
   it('cancels any prior active session for the same side before starting', async () => {

--- a/src/server/routers/tests/runOnce.test.ts
+++ b/src/server/routers/tests/runOnce.test.ts
@@ -147,6 +147,28 @@ describe('runOnce.start', () => {
     expect(dbMock.insert).not.toHaveBeenCalled()
   })
 
+  it('re-checks the guard at the hardware write and blocks a trip that lands mid-flight', async () => {
+    // Entry check passes, then the guard trips during the awaited session
+    // cancellation / settings lookup — the write-time re-check must stop the
+    // power-on and the session insert.
+    pumpStallMock.shouldBlock.mockReturnValueOnce(false).mockReturnValue(true)
+
+    await expect(caller.start({
+      side: 'left',
+      setPoints: [{ time: '23:00', temperature: 70 }],
+      wakeTime: '07:00',
+    })).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Pump stall protection active — re-enable the side first',
+    })
+
+    expect(dbMock.transactionFn).toHaveBeenCalled()
+    expect(helpersMock.client.setPower).not.toHaveBeenCalled()
+    expect(broadcastMock.broadcastMutationStatus).not.toHaveBeenCalled()
+    expect(dbMock.insert).not.toHaveBeenCalled()
+    expect(jobManagerMock.scheduleRunOnceSession).not.toHaveBeenCalled()
+  })
+
   it('powers on the side with the first set-point temperature, persists session, and schedules the rest', async () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     const expiresAt = new Date(Date.now() + 3_600_123)

--- a/src/server/tests/helpers.test.ts
+++ b/src/server/tests/helpers.test.ts
@@ -13,7 +13,13 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: hardware.getSharedHardwareClient,
 }))
 
-const { withHardwareClient } = await import('@/src/server/helpers')
+const pumpStallMock = vi.hoisted(() => ({
+  shouldBlock: vi.fn<(side: 'left' | 'right') => boolean>(() => false),
+}))
+
+vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
+
+const { assertPumpStallNotBlocked, withHardwareClient } = await import('@/src/server/helpers')
 
 beforeEach(() => {
   hardware.client.connect.mockReset().mockResolvedValue(undefined)
@@ -95,6 +101,22 @@ describe('withHardwareClient', () => {
     })
   })
 
+  it('rethrows a TRPCError from the retry attempt instead of wrapping it as a 500', async () => {
+    // e.g. the pump-stall guard trips during the reconnect window — the
+    // PRECONDITION_FAILED must reach the client, not a masked 500.
+    const precondition = new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Pump stall protection active — re-enable the side first',
+    })
+    const callback = vi.fn()
+      .mockRejectedValueOnce(new Error('socket closed'))
+      .mockRejectedValueOnce(precondition)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(withHardwareClient(callback, 'hardware failed')).rejects.toBe(precondition)
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
   it('uses the reconnect fallback for a non-Error retry rejection', async () => {
     const callback = vi.fn()
       .mockRejectedValueOnce(new Error('EPIPE'))
@@ -130,5 +152,29 @@ describe('withHardwareClient', () => {
       cause: { reason: 'bad payload' },
     })
     expect(hardware.client.disconnect).not.toHaveBeenCalled()
+  })
+})
+
+describe('assertPumpStallNotBlocked', () => {
+  it('is a no-op when the guard does not block the side', () => {
+    pumpStallMock.shouldBlock.mockReturnValueOnce(false)
+    expect(() => assertPumpStallNotBlocked('left')).not.toThrow()
+    expect(pumpStallMock.shouldBlock).toHaveBeenCalledWith('left')
+  })
+
+  it('throws PRECONDITION_FAILED with the guard message when blocked', () => {
+    pumpStallMock.shouldBlock.mockReturnValueOnce(true)
+    let caught: unknown
+    try {
+      assertPumpStallNotBlocked('right')
+    }
+    catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(TRPCError)
+    expect(caught).toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Pump stall protection active — re-enable the side first',
+    })
   })
 })

--- a/src/services/temperatureKeepalive.ts
+++ b/src/services/temperatureKeepalive.ts
@@ -14,6 +14,7 @@ import { db } from '@/src/db'
 import { deviceState, sideSettings } from '@/src/db/schema'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
+import { withSideLock } from '@/src/hardware/sideLock'
 import type { Side } from '@/src/hardware/types'
 
 const KEEPALIVE_INTERVAL_MS = 6 * 60 * 60 * 1000 // 6 hours in milliseconds
@@ -32,42 +33,47 @@ export function startKeepalive(side: Side): void {
 
   const tick = async () => {
     try {
-      // Read current device state to get target temperature
-      const [state] = db
-        .select()
-        .from(deviceState)
-        .where(eq(deviceState.side, side))
-        .limit(1)
-        .all()
+      // The whole tick runs under the side lock so the isPowered and
+      // stall-guard checks stay valid at the write — a power-off job or
+      // guard trip serialized ahead of this reissue is observed, not raced.
+      await withSideLock(side, async () => {
+        // Read current device state to get target temperature
+        const [state] = db
+          .select()
+          .from(deviceState)
+          .where(eq(deviceState.side, side))
+          .limit(1)
+          .all()
 
-      if (!state || !state.isPowered || state.targetTemperature == null) {
-        // Side is off or has no target — nothing to keepalive
-        return
-      }
+        if (!state || !state.isPowered || state.targetTemperature == null) {
+          // Side is off or has no target — nothing to keepalive
+          return
+        }
 
-      // Skip silently while the pump stall guard is holding the side off.
-      // Re-issuing the user's last setpoint here would defeat the cutoff.
-      if (pumpStallShouldBlock(side)) {
-        return
-      }
+        // Skip silently while the pump stall guard is holding the side off.
+        // Re-issuing the user's last setpoint here would defeat the cutoff.
+        if (pumpStallShouldBlock(side)) {
+          return
+        }
 
-      // Verify alwaysOn is still enabled (may have been toggled off between ticks)
-      const [settings] = db
-        .select()
-        .from(sideSettings)
-        .where(eq(sideSettings.side, side))
-        .limit(1)
-        .all()
+        // Verify alwaysOn is still enabled (may have been toggled off between ticks)
+        const [settings] = db
+          .select()
+          .from(sideSettings)
+          .where(eq(sideSettings.side, side))
+          .limit(1)
+          .all()
 
-      if (!settings?.alwaysOn) {
-        stopKeepalive(side)
-        return
-      }
+        if (!settings?.alwaysOn) {
+          stopKeepalive(side)
+          return
+        }
 
-      const client = getSharedHardwareClient()
-      await client.connect()
-      await client.setTemperature(side, state.targetTemperature)
-      console.log(`[keepalive] Re-sent temperature ${state.targetTemperature}°F for ${side}`)
+        const client = getSharedHardwareClient()
+        await client.connect()
+        await client.setTemperature(side, state.targetTemperature)
+        console.log(`[keepalive] Re-sent temperature ${state.targetTemperature}°F for ${side}`)
+      })
     }
     catch (error) {
       console.error(

--- a/src/services/tests/temperatureKeepalive.test.ts
+++ b/src/services/tests/temperatureKeepalive.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/src/db', async () => {
 })
 
 import * as dbModule from '@/src/db'
+import { withSideLock } from '@/src/hardware/sideLock'
 import {
   startKeepalive,
   stopKeepalive,
@@ -173,6 +174,55 @@ describe('startKeepalive', () => {
 
     expect(setTemperature).not.toHaveBeenCalled()
     expect(connect).not.toHaveBeenCalled()
+  })
+
+  it('serializes the reissue through the side lock — a trip while queued blocks it', async () => {
+    setSideState('left', { isPowered: 1, targetTemperature: 95 })
+    setSideSettings('left', { alwaysOn: 1 })
+
+    let release: () => void = () => {}
+    const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+      release = resolve
+    }))
+    await flushAsync()
+
+    // The immediate tick queues behind the held lock while the guard is
+    // still healthy — the trip below lands strictly after, so only an
+    // in-lock check can observe it.
+    startKeepalive('left')
+    await flushAsync()
+    expect(setTemperature).not.toHaveBeenCalled()
+
+    pumpStallShouldBlock.mockReturnValue(true)
+    release()
+    await holder
+    await flushAsync()
+
+    expect(setTemperature).not.toHaveBeenCalled()
+    expect(connect).not.toHaveBeenCalled()
+  })
+
+  it('observes a power-off that landed while the reissue was queued on the lock', async () => {
+    setSideState('left', { isPowered: 1, targetTemperature: 95 })
+    setSideSettings('left', { alwaysOn: 1 })
+
+    let release: () => void = () => {}
+    const holder = withSideLock('left', async () => new Promise<void>((resolve) => {
+      release = resolve
+    }))
+    await flushAsync()
+
+    startKeepalive('left')
+    await flushAsync()
+
+    // A power-off handler (e.g. markSideOff) serialized ahead of the queued
+    // reissue clears isPowered — the reissue must skip, not re-energize.
+    setSideState('left', { isPowered: 0 })
+    release()
+    await holder
+    await flushAsync()
+
+    expect(setTemperature).not.toHaveBeenCalled()
   })
 
   it('skips setTemperature when targetTemperature is null', async () => {


### PR DESCRIPTION
## Problem

The adversarial review of PR #669 (findings **M13** and **S4**) confirmed that the pump-stall guard's interlock was only enforced at three ingresses (`device.setTemperature`, `device.setPower`, `temperatureKeepalive`). ADR 0022's parking contract says a tripped side stays de-energized until a human acknowledges — but every other energizing path wrote straight to hardware:

- **M13 — bypassing ingresses:** scheduler jobs (temperature, power-on, alarm temperature, away-return, run-once set points), the Automations engine executor, HomeKit setters (thermostat/power switch via `sideController`), gesture actions (temperature taps, power toggle), and `runOnce.start`'s immediate power-on. Any of these could silently re-energize a side parked against a stalled pump — e.g. a 3am scheduled power-on re-heating stagnant water, which is exactly the incident ADR 0022 exists to prevent.
- **S4 — TOCTOU in device router:** the guard check ran before the debounce window (`setTemperature`) / before side-lock acquisition (`setPower`). A trip landing between the check and the hardware write let a stale queued command re-energize the side.

## Fix

Every energizing ingress now consults `shouldBlock` from `src/hardware/pumpStallGuard` (de-energizing writes are never blocked — powering off is the guard's own safe direction):

- `src/scheduler/jobManager.ts` — `runTemperatureJob`, `runPowerOnJob` (inside the side lock), `runAlarmJob` (temperature skipped, **vibration still fires**), away-return power-on (awayMode still cleared in DB), run-once set-point jobs. All degrade to a `console.warn` + skip; the scheduler loop never throws.
- `src/automation/engine.ts` — new injected `pumpStallShouldBlock` dep (wired in `instance.ts`); the check runs inside the side lock immediately before the write and records a `skipped: 'pump-stall'` action in the automation_runs audit log. `setPower(off)` still passes.
- `src/homekit/accessories/sideController.ts` — `setTargetTemperature` skips the push (target stays staged, same semantics as adjusting while OFF); `setSidePowerOn` throws inside the lock so the existing catch rolls `intendedPower` back and iOS Home reverts the toggle instead of showing a phantom ON; `setSidePowerOff` is untouched.
- `src/hardware/gestureActionHandler.ts` — temperature taps and power-on toggles skip with a warn; power-off toggles still work.
- `src/server/routers/runOnce.ts` — `start` fails fast with `PRECONDITION_FAILED` before cancelling the existing session or powering on.
- `src/server/routers/device.ts` (S4) — `setTemperature`/`setPower` now **re-check inside `withSideLock`** immediately before the hardware write, in addition to the existing early fast-fail check.

Deliberately not guarded: all `setPower(side, false)` paths (scheduler power-off/cleanup, away-start, auto-off watcher, HomeKit off, gesture power-off, automation `setPower(off)`), alarm vibration (`setAlarm` — not thermal), and daily priming (circulation-only maintenance; no heat against a stalled pump, and a prime can help clear one). `pumpAlerts.acknowledge` restores through the guarded `device` router after clearing the guard, per the ADR's acknowledgement path.

## Test plan

- Unit tests added per ingress (Stryker-pinning: exact warn strings, blocked-vs-allowed direction, and the S4 in-lock re-check):
  - `src/scheduler/tests/jobManager.test.ts` — temp/power-on/alarm/away-return/run-once blocked variants
  - `src/automation/tests/engine.test.ts` — setTemperature and setPower(on) skipped, setPower(off) allowed, per-side fan-out
  - `src/homekit/tests/sideController.test.ts` — staged-but-not-pushed target, power-on rejection + intent rollback, power-off allowed
  - `src/hardware/tests/gestureActionHandler.test.ts` — temp tap and power-on skipped, power-off allowed
  - `src/server/routers/tests/device.test.ts` — guard trip during the debounce window / lock queue blocks the queued command
  - `src/server/routers/tests/runOnce.test.ts` — start fails fast without cancelling the prior session
- `pnpm tsc && pnpm lint && pnpm test` green (3210 passed, 0 failed); pre-push hook re-ran the gates on push.
- Manual verification on a pod: trip the guard (or force `blocked` via the debug console), then confirm (1) a due temperature schedule logs the skip and sends nothing (`journalctl -u frank` shows no DAC command), (2) the Home app power toggle reverts with an error, (3) alarm vibration still fires at wake time, (4) acknowledging the alert restores the pre-stall target through the normal path.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/pump-stall-guard-enforcement
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/pump-stall-guard-enforcement/scripts/install \
  | sudo bash -s -- --branch fix/pump-stall-guard-enforcement
```

🎯 **Pin to this exact build** ([run 29890757337](https://github.com/sleepypod/core/actions/runs/29890757337) · `6afd2d6`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/6afd2d669eb443f3c11823b6a4e1407612ccb233/scripts/install \
  | sudo bash -s -- \
      --branch fix/pump-stall-guard-enforcement \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/29890757337/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/29890757337/artifacts/8518168036) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pump-stall protection now blocks temperature changes and power-on activation across automation, scheduled jobs, gesture controls, HomeKit, and server routes, with warnings and “skipped” outcomes when blocked.
  * Power-off operations continue to work while a side is blocked.
  * Queued hardware commands are rechecked inside per-side locks to prevent stale energizing after the guard activates.
  * Power-on rollbacks are corrected (e.g., HomeKit toggles revert properly), including run-once mid-flight rechecks.
  * Manual override anti-thrash no longer persists after expiry, and keepalive ticks are now serialized per side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


