### PR TITLE
feat(homekit): surface guard-blocked staged HomeKit target on the pump-stall alert card

### DIFF
--- a/docs/adr/0022-pump-stall-safety.md
+++ b/docs/adr/0022-pump-stall-safety.md
@@ -395,9 +395,37 @@ bounded to 600s past the projected end so a stale snapshot cannot
 suppress a later session's genuine stall. A zero-RPM frame mid-session
 with the pump still driven trips exactly as before.
 
+## Revisions
+
+**2026-07-29 (field data, PR #670).** Three changes after the guard ran on
+real pods:
+
+1. **Time-based dwell floor.** Frame-based dwell alone (`dwellSamples`, default
+   2 ≈ 2s) powered a side off on ~2s of bad readings. A trip now also requires
+   the pump to stay sub-threshold for `DWELL_MIN_MS` (10s) of wall clock, so a
+   brief dropped/garbled-frame blip cannot end a night. Frame time is threaded
+   through `onFrame` so the floor is driven by frame arrival.
+
+2. **Bilateral-zero de-glitch.** Both pumps dropping from clearly running to
+   exactly 0 RPM in one frame is the dropped-frame signature (loop temp/flow
+   keep moving, both read healthy again next frame), not a real dual stall —
+   which hits one side. `deviceStateSync` drops that single frame; a sustained
+   dual-stall still trips one frame later.
+
+3. **Active-probe auto-recovery.** The passive design here — "watch for
+   `recoverySamples` consecutive frames at `recoveryRpm`" — was unreachable
+   overnight: the trip powers the pump off, so RPM stays 0 and the watcher
+   never advances. Nothing re-energized the pump, so a trip only "recovered"
+   when the daily prime or a manual restart happened to spin it up. The guard
+   now *probes*: a blocked side with auto-recovery enabled is re-energized
+   after a backoff (5m, 15m, 30m); sustained healthy RPM restores it via the
+   path above, otherwise it is powered back off and the next backoff applies,
+   staying off after the last attempt until acknowledged.
+
 ## References
 
 - Incident report: Discord, 2026-05-24, free-sleep user thread.
+- Field revisions: Discord, 2026-07-29, overnight-stall + twitchy-trip thread.
 - Existing detection code: `src/hardware/deviceStateSync.ts:250`.
 - Live `eight-pod` flow data: 240 rows pulled 2026-05-25 17:15 local,
   showing 1940–2010 RPM running, 0 RPM idle, no intermediate values.

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -102,5 +102,33 @@ if getent group dac &>/dev/null; then
   fi
 fi
 
+# 6. Self-heal the reboot sudoers rule for pods that updated via sp-update
+# (which does NOT re-run scripts/install). Newer fresh installs write this
+# into /etc/sudoers.d/sleepypod-update; existing pods that only ever run
+# sp-update never get it, so the daily / pre-prime reboot jobs
+# (JobManager.executeReboot → `sudo -n systemctl reboot`) fail auth and the
+# pod never reboots on schedule. Keep the command paths in sync with the
+# sleepypod-update fragment in scripts/install. Best-effort: an ExecStartPre
+# failure would block the app from starting, so every step tolerates failure.
+REBOOT_SUDOERS=/etc/sudoers.d/sleepypod-reboot
+REBOOT_SUDOERS_CONTENT='sleepypod ALL=(root) NOPASSWD: /bin/systemctl reboot, /usr/bin/systemctl reboot'
+if [ ! -f "$REBOOT_SUDOERS" ] || [ "$(cat "$REBOOT_SUDOERS" 2>/dev/null)" != "$REBOOT_SUDOERS_CONTENT" ]; then
+  TMP_SUDOERS=$(mktemp 2>/dev/null || echo "")
+  if [ -n "$TMP_SUDOERS" ]; then
+    printf '%s\n' "$REBOOT_SUDOERS_CONTENT" > "$TMP_SUDOERS"
+    chmod 0440 "$TMP_SUDOERS" 2>/dev/null || true
+    if visudo -c -q -f "$TMP_SUDOERS" 2>/dev/null; then
+      if install -m 0440 -o root -g root "$TMP_SUDOERS" "$REBOOT_SUDOERS" 2>/dev/null; then
+        echo "Installed reboot sudoers rule ($REBOOT_SUDOERS)."
+      else
+        echo "WARNING: could not install $REBOOT_SUDOERS (need root?) — skipping" >&2
+      fi
+    else
+      echo "WARNING: reboot sudoers fragment failed visudo — skipping" >&2
+    fi
+    rm -f "$TMP_SUDOERS" 2>/dev/null || true
+  fi
+fi
+
 DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
 echo "Maintenance complete. ${DISK_AVAIL}MB free."

--- a/scripts/install
+++ b/scripts/install
@@ -745,9 +745,16 @@ fi
 # the sleepypod tools usable from any sudo shell without re-enabling the
 # system fragment, which might be commented out for a reason on the
 # vendor image.
+# The reboot rule lets the daily / pre-prime reboot jobs work: next-server
+# runs as User=sleepypod and JobManager.executeReboot shells `sudo -n
+# systemctl reboot`. Without this a bare reboot fails auth and the pod never
+# reboots on schedule (observed: 5-day uptime with reboot_daily on). Scope is
+# exactly `systemctl reboot` — both common systemctl paths so the rule matches
+# whichever the image ships. secure_path (below) lets sudo resolve it.
 SUDOERS_FILE="/etc/sudoers.d/sleepypod-update"
 SUDOERS_CONTENT='Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-sleepypod ALL=(root) NOPASSWD: /usr/local/bin/sp-update'
+sleepypod ALL=(root) NOPASSWD: /usr/local/bin/sp-update
+sleepypod ALL=(root) NOPASSWD: /bin/systemctl reboot, /usr/bin/systemctl reboot'
 SUDOERS_TMP=$(mktemp)
 printf '%s\n' "$SUDOERS_CONTENT" > "$SUDOERS_TMP"
 chmod 0440 "$SUDOERS_TMP"

--- a/src/components/TempScreen/PumpStallNotification.tsx
+++ b/src/components/TempScreen/PumpStallNotification.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, X } from 'lucide-react'
 import { trpc } from '@/src/utils/trpc'
+import { formatSetpointF, type TempUnit } from '@/src/lib/tempUtils'
 
 interface PumpStallNotificationProps {
   side: 'left' | 'right'
@@ -10,6 +11,9 @@ interface PumpStallNotificationProps {
   trippedAt: number
   /** pump_alerts row id from the notice; 0 when the trip-time insert failed. */
   alertId?: number
+  /** Setpoint Re-enable restores (notice.restore); null when the trip captured none. */
+  restoreTargetF?: number | null
+  unit?: TempUnit
   /** Called after either re-enable or dismiss settles so the parent can refetch. */
   onAction?: () => void
 }
@@ -29,12 +33,22 @@ const formatTime = (unixSeconds: number): string => {
  *     side stays off until the user powers it back on, and any command
  *     path re-triggers the guard if the pump is still bad.
  */
-export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction }: PumpStallNotificationProps) => {
+export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, restoreTargetF = null, unit = 'F', onAction }: PumpStallNotificationProps) => {
   const acknowledge = trpc.pumpAlerts.acknowledgeAndRestore.useMutation()
   const dismiss = trpc.pumpAlerts.dismissNotification.useMutation()
   // Correlate the mutation with the incident shown here — the server then
   // stamps exactly this row even across a restart. 0 means "no row".
   const alertRef = alertId || undefined
+
+  // Guard-rejected HomeKit temp writes keep the requested value staged while
+  // iOS shows the slider reverting; the next power-on heats to the staged
+  // value (PR #670 F1). This card is the only surface that can re-enable the
+  // side, so the mismatch is surfaced here. Polled, not streamed: the staged
+  // value only moves on HomeKit writes and the card is rarely mounted.
+  const { data: thermal } = trpc.health.thermal.useQuery({}, { refetchInterval: 15_000 })
+  const sideHealth = thermal?.sides.find(s => s.side === side)
+  const stagedF = sideHealth?.guardBlocked ? sideHealth.homekitStagedTargetF : null
+  const stagedMismatch = stagedF != null && stagedF !== (restoreTargetF ?? null)
 
   // While either mutation is in flight, both actions stay disabled — the
   // two paths race for the same guard state and alert row.
@@ -59,6 +73,17 @@ export const PumpStallNotification = ({ side, rpm, trippedAt, alertId, onAction 
           {formatTime(trippedAt)}
           . The side is off for safety. Re-enable to retry.
         </p>
+        {stagedMismatch && (
+          <p className="text-xs text-red-200/70">
+            HomeKit has
+            {' '}
+            {formatSetpointF(stagedF, unit)}
+            {' '}
+            staged for the next power-on
+            {restoreTargetF != null && ` — Re-enable restores ${formatSetpointF(restoreTargetF, unit)}`}
+            .
+          </p>
+        )}
       </div>
       <button
         onClick={() => acknowledge.mutate({ side, alertId: alertRef }, { onSettled: onAction })}

--- a/src/components/TempScreen/TempScreen.tsx
+++ b/src/components/TempScreen/TempScreen.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import { trpc } from '@/src/utils/trpc'
 import { useSide } from '@/src/providers/SideProvider'
 import { useDeviceStatus } from '@/src/hooks/useDeviceStatus'
+import { useGuardRejectionNotice } from '@/src/hooks/useGuardRejectionNotice'
 import { useOptimisticValue } from '@/src/hooks/useOptimisticValue'
 import { SideSelector } from '@/src/components/SideSelector/SideSelector'
 import { EnvironmentInfoPanel } from '@/src/components/EnvironmentInfo/EnvironmentInfoPanel'
@@ -13,6 +14,7 @@ import { PrimingIndicator } from '@/src/components/TempScreen/PrimingIndicator'
 import { PrimeCompleteNotification } from '@/src/components/TempScreen/PrimeCompleteNotification'
 import { PumpStallNotification } from '@/src/components/TempScreen/PumpStallNotification'
 import { AmbientLightChip } from '@/src/components/TempScreen/AmbientLightChip'
+import { SchedulerConfirmation } from '@/src/components/Schedule/SchedulerConfirmation'
 import { displayToSetpointF, setpointFToDisplay, type TempUnit } from '@/src/lib/tempUtils'
 import { TEMP } from '@/src/lib/tempColors'
 import { Minus, Plus, Power } from 'lucide-react'
@@ -82,6 +84,16 @@ export const TempScreen = () => {
   const stallNotices = status?.pumpStallNotifications
   const snoozeStatus = status?.snooze
 
+  // Transient snackbar when a guard-blocked HomeKit write was refused —
+  // the overlay rides a single WS frame, the hook latches and auto-dismisses.
+  // Extracted structurally: the HTTP fallback's side type never carries the
+  // overlay, so dotting into the WS/HTTP union does not type-check.
+  const overlayOf = (side?: object) =>
+    side && 'guardRejection' in side
+      ? side.guardRejection as { ts: number, source: string } | undefined
+      : undefined
+  const guardRejectionMessage = useGuardRejectionNotice(overlayOf(status?.leftSide), overlayOf(status?.rightSide))
+
   /** Handle continuous drag updates — visual only, no hardware calls. */
   const handleDialChange = useCallback((tempF: number) => {
     targetOpt.preview(tempF)
@@ -145,6 +157,9 @@ export const TempScreen = () => {
       {/* Side selector — only on the Temp screen */}
       <SideSelector />
 
+      {/* HomeKit write refused by the pump stall guard — transient snackbar */}
+      <SchedulerConfirmation message={guardRejectionMessage} variant="error" />
+
       {/* Pump stall — highest priority, dismissible per-side */}
       {stallNotices?.left && (
         <PumpStallNotification
@@ -152,6 +167,8 @@ export const TempScreen = () => {
           rpm={stallNotices.left.rpm}
           trippedAt={stallNotices.left.trippedAt}
           alertId={stallNotices.left.alertId}
+          restoreTargetF={stallNotices.left.restore?.targetTemperature ?? null}
+          unit={unit}
           onAction={() => refetch()}
         />
       )}
@@ -161,6 +178,8 @@ export const TempScreen = () => {
           rpm={stallNotices.right.rpm}
           trippedAt={stallNotices.right.trippedAt}
           alertId={stallNotices.right.alertId}
+          restoreTargetF={stallNotices.right.restore?.targetTemperature ?? null}
+          unit={unit}
           onAction={() => refetch()}
         />
       )}

--- a/src/components/TempScreen/tests/PumpStallNotification.test.tsx
+++ b/src/components/TempScreen/tests/PumpStallNotification.test.tsx
@@ -11,17 +11,30 @@ const trpcMock = vi.hoisted(() => {
   const ackMutate = vi.fn()
   const dismissMutate = vi.fn()
   const pending = { acknowledge: false, dismiss: false }
+  const thermal: { data: unknown } = { data: undefined }
   return {
     ackMutate,
     dismissMutate,
     pending,
+    thermal,
     trpc: {
       pumpAlerts: {
         acknowledgeAndRestore: { useMutation: () => ({ mutate: ackMutate, isPending: pending.acknowledge }) },
         dismissNotification: { useMutation: () => ({ mutate: dismissMutate, isPending: pending.dismiss }) },
       },
+      health: {
+        thermal: { useQuery: () => ({ data: thermal.data }) },
+      },
     },
   }
+})
+
+/** Minimal health.thermal payload — only the fields the card reads. */
+const thermalSides = (left: object, right: object = {}) => ({
+  sides: [
+    { side: 'left', guardBlocked: false, homekitStagedTargetF: null, ...left },
+    { side: 'right', guardBlocked: false, homekitStagedTargetF: null, ...right },
+  ],
 })
 
 vi.mock('@/src/utils/trpc', () => ({ trpc: trpcMock.trpc }))
@@ -33,6 +46,7 @@ beforeEach(() => {
   trpcMock.dismissMutate.mockClear()
   trpcMock.pending.acknowledge = false
   trpcMock.pending.dismiss = false
+  trpcMock.thermal.data = undefined
 })
 
 describe('PumpStallNotification', () => {
@@ -87,5 +101,62 @@ describe('PumpStallNotification', () => {
       <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} />,
     )
     expect(getByRole('alert').textContent).toContain('side powered off — pump stall detected')
+  })
+
+  describe('staged HomeKit target mismatch (PR #670 F1)', () => {
+    it('shows the staged target and the restore value when they differ on a guard-blocked side', () => {
+      trpcMock.thermal.data = thermalSides({ guardBlocked: true, homekitStagedTargetF: 78 })
+      const { getByRole } = render(
+        <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={72} />,
+      )
+      expect(getByRole('alert').textContent).toContain(
+        'HomeKit has 78°F staged for the next power-on — Re-enable restores 72°F.',
+      )
+    })
+
+    it('omits the restore clause when the trip captured no restore target', () => {
+      trpcMock.thermal.data = thermalSides({ guardBlocked: true, homekitStagedTargetF: 78 })
+      const { getByRole } = render(
+        <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={null} />,
+      )
+      const text = getByRole('alert').textContent
+      expect(text).toContain('HomeKit has 78°F staged for the next power-on.')
+      expect(text).not.toContain('Re-enable restores')
+    })
+
+    it('stays hidden when the staged target matches the restore target', () => {
+      trpcMock.thermal.data = thermalSides({ guardBlocked: true, homekitStagedTargetF: 72 })
+      const { getByRole } = render(
+        <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={72} />,
+      )
+      expect(getByRole('alert').textContent).not.toContain('staged')
+    })
+
+    it('stays hidden when the guard no longer blocks the side', () => {
+      trpcMock.thermal.data = thermalSides({ guardBlocked: false, homekitStagedTargetF: 78 })
+      const { getByRole } = render(
+        <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={72} />,
+      )
+      expect(getByRole('alert').textContent).not.toContain('staged')
+    })
+
+    it('reads its own side from the thermal payload', () => {
+      trpcMock.thermal.data = thermalSides({ guardBlocked: true, homekitStagedTargetF: 78 })
+      const { getByRole } = render(
+        <PumpStallNotification side="right" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={72} />,
+      )
+      expect(getByRole('alert').textContent).not.toContain('staged')
+    })
+
+    it('formats staged and restore values in the display unit', () => {
+      // 78°F → 26°C, 72°F → 22°C (rounded display values)
+      trpcMock.thermal.data = thermalSides({ guardBlocked: true, homekitStagedTargetF: 78 })
+      const { getByRole } = render(
+        <PumpStallNotification side="left" rpm={40} trippedAt={1_720_000_000} alertId={38} restoreTargetF={72} unit="C" />,
+      )
+      expect(getByRole('alert').textContent).toContain(
+        'HomeKit has 26°C staged for the next power-on — Re-enable restores 22°C.',
+      )
+    })
   })
 })

--- a/src/hardware/deviceStateSync.ts
+++ b/src/hardware/deviceStateSync.ts
@@ -104,6 +104,9 @@ export class DeviceStateSync {
   private primeEndedAt = 0
   private stallGuardInFlight: Record<Side, boolean> = { left: false, right: false }
   private stallGuardPending: Record<Side, { rpm: number, duty: number | null } | null> = { left: null, right: null }
+  // Whether the previous frzHealth frame had both pumps clearly running.
+  // Used to de-glitch a single dropped/garbled frame (see checkFlowAnomalies).
+  private prevBothRunning = false
 
   sync = async (status: DeviceStatus): Promise<void> => {
     const now = Date.now()
@@ -382,8 +385,21 @@ export class DeviceStateSync {
     // Feed the per-side stall guard. Reads current device_state to derive
     // expectedActive — a side that's commanded off should not trip on
     // RPM = 0 since that is the correct value.
-    this.queueStallGuard('left', leftRpm, leftPump.duty)
-    this.queueStallGuard('right', rightRpm, rightPump.duty)
+    //
+    // Bilateral-zero de-glitch: both pumps dropping from clearly running to
+    // exactly 0 RPM in a single frame is the dropped/garbled-frame signature,
+    // not a real dual stall — a genuine mechanical stall hits one side (loop
+    // temp/flow keep moving, and both sides read healthy again the next frame).
+    // Suppress that one frame so neither side's dwell counter advances on it.
+    // Bounded: only the frame immediately following a both-running frame is
+    // dropped, so a genuine simultaneous dual-stall still trips, one frame later.
+    const bothZero = leftRpm === 0 && rightRpm === 0
+    const suppressGlitch = bothZero && this.prevBothRunning
+    this.prevBothRunning = leftRpm >= PUMP_FAILURE_RPM_MIN && rightRpm >= PUMP_FAILURE_RPM_MIN
+    if (!suppressGlitch) {
+      this.queueStallGuard('left', leftRpm, leftPump.duty)
+      this.queueStallGuard('right', rightRpm, rightPump.duty)
+    }
 
     // Pump running but flowrate missing — possible sensor fault
     if (leftRpm >= PUMP_FAILURE_RPM_MIN && Number.isNaN(leftFlowCd)) {

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -41,6 +41,15 @@ interface GuardState {
   /** epoch ms of the first frame in the current sub-threshold run, or null
    *  when the last frame was healthy. Gates the time-based dwell floor. */
   lowSince: number | null
+  /** number of auto-recovery probes started since the trip. */
+  recoveryAttempts: number
+  /** epoch ms the current probe re-energized the side, or null when not
+   *  probing. While set, the side is physically on but the guard stays blocked
+   *  until sustained healthy RPM confirms recovery. */
+  probeStartedAt: number | null
+  /** epoch ms the last probe was powered back off; backoff is measured from
+   *  here (or the trip, for the first probe). */
+  lastProbeEndedAt: number | null
 }
 
 interface GuardSettings {
@@ -77,6 +86,9 @@ function emptyState(): GuardState {
     preStall: null,
     cutoffPending: false,
     lowSince: null,
+    recoveryAttempts: 0,
+    probeStartedAt: null,
+    lastProbeEndedAt: null,
   }
 }
 
@@ -87,6 +99,19 @@ function emptyState(): GuardState {
 // harmless (the bed takes minutes to drift). Frame-based dwell alone tripped
 // on ~2s of bad readings; see ADR 0022.
 const DWELL_MIN_MS = 10_000
+
+// Auto-recovery probe schedule. A trip powers the pump off, so RPM stays 0 and
+// recovery can never be observed passively — nothing re-energizes the pump. So
+// a blocked side with auto-recovery enabled is actively re-energized after each
+// backoff to let the pump prove itself; sustained healthy RPM restores it,
+// otherwise it is powered back off and the next (longer) backoff applies. After
+// the last backoff the side stays off until the user acknowledges. Backoffs are
+// spaced so an intermittent fault gets a few chances without thrashing a
+// genuinely dead pump against the loop all night.
+const PROBE_BACKOFFS_MS = [5 * 60_000, 15 * 60_000, 30 * 60_000]
+// How long a probe keeps the pump energized waiting for sustained healthy RPM
+// before concluding the pump is still stalled.
+const PROBE_WINDOW_MS = 60_000
 
 // ── Settings cache ─────────────────────────────────────────────────────────
 // `recordFlowData` fires every frame; reading device_settings on each call
@@ -210,15 +235,42 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
     }
   }
 
-  // Track healthy recovery frames if auto-recovery is on.
+  // Auto-recovery (opt-in). A trip powers the pump off, so RPM sits at 0 and
+  // recovery cannot be observed passively — nothing re-energizes the pump to
+  // let it prove itself. Instead, after a backoff, actively re-energize the
+  // side (a "probe"); the healthy-frame tracking below then sees whether the
+  // pump recovers. See PROBE_BACKOFFS_MS.
+  if (!settings.autoRecoveryEnabled) return
+
   if (input.rpm >= settings.recoveryRpm) {
     state.consecutiveHealthyFrames += 1
   }
   else {
     state.consecutiveHealthyFrames = 0
   }
-  if (settings.autoRecoveryEnabled && state.consecutiveHealthyFrames >= settings.recoverySamples) {
+  if (state.consecutiveHealthyFrames >= settings.recoverySamples) {
     await autoRecover(input.side)
+    return
+  }
+
+  // Don't probe while a failed trip-cutoff is still being retried — the side
+  // must reach a known-off state first.
+  if (state.cutoffPending) return
+
+  if (state.probeStartedAt == null) {
+    // Idle between probes: start one when the backoff has elapsed and attempts
+    // remain. Backoff runs from the last probe's end, or the trip.
+    if (state.recoveryAttempts < PROBE_BACKOFFS_MS.length) {
+      const backoff = PROBE_BACKOFFS_MS[state.recoveryAttempts]
+      const since = state.lastProbeEndedAt ?? state.trippedAt ?? now
+      if (now - since >= backoff) {
+        await startRecoveryProbe(input.side, now)
+      }
+    }
+  }
+  else if (now - state.probeStartedAt >= PROBE_WINDOW_MS) {
+    // Probe window elapsed without sustained healthy RPM — pump still stalled.
+    await endFailedProbe(input.side, now)
   }
 }
 
@@ -272,6 +324,9 @@ export function rearm(side: Side, params: {
   state.consecutiveLowFrames = 0
   state.consecutiveHealthyFrames = 0
   state.lowSince = null
+  state.recoveryAttempts = 0
+  state.probeStartedAt = null
+  state.lastProbeEndedAt = null
   setPumpStallNotice(side, {
     alertId: params.alertId ?? 0,
     trippedAt: Math.floor(state.trippedAt / 1000),
@@ -516,6 +571,76 @@ async function autoRecover(side: Side): Promise<void> {
   console.log(`[pumpStallGuard] auto-recovered ${side}`)
 }
 
+/**
+ * Re-energize a blocked side so its pump can attempt to spin back up. The guard
+ * stays blocked and device_state keeps mirroring off — only sustained healthy
+ * RPM (observed by onFrame → autoRecover) actually restores the side. If the
+ * pump stays low for the probe window, endFailedProbe powers it back off.
+ */
+async function startRecoveryProbe(side: Side, now: number): Promise<void> {
+  const state = getState()[side]
+  const restore = state.preStall
+  if (!restore) {
+    // No snapshot to restore to — a probe can't lead anywhere. Give up and
+    // clear the guard so a later user command isn't blocked (mirrors the
+    // no-snapshot autoRecover path).
+    reset(side)
+    return
+  }
+
+  state.recoveryAttempts += 1
+  state.probeStartedAt = now
+  state.consecutiveHealthyFrames = 0
+
+  // Same lock + deadlock rationale as trip()/autoRecover: only reachable from
+  // the frame path, and the energize must not interleave with a queued
+  // same-side writer's command sequence.
+  try {
+    await withSideLock(side, async () => {
+      const client = getSharedHardwareClient()
+      await client.setPower(side, true, restore.targetTemperature)
+      await client.setTemperature(side, restore.targetTemperature, restore.durationSeconds)
+    })
+  }
+  catch (err) {
+    // Couldn't energize — count it as a failed probe so the backoff advances.
+    state.probeStartedAt = null
+    state.lastProbeEndedAt = now
+    console.warn(`[pumpStallGuard] recovery probe energize for ${side} failed:`, err instanceof Error ? err.message : err)
+    return
+  }
+  console.log(`[pumpStallGuard] probing ${side} recovery (attempt ${state.recoveryAttempts}/${PROBE_BACKOFFS_MS.length})`)
+}
+
+/**
+ * A recovery probe elapsed without sustained healthy RPM — the pump is still
+ * stalled. Power the side back off and record the end so the next (longer)
+ * backoff applies; after the last attempt the side stays off until acknowledged.
+ */
+async function endFailedProbe(side: Side, now: number): Promise<void> {
+  const state = getState()[side]
+  state.probeStartedAt = null
+  state.lastProbeEndedAt = now
+  state.consecutiveHealthyFrames = 0
+
+  try {
+    await withSideLock(side, async () => {
+      const client = getSharedHardwareClient()
+      await client.setPower(side, false)
+    })
+  }
+  catch (err) {
+    console.warn(`[pumpStallGuard] recovery probe power-off for ${side} failed:`, err instanceof Error ? err.message : err)
+  }
+
+  if (state.recoveryAttempts >= PROBE_BACKOFFS_MS.length) {
+    console.warn(`[pumpStallGuard] ${side} pump still stalled after ${state.recoveryAttempts} recovery probes — staying off until acknowledged`)
+  }
+  else {
+    console.log(`[pumpStallGuard] ${side} recovery probe ${state.recoveryAttempts} did not restore flow — backing off`)
+  }
+}
+
 // ── Test introspection ─────────────────────────────────────────────────────
 
 export const __test__ = {
@@ -523,4 +648,6 @@ export const __test__ = {
   emptyState,
   readSettings,
   DWELL_MIN_MS,
+  PROBE_BACKOFFS_MS,
+  PROBE_WINDOW_MS,
 }

--- a/src/hardware/pumpStallGuard.ts
+++ b/src/hardware/pumpStallGuard.ts
@@ -38,6 +38,9 @@ interface GuardState {
   /** true when the trip-time hardware power-off never went out — retried
    *  on every subsequent frame until it succeeds. */
   cutoffPending: boolean
+  /** epoch ms of the first frame in the current sub-threshold run, or null
+   *  when the last frame was healthy. Gates the time-based dwell floor. */
+  lowSince: number | null
 }
 
 interface GuardSettings {
@@ -73,8 +76,17 @@ function emptyState(): GuardState {
     activeAlertId: null,
     preStall: null,
     cutoffPending: false,
+    lowSince: null,
   }
 }
+
+// Time-based dwell floor. A trip requires the pump to stay sub-threshold for
+// BOTH dwellSamples consecutive frames AND this much wall-clock — so a burst
+// of frames, or a ~1–2s dropped/garbled-frame blip, can't power a side off
+// mid-night. A genuine stall still trips within ~10s, which is thermally
+// harmless (the bed takes minutes to drift). Frame-based dwell alone tripped
+// on ~2s of bad readings; see ADR 0022.
+const DWELL_MIN_MS = 10_000
 
 // ── Settings cache ─────────────────────────────────────────────────────────
 // `recordFlowData` fires every frame; reading device_settings on each call
@@ -125,16 +137,22 @@ export interface OnFrameInput {
   expectedActive: boolean
   preStallTarget: number | null
   preStallDurationSeconds: number | null
+  /** Frame receipt time (epoch ms) for the dwell floor; defaults to now.
+   *  Threaded so the time-based dwell is driven by frame arrival, not the
+   *  guard's own clock, and stays deterministic under test. */
+  now?: number
 }
 
 export async function onFrame(input: OnFrameInput): Promise<void> {
   const settings = readSettings()
   const state = getState()[input.side]
+  const now = input.now ?? Date.now()
 
   if (!settings.enabled) {
     state.consecutiveLowFrames = 0
     state.consecutiveHealthyFrames = 0
     state.blocked = false
+    state.lowSince = null
     return
   }
 
@@ -144,6 +162,7 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
     // expectedActive is false for every post-trip frame and returning here
     // would make the cutoff retry and recovery tracking below unreachable.
     state.consecutiveLowFrames = 0
+    state.lowSince = null
     return
   }
 
@@ -160,12 +179,17 @@ export async function onFrame(input: OnFrameInput): Promise<void> {
   if (!state.blocked) {
     if (input.rpm < settings.threshold) {
       state.consecutiveLowFrames += 1
-      if (state.consecutiveLowFrames >= settings.dwellSamples) {
+      if (state.lowSince == null) state.lowSince = now
+      // Require both the frame-count dwell and the wall-clock floor so a brief
+      // burst of low frames can't trip on its own (see DWELL_MIN_MS).
+      if (state.consecutiveLowFrames >= settings.dwellSamples
+        && now - state.lowSince >= DWELL_MIN_MS) {
         await trip(input.side, input.rpm)
       }
     }
     else {
       state.consecutiveLowFrames = 0
+      state.lowSince = null
     }
     return
   }
@@ -247,6 +271,7 @@ export function rearm(side: Side, params: {
   state.preStall = params.restore
   state.consecutiveLowFrames = 0
   state.consecutiveHealthyFrames = 0
+  state.lowSince = null
   setPumpStallNotice(side, {
     alertId: params.alertId ?? 0,
     trippedAt: Math.floor(state.trippedAt / 1000),
@@ -337,6 +362,7 @@ async function trip(side: Side, rpm: number): Promise<void> {
   state.trippedAt = Date.now()
   state.consecutiveLowFrames = 0
   state.consecutiveHealthyFrames = 0
+  state.lowSince = null
 
   // Capture a snapshot from device_state if we don't already have one — the
   // preStall field is updated each healthy frame, but covers the case where
@@ -496,4 +522,5 @@ export const __test__ = {
   getState,
   emptyState,
   readSettings,
+  DWELL_MIN_MS,
 }

--- a/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
+++ b/src/hardware/tests/deviceStateSync.stallSuppression.test.ts
@@ -353,3 +353,76 @@ describe('DeviceStateSync — stall guard coalescing', () => {
     expect(leftInputs()[1]?.rpm).toBe(200)
   })
 })
+
+describe('DeviceStateSync — bilateral-zero de-glitch', () => {
+  let sync: DeviceStateSync
+
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 5; i += 1) await Promise.resolve()
+  }
+  const leftCalls = () => vi.mocked(onFrame).mock.calls
+    .map(([input]) => input)
+    .filter(input => input.side === 'left')
+
+  // Per-side frame: the shared `frame()` helper drives both sides to the same
+  // RPM, which can't express a single-side stall.
+  function asymFrame(leftRpm: number, rightRpm: number): Record<string, unknown> {
+    return {
+      left: { pump: { rpm: leftRpm }, temps: { flowrate: 25.0 } },
+      right: { pump: { rpm: rightRpm }, temps: { flowrate: 25.0 } },
+    }
+  }
+
+  beforeEach(() => {
+    resetSchema()
+    _resetMutationStamps()
+    vi.mocked(onFrame).mockClear()
+    vi.mocked(onFrame).mockResolvedValue(undefined)
+    sync = new DeviceStateSync()
+    seedSide('left', true, 75)
+    seedSide('right', true, 75)
+  })
+
+  it('drops a both-zero frame that immediately follows a both-running frame', async () => {
+    sync.recordFlowData(frame({ rpm: 1900 }))
+    await flush()
+    sync.recordFlowData(frame({ rpm: 0 })) // garble: both pumps drop to 0 at once
+    await flush()
+
+    // Only the healthy frame reached the guard — the garble was suppressed on
+    // both sides, so no dwell counter saw a low frame.
+    expect(leftCalls()).toHaveLength(1)
+    expect(leftCalls()[0]?.rpm).toBe(1900)
+  })
+
+  it('feeds a sustained both-zero once it persists past the single-frame glitch', async () => {
+    sync.recordFlowData(frame({ rpm: 1900 }))
+    await flush()
+    sync.recordFlowData(frame({ rpm: 0 })) // suppressed (glitch candidate)
+    await flush()
+    sync.recordFlowData(frame({ rpm: 0 })) // still zero next frame → real, fed
+    await flush()
+
+    expect(leftCalls()).toHaveLength(2)
+    expect(leftCalls()[1]?.rpm).toBe(0)
+  })
+
+  it('does not suppress a single-side stall (only one pump at zero)', async () => {
+    sync.recordFlowData(frame({ rpm: 1900 }))
+    await flush()
+    sync.recordFlowData(asymFrame(0, 1900)) // left stalls, right healthy
+    await flush()
+
+    expect(leftCalls()).toHaveLength(2)
+    expect(leftCalls()[1]?.rpm).toBe(0)
+  })
+
+  it('does not suppress a both-zero frame with no prior running frame', async () => {
+    // Cold start (e.g. right after a restart): a both-zero frame is fed so the
+    // existing expected-stop suppression path still governs it.
+    sync.recordFlowData(frame({ rpm: 0 }))
+    await flush()
+    expect(leftCalls()).toHaveLength(1)
+    expect(leftCalls()[0]?.rpm).toBe(0)
+  })
+})

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -121,6 +121,19 @@ function setSettings(patch: Record<string, number>): void {
   ;(sqlite as any).exec(`UPDATE device_settings SET ${cols} WHERE id = 1`)
 }
 
+// The stall guard now gates trips on a wall-clock dwell floor (DWELL_MIN_MS)
+// in addition to the frame count. `frame()` wraps onFrame with a monotonic
+// frame time that advances past the floor on every call, so a pair of low
+// frames trips exactly as it did before the floor existed. Tests that assert
+// the dwell floor itself pass an explicit `now`. Date.now() is left real, so
+// the settings-cache TTL behaviour is unchanged.
+const FRAME_GAP_MS = __test__.DWELL_MIN_MS + 1_000
+let frameClock = 1_700_000_000_000
+function frame(input: Parameters<typeof onFrame>[0]): Promise<void> {
+  frameClock += FRAME_GAP_MS
+  return onFrame({ now: frameClock, ...input })
+}
+
 describe('pumpStallGuard', () => {
   beforeEach(() => {
     resetSchema()
@@ -136,7 +149,7 @@ describe('pumpStallGuard', () => {
 
   it('does not trip when expectedActive is false (side off)', async () => {
     for (let i = 0; i < 5; i += 1) {
-      await onFrame({
+      await frame({
         side: 'left',
         rpm: 0,
         expectedActive: false,
@@ -149,9 +162,9 @@ describe('pumpStallGuard', () => {
   })
 
   it('trips after dwellSamples consecutive low-RPM frames', async () => {
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(false)
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
     expect(setPower).toHaveBeenCalledWith('left', false)
     const notice = getPumpStallNotice('left')
@@ -166,7 +179,7 @@ describe('pumpStallGuard', () => {
     setSettings({ pump_stall_protection_enabled: 0 })
     invalidateGuardSettingsCache()
     for (let i = 0; i < 5; i += 1) {
-      await onFrame({
+      await frame({
         side: 'left',
         rpm: 50,
         expectedActive: true,
@@ -179,18 +192,64 @@ describe('pumpStallGuard', () => {
   })
 
   it('clears the dwell counter on a healthy frame between low frames', async () => {
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(false)
   })
 
   it('treats RPM exactly at the trip threshold as healthy', async () => {
-    await onFrame({ side: 'left', rpm: 500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(shouldBlock('left')).toBe(false)
     expect(setPower).not.toHaveBeenCalled()
+  })
+
+  describe('time-based dwell floor', () => {
+    // Explicit frame times (bypassing the auto-advancing frame() helper) so
+    // these pin the DWELL_MIN_MS wall-clock gate directly.
+    const low = (now: number) => ({
+      side: 'left' as const,
+      rpm: 100,
+      expectedActive: true,
+      preStallTarget: 78,
+      preStallDurationSeconds: 28800,
+      now,
+    })
+    const base = 5_000_000
+
+    it('does not trip when dwellSamples is met but the time floor is not', async () => {
+      await onFrame(low(base))
+      await onFrame(low(base + 1_000)) // 2 low frames, but only ~1s apart
+      expect(shouldBlock('left')).toBe(false)
+      expect(setPower).not.toHaveBeenCalled()
+    })
+
+    it('trips once the same low run crosses the time floor', async () => {
+      await onFrame(low(base))
+      await onFrame(low(base + 1_000))
+      expect(shouldBlock('left')).toBe(false)
+      await onFrame(low(base + __test__.DWELL_MIN_MS)) // first low frame is now DWELL_MIN_MS old
+      expect(shouldBlock('left')).toBe(true)
+      expect(setPower).toHaveBeenCalledWith('left', false)
+    })
+
+    it('does not trip one millisecond short of the floor', async () => {
+      await onFrame(low(base))
+      await onFrame(low(base + __test__.DWELL_MIN_MS - 1))
+      expect(shouldBlock('left')).toBe(false)
+    })
+
+    it('restarts the floor when a healthy frame interrupts the low run', async () => {
+      await onFrame(low(base))
+      await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800, now: base + 2_000 })
+      // Two fresh low frames close together: the floor is measured from the
+      // healthy interruption, not the original first low frame.
+      await onFrame(low(base + 20_000))
+      await onFrame(low(base + 21_000))
+      expect(shouldBlock('left')).toBe(false)
+    })
   })
 
   it('refreshes cached settings at the exact five-second TTL boundary', () => {
@@ -226,13 +285,13 @@ describe('pumpStallGuard', () => {
     setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 2 })
     invalidateGuardSettingsCache()
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
 
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(false)
     expect(setPower).toHaveBeenCalledWith('left', true, 78)
     expect(setTemperature).toHaveBeenCalledWith('left', 78, 28800)
@@ -241,24 +300,24 @@ describe('pumpStallGuard', () => {
   it('counts RPM exactly at recoveryRpm as a healthy frame', async () => {
     setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 2 })
     invalidateGuardSettingsCache()
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
-    await onFrame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
-    await onFrame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(shouldBlock('left')).toBe(false)
     expect(setPower).toHaveBeenCalledWith('left', true, 78)
   })
 
   it('does not auto-recover when auto-recovery is disabled', async () => {
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     setPower.mockClear()
     setTemperature.mockClear()
     for (let i = 0; i < 5; i += 1) {
-      await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     }
     expect(shouldBlock('left')).toBe(true)
     expect(setPower).not.toHaveBeenCalled()
@@ -266,8 +325,8 @@ describe('pumpStallGuard', () => {
   })
 
   it('acknowledge returns the pre-stall snapshot and clears the guard', async () => {
-    await onFrame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 28800 })
+    await frame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 28800 })
+    await frame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 28800 })
     expect(shouldBlock('right')).toBe(true)
 
     const { restore, alertId } = acknowledge('right')
@@ -314,8 +373,8 @@ describe('pumpStallGuard', () => {
   })
 
   it('reset() clears guard and notification', async () => {
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     reset('left')
     expect(shouldBlock('left')).toBe(false)
     expect(getPumpStallNotice('left')).toBeNull()
@@ -323,8 +382,8 @@ describe('pumpStallGuard', () => {
 
   it('reset(side) preserves the other side guard and notification', async () => {
     for (const side of ['left', 'right'] as const) {
-      await onFrame({ side, rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-      await onFrame({ side, rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await frame({ side, rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await frame({ side, rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     }
 
     reset('left')
@@ -342,8 +401,8 @@ describe('pumpStallGuard', () => {
 
     // Enabled defaults false on a degraded read — a power-cutting feature must
     // not arm on missing data, even though threshold/dwell defaults still apply.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(false)
     expect(setPower).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith(
@@ -358,31 +417,31 @@ describe('pumpStallGuard', () => {
     invalidateGuardSettingsCache()
 
     // Trip
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
 
     // Two healthy, then one sub-recovery frame — counter must reset.
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
     expect(setPower).not.toHaveBeenCalledWith('left', true, expect.any(Number))
 
     // Now three back-to-back healthy frames recover.
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
     expect(setPower).not.toHaveBeenCalledWith('left', true, expect.any(Number))
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(false)
   })
 
   it('falls back to device_state target when frame carries no preStall snapshot', async () => {
     ;(sqlite as any).exec(`UPDATE device_state SET target_temperature = 82 WHERE side = 'left'`)
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
 
     const notice = getPumpStallNotice('left')
     expect(notice?.restore).toEqual({ targetTemperature: 82, durationSeconds: 28800 })
@@ -392,8 +451,8 @@ describe('pumpStallGuard', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     ;(sqlite as any).exec('DELETE FROM device_state WHERE side = \'left\'')
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
 
     expect(shouldBlock('left')).toBe(true)
     expect(warn.mock.calls.some(([message]) => String(message).includes('snapshot read failed'))).toBe(false)
@@ -405,8 +464,8 @@ describe('pumpStallGuard', () => {
     vi.spyOn(Date, 'now').mockReturnValue(now)
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    await onFrame({ side: 'right', rpm: 499, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 1234 })
-    await onFrame({ side: 'right', rpm: 499, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 1234 })
+    await frame({ side: 'right', rpm: 499, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 1234 })
+    await frame({ side: 'right', rpm: 499, expectedActive: true, preStallTarget: 80, preStallDurationSeconds: 1234 })
 
     expect((sqlite as any).prepare('SELECT is_powered, powered_on_at, target_temperature FROM device_state WHERE side = ?').get('right')).toEqual({
       is_powered: 0,
@@ -435,8 +494,8 @@ describe('pumpStallGuard', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     ;(sqlite as any).exec(`DROP TABLE device_state`)
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state snapshot read failed'),
@@ -450,8 +509,8 @@ describe('pumpStallGuard', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     setPower.mockRejectedValueOnce(new Error('hw down'))
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(shouldBlock('left')).toBe(true) // guard still flips
     expect(err).toHaveBeenCalledWith(
@@ -466,25 +525,25 @@ describe('pumpStallGuard', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     setPower.mockRejectedValueOnce(new Error('hw down'))
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
     expect(__test__.getState().left.cutoffPending).toBe(true)
 
     // First retry also fails — warn per retry, stay pending.
     setPower.mockRejectedValueOnce(new Error('still down'))
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(warn).toHaveBeenCalledWith('[pumpStallGuard] cutoff retry for left failed:', 'still down')
     expect(__test__.getState().left.cutoffPending).toBe(true)
 
     // Second retry succeeds and stops.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(setPower).toHaveBeenCalledTimes(3)
     expect(setPower).toHaveBeenLastCalledWith('left', false)
     expect(__test__.getState().left.cutoffPending).toBe(false)
 
     // No further retries once the cutoff is confirmed sent.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(setPower).toHaveBeenCalledTimes(3)
     err.mockRestore()
     warn.mockRestore()
@@ -494,13 +553,13 @@ describe('pumpStallGuard', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     setPower.mockRejectedValueOnce(new Error('hw down'))
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(__test__.getState().left.cutoffPending).toBe(true)
 
     // trip() mirrors isPowered=false, so every real post-trip frame arrives
     // with expectedActive=false — the pending cutoff must still be retried.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
     expect(setPower).toHaveBeenLastCalledWith('left', false)
     expect(__test__.getState().left.cutoffPending).toBe(false)
     err.mockRestore()
@@ -510,26 +569,26 @@ describe('pumpStallGuard', () => {
     setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 2 })
     invalidateGuardSettingsCache()
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(shouldBlock('left')).toBe(true)
 
     // Same DB-mirror reality as above: recovery tracking must keep running
     // on expectedActive=false frames or auto-recovery is unreachable.
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
     expect(shouldBlock('left')).toBe(true)
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 1900, expectedActive: false, preStallTarget: null, preStallDurationSeconds: null })
     expect(shouldBlock('left')).toBe(false)
     expect(setPower).toHaveBeenLastCalledWith('left', true, 78)
     expect(setTemperature).toHaveBeenCalledWith('left', 78, 28800)
   })
 
   it('does not retry the cutoff when the trip-time power-off succeeded', async () => {
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(__test__.getState().left.cutoffPending).toBe(false)
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(setPower).toHaveBeenCalledTimes(1)
   })
 
@@ -537,9 +596,9 @@ describe('pumpStallGuard', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     // Trip with valid schema, then drop device_state mid-trip via a fresh trip.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     ;(sqlite as any).exec(`DROP TABLE device_state`)
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state update failed'),
@@ -552,8 +611,8 @@ describe('pumpStallGuard', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     ;(biometricsSqlite as any).exec(`DROP TABLE pump_alerts`)
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(err).toHaveBeenCalledWith(
       expect.stringContaining('pump_alerts insert failed'),
@@ -570,14 +629,14 @@ describe('pumpStallGuard', () => {
     // Clear device_state target so the trip captures no snapshot.
     ;(sqlite as any).exec(`UPDATE device_state SET target_temperature = NULL WHERE side = 'left'`)
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
     expect(shouldBlock('left')).toBe(true)
     setPower.mockClear()
     setTemperature.mockClear()
 
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
 
     expect(shouldBlock('left')).toBe(false) // reset() cleared it
     expect(setPower).not.toHaveBeenCalled()
@@ -589,12 +648,12 @@ describe('pumpStallGuard', () => {
     invalidateGuardSettingsCache()
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     setPower.mockRejectedValueOnce(new Error('hw down'))
 
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(err).toHaveBeenCalledWith(
       expect.stringContaining('auto-recover hardware call failed'),
@@ -609,12 +668,12 @@ describe('pumpStallGuard', () => {
     invalidateGuardSettingsCache()
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     ;(sqlite as any).exec(`DROP TABLE device_state`)
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state restore failed'),
@@ -628,14 +687,14 @@ describe('pumpStallGuard', () => {
     invalidateGuardSettingsCache()
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     // Drop the alerts table so the auto-recover update throws.
     ;(biometricsSqlite as any).exec(`DROP TABLE pump_alerts`)
 
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('alert update failed'),
@@ -658,7 +717,7 @@ describe('pumpStallGuard', () => {
     ;(dbModule.db as any).select = () => {
       throw 'settings-string-err'
     }
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('failed to read settings'),
       'settings-string-err',
@@ -669,7 +728,7 @@ describe('pumpStallGuard', () => {
     warn.mockClear()
 
     // Warm the settings cache so readSettings doesn't trigger the next throw.
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     reset()
 
     // String throw from device_state snapshot read on a no-preStall trip.
@@ -678,8 +737,8 @@ describe('pumpStallGuard', () => {
       if (throws-- > 0) throw 'snapshot-string-err'
       return origSelect(...args)
     }
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state snapshot read failed'),
       'snapshot-string-err',
@@ -693,8 +752,8 @@ describe('pumpStallGuard', () => {
       throw 'setpower-string-err'
     })
     err.mockClear()
-    await onFrame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'right', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(err).toHaveBeenCalledWith(
       expect.stringContaining('hardware power-off failed'),
       'setpower-string-err',
@@ -707,8 +766,8 @@ describe('pumpStallGuard', () => {
       throw 'dsupdate-string-err'
     }
     warn.mockClear()
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state update failed'),
       'dsupdate-string-err',
@@ -722,8 +781,8 @@ describe('pumpStallGuard', () => {
       throw 'bio-string-err'
     }
     err.mockClear()
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(err).toHaveBeenCalledWith(
       expect.stringContaining('pump_alerts insert failed'),
       'bio-string-err',
@@ -741,15 +800,15 @@ describe('pumpStallGuard', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     // Trip first.
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     // setPower throws a non-Error during auto-recover.
     setPower.mockImplementationOnce(() => {
       throw 'recover-string-err'
     })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(err).toHaveBeenCalledWith(
       expect.stringContaining('auto-recover hardware call failed'),
       'recover-string-err',
@@ -757,8 +816,8 @@ describe('pumpStallGuard', () => {
 
     // device_state restore throws a non-Error.
     reset()
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     const origUpdate = (dbModule.db as any).update.bind(dbModule.db)
     let throws = 1
     ;(dbModule.db as any).update = (...args: unknown[]) => {
@@ -766,8 +825,8 @@ describe('pumpStallGuard', () => {
       return origUpdate(...args)
     }
     warn.mockClear()
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('device_state restore failed'),
       'recover-update-err',
@@ -776,15 +835,15 @@ describe('pumpStallGuard', () => {
 
     // Alert update throws a non-Error.
     reset()
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     const origBioUpdate = (dbModule.biometricsDb as any).update.bind(dbModule.biometricsDb)
     ;(dbModule.biometricsDb as any).update = () => {
       throw 'alert-update-err'
     }
     warn.mockClear()
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('alert update failed'),
       'alert-update-err',
@@ -806,8 +865,8 @@ describe('pumpStallGuard', () => {
       }),
     })
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(shouldBlock('left')).toBe(true)
     const { alertId } = acknowledge('left')
@@ -829,16 +888,16 @@ describe('pumpStallGuard', () => {
       throw new Error('insert fail')
     }
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     ;(dbModule.biometricsDb as any).insert = origBioInsert
 
     // Spy on biometricsDb.update so we can prove it is NOT called during recover.
     const updateSpy = vi.spyOn(dbModule.biometricsDb, 'update')
 
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-    await onFrame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+    await frame({ side: 'left', rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
 
     expect(shouldBlock('left')).toBe(false)
     expect(updateSpy).not.toHaveBeenCalled()
@@ -852,10 +911,10 @@ describe('pumpStallGuard', () => {
     invalidateGuardSettingsCache()
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
-    await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
-    await onFrame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
-    await onFrame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
+    await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
+    await frame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
+    await frame({ side: 'left', rpm: 1500, expectedActive: true, preStallTarget: 79, preStallDurationSeconds: 4321 })
 
     expect((sqlite as any).prepare('SELECT is_powered, target_temperature FROM device_state WHERE side = ?').get('left')).toEqual({
       is_powered: 1,
@@ -971,8 +1030,8 @@ describe('pumpStallGuard', () => {
     })
 
     it('does not disturb a side that is already blocked in memory', async () => {
-      await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
-      await onFrame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+      await frame({ side: 'left', rpm: 100, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
       const liveAlertId = __test__.getState().left.activeAlertId
       insertAlert({ side: 'left', timestamp: 1_700_000_000 })
 
@@ -1032,8 +1091,8 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
       order.push('writer:on')
     })
 
-    await onFrame(lowFrame('left'))
-    const tripping = onFrame(lowFrame('left'))
+    await frame(lowFrame('left'))
+    const tripping = frame(lowFrame('left'))
     await flush()
 
     // Trip already latched (block + banner) but the cutoff is still queued
@@ -1058,8 +1117,8 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
   it('serializes the cutoff retry through the side lock', async () => {
     setPower.mockRejectedValueOnce(new Error('socket gone'))
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
-    await onFrame(lowFrame('left'))
-    await onFrame(lowFrame('left'))
+    await frame(lowFrame('left'))
+    await frame(lowFrame('left'))
     expect(shouldBlock('left')).toBe(true)
     err.mockRestore()
 
@@ -1076,7 +1135,7 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
     setPower.mockImplementation(async () => {
       order.push('guard:retry')
     })
-    const retrying = onFrame(lowFrame('left'))
+    const retrying = frame(lowFrame('left'))
     await flush()
     expect(order).toEqual([])
 
@@ -1089,8 +1148,8 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
   it('serializes the auto-recovery restore through the side lock', async () => {
     setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 1 })
     invalidateGuardSettingsCache()
-    await onFrame(lowFrame('left'))
-    await onFrame(lowFrame('left'))
+    await frame(lowFrame('left'))
+    await frame(lowFrame('left'))
     expect(shouldBlock('left')).toBe(true)
     setPower.mockClear()
 
@@ -1108,7 +1167,7 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
       order.push('guard:restore-power')
     })
     const healthy = { side: 'left' as const, rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 }
-    const recovering = onFrame(healthy)
+    const recovering = frame(healthy)
     await flush()
     expect(order).toEqual([])
 
@@ -1128,8 +1187,8 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
       }),
     )
 
-    await onFrame(lowFrame('left'))
-    const tripping = onFrame(lowFrame('left'))
+    await frame(lowFrame('left'))
+    const tripping = frame(lowFrame('left'))
     await flush()
 
     // Cutoff still awaiting hardware — banner, alert row, and device_state
@@ -1153,8 +1212,8 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
       }),
     )
 
-    await onFrame(lowFrame('left'))
-    const tripping = onFrame(lowFrame('left'))
+    await frame(lowFrame('left'))
+    const tripping = frame(lowFrame('left'))
     await flush()
     expect(getPumpStallNotice('left')).not.toBeNull()
 

--- a/src/hardware/tests/pumpStallGuard.test.ts
+++ b/src/hardware/tests/pumpStallGuard.test.ts
@@ -1227,3 +1227,169 @@ describe('pumpStallGuard — side-lock serialization and notice timing', () => {
     expect(shouldBlock('left')).toBe(false)
   })
 })
+
+describe('pumpStallGuard — active recovery probe', () => {
+  // A trip powers the pump off, so RPM sits at 0 and passive recovery can never
+  // fire. These pin the active-probe path: re-energize after a backoff, restore
+  // on sustained healthy RPM, else power back off and retry with a longer
+  // backoff, giving up after the last attempt. A single mocked clock backs
+  // both trippedAt (set via Date.now) and the backoff comparison.
+  let clock = 1_700_000_000_000
+  const advance = (ms: number): void => {
+    clock += ms
+  }
+  const low = (side: 'left' | 'right' = 'left'): Promise<void> =>
+    onFrame({ side, rpm: 0, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+  const healthy = (side: 'left' | 'right' = 'left'): Promise<void> =>
+    onFrame({ side, rpm: 1900, expectedActive: true, preStallTarget: 78, preStallDurationSeconds: 28800 })
+
+  async function trip(side: 'left' | 'right' = 'left'): Promise<void> {
+    await low(side)
+    advance(__test__.DWELL_MIN_MS)
+    await low(side)
+    expect(shouldBlock(side)).toBe(true)
+    setPower.mockClear()
+    setTemperature.mockClear()
+  }
+
+  beforeEach(() => {
+    resetSchema()
+    setSettings({ pump_stall_auto_recovery_enabled: 1, pump_stall_recovery_samples: 3 })
+    invalidateGuardSettingsCache()
+    reset()
+    setPower.mockClear()
+    setTemperature.mockClear()
+    clock = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockImplementation(() => clock)
+  })
+  afterEach(() => {
+    reset()
+    vi.restoreAllMocks()
+  })
+
+  it('re-energizes after the backoff and restores when the pump spins up', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await trip()
+
+    // Nothing re-energizes before the first backoff elapses.
+    advance(__test__.PROBE_BACKOFFS_MS[0] - 1_000)
+    await low()
+    expect(setPower).not.toHaveBeenCalled()
+    expect(shouldBlock('left')).toBe(true)
+
+    // Backoff elapsed → the probe energizes the side with the captured snapshot.
+    advance(1_000)
+    await low()
+    expect(setPower).toHaveBeenCalledWith('left', true, 78)
+    expect(setTemperature).toHaveBeenCalledWith('left', 78, 28800)
+    expect(shouldBlock('left')).toBe(true) // still blocked until healthy RPM confirms
+
+    // Pump spins up: recoverySamples healthy frames → restored + logged.
+    await healthy()
+    await healthy()
+    await healthy()
+    expect(shouldBlock('left')).toBe(false)
+    expect((biometricsSqlite as any).prepare('SELECT action FROM pump_alerts').get().action).toBe('auto_recovered')
+    log.mockRestore()
+  })
+
+  it('powers back off when a probe fails, then gives up after the last attempt', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await trip()
+
+    const onCount = (): number => (setPower.mock.calls as any[]).filter(c => c[0] === 'left' && c[1] === true).length
+    const offCount = (): number => (setPower.mock.calls as any[]).filter(c => c[0] === 'left' && c[1] === false).length
+
+    for (let i = 0; i < __test__.PROBE_BACKOFFS_MS.length; i += 1) {
+      advance(__test__.PROBE_BACKOFFS_MS[i])
+      await low() // starts probe i+1 → setPower(on)
+      advance(__test__.PROBE_WINDOW_MS)
+      await low() // window elapsed, still stalled → setPower(off)
+      expect(shouldBlock('left')).toBe(true)
+    }
+    expect(onCount()).toBe(3)
+    expect(offCount()).toBe(3)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still stalled after 3 recovery probes'))
+
+    // After the last failed probe, no further probes ever start.
+    advance(__test__.PROBE_BACKOFFS_MS[__test__.PROBE_BACKOFFS_MS.length - 1] * 10)
+    setPower.mockClear()
+    await low()
+    expect(setPower).not.toHaveBeenCalled()
+    expect(shouldBlock('left')).toBe(true)
+    warn.mockRestore()
+    log.mockRestore()
+  })
+
+  it('gives up and unblocks when a probe has no snapshot to restore', async () => {
+    ;(sqlite as any).exec(`UPDATE device_state SET target_temperature = NULL WHERE side = 'left'`)
+    await onFrame({ side: 'left', rpm: 0, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    advance(__test__.DWELL_MIN_MS)
+    await onFrame({ side: 'left', rpm: 0, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+    expect(shouldBlock('left')).toBe(true)
+    setPower.mockClear()
+
+    advance(__test__.PROBE_BACKOFFS_MS[0])
+    await onFrame({ side: 'left', rpm: 0, expectedActive: true, preStallTarget: null, preStallDurationSeconds: null })
+
+    expect(shouldBlock('left')).toBe(false) // reset() cleared the guard
+    expect(setPower).not.toHaveBeenCalled()
+  })
+
+  it('treats a probe energize failure as a failed probe and backs off', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await trip()
+
+    setPower.mockRejectedValueOnce(new Error('socket gone'))
+    advance(__test__.PROBE_BACKOFFS_MS[0])
+    await low()
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('recovery probe energize for left failed'),
+      'socket gone',
+    )
+    expect(shouldBlock('left')).toBe(true)
+    expect(__test__.getState().left.probeStartedAt).toBeNull()
+    expect(__test__.getState().left.recoveryAttempts).toBe(1)
+    warn.mockRestore()
+  })
+
+  it('never probes when auto-recovery is disabled', async () => {
+    setSettings({ pump_stall_auto_recovery_enabled: 0 })
+    invalidateGuardSettingsCache()
+    await trip()
+
+    advance(__test__.PROBE_BACKOFFS_MS[0] * 2)
+    await low()
+    expect(setPower).not.toHaveBeenCalled()
+    expect(shouldBlock('left')).toBe(true)
+  })
+
+  it('serializes the probe energize through the side lock', async () => {
+    await trip()
+    advance(__test__.PROBE_BACKOFFS_MS[0])
+
+    const order: string[] = []
+    let releaseWriter!: () => void
+    const writerGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve
+    })
+    const writerDone = withSideLock('left', async () => {
+      await writerGate
+      order.push('writer')
+    })
+
+    setPower.mockImplementation(async () => {
+      order.push('probe:energize')
+    })
+    const probing = low()
+    for (let i = 0; i < 5; i += 1) await Promise.resolve()
+    expect(order).toEqual([]) // probe queued behind the writer
+
+    releaseWriter()
+    await writerDone
+    await probing
+    expect(order).toEqual(['writer', 'probe:energize'])
+  })
+})

--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -60,10 +60,28 @@ class GuardBlockedError extends HapStatusError {
 function assertNotGuardBlocked(side: Side, label: string): void {
   if (!pumpStallShouldBlock(side)) return
   console.warn(`[homekit] refused ${label} — pump stall protection active on ${side}`)
+  // Surface the refusal to web clients as a transient frame overlay — iOS
+  // only shows the control reverting, and the web UI is the surface that can
+  // actually re-enable the side. Fire-and-forget via dynamic import (same
+  // homekit→streaming decoupling as snoozeManager); a broadcast failure must
+  // never mask the refusal itself.
+  void import('@/src/streaming/broadcastMutationStatus')
+    .then(({ broadcastMutationStatus }) => broadcastMutationStatus(side, {
+      guardRejection: { ts: Date.now(), source: 'homekit' },
+    }))
+    .catch(() => {})
   throw new GuardBlockedError()
 }
 
-const lastTargetF: Record<Side, number | null> = { left: null, right: null }
+// Staged targets live on globalThis: HomeKit writes them from the HAP bridge
+// (instrumentation runtime) while health.thermal reads them from API route
+// handlers — Turbopack chunks those separately, so module-level state would
+// split (same rationale as pumpStallGuard). intendedPower below stays
+// module-level: it is only touched from the HAP runtime.
+const STAGED_KEY = '__sp_homekit_staged_target_f__'
+const G = globalThis as Record<string, unknown>
+if (!G[STAGED_KEY]) G[STAGED_KEY] = { left: null, right: null }
+const lastTargetF = G[STAGED_KEY] as Record<Side, number | null>
 
 // Intended power state as expressed by HomeKit, updated eagerly. Used to
 // resolve the "user dragged the slider mid-power-cycle" race: firmware
@@ -148,6 +166,17 @@ export function reconcileIntendedPower(status: DeviceStatus, side: Side): void {
  * NEUTRAL so a power-on without any prior context lands on a safe value
  * instead of the hardware client's hardcoded 75°F default.
  */
+/**
+ * Raw per-side staged target exactly as HomeKit last requested it — null when
+ * no HomeKit write has staged one. Unlike getStagedTargetF this does NOT fall
+ * back to firmware status: health.thermal needs to know whether a hidden
+ * staged value exists at all, so the pump-stall alert card can surface the
+ * staged/visible mismatch on a guard-blocked side (PR #670 F1).
+ */
+export function getHomekitStagedTargetF(side: Side): number | null {
+  return lastTargetF[side]
+}
+
 export function getStagedTargetF(monitor: DacMonitor, side: Side): number {
   const cached = lastTargetF[side]
   if (cached !== null) return cached

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -4,6 +4,7 @@ const setTemperature = vi.fn()
 const setPower = vi.fn()
 const registerManualOverride = vi.fn()
 const shouldBlock = vi.fn<(side: 'left' | 'right') => boolean>()
+const broadcastMutationStatus = vi.fn()
 
 vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: () => ({ setTemperature, setPower }),
@@ -14,9 +15,13 @@ vi.mock('@/src/automation', () => ({
 vi.mock('@/src/hardware/pumpStallGuard', () => ({
   shouldBlock: (side: 'left' | 'right') => shouldBlock(side),
 }))
+vi.mock('@/src/streaming/broadcastMutationStatus', () => ({
+  broadcastMutationStatus: (...args: unknown[]) => broadcastMutationStatus(...args),
+}))
 
 import {
   __resetSideController,
+  getHomekitStagedTargetF,
   getStagedTargetF,
   isCurrentlyPowered,
   isEffectivelyPowered,
@@ -55,6 +60,7 @@ describe('sideController', () => {
     setPower.mockReset()
     registerManualOverride.mockReset()
     shouldBlock.mockReset()
+    broadcastMutationStatus.mockReset()
     setTemperature.mockResolvedValue(undefined)
     setPower.mockResolvedValue(undefined)
     shouldBlock.mockReturnValue(false)
@@ -129,6 +135,75 @@ describe('sideController', () => {
         ...offStatus,
         leftSide: { ...offStatus.leftSide, targetTemperature: 82.5, targetLevel: 0 },
       }), 'left')).toBe(65)
+    })
+  })
+
+  describe('getHomekitStagedTargetF', () => {
+    it('is null until HomeKit stages a target — no firmware-status fallback', () => {
+      // Firmware knows a target (offStatus has 70/75) but HomeKit never wrote
+      // one; the raw accessor must say "nothing hidden" while getStagedTargetF
+      // still resolves its fallback.
+      expect(getHomekitStagedTargetF('left')).toBeNull()
+      expect(getHomekitStagedTargetF('right')).toBeNull()
+    })
+
+    it('tracks the staged value per side', async () => {
+      await setTargetTemperature(monitor(offStatus), 'left', 68)
+      expect(getHomekitStagedTargetF('left')).toBe(68)
+      expect(getHomekitStagedTargetF('right')).toBeNull()
+    })
+
+    it('retains the requested value after the guard rejects the firmware push', async () => {
+      // The F1 scenario this accessor exists for: iOS shows the slider
+      // reverting while the hidden cache advances to the rejected value.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      shouldBlock.mockReturnValue(true)
+      await expect(setTargetTemperature(monitor(onStatus), 'left', 68)).rejects.toThrow('Pump stall protection active')
+      expect(getHomekitStagedTargetF('left')).toBe(68)
+      warn.mockRestore()
+    })
+  })
+
+  describe('guard rejection broadcast', () => {
+    it('broadcasts a transient guardRejection overlay when a power-on is refused', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      shouldBlock.mockReturnValue(true)
+
+      await expect(setSidePowerOn(monitor(offStatus), 'left')).rejects.toThrow('Pump stall protection active')
+      await vi.waitFor(() => {
+        expect(broadcastMutationStatus).toHaveBeenCalledWith('left', {
+          guardRejection: { ts: expect.any(Number), source: 'homekit' },
+        })
+      })
+      warn.mockRestore()
+    })
+
+    it('broadcasts when a temp push on a powered side is refused', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      shouldBlock.mockReturnValue(true)
+
+      await expect(setTargetTemperature(monitor(onStatus), 'right', 68)).rejects.toThrow('Pump stall protection active')
+      await vi.waitFor(() => {
+        expect(broadcastMutationStatus).toHaveBeenCalledWith('right', {
+          guardRejection: { ts: expect.any(Number), source: 'homekit' },
+        })
+      })
+      warn.mockRestore()
+    })
+
+    it('does not broadcast on accepted writes or silent off-side staging', async () => {
+      await setSidePowerOn(monitor(offStatus), 'left')
+      await setTargetTemperature(monitor(onStatus), 'right', 72)
+      // Blocked side that is off with no intent latch → stages silently
+      // (no refusal thrown), so nothing may be broadcast either.
+      shouldBlock.mockImplementation(side => side === 'right')
+      await setTargetTemperature(monitor(offStatus), 'right', 66)
+
+      // Flush the fire-and-forget dynamic import path before asserting.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0)
+      })
+      expect(broadcastMutationStatus).not.toHaveBeenCalled()
     })
   })
 

--- a/src/hooks/tests/useGuardRejectionNotice.test.ts
+++ b/src/hooks/tests/useGuardRejectionNotice.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for useGuardRejectionNotice — latching the transient guardRejection
+ * overlay that broadcastMutationStatus attaches to a single deviceStatus
+ * frame when a guard-blocked HomeKit write is refused. The overlay vanishes
+ * on the next poll frame, so the hook must hold the message across frames,
+ * auto-dismiss it, and never resurrect an already-seen rejection.
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGuardRejectionNotice } from '../useGuardRejectionNotice'
+import type { GuardRejectionOverlay } from '../useGuardRejectionNotice'
+
+interface Props {
+  left: GuardRejectionOverlay | undefined
+  right: GuardRejectionOverlay | undefined
+}
+
+const renderNotice = (initial: Props = { left: undefined, right: undefined }) =>
+  renderHook(
+    ({ left, right }: Props) => useGuardRejectionNotice(left, right),
+    { initialProps: initial },
+  )
+
+const rejection = (ts: number): GuardRejectionOverlay => ({ ts, source: 'homekit' })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useGuardRejectionNotice', () => {
+  it('is null with no rejection overlays', () => {
+    const { result, rerender } = renderNotice()
+    expect(result.current).toBeNull()
+    rerender({ left: undefined, right: undefined })
+    expect(result.current).toBeNull()
+  })
+
+  it('surfaces a per-side message when a rejection overlay arrives', () => {
+    const { result, rerender } = renderNotice()
+    rerender({ left: rejection(1_000), right: undefined })
+    expect(result.current).toBe('Left side change from HomeKit blocked — pump stall protection active')
+
+    rerender({ left: undefined, right: rejection(2_000) })
+    expect(result.current).toBe('Right side change from HomeKit blocked — pump stall protection active')
+  })
+
+  it('keeps the message after the overlay drops off the next frame', () => {
+    const { result, rerender } = renderNotice()
+    rerender({ left: rejection(1_000), right: undefined })
+    rerender({ left: undefined, right: undefined })
+    expect(result.current).not.toBeNull()
+  })
+
+  it('auto-dismisses after the timeout', () => {
+    const { result, rerender } = renderNotice()
+    rerender({ left: rejection(1_000), right: undefined })
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('does not resurrect an already-seen rejection when the same frame re-renders', () => {
+    const { result, rerender } = renderNotice()
+    rerender({ left: rejection(1_000), right: undefined })
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(result.current).toBeNull()
+
+    // Same ts delivered again (stale frame re-render) — must stay dismissed.
+    rerender({ left: rejection(1_000), right: undefined })
+    expect(result.current).toBeNull()
+  })
+
+  it('a newer rejection restarts the dismiss timer', () => {
+    const { result, rerender } = renderNotice()
+    rerender({ left: rejection(1_000), right: undefined })
+    act(() => {
+      vi.advanceTimersByTime(4_000)
+    })
+    rerender({ left: rejection(9_000), right: undefined })
+    act(() => {
+      vi.advanceTimersByTime(4_000)
+    })
+    // 8s after the first rejection but only 4s after the second — still shown.
+    expect(result.current).not.toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(1_000)
+    })
+    expect(result.current).toBeNull()
+  })
+})

--- a/src/hooks/useGuardRejectionNotice.ts
+++ b/src/hooks/useGuardRejectionNotice.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+/** Transient overlay riding a single deviceStatus frame's side payload. */
+export interface GuardRejectionOverlay {
+  ts: number
+  source: string
+}
+
+const AUTO_DISMISS_MS = 5_000
+
+/**
+ * Latch the transient guardRejection overlay broadcast when a guard-blocked
+ * HomeKit write is refused (sideController). The overlay rides exactly one
+ * WS frame — the next poll frame drops it — so this hook remembers the last
+ * seen rejection ts per side and surfaces a snackbar message for a few
+ * seconds. A repeat rejection (newer ts) restarts the dismiss timer.
+ */
+export function useGuardRejectionNotice(
+  leftRejection: GuardRejectionOverlay | undefined,
+  rightRejection: GuardRejectionOverlay | undefined,
+): string | null {
+  const [notice, setNotice] = useState<{ text: string, ts: number } | null>(null)
+  const seen = useRef<Record<'left' | 'right', number>>({ left: 0, right: 0 })
+
+  const leftTs = leftRejection?.ts ?? null
+  const rightTs = rightRejection?.ts ?? null
+
+  useEffect(() => {
+    const sides = [['left', leftTs], ['right', rightTs]] as const
+    for (const [side, ts] of sides) {
+      if (ts != null && ts > seen.current[side]) {
+        seen.current[side] = ts
+        setNotice({
+          text: `${side === 'left' ? 'Left' : 'Right'} side change from HomeKit blocked — pump stall protection active`,
+          ts,
+        })
+      }
+    }
+  }, [leftTs, rightTs])
+
+  useEffect(() => {
+    if (!notice) return
+    const timer = setTimeout(() => setNotice(null), AUTO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [notice])
+
+  return notice?.text ?? null
+}

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -117,6 +117,14 @@ export interface GestureFrame {
   tapType: string
 }
 
+/** Extras the producers merge onto a side payload. guardRejection is a
+ * transient overlay broadcast when a guard-blocked write was refused
+ * (sideController) — present on exactly one frame; consumers must latch it. */
+interface DeviceStatusSideExtras {
+  isAlarmVibrating: boolean
+  guardRejection?: { ts: number, source: 'homekit' }
+}
+
 /** Device status frame — pushed on DacMonitor's adaptive poll (1s active /
  * 2s default / 5s idle) and immediately after mutations via
  * broadcastMutationStatus. Sides carry the full SideStatus payload the
@@ -124,8 +132,8 @@ export interface GestureFrame {
 export interface DeviceStatusFrame {
   type: 'deviceStatus'
   ts: number
-  leftSide: SideStatus & { isAlarmVibrating: boolean }
-  rightSide: SideStatus & { isAlarmVibrating: boolean }
+  leftSide: SideStatus & DeviceStatusSideExtras
+  rightSide: SideStatus & DeviceStatusSideExtras
   waterLevel: 'low' | 'ok'
   isPriming: boolean
   primeCompletedNotification?: { timestamp: number }

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -765,11 +765,18 @@ export class JobManager {
   /**
    * Execute a system reboot via systemctl.
    * Returns a Promise so callers can await and the scheduler can surface failures.
+   *
+   * The systemd unit drops next-server to User=sleepypod, which cannot reboot
+   * the machine directly — a bare `systemctl reboot` fails with "Interactive
+   * authentication required" and the daily / pre-prime reboot jobs silently
+   * never fire. We sudo via the NOPASSWD rule installed by scripts/install
+   * (/etc/sudoers.d/sleepypod-update), mirroring system.triggerUpdate. `-n`
+   * makes sudo fail loudly rather than prompt when the rule is absent.
    */
   private async executeReboot(): Promise<void> {
     const { exec } = await import('child_process')
     return new Promise((resolve, reject) => {
-      exec('systemctl reboot', (error) => {
+      exec('sudo -n systemctl reboot', (error) => {
         if (error) {
           console.error('Reboot command failed:', error.message)
           reject(error)

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -1748,9 +1748,15 @@ describe('JobManager residual mutation contracts', () => {
 
     reboot.mockRestore()
     const failure = new Error('permission denied')
-    execMock.mockImplementationOnce((_command: string, callback: (error: Error) => void) => callback(failure))
+    let rebootCommand = ''
+    execMock.mockImplementationOnce((command: string, callback: (error: Error) => void) => {
+      rebootCommand = command
+      callback(failure)
+    })
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     await expect((manager as any).executeReboot()).rejects.toBe(failure)
+    // Must sudo — User=sleepypod cannot reboot directly (see executeReboot).
+    expect(rebootCommand).toBe('sudo -n systemctl reboot')
     expect(error).toHaveBeenCalledWith('Reboot command failed:', 'permission denied')
   })
 

--- a/src/scheduler/tests/jobOrdering.test.ts
+++ b/src/scheduler/tests/jobOrdering.test.ts
@@ -1405,7 +1405,7 @@ describe('JobManager handler closures', () => {
 
     await handler!()
 
-    expect(execMock).toHaveBeenCalledWith('systemctl reboot', expect.any(Function))
+    expect(execMock).toHaveBeenCalledWith('sudo -n systemctl reboot', expect.any(Function))
   })
 
   it('daily-reboot handler surfaces exec failure as a rejected promise', async () => {
@@ -1426,7 +1426,7 @@ describe('JobManager handler closures', () => {
     execMock.mockImplementationOnce((_cmd, cb) => cb(null))
 
     await handler()
-    expect(execMock).toHaveBeenCalledWith('systemctl reboot', expect.any(Function))
+    expect(execMock).toHaveBeenCalledWith('sudo -n systemctl reboot', expect.any(Function))
   })
 
   it('pre-prime-calibration handler writes a trigger file', async () => {

--- a/src/server/routers/health.ts
+++ b/src/server/routers/health.ts
@@ -16,6 +16,7 @@ import { desc, eq } from 'drizzle-orm'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
+import { getHomekitStagedTargetF } from '@/src/homekit/accessories/sideController'
 import { centiDegreesToF } from '@/src/lib/tempUtils'
 
 const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
@@ -394,6 +395,7 @@ export const healthRouter = router({
         waterTempF: z.number().nullable(),
         bedSurfaceTempF: z.number().nullable(),
         guardBlocked: z.boolean(),
+        homekitStagedTargetF: z.number().nullable(),
         verdict: z.enum(['off', 'delivering', 'idle', 'stalled']),
         note: z.string().nullable(),
       })),
@@ -493,6 +495,10 @@ export const healthRouter = router({
           waterTempF: waterCd != null ? Math.round(centiDegreesToF(waterCd) * 10) / 10 : null,
           bedSurfaceTempF: bedCd != null ? Math.round(centiDegreesToF(bedCd) * 10) / 10 : null,
           guardBlocked: pumpStallShouldBlock(side),
+          // Hidden HomeKit setpoint (PR #670 F1): guard-rejected temp writes
+          // stay staged and apply on the next power-on. The pump-stall alert
+          // card reads this to surface the staged/visible mismatch.
+          homekitStagedTargetF: getHomekitStagedTargetF(side),
           verdict,
           note,
         }

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -94,6 +94,9 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getDacMonitorIfRunning: sharedClientMock.getDacMonitorIfRunning,
 }))
 vi.mock('@/src/hardware/iptablesCheck', () => iptablesMock)
+// Keep hap-nodejs and the HAP bridge out of this suite — only thermal (tested
+// separately) reads the staged target.
+vi.mock('@/src/homekit/accessories/sideController', () => ({ getHomekitStagedTargetF: vi.fn(() => null) }))
 
 const { healthRouter } = await import('@/src/server/routers/health')
 const caller = healthRouter.createCaller({})

--- a/src/server/routers/tests/health.thermal.test.ts
+++ b/src/server/routers/tests/health.thermal.test.ts
@@ -15,6 +15,7 @@ import { deviceSettings, deviceState } from '@/src/db/schema'
 import { bedTemp, flowReadings, freezerTemp } from '@/src/db/biometrics-schema'
 
 const guardMock = vi.hoisted(() => ({ shouldBlock: vi.fn<(side: string) => boolean>(() => false) }))
+const homekitMock = vi.hoisted(() => ({ getHomekitStagedTargetF: vi.fn<(side: string) => number | null>(() => null) }))
 
 // Rows returned per table. device_state is a left→right queue (one query/side).
 const rows = vi.hoisted(() => ({
@@ -47,6 +48,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
 }))
 vi.mock('@/src/hardware/iptablesCheck', () => ({ checkIptables: vi.fn(() => ({ ok: true, rules: [] })) }))
 vi.mock('@/src/hardware/pumpStallGuard', () => ({ shouldBlock: guardMock.shouldBlock }))
+vi.mock('@/src/homekit/accessories/sideController', () => ({ getHomekitStagedTargetF: homekitMock.getHomekitStagedTargetF }))
 
 function resolveFor(table: unknown): unknown[] {
   if (table === deviceSettings) return rows.settings
@@ -79,6 +81,7 @@ const FRESH = new Date(Date.now() - 30_000) // 30s old → not stale
 
 beforeEach(() => {
   guardMock.shouldBlock.mockReset().mockReturnValue(false)
+  homekitMock.getHomekitStagedTargetF.mockReset().mockReturnValue(null)
   rows.settings = [{ enabled: false }]
   rows.deviceStateQueue = []
   rows.deviceStateCursor.i = 0
@@ -277,5 +280,20 @@ describe('health.thermal verdicts', () => {
     expect(left.bedSurfaceTempF).toBeCloseTo(75.2, 1) // 24.00°C
     expect(left.guardBlocked).toBe(true)
     expect(left.isAlarmVibrating).toBe(true)
+  })
+
+  it('surfaces the hidden HomeKit staged target per side', async () => {
+    // PR #670 F1: a guard-rejected HomeKit temp write leaves the requested
+    // value staged for the next power-on. The alert card reads it from here.
+    homekitMock.getHomekitStagedTargetF.mockImplementation(side => (side === 'left' ? 78 : null))
+    rows.deviceStateQueue = [
+      [{ side: 'left', isPowered: false, targetTemperature: null, currentTemperature: 70, isAlarmVibrating: false, poweredOnAt: null }],
+      [{ side: 'right', isPowered: false, targetTemperature: null, currentTemperature: 70, isAlarmVibrating: false, poweredOnAt: null }],
+    ]
+    const res = await caller.thermal({})
+    expect(res.sides[0].homekitStagedTargetF).toBe(78)
+    expect(res.sides[1].homekitStagedTargetF).toBeNull()
+    expect(homekitMock.getHomekitStagedTargetF).toHaveBeenCalledWith('left')
+    expect(homekitMock.getHomekitStagedTargetF).toHaveBeenCalledWith('right')
   })
 })


### PR DESCRIPTION
## Why

PR #670's F1 decision (option c): when the pump-stall guard rejects a HomeKit temperature write, the requested value deliberately stays staged in the sideController cache — iOS Home shows the slider reverting while the hidden cache advances, and the next explicit power-on heats to the staged value. The web UI's pump-stall alert card is the only surface that can re-enable the side, so it must surface that staged/visible mismatch. Closes sleepypod-core-19.

## What

- **`sideController.ts`**: new `getHomekitStagedTargetF(side)` accessor exposing the raw staged target (null when HomeKit never staged one — no firmware fallback). The backing store moved to `globalThis` so the API runtime reads the same instance the HAP bridge writes (Turbopack chunk-duplication, same rationale as `pumpStallGuard`). Guard rejections now also broadcast a transient `guardRejection` overlay via `broadcastMutationStatus(side, ...)` (fire-and-forget dynamic import, same pattern as `snoozeManager`).
- **`health.ts`**: `health.thermal` sides now expose `homekitStagedTargetF` alongside `guardBlocked`.
- **`PumpStallNotification`**: polls `health.thermal` (15s, only while mounted) and renders a staged-target line when the side is guard-blocked and the staged target differs from the pre-stall restore target, formatted in the user's display unit.
- **`TempScreen` + `useGuardRejectionNotice`**: latches the one-frame `guardRejection` WS overlay and shows a transient error snackbar (reuses `SchedulerConfirmation`), auto-dismissing after 5s.

## Test plan

- `pnpm tsc && pnpm lint && pnpm test` clean (3316 passed; also enforced by the pre-push hook).
- New unit coverage:
  - `sideController.test.ts` — accessor null-until-staged / per-side / retained-after-rejection; `guardRejection` broadcast on refused power-on and temp push; no broadcast on accepted writes or silent off-side staging.
  - `health.thermal.test.ts` — `homekitStagedTargetF` surfaced per side.
  - `PumpStallNotification.test.tsx` — staged line shown on mismatch, restore clause omitted when trip captured no restore, hidden when equal / guard clear / other side, °C formatting.
  - `useGuardRejectionNotice.test.ts` — latch across frames, auto-dismiss, no resurrect on stale ts, timer restart on newer rejection.
- Manual verification on a pod: trip the guard (block a side), drag the iOS Home slider → web snackbar appears; alert card shows "HomeKit has X° staged for the next power-on — Re-enable restores Y°."; Re-enable clears both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/homekit-staged-target-surfacing
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/homekit-staged-target-surfacing/scripts/install \
  | sudo bash -s -- --branch feat/homekit-staged-target-surfacing
```

🎯 **Pin to this exact build** ([run 30490219992](https://github.com/sleepypod/core/actions/runs/30490219992) · `3e5682f`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/3e5682ff3488494425b09f9b581ad22b841509e7/scripts/install \
  | sudo bash -s -- \
      --branch feat/homekit-staged-target-surfacing \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/30490219992/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/30490219992/artifacts/8739395101) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced pump-stall notifications to show HomeKit staged temperatures and the “Re-enable” restore value when they differ.
  - Added Celsius-aware formatting for staged/restore values.
  - Added a brief on-screen error notice when HomeKit updates are blocked by pump-stall protection.
  - Exposed staged “hidden” HomeKit setpoint details in thermal status.

- **Bug Fixes**
  - Improved pump-stall safety logic with time-based dwell, bilateral-zero glitch suppression, and a more robust active-recovery probe approach.
  - Updated reboot scheduling to use non-interactive sudo to prevent reboot failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

