### PR TITLE
test(hardware): kill types.ts surviving mutants (#591 hit list)

### DIFF
--- a/src/hardware/tests/types.mutation.test.ts
+++ b/src/hardware/tests/types.mutation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const completeDeviceData = {
+  tgHeatLevelR: '50',
+  tgHeatLevelL: '-30',
+  heatTimeL: '1800',
+  heatLevelL: '-25',
+  heatTimeR: '3600',
+  heatLevelR: '45',
+  sensorLabel: '8SLEEP-SN-12345-I00',
+  waterLevel: 'true',
+  priming: 'false',
+} as const
+
+async function loadRawDeviceDataSchema() {
+  // The schema is constructed at module load. Stryker activates static mutants
+  // after Vitest collects the suite, so a cached import would exercise the
+  // original regexes and enum members and report false survivors.
+  vi.resetModules()
+  const { rawDeviceDataSchema } = await import('../types')
+  return rawDeviceDataSchema
+}
+
+describe('rawDeviceDataSchema mutation boundaries', () => {
+  it('pins every signed integer field to the complete decimal wire format', async () => {
+    const schema = await loadRawDeviceDataSchema()
+    const fields = ['tgHeatLevelR', 'tgHeatLevelL', 'heatLevelL', 'heatLevelR'] as const
+
+    for (const field of fields) {
+      for (const valid of ['0', '50', '-50', '123']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: valid }).success,
+          `${field} rejected ${valid}`,
+        ).toBe(true)
+      }
+
+      for (const invalid of ['x50', '50x', '--50', '+50', '5.0', 'word']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: invalid }).success,
+          `${field} accepted ${invalid}`,
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('pins both duration fields to complete unsigned decimal strings', async () => {
+    const schema = await loadRawDeviceDataSchema()
+    const fields = ['heatTimeL', 'heatTimeR'] as const
+
+    for (const field of fields) {
+      for (const valid of ['0', '9', '1800']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: valid }).success,
+          `${field} rejected ${valid}`,
+        ).toBe(true)
+      }
+
+      for (const invalid of ['x1800', '1800x', '-1800', '+1800', '18.00', 'word']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: invalid }).success,
+          `${field} accepted ${invalid}`,
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('pins both boolean wire fields to their two exact enum members', async () => {
+    const schema = await loadRawDeviceDataSchema()
+
+    for (const field of ['waterLevel', 'priming'] as const) {
+      for (const valid of ['true', 'false']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: valid }).success,
+          `${field} rejected ${valid}`,
+        ).toBe(true)
+      }
+
+      for (const invalid of ['', 'TRUE', 'False', '0', '1']) {
+        expect(
+          schema.safeParse({ ...completeDeviceData, [field]: invalid }).success,
+          `${field} accepted ${invalid}`,
+        ).toBe(false)
+      }
+    }
+  })
+})

--- a/src/hardware/tests/types.mutation.test.ts
+++ b/src/hardware/tests/types.mutation.test.ts
@@ -34,7 +34,7 @@ describe('rawDeviceDataSchema mutation boundaries', () => {
         ).toBe(true)
       }
 
-      for (const invalid of ['x50', '50x', '--50', '+50', '5.0', 'word']) {
+      for (const invalid of ['', 'x50', '50x', '--50', '+50', '5.0', 'word']) {
         expect(
           schema.safeParse({ ...completeDeviceData, [field]: invalid }).success,
           `${field} accepted ${invalid}`,
@@ -55,7 +55,7 @@ describe('rawDeviceDataSchema mutation boundaries', () => {
         ).toBe(true)
       }
 
-      for (const invalid of ['x1800', '1800x', '-1800', '+1800', '18.00', 'word']) {
+      for (const invalid of ['', 'x1800', '1800x', '-1800', '+1800', '18.00', 'word']) {
         expect(
           schema.safeParse({ ...completeDeviceData, [field]: invalid }).success,
           `${field} accepted ${invalid}`,


### PR DESCRIPTION
## Summary

- Add fresh-import coverage for the 32 static rawDeviceDataSchema survivors from mutation run 30691717867.
- Pin every signed and unsigned decimal wire-format regex across all affected fields.
- Pin the exact true/false enum members for waterLevel and priming.
- Reset the Vitest module cache before dynamic imports so schema initialization executes while each static mutant is active.

## Mutation result

The hardware artifact from run 30711581038 reduced src/hardware/types.ts from 33 survivors to 1 and raised its file score from 29.8% to 97.9%. The remaining unary mutation changes 100 to +100, which is semantically equivalent JavaScript.

## Verification

- pnpm exec vitest run src/hardware/tests/types.mutation.test.ts src/hardware/tests/types.test.ts
- pnpm tsc
- pnpm lint
- pnpm drizzle-kit check
- pnpm drizzle-kit check --config=drizzle.biometrics.config.ts

Tracks #591.

Source run: https://github.com/sleepypod/core/actions/runs/30691717867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify hardware data validation accepts only supported signed integer, unsigned duration, and boolean formats.
  * Added checks that malformed wire-format values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/mutation-run-30691717867
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/mutation-run-30691717867/scripts/install \
  | sudo bash -s -- --branch test/mutation-run-30691717867
```

🎯 **Pin to this exact build** ([run 30711851954](https://github.com/sleepypod/core/actions/runs/30711851954) · `dd64b66`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/dd64b66242e714f2534bc326889ea008ac5caaf1/scripts/install \
  | sudo bash -s -- \
      --branch test/mutation-run-30691717867 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/30711851954/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/30711851954/artifacts/8822131655) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
