### PR TITLE
fix(biometrics): cap archive by folder size; check every fs in sp-update preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ graph LR
 
 ### Biometrics data flow
 
-The Pod hardware daemon (frankenfirmware) writes raw sensor data continuously as CBOR-encoded binary records into `/persistent/biometrics/*.RAW`, which is a **500 MB tmpfs** to keep ~1 GB/day of writes off the eMMC. An archiver timer gzips files older than 15 minutes into `/persistent/biometrics-archive/` on eMMC (cold storage with a pruner cap of 80% disk usage). See **[ADR 0018](docs/adr/0018-tmpfs-raw-frames.md)** for the firmware-integration rationale, including how `SEQNO.RAW` and state directories are symlinked through so the firmware sees its persistent state unchanged.
+The Pod hardware daemon (frankenfirmware) writes raw sensor data continuously as CBOR-encoded binary records into `/persistent/biometrics/*.RAW`, which is a **500 MB tmpfs** to keep ~1 GB/day of writes off the eMMC. An archiver timer gzips files older than 15 minutes into `/persistent/biometrics-archive/` on eMMC (cold storage; a pruner caps the folder at `MAX_ARCHIVE_MB`, default 6 GiB, with an 80% whole-disk safety ceiling). See **[ADR 0018](docs/adr/0018-tmpfs-raw-frames.md)** for the firmware-integration rationale, including how `SEQNO.RAW` and state directories are symlinked through so the firmware sees its persistent state unchanged.
 
 Independent Python sidecar processes tail the hot tmpfs files, extract signals, and write results to `biometrics.db` (durable on eMMC). The core app never touches raw data — it reads clean rows via tRPC.
 

--- a/docs/adr/0018-tmpfs-raw-frames.md
+++ b/docs/adr/0018-tmpfs-raw-frames.md
@@ -18,7 +18,7 @@ Mount a **500 MB tmpfs at `/persistent/biometrics`**, redirect frankenfirmware's
 frank → /persistent/biometrics/         (tmpfs, hot live RAW)
            ↓ archiver every 15 min: gzip oldest, atomic rename
         /persistent/biometrics-archive/<seqno>.RAW.gz
-           ↓ pruner every 15 min: drop oldest until df < 80%
+           ↓ pruner every 15 min: drop oldest until folder <= MAX_ARCHIVE_MB (and df < 80%)
 ```
 
 ### Firmware integration without a binary patch
@@ -41,7 +41,19 @@ tmpfs loses contents on reboot. The acceptable loss window is bounded by the arc
 - **Unclean reboot**: up to ~30 min of live waveform lost (one rotation period the archiver hadn't picked up yet, plus the in-progress file the archiver intentionally skips while firmware is still writing it).
 - **`biometrics.db` rows are unaffected** — sidecar processors (piezo-processor, sleep-detector, environment-monitor) consume RAW frames as they stream and persist HR/HRV/BR/session rows to SQLite on the same `/persistent/sleepypod-data/` (eMMC) path. Vitals durability is unchanged.
 
-Loss of 30 min of upstream waveform is a worthwhile trade for years of eMMC wear avoidance plus an indefinitely growable cold archive (capped by the pruner at 80% disk).
+Loss of 30 min of upstream waveform is a worthwhile trade for years of eMMC wear avoidance plus a cold archive bounded by the pruner (folder capped at `MAX_ARCHIVE_MB`, default 6 GiB, with an 80% whole-disk safety ceiling).
+
+## Pruner constraints (learned the hard way)
+
+`archive-push` is copy-only and never deletes locally, so the pruner is the **only** thing bounding the cold archive. It has no second line of defence, and its failures are silent by nature — nothing else notices an archive that stops shrinking. Three constraints follow, each from a bug that reached a live pod:
+
+1. **No `head` in a pipeline.** `find … | sort -n | head -1` looks fine and passes every small-archive test: all of `sort`'s output fits the 64 KB pipe buffer, so `sort` exits 0 before `head` closes the pipe. Once the archive is large enough to overrun that buffer, `sort` takes `EPIPE` and dies with status 141; `pipefail` promotes it and `set -e` aborts the script **before the first file is removed**. The failure therefore appears only when the archive is big — exactly when pruning matters. Observed in the field: `sort: write failed: 'standard output': Broken pipe`, `status=2/INVALIDARGUMENT`, every 15 minutes for a month, while 1983 files / 13 GB filled a 15 GB eMMC to 100%.
+
+2. **GNU-only tools are a trap.** Pods can ship busybox (see the `sha256sum`/busybox fallback in `scripts/install`), where `find -printf` silently no-ops and `df --output=pcent` is rejected outright — the latter yielding an empty read that defaults to `0%`, so the loop concludes there is nothing to do. Use `ls -1tr`, `du -k`, and `df -P`.
+
+3. **Cap the folder, and fail loudly.** A percent-of-disk bound makes the archive's size depend on everything else on `/persistent`, and `df`'s integer percent steps ~150 MB at a time on a 15 GB eMMC. Worse, the original `-le TARGET` stopped as soon as usage was *at* target, pinning the disk at exactly 80% with no headroom ever recovered. `MAX_ARCHIVE_MB` is now the primary bound and the 80% ceiling only a backstop; when the pruner cannot reach its target it exits non-zero so `systemctl --failed` shows it.
+
+The blast radius reached well past lost waveform: `pnpm install` writes to `node_modules`, which is bind-mounted onto `/persistent` (see `scripts/lib/relocation-helpers`), so a full eMMC also broke `sp-update` — whose own pre-flight measured only the rootfs and so reported plenty of space. The archiver meanwhile failed with `gzip: stdout: No space left on device`, dropping live frames.
 
 ## Alternatives considered
 

--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner
@@ -1,11 +1,28 @@
 #!/bin/bash
-# Prune oldest gzipped RAW archives until /persistent disk usage falls
-# below TARGET_USED_PCT. Runs every 15 min after archiver. Never touches
-# files outside /persistent/biometrics-archive/.
+# Prune oldest gzipped RAW archives until BOTH bounds hold:
+#   1. the archive folder is <= MAX_ARCHIVE_MB   (primary cap)
+#   2. /persistent usage is  <  DISK_CEIL_PCT    (safety ceiling)
+# Runs every 15 min after archiver. Never touches files outside
+# /persistent/biometrics-archive/.
+#
+# Why an absolute folder cap, and not disk-percent alone (the original bound):
+#
+#   - archive-push is copy-only and never deletes locally, so this script is
+#     the ONLY thing bounding the cold archive. There is no second line of
+#     defence when it stops working, or stops early.
+#   - A percent-of-disk bound leaves the archive's size dependent on whatever
+#     else lives on /persistent, and `df`'s integer percent steps ~150 MB at a
+#     time on a 15 GB eMMC.
+#   - `-le TARGET` stopped as soon as usage was *at* the target, so the disk sat
+#     pinned at exactly 80% and never regained headroom. The ceiling below uses
+#     `-lt`, and is now only a backstop against growth outside the archive.
 set -euo pipefail
 
 ARCHIVE_DIR="/persistent/biometrics-archive"
-TARGET_USED_PCT="${TARGET_USED_PCT:-80}"
+# Primary cap: maximum size of the archive folder, in MiB.
+MAX_ARCHIVE_MB="${MAX_ARCHIVE_MB:-6144}"
+# Safety ceiling: also prune while whole-disk usage is at or above this percent.
+DISK_CEIL_PCT="${DISK_CEIL_PCT:-80}"
 
 mkdir -p "$ARCHIVE_DIR"
 
@@ -21,27 +38,70 @@ disk_used_pct() {
   echo "${pct:-0}"
 }
 
+max_archive_kb=$((MAX_ARCHIVE_MB * 1024))
+
+# Oldest-first candidate list, materialised once.
+#
+# `ls -1tr` (mtime order, oldest first) is busybox-safe; `find -printf` is
+# GNU-only and silently no-ops on busybox find. The list is written to a file
+# rather than re-derived per deletion for two reasons:
+#
+#   1. Reaching the folder cap can mean ~1300 removals, and re-running
+#      `ls -1tr` over ~2000 entries each time is O(n²) stat+sort work on eMMC.
+#   2. It keeps `head` out of every pipeline. Under `set -o pipefail` a
+#      `… | head -1` aborts the script on SIGPIPE once the upstream command's
+#      output exceeds the 64K pipe buffer — so it breaks only when the archive
+#      is large, i.e. exactly when pruning is needed, while passing every
+#      small-archive test. That is how an earlier revision silently stopped
+#      pruning and let 1983 files / 13 GB fill a 15 GB eMMC to 100%.
+list=$(mktemp) || { echo "pruner: mktemp failed" >&2; exit 1; }
+trap 'rm -f "$list"' EXIT
+ls -1tr "$ARCHIVE_DIR"/*.RAW.gz > "$list" 2>/dev/null || true
+
+# Folder total from du rather than a sum over the list, so stray *.tmp files
+# left behind by an interrupted archiver still count against the cap.
+archive_kb=$(du -sk "$ARCHIVE_DIR" 2>/dev/null | awk '{print $1}')
+archive_kb=${archive_kb:-0}
+
 pruned=0
-while :; do
-  used_pct=$(disk_used_pct)
-  if [ "$used_pct" -le "$TARGET_USED_PCT" ]; then
+used_pct=$(disk_used_pct)
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+
+  # Both bounds satisfied — done.
+  if [ "$archive_kb" -le "$max_archive_kb" ] && [ "$used_pct" -lt "$DISK_CEIL_PCT" ]; then
     break
   fi
 
-  # Oldest archive by mtime. `ls -tr` (mtime order, oldest first) is
-  # busybox-safe; the old `find -printf` is GNU-only and silently no-ops on
-  # busybox find. `awk NR==1` rather than `head -1` consumes the whole stream —
-  # `head` closes the pipe early and, under `set -o pipefail`, aborts the
-  # script on SIGPIPE so it never prunes (archive grows unbounded, /persistent
-  # fills past target).
-  oldest=$(ls -1tr "$ARCHIVE_DIR"/*.RAW.gz 2>/dev/null | awk 'NR==1')
-  if [ -z "$oldest" ]; then
-    echo "pruner: $used_pct% used but archive is empty — nothing to prune" >&2
-    break
-  fi
-
-  rm -f "$oldest"
+  # Size before unlinking. One `du` fork per removal, which measured ~19 s for a
+  # 1488-file catch-up run on a Pod and ~0.05 s in steady state (a couple of
+  # files per 15 min) — cheap enough at Nice=10 / IOSchedulingClass=idle to keep
+  # the accounting obvious. `find -printf '%k'` would avoid the fork but is
+  # GNU-only and no-ops on busybox.
+  kb=$(du -k "$path" 2>/dev/null | awk '{print $1}')
+  rm -f "$path" || continue
+  archive_kb=$((archive_kb - ${kb:-0}))
+  [ "$archive_kb" -lt 0 ] && archive_kb=0
   pruned=$((pruned + 1))
-done
 
-echo "pruner: pruned=$pruned used_pct=$(disk_used_pct)%"
+  # Re-read df only once the folder cap is satisfied and the ceiling is the
+  # sole remaining reason to keep going — while over the cap it cannot end the
+  # loop, so polling it would be a wasted fork per removal.
+  if [ "$archive_kb" -le "$max_archive_kb" ]; then
+    used_pct=$(disk_used_pct)
+  fi
+done < "$list"
+
+used_pct=$(disk_used_pct)
+echo "pruner: pruned=$pruned archive_mb=$((archive_kb / 1024)) used_pct=${used_pct}%"
+
+# Over budget with nothing left to remove means /persistent is filling from
+# outside the archive. Exit non-zero so it surfaces in `systemctl --failed`
+# rather than scrolling past inside a success log — the previous revision's
+# silent give-up is why a full disk went unnoticed for a month.
+if [ "$archive_kb" -gt "$max_archive_kb" ] || [ "$used_pct" -ge "$DISK_CEIL_PCT" ]; then
+  echo "pruner: still over budget — archive=$((archive_kb / 1024))MB (cap ${MAX_ARCHIVE_MB}MB)," \
+       "disk=${used_pct}% (ceiling ${DISK_CEIL_PCT}%), no *.RAW.gz left to remove" >&2
+  exit 1
+fi

--- a/modules/biometrics-archiver/sleepypod-biometrics-pruner.service
+++ b/modules/biometrics-archiver/sleepypod-biometrics-pruner.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Sleepypod biometrics archive pruner (keep /persistent < 80%)
+Description=Sleepypod biometrics archive pruner (cap archive folder; 80% disk ceiling)
 Documentation=https://github.com/sleepypod/core/tree/main/modules/biometrics-archiver
 After=sleepypod-biometrics-archiver.service
 

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -135,9 +135,69 @@ cleanup() {
 trap cleanup EXIT
 
 # Pre-flight: disk space
-DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
-if [ "$DISK_AVAIL" -lt 300 ]; then
-  echo "Error: Need 300MB free, only ${DISK_AVAIL}MB available" >&2
+#
+# Measuring only $INSTALL_DIR is not enough — an update writes to three
+# separate filesystems:
+#
+#   $INSTALL_DIR             rootfs (5.9 GB)  source tree + .next
+#   node_modules             eMMC   (15 GB)   bind-mounted onto /persistent
+#                                             (see scripts/lib/relocation-helpers)
+#   $WORK_DIR / $BACKUP_DIR  tmpfs  (/tmp)    release tarball + rollback copy
+#
+# A pod with a healthy rootfs and a 100%-full /persistent sailed through the
+# old single-path check and then died mid-`pnpm install` with ENOSPC: the tree
+# it measured and the node_modules it filled were different volumes. Seen in
+# the field once the biometrics archive filled the eMMC — the 300 MB it found
+# free on rootfs said nothing about the volume pnpm was about to write to.
+#
+# `df -Pk` throughout: -P is POSIX (busybox and GNU) and guarantees a single
+# unwrapped data row, and -k avoids `-m`, which busybox df need not provide.
+# Same portability reason sleepypod-biometrics-pruner uses `df -P`.
+declare -A NEED_MB=()
+declare -A NEED_PATH=()
+
+require_space() {
+  local path="$1" mb="$2" mp
+  # df needs a path that exists — walk up to the nearest existing ancestor.
+  while [ ! -e "$path" ] && [ "$path" != "/" ]; do path=$(dirname "$path"); done
+  mp=$(df -Pk "$path" | awk 'NR==2{print $6}')
+  mp=${mp:-$path}
+  # Keyed by mount point so paths sharing a filesystem sum instead of racing.
+  NEED_MB["$mp"]=$(( ${NEED_MB["$mp"]:-0} + mb ))
+  NEED_PATH["$mp"]="${NEED_PATH["$mp"]:-$path}"
+}
+
+require_space "$INSTALL_DIR" 500            # source tree + .next
+require_space "${TMPDIR:-/tmp}" 700         # WORK_DIR and BACKUP_DIR coexist
+require_space /opt/sleepypod 300            # module venvs + uv cache
+# node_modules (~700 MB) lands on /persistent once relocated, rootfs before.
+if mountpoint -q /persistent 2>/dev/null; then
+  require_space /persistent/sleepypod-core 900
+else
+  require_space "$INSTALL_DIR" 900
+fi
+
+DISK_SHORT=false
+for mp in "${!NEED_MB[@]}"; do
+  need_mb=${NEED_MB["$mp"]}
+  avail_kb=$(df -Pk "${NEED_PATH["$mp"]}" | awk 'NR==2{print $4}')
+  avail_mb=$(( ${avail_kb:-0} / 1024 ))
+  if [ "$avail_mb" -lt "$need_mb" ]; then
+    echo "Error: $mp needs ${need_mb}MB free, only ${avail_mb}MB available" >&2
+    DISK_SHORT=true
+  fi
+done
+
+if [ "$DISK_SHORT" = true ]; then
+  cat >&2 <<HINT
+
+Free space and retry. Usual suspects:
+  /persistent full   du -sh /persistent/biometrics-archive
+                     then run /usr/local/bin/sleepypod-biometrics-pruner
+  stale DB backups   ls -la $DATA_DIR/sleepypod.db.bak.*
+                     (sp-maintenance keeps the 3 most recent)
+  rootfs full        du -shx /opt/sleepypod/* /var/log
+HINT
   exit 1
 fi
 

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -155,32 +155,47 @@ trap cleanup EXIT
 # Same portability reason sleepypod-biometrics-pruner uses `df -P`.
 declare -A NEED_MB=()
 declare -A NEED_PATH=()
+declare -A NEED_MOUNT=()
 
 require_space() {
-  local path="$1" mb="$2" mp
+  local path="$1" mb="$2" mp fs
   # df needs a path that exists — walk up to the nearest existing ancestor.
   while [ ! -e "$path" ] && [ "$path" != "/" ]; do path=$(dirname "$path"); done
   mp=$(df -Pk "$path" | awk 'NR==2{print $6}')
   mp=${mp:-$path}
-  # Keyed by mount point so paths sharing a filesystem sum instead of racing.
-  NEED_MB["$mp"]=$(( ${NEED_MB["$mp"]:-0} + mb ))
-  NEED_PATH["$mp"]="${NEED_PATH["$mp"]:-$path}"
+  # Bind mounts have different mount points but consume the same free space.
+  # st_dev identifies the backing filesystem (GNU and busybox stat support -c).
+  fs=$(stat -L -c %d "$path")
+  NEED_MB["$fs"]=$(( ${NEED_MB["$fs"]:-0} + mb ))
+  NEED_PATH["$fs"]="${NEED_PATH["$fs"]:-$path}"
+  NEED_MOUNT["$fs"]="${NEED_MOUNT["$fs"]:-$mp}"
 }
 
 require_space "$INSTALL_DIR" 500            # source tree + .next
-require_space "${TMPDIR:-/tmp}" 700         # WORK_DIR and BACKUP_DIR coexist
+# Rollback always uses /tmp; mktemp uses TMPDIR when set. Both copies coexist.
+require_space /tmp 350                     # BACKUP_DIR
+require_space "${TMPDIR:-/tmp}" 350         # WORK_DIR
 require_space /opt/sleepypod 300            # module venvs + uv cache
-# node_modules (~700 MB) lands on /persistent once relocated, rootfs before.
-if mountpoint -q /persistent 2>/dev/null; then
-  require_space /persistent/sleepypod-core 900
-else
+# Use the same target selection as relocation, including small /persistent
+# partitions and NODE_MODULES_DIR overrides. The install path's current bind
+# mount may be removed by relocation, so budget its parent when rootfs wins.
+node_modules_target="$INSTALL_DIR/node_modules"
+if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/relocation-helpers"
+  node_modules_target="${NODE_MODULES_DIR:-$(_auto_pick_node_modules_target "$INSTALL_DIR/node_modules")}"
+fi
+if [ "$node_modules_target" = "$INSTALL_DIR/node_modules" ] && \
+   [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
   require_space "$INSTALL_DIR" 900
+else
+  require_space "$node_modules_target" 900
 fi
 
 DISK_SHORT=false
-for mp in "${!NEED_MB[@]}"; do
-  need_mb=${NEED_MB["$mp"]}
-  avail_kb=$(df -Pk "${NEED_PATH["$mp"]}" | awk 'NR==2{print $4}')
+for fs in "${!NEED_MB[@]}"; do
+  mp=${NEED_MOUNT["$fs"]}
+  need_mb=${NEED_MB["$fs"]}
+  avail_kb=$(df -Pk "${NEED_PATH["$fs"]}" | awk 'NR==2{print $4}')
   avail_mb=$(( ${avail_kb:-0} / 1024 ))
   if [ "$avail_mb" -lt "$need_mb" ]; then
     echo "Error: $mp needs ${need_mb}MB free, only ${avail_mb}MB available" >&2

--- a/scripts/lib/biometrics-archiver-helpers
+++ b/scripts/lib/biometrics-archiver-helpers
@@ -4,7 +4,8 @@
 # Frankenfirmware writes ~1 GB/day of *.RAW frames. We move them to a
 # 500 MB tmpfs at /persistent/biometrics so wear stays off eMMC; an
 # archiver gzips files older than 15 min into /persistent/biometrics-archive/,
-# a pruner keeps /persistent < 80% full. SEQNO.RAW + persistent state
+# a pruner caps that folder at MAX_ARCHIVE_MB (default 6 GiB) with an 80%
+# whole-disk safety ceiling. SEQNO.RAW + persistent state
 # subdirs are symlinked from tmpfs back to /persistent so the firmware
 # sees its state without code changes. See modules/biometrics-archiver/README.
 #

--- a/scripts/tests/test_biometrics_pruner.py
+++ b/scripts/tests/test_biometrics_pruner.py
@@ -1,0 +1,72 @@
+"""Exercise the pruner with real temporary archives and simulated disk usage."""
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class BiometricsPrunerTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.archive = Path(self.temp.name)
+
+    def archive_file(self, name, age):
+        path = self.archive / name
+        path.write_bytes(b'x' * (600 * 1024))
+        os.utime(path, (age, age))
+        return path
+
+    def prune(self, cap=1, disk_usage='20'):
+        script = (ROOT / 'modules/biometrics-archiver/sleepypod-biometrics-pruner').read_text()
+        script = script.replace('ARCHIVE_DIR="/persistent/biometrics-archive"',
+                                'ARCHIVE_DIR=' + shlex.quote(str(self.archive)))
+        # The script uses real du, ls and rm, but must never inspect a Pod disk.
+        df = f'''df() {{
+  pct={disk_usage}
+  printf 'Filesystem Blocks Used Available Capacity Mounted on\\n'
+  printf '/dev/mock 1000 0 1000 %s%% /persistent\\n' "$pct"
+}}
+'''
+        return subprocess.run([shutil.which('bash'), '-c', df + script],
+                              env={**os.environ, 'MAX_ARCHIVE_MB': str(cap),
+                                   'DISK_CEIL_PCT': '80'}, text=True, capture_output=True)
+
+    def test_prunes_oldest_then_stops_and_rerun_is_noop(self):
+        old = self.archive_file('3.RAW.gz', 1000)
+        middle = self.archive_file('1.RAW.gz', 2000)
+        newest = self.archive_file('2.RAW.gz', 3000)
+        result = self.prune()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(old.exists())
+        self.assertFalse(middle.exists())
+        self.assertTrue(newest.exists())
+        result = self.prune()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('pruned=0', result.stdout)
+
+    def test_unprunable_files_count_against_cap_and_fail_loudly(self):
+        stray = self.archive_file('unfinished.tmp', 1000)
+        result = self.prune(cap=0)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('still over budget', result.stderr)
+        self.assertTrue(stray.exists())
+
+    def test_exact_disk_ceiling_requires_pruning_below_ceiling(self):
+        old = self.archive_file('1.RAW.gz', 1000)
+        newest = self.archive_file('2.RAW.gz', 2000)
+        # Disk falls below the ceiling after the first unlink.
+        usage = '$(if [ -f "$ARCHIVE_DIR/1.RAW.gz" ]; then echo 80; else echo 79; fi)'
+        result = self.prune(cap=100, disk_usage=usage)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(old.exists())
+        self.assertTrue(newest.exists())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tests/test_update_disk_space.py
+++ b/scripts/tests/test_update_disk_space.py
@@ -1,0 +1,122 @@
+"""Run the updater's real preflight with simulated Pod filesystem layouts.
+
+No updater side effects run: only the preflight block is executed. Invoke with
+`python3 -m unittest discover -s scripts/tests -p 'test_*.py'` using Bash 4+.
+"""
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class UpdateDiskSpaceTests(unittest.TestCase):
+    def preflight(self, *, persistent_mb=15000, root_free=3000,
+                  persistent_free=3000, tmp_free=1000, work_free=1000,
+                  separate_work=False, override=False, bind_override=False,
+                  stale_bind=False):
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            install = base / 'app'
+            lib = install / 'scripts/lib'
+            lib.mkdir(parents=True)
+            shutil.copyfile(ROOT / 'scripts/lib/relocation-helpers', lib / 'relocation-helpers')
+            # A real existing path lets require_space exercise ancestor lookup.
+            nm = install / 'node_modules'
+            nm.mkdir()
+            work = base / 'work'
+            work.mkdir()
+            custom = base / 'custom'
+            custom.mkdir()
+            code = (ROOT / 'scripts/bin/sp-update').read_text()
+            block = code.split('# Pre-flight: disk space\n', 1)[1].split('# Open WAN if blocked', 1)[0]
+            setup = f'''
+set -euo pipefail
+INSTALL_DIR={shlex.quote(str(install))}
+DATA_DIR=/persistent/sleepypod-data
+TMPDIR={shlex.quote(str(work)) if separate_work else '/tmp'}
+NODE_MODULES_DIR={shlex.quote(str(custom / 'missing/node_modules')) if override else "''"}
+layout() {{
+  fs=1; mp=/; total=6000; free={root_free}
+  case "$1" in
+    /persistent*) fs=2; mp=/persistent; total={persistent_mb}; free={persistent_free} ;;
+    /tmp) fs=3; mp=/tmp; free={tmp_free} ;;
+    "$INSTALL_DIR"*)
+      if [ "$1" = "$INSTALL_DIR/node_modules" ] && {str(stale_bind).lower()}; then
+        fs=2; mp="$INSTALL_DIR/node_modules"; free={persistent_free}
+      fi ;;
+    {shlex.quote(str(custom))}*)
+      fs=4; mp=/custom; free=800
+      if {str(bind_override).lower()}; then fs=1; free={root_free}; fi ;;
+    {shlex.quote(str(work))}*) fs=4; mp=/work; free={work_free} ;;
+  esac
+}}
+df() {{
+  local fs mp total free
+  layout "${{@: -1}}"
+  if [ "$1" = -Pk ]; then total=$((total * 1024)); free=$((free * 1024)); fi
+  printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'
+  printf '/dev/mock%s %s 0 %s 10%% %s\\n' "$fs" "$total" "$free" "$mp"
+}}
+stat() {{
+  local fs mp total free
+  layout "${{@: -1}}"
+  printf '%s\\n' "$fs"
+}}
+mountpoint() {{ [ "${{@: -1}}" = /persistent ]; }}
+'''
+            # Only filesystem existence is virtualized; arithmetic, df parsing,
+            # target selection and the final failure path remain production code.
+            block = block.replace('[ ! -e "$path" ]', '[ ! -e "$path" ] && [[ "$path" != /persistent* ]]')
+            return subprocess.run([shutil.which('bash'), '-c', setup + block],
+                                  text=True, capture_output=True, env=os.environ)
+
+    def test_healthy_standard_layout(self):
+        result = self.preflight()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_small_persistent_does_not_block_rootfs_install(self):
+        result = self.preflight(persistent_mb=966, persistent_free=100)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rootfs_target_sums_dependencies_with_code_and_modules(self):
+        result = self.preflight(persistent_mb=966, root_free=1200)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/ needs 1700MB free', result.stderr)
+
+    def test_stale_bind_is_not_charged_when_relocation_chooses_rootfs(self):
+        result = self.preflight(persistent_mb=966, persistent_free=100, stale_bind=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_override_checks_nearest_existing_ancestor(self):
+        result = self.preflight(override=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/custom needs 900MB free, only 800MB available', result.stderr)
+
+    def test_bind_mount_and_root_share_one_budget(self):
+        result = self.preflight(override=True, bind_override=True, root_free=1200)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/ needs 1700MB free', result.stderr)
+
+    def test_tmpdir_does_not_hide_full_rollback_volume(self):
+        result = self.preflight(separate_work=True, tmp_free=100)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/tmp needs 350MB free, only 100MB available', result.stderr)
+
+    def test_separate_work_volume_is_checked(self):
+        result = self.preflight(separate_work=True, work_free=100)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/work needs 350MB free, only 100MB available', result.stderr)
+
+    def test_shared_tmp_volume_sums_both_copies(self):
+        result = self.preflight(tmp_free=600)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('/tmp needs 700MB free, only 600MB available', result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What happened

A pod filled its 15 GB eMMC to 100% — 1983 files / 13 GB of cold archive — and `sp-update` then failed with `No space left on device`. Two independent gaps let that happen, and a third made it invisible.

The pruner had been failing **every 15 minutes for a month**:

```
sleepypod-biometrics-pruner[462957]: sort: write failed: 'standard output': Broken pipe
systemd[1]: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

That specific `head`-in-a-pipeline SIGPIPE is already fixed on `dev` (`awk NR==1`) — the pod was simply running a month-old build. This PR addresses what's left.

## Changes

**Pruner: cap the folder, not the disk percent.** The bound was whole-disk percent with `-le`, so it stopped as soon as usage was *at* 80% and never recovered headroom. On a 15 GB eMMC that blesses a ~12 GB archive and leaves the disk permanently pinned at 80%. Since `archive-push` is copy-only, the pruner is the only thing bounding the archive, so it now caps the folder at `MAX_ARCHIVE_MB` (default 6 GiB), with the 80% ceiling kept only as a backstop against growth from *outside* the archive.

**Pruner: fail loudly.** When neither bound can be reached it exits non-zero, so a disk filling from elsewhere shows up in `systemctl --failed` instead of a silent give-up inside a success log. The silent give-up is a large part of why this went unnoticed for a month.

**Pruner: materialise the list once.** A catch-up run can be ~1300 removals, and re-deriving the oldest entry with `ls -1tr` over ~2000 entries per deletion is O(n²) on eMMC. Both existing portability choices are deliberately preserved — `find -printf` silently no-ops on busybox and `df --output=pcent` is rejected outright, so this keeps `ls -1tr`, `du -k`, and `df -P`.

**`sp-update` pre-flight: check every filesystem it writes to.** It measured only `$INSTALL_DIR`, but an update writes to three volumes:

| path | filesystem | holds |
|---|---|---|
| `$INSTALL_DIR` | rootfs (5.9 GB) | source tree + `.next` |
| `node_modules` | eMMC (15 GB) | bind-mounted onto `/persistent` |
| `$WORK_DIR` / `$BACKUP_DIR` | tmpfs (`/tmp`) | release tarball + rollback copy |

A healthy rootfs with a full `/persistent` passed the old 300 MB check and then died mid-`pnpm install`, where a bare `ENOSPC` says nothing about which volume ran out. Requirements are now accumulated per mount point (paths sharing a filesystem sum) and reported per filesystem with the actual shortfall.

## Verification

Tested on the affected Pod 3 (bash 5.1, GNU coreutils 9.0):

- 2000 files / 196 MB pruned to a 50 MB cap — oldest-first order confirmed, exit 0; re-run is a no-op
- ~19 s for 1488 removals, 0.05 s in steady state (at `Nice=10` / `IOSchedulingClass=idle`)
- unreachable bound exits 1 with the shortfall reported
- pre-flight: passes when healthy; fails per-filesystem when short; **sums two requirements on a shared filesystem** (9000 + 300 → `/ needs 9300MB`); tolerates a not-yet-created path
- live pod: pruner now logs `Finished` (`pruned=0 archive_mb=2266 used_pct=29%`) instead of `Failed to start`, and `sp-update` completed successfully

ADR 0018 gains a "Pruner constraints (learned the hard way)" section recording all three constraints, so they don't get re-broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyKwc4SYgs69bNg7iqA8f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - RAW biometrics archives now use a configurable size cap (6 GiB by default) alongside an 80% whole-disk safety ceiling.
  - Archive cleanup removes the oldest files first when either limit is exceeded.

- **Bug Fixes**
  - System updates now accurately check available space across shared and separate filesystems.
  - Disk-space failures provide clearer information about the affected storage location.

- **Documentation**
  - Updated storage and operational guidance to reflect archive limits and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->