### PR TITLE
fix(homekit): keep AUTO-on from falling back to off

### DIFF
--- a/src/homekit/accessories/sideController.ts
+++ b/src/homekit/accessories/sideController.ts
@@ -21,7 +21,7 @@ import { HapStatusError } from 'hap-nodejs'
 import type { HAPStatus } from 'hap-nodejs'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus, Side } from '@/src/hardware/types'
-import { MAX_TEMP, MIN_TEMP, TEMP_NEUTRAL } from '@/src/hardware/types'
+import { MAX_TEMP, MIN_TEMP } from '@/src/hardware/types'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getAutomationEngineIfRunning } from '@/src/automation'
 import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
@@ -64,6 +64,11 @@ function assertNotGuardBlocked(side: Side, label: string): void {
 }
 
 const lastTargetF: Record<Side, number | null> = { left: null, right: null }
+
+// Match the web and shared-hardware power-on default. TEMP_NEUTRAL (82.5°F)
+// is hardware level 0 — the pod's OFF state — so it must never be used as
+// the fallback for an explicit HomeKit AUTO/ON request.
+const POWER_ON_FALLBACK_F = 75
 
 // Intended power state as expressed by HomeKit, updated eagerly. Used to
 // resolve the "user dragged the slider mid-power-cycle" race: firmware
@@ -145,16 +150,17 @@ export function reconcileIntendedPower(status: DeviceStatus, side: Side): void {
  * Resolve the target setpoint to use when powering a side back on.
  * Cache wins because firmware may not preserve targetTemperature across
  * a level=0 (off) write. Falls back to the last firmware status, then to
- * NEUTRAL so a power-on without any prior context lands on a safe value
- * instead of the hardware client's hardcoded 75°F default.
+ * the same non-neutral 75°F default as the web and shared-hardware paths.
+ * Falling back to TEMP_NEUTRAL would send level 0 and immediately make
+ * HomeKit's AUTO/ON characteristic read back as OFF.
  */
 export function getStagedTargetF(monitor: DacMonitor, side: Side): number {
   const cached = lastTargetF[side]
   if (cached !== null) return cached
   const status = monitor.getLastStatus()
-  if (!status) return TEMP_NEUTRAL
+  if (!status) return POWER_ON_FALLBACK_F
   const s = side === 'left' ? status.leftSide : status.rightSide
-  return s.targetTemperature ?? TEMP_NEUTRAL
+  return s.targetTemperature ?? POWER_ON_FALLBACK_F
 }
 
 /**

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -29,6 +29,7 @@ import {
 import { withSideLock } from '@/src/hardware/sideLock'
 import type { DacMonitor } from '@/src/hardware/dacMonitor'
 import type { DeviceStatus } from '@/src/hardware/types'
+import { fahrenheitToLevel } from '@/src/hardware/types'
 
 const offStatus: DeviceStatus = {
   leftSide: { currentTemperature: 75, targetTemperature: 70, currentLevel: 0, targetLevel: 0, heatingDuration: 0 },
@@ -100,19 +101,20 @@ describe('sideController', () => {
       expect(getStagedTargetF(monitor(offStatus), 'right')).toBe(75)
     })
 
-    it('falls back to TEMP_NEUTRAL when monitor has no status', () => {
-      // TEMP_NEUTRAL = 82.5
-      expect(getStagedTargetF(monitor(null), 'left')).toBe(82.5)
+    it('falls back to the non-neutral power-on default when monitor has no status', () => {
+      expect(getStagedTargetF(monitor(null), 'left')).toBe(75)
     })
 
-    it('falls back to TEMP_NEUTRAL when firmware reports a null (off) target', () => {
+    it('falls back to the non-neutral power-on default when firmware reports a null target', () => {
       // Status exists but the off side reports a null level-0 target; with no
-      // cache the staged target must land on neutral, not null.
+      // cache the staged target must still energize the side.
       const offNullTarget = monitor({
         ...offStatus,
         leftSide: { ...offStatus.leftSide, targetTemperature: null },
       })
-      expect(getStagedTargetF(offNullTarget, 'left')).toBe(82.5)
+      const target = getStagedTargetF(offNullTarget, 'left')
+      expect(target).toBe(75)
+      expect(fahrenheitToLevel(target)).not.toBe(0)
     })
 
     it('prefers cached target once setTargetTemperature runs', async () => {
@@ -172,9 +174,22 @@ describe('sideController', () => {
       expect(setPower).toHaveBeenCalledWith('right', true, 75)
     })
 
-    it('falls back to TEMP_NEUTRAL when no status and no cache', async () => {
+    it('falls back to 75°F when no status and no cache', async () => {
       await setSidePowerOn(monitor(null), 'left')
-      expect(setPower).toHaveBeenCalledWith('left', true, 82.5)
+      expect(setPower).toHaveBeenCalledWith('left', true, 75)
+    })
+
+    it('powers on with a non-zero level when firmware reports a null off target', async () => {
+      const offNullTarget = monitor({
+        ...offStatus,
+        leftSide: { ...offStatus.leftSide, targetTemperature: null },
+      })
+
+      await setSidePowerOn(offNullTarget, 'left')
+
+      const target = setPower.mock.calls[0]?.[2]
+      expect(setPower).toHaveBeenCalledWith('left', true, 75)
+      expect(fahrenheitToLevel(target)).not.toBe(0)
     })
   })
 


### PR DESCRIPTION
## Summary

- use the standard 75°F power-on fallback when HomeKit has no cached or firmware target
- preserve existing cached and firmware targets
- add regression coverage proving an OFF-to-AUTO fallback converts to a nonzero hardware level

## Root cause

When an off side reported a null target, HomeKit substituted TEMP_NEUTRAL (82.5°F). That temperature is hardware level 0, which is the pod OFF state, so the AUTO/ON write immediately read back as OFF. The web path uses 75°F and therefore energizes the side normally.

Live pod logs matched this path: each HomeKit attempt sent level 0 plus the duration command, while the successful web request sent level -27 plus the same duration.

## Validation

- GitHub Actions: lint, typecheck, unit tests, both production builds, and branch release passed
- pre-push checks: TypeScript, ESLint, Drizzle schema validation, 438 changed-file tests
- focused HomeKit suite: 68 tests passed
- independent read-only review: no material findings