### PR TITLE
test: kill pod and HomeKit mutation survivors

### DIFF
--- a/src/hardware/tests/pods.mutation.test.ts
+++ b/src/hardware/tests/pods.mutation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadPodCapabilities() {
+  // POD_CAPS is built at module load. Reload it while each static Stryker
+  // mutant is active so catalog changes are observable instead of reading the
+  // original object from Vitest's module cache.
+  vi.resetModules()
+  const { POD_CAPS } = await import('../pods')
+  return POD_CAPS
+}
+
+describe('POD_CAPS mutation contract', () => {
+  it('pins every deployed pod capability after a fresh module import', async () => {
+    await expect(loadPodCapabilities()).resolves.toEqual({
+      H00: {
+        modelName: 'Pod 3',
+        os: 'yocto',
+        iptablesPath: '/sbin/iptables',
+        hasPackageManager: false,
+        pythonVersion: '3.9',
+        hasEnsurepip: false,
+        hasNftables: false,
+        dacSocketPath: '/deviceinfo/dac.sock',
+        hasIptablesPersistent: false,
+      },
+      I00: {
+        modelName: 'Pod 4',
+        os: 'yocto',
+        iptablesPath: '/sbin/iptables',
+        hasPackageManager: false,
+        pythonVersion: '3.10',
+        hasEnsurepip: false,
+        hasNftables: false,
+        dacSocketPath: '/deviceinfo/dac.sock',
+        hasIptablesPersistent: false,
+      },
+      J00: {
+        modelName: 'Pod 5',
+        os: 'debian',
+        iptablesPath: '/usr/sbin/iptables',
+        hasPackageManager: true,
+        packageManager: 'apt',
+        pythonVersion: '3.10',
+        hasEnsurepip: true,
+        hasNftables: true,
+        dacSocketPath: '/persistent/deviceinfo/dac.sock',
+        hasIptablesPersistent: true,
+      },
+    })
+  })
+})

--- a/src/homekit/tests/sideController.test.ts
+++ b/src/homekit/tests/sideController.test.ts
@@ -409,6 +409,30 @@ describe('sideController', () => {
       expect(() => reconcileIntendedPower(onStatus, 'left')).not.toThrow()
       expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
     })
+
+    it('does not read firmware status while no intent is latched', () => {
+      // The null-latch early return must fire before any status inspection:
+      // reconcile runs on every status frame for both sides, so with no
+      // intent to resolve it must not touch the frame at all.
+      const trapped = new Proxy({} as DeviceStatus, {
+        get: (_t, prop) => {
+          throw new Error(`unexpected status read: ${String(prop)}`)
+        },
+      })
+      expect(() => reconcileIntendedPower(trapped, 'left')).not.toThrow()
+    })
+
+    it('keeps an in-flight OFF latch on a guard-blocked side that firmware still reports ON', async () => {
+      // A trip can land while a power-off is in flight: firmware keeps
+      // reporting ON for one more poll. Only a stale *ON* latch may be
+      // dropped on a blocked side — dropping this OFF latch would flip
+      // iOS Home back to a phantom ON until the off-write lands.
+      await setSidePowerOff(monitor(onStatus), 'left')
+      shouldBlock.mockReturnValue(true)
+
+      reconcileIntendedPower(onStatus, 'left')
+      expect(isEffectivelyPowered(monitor(onStatus), 'left')).toBe(false)
+    })
   })
 
   describe('intendedPower rollback', () => {
@@ -462,6 +486,10 @@ describe('sideController', () => {
       })
       expect(setPower).not.toHaveBeenCalled()
       expect(registerManualOverride).not.toHaveBeenCalled()
+      // The ingress assert (not the in-lock re-check) refused this call —
+      // its log must name the exact write so field debugging can tell the
+      // two gates' refusals apart from a silent drop.
+      expect(warn).toHaveBeenCalledWith('[homekit] refused setPower(left, true) — pump stall protection active on left')
       // Latch must stay untouched so onGet keeps reporting the true (off) state.
       expect(isEffectivelyPowered(monitor(offStatus), 'left')).toBe(false)
       warn.mockRestore()
@@ -570,6 +598,9 @@ describe('sideController', () => {
 
       await expect(setTargetTemperature(monitor(onStatus), 'left', 68)).rejects.toThrow('Pump stall protection active')
       expect(setTemperature).not.toHaveBeenCalled()
+      // The refusal log must name the exact blocked write (side + clamped
+      // value), mirroring the setPower gate's message contract.
+      expect(warn).toHaveBeenCalledWith('[homekit] refused setTemperature(left, 68) — pump stall protection active on left')
       // A rejected write must not suspend autopilot (same ordering contract
       // as the REST path: the override registers only after the gate passes).
       expect(registerManualOverride).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- review scheduled mutation run 31245115320 against the previous weekly baseline
- add a fresh-import POD_CAPS manifest contract so static catalog mutations are observable
- pin HomeKit intent reconciliation, guard behavior, and refusal diagnostics

## Review findings

- the six completed shards introduced no new Survived or NoCoverage regressions
- the database shard timed out before writing a fresh mutation.json, so the reported aggregate excludes database results
- its incremental cache is stale and was saved again after cancellation; follow-up should avoid caching cancelled runs and either trim schema literals from the mutate scope or seed a fresh database cache with a longer run

## Mutation result

- src/hardware/pods.ts: 24 killed, 0 survived, 0 no coverage, 0 timeout, 9 compile errors
- src/homekit/sideController.ts: 59 killed, 1 equivalent survivor, 0 no coverage, 0 timeout, 28 compile errors, 2 ignored
- combined: 28 former survivors killed; projected completed-shard score rises from 94.3% to about 94.6%

## Verification

- full Vitest suite: 3,309 tests, 0 failures, 0 errors
- targeted Vitest: 56 tests passed
- TypeScript, ESLint, and both Drizzle schema checks passed
- scoped Stryker runs passed with the results above

Tracks #591.

Source run: https://github.com/sleepypod/core/actions/runs/31245115320

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/mutation-run-31245115320
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/mutation-run-31245115320/scripts/install \
  | sudo bash -s -- --branch test/mutation-run-31245115320
```

🎯 **Pin to this exact build** ([run 31344575818](https://github.com/sleepypod/core/actions/runs/31344575818) · `2c76c91`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/2c76c91dc167a7361d217c202c5be74490d8b32f/scripts/install \
  | sudo bash -s -- \
      --branch test/mutation-run-31245115320 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/31344575818/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/31344575818/artifacts/9046895740) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
