### PR TITLE
fix(install): write the SSH key where sshd actually reads it

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,10 +63,22 @@ curl -fsSL https://raw.githubusercontent.com/sleepypod/core/main/scripts/install
 ```
 
 The optional SSH-setup step at the end of the installer writes your public
-key to `/root/.ssh/authorized_keys` and re-hardens sshd (port 8822,
-key-only, no root password login, no empty passwords). After that first
-install Pod 5 behaves like Pod 4 — key-based root ssh on port 8822, no
-`rewt` user needed for updates.
+key to whichever `authorized_keys` file sshd actually reads for root, then
+re-hardens sshd (port 8822, key-only, no root password login, no empty
+passwords). After that first install Pod 5 behaves like Pod 4 — key-based
+root ssh on port 8822, no `rewt` user needed for updates.
+
+The path is resolved at runtime by `scripts/lib/ssh-helpers` rather than
+hardcoded, because **`/root/.ssh/authorized_keys` is the wrong answer on
+this firmware**: root's home is `/home/root` (Yocto/poky convention), and
+free-sleep's `setup_ssh.sh` pins an absolute
+`AuthorizedKeysFile /home/root/ssh/authorized_keys` that survives the
+installer's edits. Writing to a path sshd doesn't read, while also setting
+`PasswordAuthentication no`, is an unrecoverable lockout — port 8822 is the
+pod's only remote entry point. For the same reason the installer only
+disables password auth **after** a key is verifiably in place, and folds
+any keys stranded in `/root/.ssh/authorized_keys` by an older installer
+into the real file on re-run.
 
 ## Installation
 
@@ -189,8 +201,13 @@ During installation, you'll be prompted to configure SSH on port 8822 with keys-
 If you need to configure SSH later:
 1. Edit `/etc/ssh/sshd_config`
 2. Set `Port 8822` and `PermitRootLogin prohibit-password`
-3. Add your public key to `/root/.ssh/authorized_keys`
-4. Restart: `systemctl restart sshd`
+3. Add your public key to the file sshd reads for root — check with
+   `sshd -T | grep -i authorizedkeysfile`, and remember root's home is
+   `/home/root`, so the default resolves to
+   `/home/root/.ssh/authorized_keys`, **not** `/root/.ssh/authorized_keys`
+4. Confirm key auth works (`ssh -p 8822 root@<POD_IP>`) *before* setting
+   `PasswordAuthentication no` — there is no other way back in
+5. Restart: `systemctl restart sshd`
 
 Connect with:
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,10 +75,24 @@ free-sleep's `setup_ssh.sh` pins an absolute
 `AuthorizedKeysFile /home/root/ssh/authorized_keys` that survives the
 installer's edits. Writing to a path sshd doesn't read, while also setting
 `PasswordAuthentication no`, is an unrecoverable lockout — port 8822 is the
-pod's only remote entry point. For the same reason the installer only
-disables password auth **after** a key is verifiably in place, and folds
-any keys stranded in `/root/.ssh/authorized_keys` by an older installer
-into the real file on re-run.
+pod's only remote entry point. For the same reason the installer folds any
+keys stranded in `/root/.ssh/authorized_keys` by an older installer into the
+real file on re-run.
+
+Everything else in that step exists to avoid locking you out against a key
+that can't actually authenticate. Before password auth is disabled, the
+installer:
+
+- parses your key with `ssh-keygen -l` (a format regex accepts
+  `ssh-ed25519 A`, which sshd silently ignores), and declines to harden if
+  `ssh-keygen` is missing;
+- refuses to guess a path when sshd is set to `AuthorizedKeysFile none`,
+  including via a `Match User root` block;
+- adds directives that are absent rather than only rewriting ones that are
+  present — `PasswordAuthentication` defaults to `yes`, so a config that
+  never mentions it stays wide open;
+- re-reads the effective config with `sshd -T` and aborts, restoring the
+  backup, unless port/auth values are what it just asked for.
 
 ## Installation
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,12 +87,17 @@ installer:
   `ssh-ed25519 A`, which sshd silently ignores), and declines to harden if
   `ssh-keygen` is missing;
 - refuses to guess a path when sshd is set to `AuthorizedKeysFile none`,
-  including via a `Match User root` block;
+  including via a `Match User root` block, or when root's home directory
+  can't be resolved at all;
 - adds directives that are absent rather than only rewriting ones that are
   present — `PasswordAuthentication` defaults to `yes`, so a config that
   never mentions it stays wide open;
 - re-reads the effective config with `sshd -T` and aborts, restoring the
-  backup, unless port/auth values are what it just asked for.
+  per-run `/etc/ssh/sshd_config.pre-install` snapshot, unless port/auth
+  values are what it just asked for. The auth directives are read in root's
+  connection context (`sshd -T -C user=root,…`), since all three are
+  Match-able — a global reading would pass while `Match User root` quietly
+  re-enabled password auth for the account being hardened.
 
 ## Installation
 
@@ -216,7 +221,9 @@ If you need to configure SSH later:
 1. Edit `/etc/ssh/sshd_config`
 2. Set `Port 8822` and `PermitRootLogin prohibit-password`
 3. Add your public key to the file sshd reads for root — check with
-   `sshd -T | grep -i authorizedkeysfile`, and remember root's home is
+   `sshd -T -C user=root,host=localhost,addr=127.0.0.1 | grep -i authorizedkeysfile`
+   (the `-C` matters: a plain `sshd -T` reports the global value and misses
+   any `Match User root` override), and remember root's home is
    `/home/root`, so the default resolves to
    `/home/root/.ssh/authorized_keys`, **not** `/root/.ssh/authorized_keys`
 4. Confirm key auth works (`ssh -p 8822 root@<POD_IP>`) *before* setting

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,7 +97,11 @@ installer:
   values are what it just asked for. The auth directives are read in root's
   connection context (`sshd -T -C user=root,…`), since all three are
   Match-able — a global reading would pass while `Match User root` quietly
-  re-enabled password auth for the account being hardened.
+  re-enabled password auth for the account being hardened. If sshd can't be
+  asked in that context at all (an older sshd that rejects the `-C` spec), the
+  installer treats the auth directives as unverifiable and aborts+restores
+  rather than trusting the global reading — it will not claim a hardened pod
+  it can't confirm.
 
 ## Installation
 

--- a/scripts/install
+++ b/scripts/install
@@ -1791,17 +1791,26 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
   fi
 
   # A directive can be syntactically valid and still not take effect — an
-  # Include or a later duplicate can override it. Confirm what sshd will
-  # actually do before we restart it into that config.
+  # Include, a later duplicate, or a Match block can override it. Confirm
+  # what sshd will actually do before we restart it into that config.
+  #
+  # The auth directives are checked in root's connection context: all three
+  # are Match-able, so a global reading would pass while `Match User root`
+  # re-enabled password auth for exactly the account being hardened. Port
+  # can't appear in a Match block, so it stays global.
   SSH_EXPECTED="port=8822"
   if [ "$SSH_KEY_INSTALLED" = true ]; then
-    SSH_EXPECTED="$SSH_EXPECTED permitrootlogin=prohibit-password"
-    SSH_EXPECTED="$SSH_EXPECTED passwordauthentication=no permitemptypasswords=no"
+    SSH_EXPECTED="$SSH_EXPECTED root:permitrootlogin=prohibit-password"
+    SSH_EXPECTED="$SSH_EXPECTED root:passwordauthentication=no root:permitemptypasswords=no"
   fi
   for expectation in $SSH_EXPECTED; do
+    case "$expectation" in
+      *:*) SSH_CONTEXT="${expectation%%:*}"; expectation="${expectation#*:}" ;;
+      *)   SSH_CONTEXT="" ;;
+    esac
     directive="${expectation%%=*}"
     want="${expectation#*=}"
-    got="$(sshd_effective_value "$directive")"
+    got="$(sshd_effective_value "$directive" /etc/ssh/sshd_config "$SSH_CONTEXT")"
     if [ "$got" != "$want" ]; then
       echo "Error: sshd reports $directive=${got:-<unset>}, expected $want." >&2
       echo "Restoring backup and leaving sshd untouched..." >&2

--- a/scripts/install
+++ b/scripts/install
@@ -1719,16 +1719,20 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
     # Without the helpers we can't tell where sshd reads authorized_keys
     # from, and hardening on a guess locks the pod out for good. Leave sshd
     # exactly as it is.
-    echo "Error: $INSTALL_DIR/scripts/lib/ssh-helpers not found — skipping SSH setup." >&2
+    echo "Error: $INSTALL_DIR/scripts/lib/ssh-helpers not found — aborting install." >&2
     echo "sshd was left unchanged. Re-run the installer once the source tree is complete." >&2
     exit 1
   fi
   source "$INSTALL_DIR/scripts/lib/ssh-helpers"
 
-  # Backup sshd_config
+  # Keep the first-ever config as a historical artifact, but restore from a
+  # fresh per-run snapshot — .backup is frozen at the first run, so restoring
+  # it on a re-run reverts to the stock config (port 22, password auth on)
+  # rather than to the state this run started from.
   if [ ! -f /etc/ssh/sshd_config.backup ]; then
     cp /etc/ssh/sshd_config /etc/ssh/sshd_config.backup
   fi
+  cp -f /etc/ssh/sshd_config /etc/ssh/sshd_config.pre-install
 
   # Port is safe to set before we know whether a key will land — it doesn't
   # change who can authenticate. The rest of the hardening waits until the
@@ -1782,7 +1786,7 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
   # Validate SSH config before restarting
   if ! sshd -t; then
     echo "Error: sshd_config validation failed. Restoring backup..." >&2
-    cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
+    cp /etc/ssh/sshd_config.pre-install /etc/ssh/sshd_config
     exit 1
   fi
 
@@ -1801,7 +1805,7 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
     if [ "$got" != "$want" ]; then
       echo "Error: sshd reports $directive=${got:-<unset>}, expected $want." >&2
       echo "Restoring backup and leaving sshd untouched..." >&2
-      cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
+      cp /etc/ssh/sshd_config.pre-install /etc/ssh/sshd_config
       exit 1
     fi
   done
@@ -1819,7 +1823,7 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
     echo "$SSH_RESULT"
   else
     echo "Error: Failed to restart SSH service" >&2
-    cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
+    cp /etc/ssh/sshd_config.pre-install /etc/ssh/sshd_config
     exit 1
   fi
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -547,9 +547,11 @@ preflight_free_sleep_conflict() {
 #   su -                            # switch to root with the passwd you set
 #   bash scripts/install            # run this script
 # The optional SSH-setup block at the end of this script writes your key to
-# /root/.ssh/authorized_keys and re-hardens sshd (port 8822, key-only, no
-# password auth, no root password login). After that you can ssh directly as
-# root with your key.
+# whichever authorized_keys file sshd actually reads for root (resolved by
+# scripts/lib/ssh-helpers — root's home is /home/root here, and free-sleep
+# may have pinned an absolute AuthorizedKeysFile) and only then re-hardens
+# sshd (port 8822, key-only, no password auth, no root password login).
+# After that you can ssh directly as root with your key.
 if [ "$EUID" -ne 0 ]; then
   echo "Error: This script must be run as root (use sudo or su -)" >&2
   echo "" >&2
@@ -1713,32 +1715,57 @@ fi
 if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; then
   echo "Configuring SSH..."
 
+  if [ ! -f "$INSTALL_DIR/scripts/lib/ssh-helpers" ]; then
+    # Without the helpers we can't tell where sshd reads authorized_keys
+    # from, and hardening on a guess locks the pod out for good. Leave sshd
+    # exactly as it is.
+    echo "Error: $INSTALL_DIR/scripts/lib/ssh-helpers not found — skipping SSH setup." >&2
+    echo "sshd was left unchanged. Re-run the installer once the source tree is complete." >&2
+    exit 1
+  fi
+  source "$INSTALL_DIR/scripts/lib/ssh-helpers"
+
   # Backup sshd_config
   if [ ! -f /etc/ssh/sshd_config.backup ]; then
     cp /etc/ssh/sshd_config /etc/ssh/sshd_config.backup
   fi
 
-  # Update SSH configuration
+  # Port is safe to set before we know whether a key will land — it doesn't
+  # change who can authenticate. The rest of the hardening waits until the
+  # key is verifiably in place.
   sed -i "s/#\?Port .*/Port 8822/" /etc/ssh/sshd_config
-  sed -i "s/#\?PermitRootLogin .*/PermitRootLogin prohibit-password/" /etc/ssh/sshd_config
-  sed -i "s/#\?PasswordAuthentication .*/PasswordAuthentication no/" /etc/ssh/sshd_config
-  sed -i "s/#\?PermitEmptyPasswords .*/PermitEmptyPasswords no/" /etc/ssh/sshd_config
+
+  # Repair installs from before the authorized_keys path fix, where the key
+  # went to /root/.ssh and sshd (root home = /home/root) never read it.
+  migrate_stranded_authorized_keys root
 
   echo ""
   echo "Enter your SSH public key:"
   read -r SSH_KEY
 
+  SSH_KEY_INSTALLED=false
   if [ -n "$SSH_KEY" ]; then
     # Validate key format
     if echo "$SSH_KEY" | grep -qE '^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+) [A-Za-z0-9+/=]+'; then
-      mkdir -p /root/.ssh
-      echo "$SSH_KEY" >> /root/.ssh/authorized_keys
-      chmod 700 /root/.ssh
-      chmod 600 /root/.ssh/authorized_keys
-      echo "SSH key added"
+      AUTHORIZED_KEYS="$(install_authorized_key root "$SSH_KEY")"
+      echo "SSH key added to $AUTHORIZED_KEYS"
+      SSH_KEY_INSTALLED=true
     else
       echo "Warning: Invalid SSH key format, skipping"
     fi
+  fi
+
+  # Only disable password auth once root has a key sshd can actually read.
+  # Hardening without one is an unrecoverable lockout — port 8822 is the
+  # pod's only remote entry point, and getting back in means opening the
+  # case for a serial console.
+  if [ "$SSH_KEY_INSTALLED" = true ]; then
+    sed -i "s/#\?PermitRootLogin .*/PermitRootLogin prohibit-password/" /etc/ssh/sshd_config
+    sed -i "s/#\?PasswordAuthentication .*/PasswordAuthentication no/" /etc/ssh/sshd_config
+    sed -i "s/#\?PermitEmptyPasswords .*/PermitEmptyPasswords no/" /etc/ssh/sshd_config
+  else
+    echo "No SSH key installed — leaving password authentication as-is." >&2
+    echo "Re-run the installer with a valid public key to harden sshd." >&2
   fi
 
   # Validate SSH config before restarting
@@ -1748,11 +1775,17 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
     exit 1
   fi
 
+  if [ "$SSH_KEY_INSTALLED" = true ]; then
+    SSH_RESULT="SSH configured on port 8822 (keys only)"
+  else
+    SSH_RESULT="SSH configured on port 8822 (existing auth methods unchanged)"
+  fi
+
   # Restart SSH (try both service names for compatibility)
   if systemctl restart sshd 2>/dev/null; then
-    echo "SSH configured on port 8822 (keys only)"
+    echo "$SSH_RESULT"
   elif systemctl restart ssh 2>/dev/null; then
-    echo "SSH configured on port 8822 (keys only)"
+    echo "$SSH_RESULT"
   else
     echo "Error: Failed to restart SSH service" >&2
     cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config

--- a/scripts/install
+++ b/scripts/install
@@ -1733,7 +1733,7 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
   # Port is safe to set before we know whether a key will land — it doesn't
   # change who can authenticate. The rest of the hardening waits until the
   # key is verifiably in place.
-  sed -i "s/#\?Port .*/Port 8822/" /etc/ssh/sshd_config
+  set_sshd_directive Port 8822
 
   # Repair installs from before the authorized_keys path fix, where the key
   # went to /root/.ssh and sshd (root home = /home/root) never read it.
@@ -1745,14 +1745,25 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
 
   SSH_KEY_INSTALLED=false
   if [ -n "$SSH_KEY" ]; then
-    # Validate key format
-    if echo "$SSH_KEY" | grep -qE '^(ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+) [A-Za-z0-9+/=]+'; then
-      AUTHORIZED_KEYS="$(install_authorized_key root "$SSH_KEY")"
-      echo "SSH key added to $AUTHORIZED_KEYS"
-      SSH_KEY_INSTALLED=true
-    else
-      echo "Warning: Invalid SSH key format, skipping"
-    fi
+    # Parse the key with ssh-keygen rather than pattern-matching it. A key
+    # that merely looks well-formed but sshd can't load would leave us
+    # disabling password auth against an unusable credential.
+    KEY_STATUS=0
+    validate_public_key "$SSH_KEY" || KEY_STATUS=$?
+    case "$KEY_STATUS" in
+      0)
+        if AUTHORIZED_KEYS="$(install_authorized_key root "$SSH_KEY")"; then
+          echo "SSH key added to $AUTHORIZED_KEYS"
+          SSH_KEY_INSTALLED=true
+        fi
+        ;;
+      1)
+        echo "Warning: ssh-keygen could not parse that public key, skipping" >&2
+        ;;
+      *)
+        echo "Warning: ssh-keygen is unavailable — cannot verify the key, skipping" >&2
+        ;;
+    esac
   fi
 
   # Only disable password auth once root has a key sshd can actually read.
@@ -1760,9 +1771,9 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
   # pod's only remote entry point, and getting back in means opening the
   # case for a serial console.
   if [ "$SSH_KEY_INSTALLED" = true ]; then
-    sed -i "s/#\?PermitRootLogin .*/PermitRootLogin prohibit-password/" /etc/ssh/sshd_config
-    sed -i "s/#\?PasswordAuthentication .*/PasswordAuthentication no/" /etc/ssh/sshd_config
-    sed -i "s/#\?PermitEmptyPasswords .*/PermitEmptyPasswords no/" /etc/ssh/sshd_config
+    set_sshd_directive PermitRootLogin prohibit-password
+    set_sshd_directive PasswordAuthentication no
+    set_sshd_directive PermitEmptyPasswords no
   else
     echo "No SSH key installed — leaving password authentication as-is." >&2
     echo "Re-run the installer with a valid public key to harden sshd." >&2
@@ -1774,6 +1785,26 @@ if [ "${SKIP_SSH:-}" != true ] && [ -t 0 ] && [[ "${SETUP_SSH:-}" =~ ^[Yy]$ ]]; 
     cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
     exit 1
   fi
+
+  # A directive can be syntactically valid and still not take effect — an
+  # Include or a later duplicate can override it. Confirm what sshd will
+  # actually do before we restart it into that config.
+  SSH_EXPECTED="port=8822"
+  if [ "$SSH_KEY_INSTALLED" = true ]; then
+    SSH_EXPECTED="$SSH_EXPECTED permitrootlogin=prohibit-password"
+    SSH_EXPECTED="$SSH_EXPECTED passwordauthentication=no permitemptypasswords=no"
+  fi
+  for expectation in $SSH_EXPECTED; do
+    directive="${expectation%%=*}"
+    want="${expectation#*=}"
+    got="$(sshd_effective_value "$directive")"
+    if [ "$got" != "$want" ]; then
+      echo "Error: sshd reports $directive=${got:-<unset>}, expected $want." >&2
+      echo "Restoring backup and leaving sshd untouched..." >&2
+      cp /etc/ssh/sshd_config.backup /etc/ssh/sshd_config
+      exit 1
+    fi
+  done
 
   if [ "$SSH_KEY_INSTALLED" = true ]; then
     SSH_RESULT="SSH configured on port 8822 (keys only)"

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -77,11 +77,15 @@ resolve_authorized_keys_path() {
     return 0
   fi
 
-  # %% must expand last so a literal %%h stays literal.
+  # Protect a literal %% before the token passes, not after: in `%%h` the %h
+  # pass matches the second % plus the h, so expanding %% last would still
+  # yield `%<home>`. The sentinel is a byte sshd_config cannot contain.
+  local sentinel=$'\x01'
+  keyfile="${keyfile//%%/$sentinel}"
   keyfile="${keyfile//%h/$home}"
   keyfile="${keyfile//%U/$uid}"
   keyfile="${keyfile//%u/$user}"
-  keyfile="${keyfile//%%/%}"
+  keyfile="${keyfile//$sentinel/%}"
 
   case "$keyfile" in
     /*) printf '%s\n' "$keyfile" ;;
@@ -113,6 +117,12 @@ validate_public_key() {
 # creating it with the ownership and modes sshd's StrictModes check demands.
 # Prints the path written. Idempotent: re-running the installer with the same
 # key is a no-op. Fails when sshd reads no key file at all.
+#
+# Every step is checked explicitly. The caller invokes this inside an `if`,
+# which suppresses `set -e` for the whole function body — an unchecked mkdir
+# or append would fall through to the final printf and report success with
+# nothing on disk, and the installer would disable password auth on the
+# strength of that.
 install_authorized_key() {
   local user="$1" key="$2"
   local keyfile keydir
@@ -125,7 +135,7 @@ install_authorized_key() {
   fi
 
   keydir="$(dirname "$keyfile")"
-  mkdir -p "$keydir"
+  mkdir -p "$keydir" || return 1
   if ! grep -qxF "$key" "$keyfile" 2>/dev/null; then
     printf '%s\n' "$key" >> "$keyfile"
   fi
@@ -133,8 +143,12 @@ install_authorized_key() {
   # StrictModes rejects a key file (or its directory) that is group- or
   # world-writable, or owned by anyone but the user or root.
   chown "$user" "$keydir" "$keyfile" 2>/dev/null || true
-  chmod 700 "$keydir"
-  chmod 600 "$keyfile"
+  chmod 700 "$keydir" || return 1
+  chmod 600 "$keyfile" || return 1
+
+  # Don't take the write on faith: a full filesystem can append a partial
+  # line, which sshd silently ignores. Require the exact key line to be back.
+  grep -qxF "$key" "$keyfile" 2>/dev/null || return 1
 
   printf '%s\n' "$keyfile"
 }
@@ -195,7 +209,13 @@ set_sshd_directive() {
   # A commented directive is recognised only as `#Key value`, the form
   # OpenSSH's shipped config uses. `# Key ...` with a space is prose — the
   # unanchored substitution this replaced rewrote `# Port forwarding is
-  # disabled below` into `# Port 8822`.
+  # disabled below` into `# Port 8822`. Falling out of the name extraction
+  # below: prose leaves `name` empty, so it can never match a directive.
+  #
+  # Both separators sshd accepts are handled — `Key value` and `Key=value`
+  # are equivalent to sshd, and matching only the first would leave a stale
+  # `=`-form directive in place to win over the one we append (sshd takes
+  # the first occurrence).
   if awk -v key="$key" -v value="$value" '
     BEGIN { done = 0; in_match = 0 }
     {
@@ -210,8 +230,12 @@ set_sshd_directive() {
       if (!in_match) {
         candidate = probe
         sub(/^#/, "", candidate)
-        split(candidate, parts, /[ \t]+/)
-        if (tolower(parts[1]) == tolower(key) && candidate ~ /^[^ \t]+[ \t]/) {
+
+        name = candidate
+        sub(/[ \t=].*$/, "", name)
+        rest = substr(candidate, length(name) + 1)
+
+        if (name != "" && tolower(name) == tolower(key) && rest ~ /^[ \t]*=?[ \t]*[^ \t]/) {
           # First occurrence becomes the directive; later duplicates go, so
           # nothing downstream can override what we just set.
           if (!done) { print key " " value; done = 1 }

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Shared helpers for enrolling an SSH public key on the pod.
+# Sourced by scripts/install at runtime (after the source tree is on disk).
+#
+# Getting the authorized_keys path wrong on this firmware is a hard lockout:
+# the installer also sets `PasswordAuthentication no`, and the pod has no
+# other remote entry point — recovery means a serial console and a U-Boot
+# `init=/bin/bash` boot. Two traps make the obvious `/root/.ssh` guess wrong:
+#
+#   1. root's home is /home/root on this Yocto image (poky convention), not
+#      /root, so sshd resolves the default `.ssh/authorized_keys` relative to
+#      /home/root.
+#   2. free-sleep's setup_ssh.sh pins an absolute
+#      `AuthorizedKeysFile /home/root/ssh/authorized_keys`. That directive
+#      survives the installer's sed edits, so it has to be honoured.
+
+# Print the absolute path sshd will read authorized keys from for $1 (a
+# username). Prefers sshd's own view of the effective config, falls back to
+# parsing sshd_config, then to sshd's compiled-in default.
+resolve_authorized_keys_path() {
+  local user="$1"
+  local sshd_config="${2:-/etc/ssh/sshd_config}"
+  local home keyfile
+
+  # The `|| true` guards matter: scripts/install runs under `set -euo
+  # pipefail`, where a missing getent or a non-zero sshd would otherwise
+  # abort the installer mid-hardening.
+  home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
+  [ -n "$home" ] || home="/root"
+
+  # `sshd -T` prints the effective config with defaults filled in, which
+  # catches an AuthorizedKeysFile set anywhere sshd looks — including files
+  # pulled in by an Include directive that a plain grep would miss.
+  keyfile="$(sshd -T -f "$sshd_config" 2>/dev/null |
+    awk 'tolower($1) == "authorizedkeysfile" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }' \
+    || true)"
+
+  # sshd -T is unavailable when not running as root, and refuses configs it
+  # considers invalid. Read the directive directly before giving up on it.
+  [ -n "$keyfile" ] || keyfile="$(
+    awk 'tolower($1) == "authorizedkeysfile" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }' \
+      "$sshd_config" 2>/dev/null || true
+  )"
+
+  [ -n "$keyfile" ] || keyfile=".ssh/authorized_keys"
+
+  # The directive takes a list; sshd reads every entry but writing the first
+  # is enough to authenticate.
+  keyfile="${keyfile%%[[:space:]]*}"
+
+  # %% must expand last so a literal %%h stays literal.
+  keyfile="${keyfile//%h/$home}"
+  keyfile="${keyfile//%u/$user}"
+  keyfile="${keyfile//%%/%}"
+
+  case "$keyfile" in
+    /*) printf '%s\n' "$keyfile" ;;
+    *)  printf '%s\n' "${home%/}/$keyfile" ;;
+  esac
+}
+
+# Append $2 (a public key line) to the authorized_keys file for user $1,
+# creating it with the ownership and modes sshd's StrictModes check demands.
+# Idempotent: re-running the installer with the same key is a no-op.
+install_authorized_key() {
+  local user="$1" key="$2"
+  local keyfile keydir
+  keyfile="$(resolve_authorized_keys_path "$user")"
+  keydir="$(dirname "$keyfile")"
+
+  mkdir -p "$keydir"
+  if ! grep -qxF "$key" "$keyfile" 2>/dev/null; then
+    printf '%s\n' "$key" >> "$keyfile"
+  fi
+
+  # StrictModes rejects a key file (or its directory) that is group- or
+  # world-writable, or owned by anyone but the user or root.
+  chown "$user" "$keydir" "$keyfile" 2>/dev/null || true
+  chmod 700 "$keydir"
+  chmod 600 "$keyfile"
+
+  printf '%s\n' "$keyfile"
+}
+
+# Earlier installers wrote to a hardcoded /root/.ssh/authorized_keys, which
+# sshd never reads when root's home is /home/root. Fold any keys stranded
+# there into the real file so re-running the installer repairs the lockout
+# rather than silently re-creating it.
+migrate_stranded_authorized_keys() {
+  local user="$1"
+  local stranded="${2:-/root/.ssh/authorized_keys}"
+  local keyfile
+  keyfile="$(resolve_authorized_keys_path "$user")"
+
+  [ -f "$stranded" ] || return 0
+  [ "$stranded" != "$keyfile" ] || return 0
+
+  local migrated=0 line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in \#*) continue ;; esac
+    if ! grep -qxF "$line" "$keyfile" 2>/dev/null; then
+      mkdir -p "$(dirname "$keyfile")"
+      printf '%s\n' "$line" >> "$keyfile"
+      migrated=$((migrated + 1))
+    fi
+  done < "$stranded"
+
+  if [ "$migrated" -gt 0 ]; then
+    echo "Recovered $migrated SSH key(s) from $stranded -> $keyfile"
+    chown "$user" "$(dirname "$keyfile")" "$keyfile" 2>/dev/null || true
+    chmod 700 "$(dirname "$keyfile")"
+    chmod 600 "$keyfile"
+  fi
+}

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -40,8 +40,20 @@ resolve_authorized_keys_path() {
   # pipefail`, where a missing getent or a non-zero sshd would otherwise
   # abort the installer mid-hardening.
   home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
-  [ -n "$home" ] || home="/root"
+  # getent is glibc's; read the file directly if this image doesn't ship it.
+  [ -n "$home" ] || home="$(awk -F: -v u="$user" '$1 == u { print $6; exit }' /etc/passwd 2>/dev/null || true)"
+
+  # No guess here. Defaulting to /root is what shipped the original bug: on
+  # this firmware root's home is /home/root, so a fallback would write and
+  # verify a key somewhere sshd never reads, and the caller would disable
+  # password auth on the strength of it. Fail and let the caller decline.
+  if [ -z "$home" ]; then
+    echo "Error: cannot resolve the home directory for '$user' — refusing to guess." >&2
+    return 1
+  fi
+
   uid="$(id -u "$user" 2>/dev/null || true)"
+  [ -n "$uid" ] || uid="$(awk -F: -v u="$user" '$1 == u { print $3; exit }' /etc/passwd 2>/dev/null || true)"
   [ -n "$uid" ] || uid="0"
 
   # `sshd -T` prints the effective config with defaults filled in, which
@@ -126,7 +138,7 @@ validate_public_key() {
 install_authorized_key() {
   local user="$1" key="$2"
   local keyfile keydir
-  keyfile="$(resolve_authorized_keys_path "$user")"
+  keyfile="$(resolve_authorized_keys_path "$user")" || return 1
 
   if [ "$keyfile" = "none" ]; then
     echo "Error: sshd is configured with 'AuthorizedKeysFile none' for $user —" >&2
@@ -161,7 +173,16 @@ migrate_stranded_authorized_keys() {
   local user="$1"
   local stranded="${2:-/root/.ssh/authorized_keys}"
   local keyfile
-  keyfile="$(resolve_authorized_keys_path "$user")"
+
+  # Best-effort repair, so an unresolvable home is a skip, not a failure: the
+  # installer calls this bare under `set -e`, and returning non-zero would
+  # abort an otherwise-complete install. Nothing unsafe follows from skipping
+  # — install_authorized_key fails on the same condition, which is what keeps
+  # the hardening from running.
+  if ! keyfile="$(resolve_authorized_keys_path "$user")"; then
+    echo "Skipping stranded-key migration: cannot resolve $user's authorized_keys path." >&2
+    return 0
+  fi
 
   [ "$keyfile" != "none" ] || return 0
   [ -f "$stranded" ] || return 0
@@ -198,8 +219,18 @@ migrate_stranded_authorized_keys() {
 # the pod silently no-ops on a dev machine. awk behaves the same on both.
 set_sshd_directive() {
   local key="$1" value="$2" sshd_config="${3:-/etc/ssh/sshd_config}"
-  local tmp
-  tmp="$(mktemp)" || return 1
+  local target tmp
+
+  # Follow a symlinked sshd_config so the rename replaces the real file
+  # instead of the link.
+  target="$(readlink -f "$sshd_config" 2>/dev/null || true)"
+  [ -n "$target" ] || target="$sshd_config"
+
+  # The temp file lives beside the target: same filesystem, so the rename
+  # below is atomic. `cp -p` seeds it with the original's mode and owner,
+  # which mktemp's 0600 would otherwise drop.
+  tmp="$(mktemp "${target}.XXXXXX")" || return 1
+  cp -p "$target" "$tmp" || { rm -f "$tmp"; return 1; }
 
   # Only the global section is rewritten. A directive inside `Match` applies
   # to that block's connections alone; overwriting it there would change
@@ -246,10 +277,13 @@ set_sshd_directive() {
       print $0
     }
     END { if (!done) print key " " value }
-  ' "$sshd_config" > "$tmp"; then
-    cat "$tmp" > "$sshd_config"
-    rm -f "$tmp"
-    return 0
+  ' "$target" > "$tmp"; then
+    # Rename rather than copy-over-in-place. `cat > "$target"` truncates the
+    # live config before it writes, so an ENOSPC or I/O error mid-copy leaves
+    # a half-written sshd_config; a rename either happens or doesn't.
+    if mv -f "$tmp" "$target"; then
+      return 0
+    fi
   fi
 
   rm -f "$tmp"
@@ -258,10 +292,28 @@ set_sshd_directive() {
 
 # Print sshd's effective value for directive $1, so the installer can confirm
 # what it asked for is what sshd will actually do before restarting it.
+#
+# $3 is an optional username. Pass it for anything a Match block can override
+# — PermitRootLogin, PasswordAuthentication and PermitEmptyPasswords are all
+# Match-able, so a global reading would report the hardening succeeded while
+# `Match User root` quietly re-enabled password auth for the one account that
+# matters. Port is global-only and needs no context.
 sshd_effective_value() {
-  local name="$1" sshd_config="${2:-/etc/ssh/sshd_config}"
-  local lowered
+  local name="$1" sshd_config="${2:-/etc/ssh/sshd_config}" user="${3:-}"
+  local lowered value
   lowered="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+
+  if [ -n "$user" ]; then
+    value="$(sshd -T -C "user=$user,host=localhost,addr=127.0.0.1" -f "$sshd_config" 2>/dev/null |
+      awk -v want="$lowered" 'tolower($1) == want { print $2; exit }' || true)"
+    # Older sshd rejects a partial connection spec. Degrade to the global
+    # reading rather than aborting an install over an unsupported flag —
+    # same fallback resolve_authorized_keys_path uses.
+    if [ -n "$value" ]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
 
   sshd -T -f "$sshd_config" 2>/dev/null |
     awk -v want="$lowered" 'tolower($1) == want { print $2; exit }' \

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -247,16 +247,24 @@ set_sshd_directive() {
   # are equivalent to sshd, and matching only the first would leave a stale
   # `=`-form directive in place to win over the one we append (sshd takes
   # the first occurrence).
+  #
+  # `Include` is a boundary as well as `Match`: sshd splices the included
+  # file in at that point and keeps the first value it obtains, so a directive
+  # set by an early Include beats anything written further down this file.
+  # Emitting ours above the first Include is what makes it the winning value —
+  # otherwise set_sshd_directive reports success and the installer's
+  # effective-value check then fails and rolls the whole thing back.
   if awk -v key="$key" -v value="$value" '
-    BEGIN { done = 0; in_match = 0 }
+    BEGIN { done = 0; in_match = 0; boundary = 0 }
     {
       probe = $0
       sub(/^[ \t]+/, "", probe)
 
-      if (!in_match && tolower(probe) ~ /^match[ \t]/) {
-        in_match = 1
+      if (!boundary && (tolower(probe) ~ /^match[ \t]/ || tolower(probe) ~ /^include[ \t]/)) {
+        boundary = 1
         if (!done) { print key " " value; done = 1 }
       }
+      if (tolower(probe) ~ /^match[ \t]/) in_match = 1
 
       if (!in_match) {
         candidate = probe

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -195,8 +195,12 @@ migrate_stranded_authorized_keys() {
     [ -n "$line" ] || continue
     case "$line" in \#*) continue ;; esac
     if ! grep -qxF "$line" "$keyfile" 2>/dev/null; then
-      mkdir -p "$(dirname "$keyfile")"
-      printf '%s\n' "$line" >> "$keyfile"
+      # Best-effort: an ENOSPC append or a failed mkdir is a skip, not an
+      # abort — this runs bare under the installer's `set -e`, and the same
+      # condition also fails install_authorized_key, which is what actually
+      # blocks the hardening.
+      mkdir -p "$(dirname "$keyfile")" || continue
+      printf '%s\n' "$line" >> "$keyfile" || continue
       migrated=$((migrated + 1))
     fi
   done < "$stranded"
@@ -204,8 +208,8 @@ migrate_stranded_authorized_keys() {
   if [ "$migrated" -gt 0 ]; then
     echo "Recovered $migrated SSH key(s) from $stranded -> $keyfile"
     chown "$user" "$(dirname "$keyfile")" "$keyfile" 2>/dev/null || true
-    chmod 700 "$(dirname "$keyfile")"
-    chmod 600 "$keyfile"
+    chmod 700 "$(dirname "$keyfile")" 2>/dev/null || true
+    chmod 600 "$keyfile" 2>/dev/null || true
   fi
 }
 
@@ -254,17 +258,26 @@ set_sshd_directive() {
   # Emitting ours above the first Include is what makes it the winning value —
   # otherwise set_sshd_directive reports success and the installer's
   # effective-value check then fails and rolls the whole thing back.
+  #
+  # The boundary keyword is extracted with the same whitespace-or-`=` rule as
+  # the directive name below: sshd accepts `Include=/path` and `Match=User x`
+  # exactly like their space-separated forms, and matching only whitespace
+  # would miss the `=` form — appending our directive below an `Include=…`
+  # boundary, where it loses to the value sshd already took from the include.
   if awk -v key="$key" -v value="$value" '
     BEGIN { done = 0; in_match = 0; boundary = 0 }
     {
       probe = $0
       sub(/^[ \t]+/, "", probe)
 
-      if (!boundary && (tolower(probe) ~ /^match[ \t]/ || tolower(probe) ~ /^include[ \t]/)) {
+      boundary_name = probe
+      sub(/[ \t=].*$/, "", boundary_name)
+
+      if (!boundary && (tolower(boundary_name) == "match" || tolower(boundary_name) == "include")) {
         boundary = 1
         if (!done) { print key " " value; done = 1 }
       }
-      if (tolower(probe) ~ /^match[ \t]/) in_match = 1
+      if (tolower(boundary_name) == "match") in_match = 1
 
       if (!in_match) {
         candidate = probe
@@ -314,13 +327,20 @@ sshd_effective_value() {
   if [ -n "$user" ]; then
     value="$(sshd -T -C "user=$user,host=localhost,addr=127.0.0.1" -f "$sshd_config" 2>/dev/null |
       awk -v want="$lowered" 'tolower($1) == want { print $2; exit }' || true)"
-    # Older sshd rejects a partial connection spec. Degrade to the global
-    # reading rather than aborting an install over an unsupported flag —
-    # same fallback resolve_authorized_keys_path uses.
     if [ -n "$value" ]; then
       printf '%s\n' "$value"
-      return 0
+    else
+      # Root-context evaluation is unavailable — an older sshd that rejects the
+      # partial connection spec, or a config sshd won't dump. Do NOT degrade to
+      # a plain `sshd -T`: the global reading can't see a `Match User $user`
+      # block re-enabling password auth for exactly the account being hardened,
+      # so accepting it would report a hardened pod we can't actually vouch for.
+      # Emit nothing — the installer reads the empty result as a verification
+      # failure, restores the snapshot, and declines to harden. Fail closed,
+      # per this file's contract.
+      echo "Error: sshd cannot evaluate '$name' in $user's context — refusing to verify." >&2
     fi
+    return 0
   fi
 
   sshd -T -f "$sshd_config" 2>/dev/null |

--- a/scripts/lib/ssh-helpers
+++ b/scripts/lib/ssh-helpers
@@ -2,10 +2,13 @@
 # Shared helpers for enrolling an SSH public key on the pod.
 # Sourced by scripts/install at runtime (after the source tree is on disk).
 #
-# Getting the authorized_keys path wrong on this firmware is a hard lockout:
-# the installer also sets `PasswordAuthentication no`, and the pod has no
-# other remote entry point — recovery means a serial console and a U-Boot
-# `init=/bin/bash` boot. Two traps make the obvious `/root/.ssh` guess wrong:
+# Getting any of this wrong is a hard lockout: the installer also sets
+# `PasswordAuthentication no`, and the pod has no other remote entry point —
+# recovery means a serial console and a U-Boot `init=/bin/bash` boot, or a
+# hardware firmware reset that wipes the install. Every function here fails
+# closed so the caller can decline to harden.
+#
+# Two traps make the obvious `/root/.ssh` guess wrong:
 #
 #   1. root's home is /home/root on this Yocto image (poky convention), not
 #      /root, so sshd resolves the default `.ssh/authorized_keys` relative to
@@ -14,29 +17,48 @@
 #      `AuthorizedKeysFile /home/root/ssh/authorized_keys`. That directive
 #      survives the installer's sed edits, so it has to be honoured.
 
+# Read the effective AuthorizedKeysFile out of `sshd -T`. Extra sshd flags are
+# passed through so the caller can choose whether Match blocks are evaluated.
+_sshd_authorized_keys_directive() {
+  local sshd_config="$1"
+  shift
+  sshd -T "$@" -f "$sshd_config" 2>/dev/null |
+    awk 'tolower($1) == "authorizedkeysfile" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }' \
+    || true
+}
+
 # Print the absolute path sshd will read authorized keys from for $1 (a
-# username). Prefers sshd's own view of the effective config, falls back to
-# parsing sshd_config, then to sshd's compiled-in default.
+# username), or the literal `none` when file-based key auth is switched off.
+# Prefers sshd's own view of the effective config, falls back to parsing
+# sshd_config, then to sshd's compiled-in default.
 resolve_authorized_keys_path() {
   local user="$1"
   local sshd_config="${2:-/etc/ssh/sshd_config}"
-  local home keyfile
+  local home uid keyfile
 
   # The `|| true` guards matter: scripts/install runs under `set -euo
   # pipefail`, where a missing getent or a non-zero sshd would otherwise
   # abort the installer mid-hardening.
   home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
   [ -n "$home" ] || home="/root"
+  uid="$(id -u "$user" 2>/dev/null || true)"
+  [ -n "$uid" ] || uid="0"
 
   # `sshd -T` prints the effective config with defaults filled in, which
   # catches an AuthorizedKeysFile set anywhere sshd looks — including files
   # pulled in by an Include directive that a plain grep would miss.
-  keyfile="$(sshd -T -f "$sshd_config" 2>/dev/null |
-    awk 'tolower($1) == "authorizedkeysfile" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }' \
-    || true)"
+  #
+  # -C evaluates Match blocks the way they'd apply to a real login as $user,
+  # so a `Match User root` override (worst case `AuthorizedKeysFile none`)
+  # isn't missed. Older sshd rejects a partial connection spec, hence the
+  # plain `sshd -T` retry.
+  keyfile="$(_sshd_authorized_keys_directive "$sshd_config" \
+    -C "user=$user,host=localhost,addr=127.0.0.1")"
+  [ -n "$keyfile" ] || keyfile="$(_sshd_authorized_keys_directive "$sshd_config")"
 
   # sshd -T is unavailable when not running as root, and refuses configs it
   # considers invalid. Read the directive directly before giving up on it.
+  # This fallback can't evaluate Match blocks — it reports the global value.
   [ -n "$keyfile" ] || keyfile="$(
     awk 'tolower($1) == "authorizedkeysfile" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }' \
       "$sshd_config" 2>/dev/null || true
@@ -48,8 +70,16 @@ resolve_authorized_keys_path() {
   # is enough to authenticate.
   keyfile="${keyfile%%[[:space:]]*}"
 
+  # `none` means sshd consults no authorized_keys file at all. There is no
+  # path to write to — say so rather than inventing one.
+  if [ "$keyfile" = "none" ]; then
+    printf 'none\n'
+    return 0
+  fi
+
   # %% must expand last so a literal %%h stays literal.
   keyfile="${keyfile//%h/$home}"
+  keyfile="${keyfile//%U/$uid}"
   keyfile="${keyfile//%u/$user}"
   keyfile="${keyfile//%%/%}"
 
@@ -59,15 +89,42 @@ resolve_authorized_keys_path() {
   esac
 }
 
+# Check that $1 is a public key sshd will actually accept. The format regex
+# the installer used before this was happy with `ssh-ed25519 A`, which sshd
+# silently ignores — enough to disable password auth against a key that can
+# never authenticate.
+#
+# Exit codes: 0 valid, 1 rejected, 2 unable to tell (no ssh-keygen). Callers
+# must treat 2 as "do not harden".
+validate_public_key() {
+  local key="$1" tmp status=0
+
+  command -v ssh-keygen >/dev/null 2>&1 || return 2
+  tmp="$(mktemp 2>/dev/null)" || return 2
+
+  printf '%s\n' "$key" > "$tmp"
+  ssh-keygen -l -f "$tmp" >/dev/null 2>&1 || status=1
+  rm -f "$tmp"
+
+  return "$status"
+}
+
 # Append $2 (a public key line) to the authorized_keys file for user $1,
 # creating it with the ownership and modes sshd's StrictModes check demands.
-# Idempotent: re-running the installer with the same key is a no-op.
+# Prints the path written. Idempotent: re-running the installer with the same
+# key is a no-op. Fails when sshd reads no key file at all.
 install_authorized_key() {
   local user="$1" key="$2"
   local keyfile keydir
   keyfile="$(resolve_authorized_keys_path "$user")"
-  keydir="$(dirname "$keyfile")"
 
+  if [ "$keyfile" = "none" ]; then
+    echo "Error: sshd is configured with 'AuthorizedKeysFile none' for $user —" >&2
+    echo "there is no file to enrol a key in. Fix /etc/ssh/sshd_config first." >&2
+    return 1
+  fi
+
+  keydir="$(dirname "$keyfile")"
   mkdir -p "$keydir"
   if ! grep -qxF "$key" "$keyfile" 2>/dev/null; then
     printf '%s\n' "$key" >> "$keyfile"
@@ -92,11 +149,14 @@ migrate_stranded_authorized_keys() {
   local keyfile
   keyfile="$(resolve_authorized_keys_path "$user")"
 
+  [ "$keyfile" != "none" ] || return 0
   [ -f "$stranded" ] || return 0
   [ "$stranded" != "$keyfile" ] || return 0
 
   local migrated=0 line
-  while IFS= read -r line; do
+  # `|| [ -n "$line" ]` keeps the last line when the file has no trailing
+  # newline — a hand-edited authorized_keys often doesn't.
+  while IFS= read -r line || [ -n "$line" ]; do
     [ -n "$line" ] || continue
     case "$line" in \#*) continue ;; esac
     if ! grep -qxF "$line" "$keyfile" 2>/dev/null; then
@@ -112,4 +172,74 @@ migrate_stranded_authorized_keys() {
     chmod 700 "$(dirname "$keyfile")"
     chmod 600 "$keyfile"
   fi
+}
+
+# Force `$1 $2` in sshd_config. Substitution alone isn't enough: a config
+# that never mentions the directive keeps sshd's default (PasswordAuthentication
+# defaults to yes, Port to 22), so the installer would report hardening it
+# hadn't done.
+#
+# awk rather than `sed -i` because the two are not portable together — BSD sed
+# takes the next argument as a backup suffix, so a `sed -i -E …` that works on
+# the pod silently no-ops on a dev machine. awk behaves the same on both.
+set_sshd_directive() {
+  local key="$1" value="$2" sshd_config="${3:-/etc/ssh/sshd_config}"
+  local tmp
+  tmp="$(mktemp)" || return 1
+
+  # Only the global section is rewritten. A directive inside `Match` applies
+  # to that block's connections alone; overwriting it there would change
+  # semantics we were never asked to touch, and appending after a Match block
+  # would land the new directive inside it.
+  #
+  # A commented directive is recognised only as `#Key value`, the form
+  # OpenSSH's shipped config uses. `# Key ...` with a space is prose — the
+  # unanchored substitution this replaced rewrote `# Port forwarding is
+  # disabled below` into `# Port 8822`.
+  if awk -v key="$key" -v value="$value" '
+    BEGIN { done = 0; in_match = 0 }
+    {
+      probe = $0
+      sub(/^[ \t]+/, "", probe)
+
+      if (!in_match && tolower(probe) ~ /^match[ \t]/) {
+        in_match = 1
+        if (!done) { print key " " value; done = 1 }
+      }
+
+      if (!in_match) {
+        candidate = probe
+        sub(/^#/, "", candidate)
+        split(candidate, parts, /[ \t]+/)
+        if (tolower(parts[1]) == tolower(key) && candidate ~ /^[^ \t]+[ \t]/) {
+          # First occurrence becomes the directive; later duplicates go, so
+          # nothing downstream can override what we just set.
+          if (!done) { print key " " value; done = 1 }
+          next
+        }
+      }
+
+      print $0
+    }
+    END { if (!done) print key " " value }
+  ' "$sshd_config" > "$tmp"; then
+    cat "$tmp" > "$sshd_config"
+    rm -f "$tmp"
+    return 0
+  fi
+
+  rm -f "$tmp"
+  return 1
+}
+
+# Print sshd's effective value for directive $1, so the installer can confirm
+# what it asked for is what sshd will actually do before restarting it.
+sshd_effective_value() {
+  local name="$1" sshd_config="${2:-/etc/ssh/sshd_config}"
+  local lowered
+  lowered="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+
+  sshd -T -f "$sshd_config" 2>/dev/null |
+    awk -v want="$lowered" 'tolower($1) == want { print $2; exit }' \
+    || true
 }

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -10,6 +10,11 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 // pinned here rather than trusted to review.
 const HELPERS = resolve(process.cwd(), 'scripts/lib/ssh-helpers')
 
+// Permission-based failure tests prove nothing as uid 0 — mode bits don't
+// stop root, so the command succeeds and the assertion fails for the wrong
+// reason. Each has a stub-driven twin that runs everywhere.
+const isRoot = process.getuid?.() === 0
+
 let dir: string
 let keyDir: string
 let realKey: string
@@ -251,6 +256,17 @@ describe('install_authorized_key', () => {
     // never reached disk.
     const home = join(dir, 'home', 'root')
     mkdirSync(home, { recursive: true })
+
+    const snippet = `mkdir() { return 1; }; install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
+
+    expect(runBash(snippet, { rootHome: home })).toBe('REFUSED')
+  })
+
+  test.skipIf(isRoot)('fails against a genuinely unwritable home directory', () => {
+    // @ng's original repro, kept as an integration-level check. Skipped as
+    // uid 0, which is not stopped by the mode bits.
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
     chmodSync(home, 0o555)
 
     const snippet = `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
@@ -402,6 +418,24 @@ describe('set_sshd_directive', () => {
       .toBe('# Port forwarding is disabled below\nPort 8822\n')
   })
 
+  test('emits the directive above the first Include so it wins', () => {
+    // sshd splices the included file in at that point and keeps the first
+    // value it obtains, so a directive appended below an Include loses to
+    // anything the Include sets.
+    expect(applied('Include /etc/ssh/sshd_config.d/*.conf\nX11Forwarding yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('PasswordAuthentication no\nInclude /etc/ssh/sshd_config.d/*.conf\nX11Forwarding yes\n')
+  })
+
+  test('keeps an existing directive in place when it already precedes the Include', () => {
+    expect(applied('Port 22\nInclude /etc/ssh/sshd_config.d/*.conf\n', 'Port', '8822'))
+      .toBe('Port 8822\nInclude /etc/ssh/sshd_config.d/*.conf\n')
+  })
+
+  test('drops a stale duplicate that sits below the Include', () => {
+    expect(applied('Include /etc/ssh/sshd_config.d/*.conf\nPasswordAuthentication yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('PasswordAuthentication no\nInclude /etc/ssh/sshd_config.d/*.conf\n')
+  })
+
   test('preserves the config file mode across the rewrite', () => {
     // The rewrite renames a temp file over the target, so the mode has to be
     // carried across explicitly — mktemp would otherwise leave it 0600.
@@ -413,7 +447,22 @@ describe('set_sshd_directive', () => {
     expect(statSync(config).mode & 0o777).toBe(0o644)
   })
 
-  test('reports failure and leaves the config intact when it cannot be replaced', () => {
+  test('reports failure and leaves the config intact when the replace fails', () => {
+    // Stubbing mv rather than using directory permissions: a suite running as
+    // uid 0 walks straight through a 0555 directory and the test would fail
+    // for the wrong reason.
+    const config = writeConfig('Port 22\n')
+
+    const output = runBash(
+      `mv() { return 1; }; set_sshd_directive Port 8822 ${JSON.stringify(config)} 2>/dev/null || echo FAILED`,
+    )
+
+    expect(output).toBe('FAILED')
+    expect(readFileSync(config, 'utf8')).toBe('Port 22\n')
+  })
+
+  test.skipIf(isRoot)('reports failure when the config directory is not writable', () => {
+    // The same guarantee against the real filesystem rather than a stub.
     const configDir = join(dir, 'ro')
     mkdirSync(configDir)
     const config = join(configDir, 'sshd_config')

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -141,11 +141,37 @@ describe('resolve_authorized_keys_path', () => {
       .toBe('/home/root/.ssh/authorized_keys')
   })
 
-  test('falls back to /root when the user has no passwd entry', () => {
+  test('refuses to guess when the home directory cannot be resolved', () => {
+    // Defaulting to /root is what shipped the original bug — root's home is
+    // /home/root here, so a guess would be verified in a file sshd never
+    // reads and password auth would be disabled against it.
     const config = writeConfig('Port 8822\n')
+    const snippet = [
+      'getent() { return 2; }',
+      // Shadow the /etc/passwd fallback too.
+      'awk() { return 1; }',
+      `resolve_authorized_keys_path root ${JSON.stringify(config)} 2>/dev/null || echo REFUSED`,
+    ].join('; ')
 
-    expect(runBash(`getent() { return 2; }; resolve_authorized_keys_path root ${JSON.stringify(config)}`))
-      .toBe('/root/.ssh/authorized_keys')
+    expect(runBash(snippet)).toBe('REFUSED')
+  })
+
+  test('reads the home directory from /etc/passwd when getent is missing', () => {
+    const config = writeConfig('Port 8822\n')
+    const passwd = join(dir, 'passwd')
+    writeFileSync(passwd, 'dac:x:1000:1000::/home/dac:/sbin/nologin\nroot:x:0:0:root:/home/root:/bin/sh\n')
+    // Redirect only the /etc/passwd read; every other awk call runs normally.
+    const snippet = [
+      'getent() { return 2; }',
+      `awk() {
+         local args=("$@") last=$(( $# - 1 ))
+         [ "\${args[$last]}" != /etc/passwd ] || args[$last]=${JSON.stringify(passwd)}
+         command awk "\${args[@]}"
+       }`,
+      `resolve_authorized_keys_path root ${JSON.stringify(config)}`,
+    ].join('; ')
+
+    expect(runBash(snippet)).toBe('/home/root/.ssh/authorized_keys')
   })
 })
 
@@ -206,6 +232,16 @@ describe('install_authorized_key', () => {
     const snippet = `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
 
     expect(runBash(snippet, { sshdT: 'authorizedkeysfile none' })).toBe('REFUSED')
+  })
+
+  test('propagates a failed path resolution instead of writing somewhere', () => {
+    const snippet = [
+      'getent() { return 2; }',
+      'awk() { return 1; }',
+      `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`,
+    ].join('; ')
+
+    expect(runBash(snippet)).toBe('REFUSED')
   })
 
   test('fails rather than reporting success when the key cannot be written', () => {
@@ -290,6 +326,22 @@ describe('migrate_stranded_authorized_keys', () => {
     expect(output).toBe('done')
   })
 
+  test('skips rather than aborting the installer when the path is unresolvable', () => {
+    // Called bare under `set -e`, so a non-zero return would abort an
+    // otherwise-complete install. install_authorized_key fails on the same
+    // condition, which is what actually blocks the hardening.
+    const stranded = strandedPath()
+    writeFileSync(stranded, `${OLD_KEY}\n`)
+    const snippet = [
+      'getent() { return 2; }',
+      'awk() { return 1; }',
+      `migrate_stranded_authorized_keys root ${JSON.stringify(stranded)} 2>/dev/null`,
+      'echo done',
+    ].join('; ')
+
+    expect(runBash(snippet)).toBe('done')
+  })
+
   test('is a no-op when there is nothing stranded', () => {
     const home = join(dir, 'home', 'root')
     mkdirSync(home, { recursive: true })
@@ -349,6 +401,33 @@ describe('set_sshd_directive', () => {
     expect(applied('# Port forwarding is disabled below\nPort 22\n', 'Port', '8822'))
       .toBe('# Port forwarding is disabled below\nPort 8822\n')
   })
+
+  test('preserves the config file mode across the rewrite', () => {
+    // The rewrite renames a temp file over the target, so the mode has to be
+    // carried across explicitly — mktemp would otherwise leave it 0600.
+    const config = writeConfig('Port 22\n')
+    chmodSync(config, 0o644)
+
+    runBash(`set_sshd_directive Port 8822 ${JSON.stringify(config)}`)
+
+    expect(statSync(config).mode & 0o777).toBe(0o644)
+  })
+
+  test('reports failure and leaves the config intact when it cannot be replaced', () => {
+    const configDir = join(dir, 'ro')
+    mkdirSync(configDir)
+    const config = join(configDir, 'sshd_config')
+    writeFileSync(config, 'Port 22\n')
+    chmodSync(configDir, 0o555)
+
+    const output = runBash(
+      `set_sshd_directive Port 8822 ${JSON.stringify(config)} 2>/dev/null || echo FAILED`,
+    )
+    chmodSync(configDir, 0o755)
+
+    expect(output).toBe('FAILED')
+    expect(readFileSync(config, 'utf8')).toBe('Port 22\n')
+  })
 })
 
 describe('sshd_effective_value', () => {
@@ -365,5 +444,26 @@ describe('sshd_effective_value', () => {
 
     expect(runBash(`echo "[$(sshd_effective_value PasswordAuthentication ${JSON.stringify(config)})]"`))
       .toBe('[]')
+  })
+
+  test('sees a Match User root override that the global reading misses', () => {
+    // Global says hardened, root context says password auth is still on.
+    // Without the context the installer would report success over a pod that
+    // still accepts a root password.
+    const config = writeConfig('PasswordAuthentication no\nMatch User root\n  PasswordAuthentication yes\n')
+
+    expect(runBash(`sshd_effective_value PasswordAuthentication ${JSON.stringify(config)} root`, {
+      sshdT: 'passwordauthentication no',
+      sshdTC: 'passwordauthentication yes',
+    })).toBe('yes')
+  })
+
+  test('degrades to the global reading when sshd rejects -C', () => {
+    const config = writeConfig('PasswordAuthentication no\n')
+
+    expect(runBash(`sshd_effective_value PasswordAuthentication ${JSON.stringify(config)} root`, {
+      sshdT: 'passwordauthentication no',
+      sshdTC: false,
+    })).toBe('no')
   })
 })

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -436,6 +436,21 @@ describe('set_sshd_directive', () => {
       .toBe('PasswordAuthentication no\nInclude /etc/ssh/sshd_config.d/*.conf\n')
   })
 
+  test('treats the Include=path form as a boundary too', () => {
+    // sshd accepts `Include=/path` as readily as the space-separated form.
+    // Missing it would append our directive below the include, where it loses
+    // to whatever the included file already set.
+    expect(applied('Include=/etc/ssh/sshd_config.d/*.conf\nX11Forwarding yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('PasswordAuthentication no\nInclude=/etc/ssh/sshd_config.d/*.conf\nX11Forwarding yes\n')
+  })
+
+  test('does not rewrite a directive inside a Match=criteria block', () => {
+    // `Match=User dac` is the equals form of a Match boundary; a directive
+    // scoped to it must stay put, not be hoisted or overwritten.
+    expect(applied('Port 8822\nMatch=User dac\n  PasswordAuthentication yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('Port 8822\nPasswordAuthentication no\nMatch=User dac\n  PasswordAuthentication yes\n')
+  })
+
   test('preserves the config file mode across the rewrite', () => {
     // The rewrite renames a temp file over the target, so the mode has to be
     // carried across explicitly — mktemp would otherwise leave it 0600.
@@ -507,12 +522,16 @@ describe('sshd_effective_value', () => {
     })).toBe('yes')
   })
 
-  test('degrades to the global reading when sshd rejects -C', () => {
+  test('fails closed, not to the global reading, when sshd rejects -C', () => {
+    // A global `sshd -T` can't see a `Match User root` block re-enabling the
+    // password. Reporting its value would let the installer claim a hardened
+    // pod it can't verify, so an unusable root context yields no value — the
+    // installer reads the empty result as a failure and restores the snapshot.
     const config = writeConfig('PasswordAuthentication no\n')
 
-    expect(runBash(`sshd_effective_value PasswordAuthentication ${JSON.stringify(config)} root`, {
+    expect(runBash(`echo "[$(sshd_effective_value PasswordAuthentication ${JSON.stringify(config)} root 2>/dev/null)]"`, {
       sshdT: 'passwordauthentication no',
       sshdTC: false,
-    })).toBe('no')
+    })).toBe('[]')
   })
 })

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -1,0 +1,176 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+// scripts/lib/ssh-helpers decides where the installer writes root's public
+// key. Getting it wrong is an unrecoverable lockout on a real pod (the same
+// installer block then sets PasswordAuthentication no), so the resolution
+// rules are pinned here rather than trusted to review.
+const HELPERS = resolve(process.cwd(), 'scripts/lib/ssh-helpers')
+
+let dir: string
+
+/**
+ * Run a snippet with the helpers sourced. `getent` and `sshd` are shadowed by
+ * shell functions so the tests describe a pod's environment (root home at
+ * /home/root) from a dev machine, which has neither.
+ */
+function runBash(snippet: string, { rootHome = '/home/root', sshdT = '' } = {}): string {
+  const script = `
+    set -euo pipefail
+    getent() { [ "\${2:-}" = root ] && echo "root:x:0:0:root:${rootHome}:/bin/sh" || return 2; }
+    sshd() { ${sshdT ? `printf '%b\\n' ${JSON.stringify(sshdT)}` : 'return 1'}; }
+    source ${JSON.stringify(HELPERS)}
+    ${snippet}
+  `
+  return execFileSync('bash', ['-c', script], { encoding: 'utf8' }).trim()
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ssh-helpers-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('resolve_authorized_keys_path', () => {
+  test('resolves the default relative path against root\'s real home, not /root', () => {
+    const config = join(dir, 'sshd_config')
+    writeFileSync(config, 'Port 8822\nPermitRootLogin prohibit-password\n')
+
+    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
+
+    expect(resolved).toBe('/home/root/.ssh/authorized_keys')
+  })
+
+  test('honours an absolute AuthorizedKeysFile pinned by free-sleep', () => {
+    const config = join(dir, 'sshd_config')
+    writeFileSync(config, 'Port 8822\nAuthorizedKeysFile /home/root/ssh/authorized_keys\n')
+
+    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
+
+    expect(resolved).toBe('/home/root/ssh/authorized_keys')
+  })
+
+  test('prefers sshd -T over the raw config so an Included directive still wins', () => {
+    const config = join(dir, 'sshd_config')
+    writeFileSync(config, 'Include /etc/ssh/sshd_config.d/*.conf\n')
+
+    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`, {
+      sshdT: 'port 8822\nauthorizedkeysfile /etc/ssh/keys/%u\npermitrootlogin prohibit-password',
+    })
+
+    expect(resolved).toBe('/etc/ssh/keys/root')
+  })
+
+  test('expands %h and takes the first file when several are listed', () => {
+    const config = join(dir, 'sshd_config')
+    writeFileSync(config, 'AuthorizedKeysFile %h/.ssh/authorized_keys .ssh/authorized_keys2\n')
+
+    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
+
+    expect(resolved).toBe('/home/root/.ssh/authorized_keys')
+  })
+
+  test('falls back to /root when the user has no passwd entry', () => {
+    const config = join(dir, 'sshd_config')
+    writeFileSync(config, 'Port 8822\n')
+
+    const resolved = runBash(
+      `getent() { return 2; }; resolve_authorized_keys_path root ${JSON.stringify(config)}`,
+    )
+
+    expect(resolved).toBe('/root/.ssh/authorized_keys')
+  })
+})
+
+describe('install_authorized_key', () => {
+  const KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY test@example'
+
+  test('creates the key file with modes StrictModes accepts', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
+
+    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+
+    expect(written).toBe(join(home, '.ssh/authorized_keys'))
+    expect(readFileSync(written, 'utf8')).toBe(`${KEY}\n`)
+    expect(statSync(written).mode & 0o777).toBe(0o600)
+    expect(statSync(join(home, '.ssh')).mode & 0o777).toBe(0o700)
+  })
+
+  test('is idempotent — re-running the installer does not duplicate the key', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
+
+    runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+
+    expect(readFileSync(written, 'utf8')).toBe(`${KEY}\n`)
+  })
+
+  test('appends alongside a key that is already enrolled', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(join(home, '.ssh'), { recursive: true })
+    writeFileSync(join(home, '.ssh/authorized_keys'), 'ssh-rsa AAAAOLD old@example\n')
+
+    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+
+    expect(readFileSync(written, 'utf8')).toBe(`ssh-rsa AAAAOLD old@example\n${KEY}\n`)
+  })
+})
+
+describe('migrate_stranded_authorized_keys', () => {
+  const KEY = 'ssh-rsa AAAASTRANDED jason@mac'
+
+  test('recovers keys the old installer left in /root/.ssh', () => {
+    const home = join(dir, 'home', 'root')
+    const stranded = join(dir, 'root', '.ssh', 'authorized_keys')
+    mkdirSync(home, { recursive: true })
+    mkdirSync(join(dir, 'root', '.ssh'), { recursive: true })
+    writeFileSync(stranded, `# comment\n\n${KEY}\n`)
+
+    runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}`, { rootHome: home })
+
+    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${KEY}\n`)
+  })
+
+  test('does not duplicate a key that is already in the live file', () => {
+    const home = join(dir, 'home', 'root')
+    const stranded = join(dir, 'root', '.ssh', 'authorized_keys')
+    mkdirSync(join(home, '.ssh'), { recursive: true })
+    mkdirSync(join(dir, 'root', '.ssh'), { recursive: true })
+    writeFileSync(join(home, '.ssh/authorized_keys'), `${KEY}\n`)
+    writeFileSync(stranded, `${KEY}\n`)
+
+    runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}`, { rootHome: home })
+
+    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${KEY}\n`)
+  })
+
+  test('is a no-op when the stranded file is the live file', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(join(home, '.ssh'), { recursive: true })
+    const live = join(home, '.ssh/authorized_keys')
+    writeFileSync(live, `${KEY}\n`)
+
+    runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(live)}`, { rootHome: home })
+
+    expect(readFileSync(live, 'utf8')).toBe(`${KEY}\n`)
+  })
+
+  test('is a no-op when there is nothing stranded', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
+
+    const output = runBash(
+      `migrate_stranded_authorized_keys root ${JSON.stringify(join(dir, 'nope'))}; echo done`,
+      { rootHome: home },
+    )
+
+    expect(output).toBe('done')
+  })
+})

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -2,31 +2,74 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 // scripts/lib/ssh-helpers decides where the installer writes root's public
-// key. Getting it wrong is an unrecoverable lockout on a real pod (the same
-// installer block then sets PasswordAuthentication no), so the resolution
-// rules are pinned here rather than trusted to review.
+// key and whether it is safe to disable password authentication. Getting
+// either wrong is an unrecoverable lockout on a real pod, so the rules are
+// pinned here rather than trusted to review.
 const HELPERS = resolve(process.cwd(), 'scripts/lib/ssh-helpers')
 
 let dir: string
+let keyDir: string
+let realKey: string
+
+interface RunOptions {
+  rootHome?: string
+  /** stdout for a plain `sshd -T`; empty means the call fails. */
+  sshdT?: string
+  /**
+   * stdout for `sshd -T -C …`. Omit to mirror `sshdT` (what a modern sshd
+   * does); pass `false` to model an older sshd that rejects `-C`.
+   */
+  sshdTC?: string | false
+}
 
 /**
  * Run a snippet with the helpers sourced. `getent` and `sshd` are shadowed by
- * shell functions so the tests describe a pod's environment (root home at
- * /home/root) from a dev machine, which has neither.
+ * shell functions so the tests can describe a pod's environment (root home at
+ * /home/root, Match blocks, ancient sshd) from a dev machine that has neither.
  */
-function runBash(snippet: string, { rootHome = '/home/root', sshdT = '' } = {}): string {
+function runBash(snippet: string, { rootHome = '/home/root', sshdT = '', sshdTC }: RunOptions = {}): string {
+  const emit = (out: string | false | undefined) =>
+    out ? `printf '%b\\n' ${JSON.stringify(out)}` : 'return 1'
+  const plain = emit(sshdT)
+  const withC = sshdTC === undefined ? plain : emit(sshdTC)
+
   const script = `
     set -euo pipefail
     getent() { [ "\${2:-}" = root ] && echo "root:x:0:0:root:${rootHome}:/bin/sh" || return 2; }
-    sshd() { ${sshdT ? `printf '%b\\n' ${JSON.stringify(sshdT)}` : 'return 1'}; }
+    sshd() {
+      local arg with_c=false
+      for arg in "$@"; do [ "$arg" = "-C" ] && with_c=true; done
+      if [ "$with_c" = true ]; then ${withC}; else ${plain}; fi
+    }
     source ${JSON.stringify(HELPERS)}
     ${snippet}
   `
   return execFileSync('bash', ['-c', script], { encoding: 'utf8' }).trim()
 }
+
+function writeConfig(contents: string): string {
+  const path = join(dir, 'sshd_config')
+  writeFileSync(path, contents)
+  return path
+}
+
+beforeAll(() => {
+  // A real, parseable key — the whole point of validate_public_key is that
+  // a hand-written lookalike is not good enough.
+  keyDir = mkdtempSync(join(tmpdir(), 'ssh-helpers-key-'))
+  const keyPath = join(keyDir, 'id_ed25519')
+  execFileSync('ssh-keygen', ['-t', 'ed25519', '-N', '', '-C', 'test@example', '-f', keyPath], {
+    stdio: 'ignore',
+  })
+  realKey = readFileSync(`${keyPath}.pub`, 'utf8').trim()
+})
+
+afterAll(() => {
+  rmSync(keyDir, { recursive: true, force: true })
+})
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'ssh-helpers-'))
@@ -38,66 +81,96 @@ afterEach(() => {
 
 describe('resolve_authorized_keys_path', () => {
   test('resolves the default relative path against root\'s real home, not /root', () => {
-    const config = join(dir, 'sshd_config')
-    writeFileSync(config, 'Port 8822\nPermitRootLogin prohibit-password\n')
+    const config = writeConfig('Port 8822\nPermitRootLogin prohibit-password\n')
 
-    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
-
-    expect(resolved).toBe('/home/root/.ssh/authorized_keys')
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/home/root/.ssh/authorized_keys')
   })
 
   test('honours an absolute AuthorizedKeysFile pinned by free-sleep', () => {
-    const config = join(dir, 'sshd_config')
-    writeFileSync(config, 'Port 8822\nAuthorizedKeysFile /home/root/ssh/authorized_keys\n')
+    const config = writeConfig('Port 8822\nAuthorizedKeysFile /home/root/ssh/authorized_keys\n')
 
-    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
-
-    expect(resolved).toBe('/home/root/ssh/authorized_keys')
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/home/root/ssh/authorized_keys')
   })
 
   test('prefers sshd -T over the raw config so an Included directive still wins', () => {
-    const config = join(dir, 'sshd_config')
-    writeFileSync(config, 'Include /etc/ssh/sshd_config.d/*.conf\n')
+    const config = writeConfig('Include /etc/ssh/sshd_config.d/*.conf\n')
 
-    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`, {
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`, {
       sshdT: 'port 8822\nauthorizedkeysfile /etc/ssh/keys/%u\npermitrootlogin prohibit-password',
-    })
+    })).toBe('/etc/ssh/keys/root')
+  })
 
-    expect(resolved).toBe('/etc/ssh/keys/root')
+  test('applies a Match User root override, which only -C surfaces', () => {
+    const config = writeConfig('AuthorizedKeysFile .ssh/authorized_keys\nMatch User root\n  AuthorizedKeysFile none\n')
+
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`, {
+      sshdT: 'authorizedkeysfile .ssh/authorized_keys',
+      sshdTC: 'authorizedkeysfile none',
+    })).toBe('none')
+  })
+
+  test('falls back to a plain sshd -T when the installed sshd rejects -C', () => {
+    const config = writeConfig('Include /etc/ssh/sshd_config.d/*.conf\n')
+
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`, {
+      sshdT: 'authorizedkeysfile /etc/ssh/keys/%u',
+      sshdTC: false,
+    })).toBe('/etc/ssh/keys/root')
+  })
+
+  test('expands %U to the target uid', () => {
+    const config = writeConfig('AuthorizedKeysFile /etc/ssh/keys/%U/authorized_keys\n')
+
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/etc/ssh/keys/0/authorized_keys')
   })
 
   test('expands %h and takes the first file when several are listed', () => {
-    const config = join(dir, 'sshd_config')
-    writeFileSync(config, 'AuthorizedKeysFile %h/.ssh/authorized_keys .ssh/authorized_keys2\n')
+    const config = writeConfig('AuthorizedKeysFile %h/.ssh/authorized_keys .ssh/authorized_keys2\n')
 
-    const resolved = runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`)
-
-    expect(resolved).toBe('/home/root/.ssh/authorized_keys')
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/home/root/.ssh/authorized_keys')
   })
 
   test('falls back to /root when the user has no passwd entry', () => {
-    const config = join(dir, 'sshd_config')
-    writeFileSync(config, 'Port 8822\n')
+    const config = writeConfig('Port 8822\n')
 
-    const resolved = runBash(
-      `getent() { return 2; }; resolve_authorized_keys_path root ${JSON.stringify(config)}`,
-    )
+    expect(runBash(`getent() { return 2; }; resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/root/.ssh/authorized_keys')
+  })
+})
 
-    expect(resolved).toBe('/root/.ssh/authorized_keys')
+describe('validate_public_key', () => {
+  test('accepts a key ssh-keygen can parse', () => {
+    expect(runBash(`validate_public_key ${JSON.stringify(realKey)} && echo ok`)).toBe('ok')
+  })
+
+  test('rejects a well-shaped but unparseable key the old regex allowed', () => {
+    // `ssh-ed25519 A` matched the previous format check and would have been
+    // installed, then password auth disabled against it.
+    const snippet = 'status=0; validate_public_key "ssh-ed25519 A" || status=$?; echo "$status"'
+
+    expect(runBash(snippet)).toBe('1')
+  })
+
+  test('reports "cannot tell" rather than success when ssh-keygen is missing', () => {
+    const snippet = `PATH=/var/empty; status=0; validate_public_key ${JSON.stringify(realKey)} || status=$?; echo "$status"`
+
+    expect(runBash(snippet)).toBe('2')
   })
 })
 
 describe('install_authorized_key', () => {
-  const KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY test@example'
-
   test('creates the key file with modes StrictModes accepts', () => {
     const home = join(dir, 'home', 'root')
     mkdirSync(home, { recursive: true })
 
-    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+    const written = runBash(`install_authorized_key root ${JSON.stringify(realKey)}`, { rootHome: home })
 
     expect(written).toBe(join(home, '.ssh/authorized_keys'))
-    expect(readFileSync(written, 'utf8')).toBe(`${KEY}\n`)
+    expect(readFileSync(written, 'utf8')).toBe(`${realKey}\n`)
     expect(statSync(written).mode & 0o777).toBe(0o600)
     expect(statSync(join(home, '.ssh')).mode & 0o777).toBe(0o700)
   })
@@ -106,10 +179,10 @@ describe('install_authorized_key', () => {
     const home = join(dir, 'home', 'root')
     mkdirSync(home, { recursive: true })
 
-    runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
-    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+    runBash(`install_authorized_key root ${JSON.stringify(realKey)}`, { rootHome: home })
+    const written = runBash(`install_authorized_key root ${JSON.stringify(realKey)}`, { rootHome: home })
 
-    expect(readFileSync(written, 'utf8')).toBe(`${KEY}\n`)
+    expect(readFileSync(written, 'utf8')).toBe(`${realKey}\n`)
   })
 
   test('appends alongside a key that is already enrolled', () => {
@@ -117,49 +190,81 @@ describe('install_authorized_key', () => {
     mkdirSync(join(home, '.ssh'), { recursive: true })
     writeFileSync(join(home, '.ssh/authorized_keys'), 'ssh-rsa AAAAOLD old@example\n')
 
-    const written = runBash(`install_authorized_key root ${JSON.stringify(KEY)}`, { rootHome: home })
+    const written = runBash(`install_authorized_key root ${JSON.stringify(realKey)}`, { rootHome: home })
 
-    expect(readFileSync(written, 'utf8')).toBe(`ssh-rsa AAAAOLD old@example\n${KEY}\n`)
+    expect(readFileSync(written, 'utf8')).toBe(`ssh-rsa AAAAOLD old@example\n${realKey}\n`)
+  })
+
+  test('refuses to invent a path when AuthorizedKeysFile is none', () => {
+    const snippet = `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
+
+    expect(runBash(snippet, { sshdT: 'authorizedkeysfile none' })).toBe('REFUSED')
   })
 })
 
 describe('migrate_stranded_authorized_keys', () => {
-  const KEY = 'ssh-rsa AAAASTRANDED jason@mac'
+  const OLD_KEY = 'ssh-rsa AAAASTRANDED jason@mac'
+
+  function strandedPath(): string {
+    mkdirSync(join(dir, 'root', '.ssh'), { recursive: true })
+    return join(dir, 'root', '.ssh', 'authorized_keys')
+  }
 
   test('recovers keys the old installer left in /root/.ssh', () => {
     const home = join(dir, 'home', 'root')
-    const stranded = join(dir, 'root', '.ssh', 'authorized_keys')
     mkdirSync(home, { recursive: true })
-    mkdirSync(join(dir, 'root', '.ssh'), { recursive: true })
-    writeFileSync(stranded, `# comment\n\n${KEY}\n`)
+    const stranded = strandedPath()
+    writeFileSync(stranded, `# comment\n\n${OLD_KEY}\n`)
 
     runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}`, { rootHome: home })
 
-    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${KEY}\n`)
+    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${OLD_KEY}\n`)
+  })
+
+  test('recovers a final key with no trailing newline', () => {
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
+    const stranded = strandedPath()
+    writeFileSync(stranded, `${OLD_KEY}`)
+
+    runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}`, { rootHome: home })
+
+    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${OLD_KEY}\n`)
   })
 
   test('does not duplicate a key that is already in the live file', () => {
     const home = join(dir, 'home', 'root')
-    const stranded = join(dir, 'root', '.ssh', 'authorized_keys')
     mkdirSync(join(home, '.ssh'), { recursive: true })
-    mkdirSync(join(dir, 'root', '.ssh'), { recursive: true })
-    writeFileSync(join(home, '.ssh/authorized_keys'), `${KEY}\n`)
-    writeFileSync(stranded, `${KEY}\n`)
+    const stranded = strandedPath()
+    writeFileSync(join(home, '.ssh/authorized_keys'), `${OLD_KEY}\n`)
+    writeFileSync(stranded, `${OLD_KEY}\n`)
 
     runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}`, { rootHome: home })
 
-    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${KEY}\n`)
+    expect(readFileSync(join(home, '.ssh/authorized_keys'), 'utf8')).toBe(`${OLD_KEY}\n`)
   })
 
   test('is a no-op when the stranded file is the live file', () => {
     const home = join(dir, 'home', 'root')
     mkdirSync(join(home, '.ssh'), { recursive: true })
     const live = join(home, '.ssh/authorized_keys')
-    writeFileSync(live, `${KEY}\n`)
+    writeFileSync(live, `${OLD_KEY}\n`)
 
     runBash(`migrate_stranded_authorized_keys root ${JSON.stringify(live)}`, { rootHome: home })
 
-    expect(readFileSync(live, 'utf8')).toBe(`${KEY}\n`)
+    expect(readFileSync(live, 'utf8')).toBe(`${OLD_KEY}\n`)
+  })
+
+  test('is a no-op when key files are disabled entirely', () => {
+    const stranded = strandedPath()
+    writeFileSync(stranded, `${OLD_KEY}\n`)
+
+    const output = runBash(
+      `migrate_stranded_authorized_keys root ${JSON.stringify(stranded)}; echo done`,
+      { sshdT: 'authorizedkeysfile none' },
+    )
+
+    expect(output).toBe('done')
   })
 
   test('is a no-op when there is nothing stranded', () => {
@@ -172,5 +277,58 @@ describe('migrate_stranded_authorized_keys', () => {
     )
 
     expect(output).toBe('done')
+  })
+})
+
+describe('set_sshd_directive', () => {
+  function applied(contents: string, key: string, value: string): string {
+    const config = writeConfig(contents)
+    runBash(`set_sshd_directive ${key} ${value} ${JSON.stringify(config)}`)
+    return readFileSync(config, 'utf8')
+  }
+
+  test('overwrites an active directive', () => {
+    expect(applied('Port 22\nX11Forwarding yes\n', 'Port', '8822'))
+      .toBe('Port 8822\nX11Forwarding yes\n')
+  })
+
+  test('uncomments and sets a commented-out directive', () => {
+    expect(applied('#PasswordAuthentication yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('PasswordAuthentication no\n')
+  })
+
+  test('appends the directive when the config never mentions it', () => {
+    // The substitution this replaced was a silent no-op here, leaving sshd on
+    // its default (PasswordAuthentication yes) while reporting success.
+    expect(applied('Port 8822\n', 'PermitEmptyPasswords', 'no'))
+      .toBe('Port 8822\nPermitEmptyPasswords no\n')
+  })
+
+  test('inserts above the first Match block instead of inside it', () => {
+    expect(applied('Port 8822\nMatch User dac\n  X11Forwarding no\n', 'PasswordAuthentication', 'no'))
+      .toBe('Port 8822\nPasswordAuthentication no\nMatch User dac\n  X11Forwarding no\n')
+  })
+
+  test('leaves the directive name in prose alone', () => {
+    // An unanchored substitution rewrote this comment into `# Port 8822`.
+    expect(applied('# Port forwarding is disabled below\nPort 22\n', 'Port', '8822'))
+      .toBe('# Port forwarding is disabled below\nPort 8822\n')
+  })
+})
+
+describe('sshd_effective_value', () => {
+  test('reads the value sshd will actually use', () => {
+    const config = writeConfig('Port 8822\n')
+
+    expect(runBash(`sshd_effective_value PasswordAuthentication ${JSON.stringify(config)}`, {
+      sshdT: 'port 8822\npasswordauthentication no',
+    })).toBe('no')
+  })
+
+  test('prints nothing when sshd cannot report a value', () => {
+    const config = writeConfig('Port 8822\n')
+
+    expect(runBash(`echo "[$(sshd_effective_value PasswordAuthentication ${JSON.stringify(config)})]"`))
+      .toBe('[]')
   })
 })

--- a/tests/ssh-helpers.test.ts
+++ b/tests/ssh-helpers.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
@@ -127,6 +127,13 @@ describe('resolve_authorized_keys_path', () => {
       .toBe('/etc/ssh/keys/0/authorized_keys')
   })
 
+  test('keeps a literal %% from being eaten by the %h pass', () => {
+    const config = writeConfig('AuthorizedKeysFile /etc/ssh/%%h/authorized_keys\n')
+
+    expect(runBash(`resolve_authorized_keys_path root ${JSON.stringify(config)}`))
+      .toBe('/etc/ssh/%h/authorized_keys')
+  })
+
   test('expands %h and takes the first file when several are listed', () => {
     const config = writeConfig('AuthorizedKeysFile %h/.ssh/authorized_keys .ssh/authorized_keys2\n')
 
@@ -199,6 +206,22 @@ describe('install_authorized_key', () => {
     const snippet = `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
 
     expect(runBash(snippet, { sshdT: 'authorizedkeysfile none' })).toBe('REFUSED')
+  })
+
+  test('fails rather than reporting success when the key cannot be written', () => {
+    // The call site runs this inside an `if`, which suppresses set -e for the
+    // whole function — an unchecked mkdir would fall through to the final
+    // printf and the installer would disable password auth against a key that
+    // never reached disk.
+    const home = join(dir, 'home', 'root')
+    mkdirSync(home, { recursive: true })
+    chmodSync(home, 0o555)
+
+    const snippet = `install_authorized_key root ${JSON.stringify(realKey)} 2>/dev/null || echo REFUSED`
+    const output = runBash(snippet, { rootHome: home })
+    chmodSync(home, 0o755)
+
+    expect(output).toBe('REFUSED')
   })
 })
 
@@ -307,6 +330,18 @@ describe('set_sshd_directive', () => {
   test('inserts above the first Match block instead of inside it', () => {
     expect(applied('Port 8822\nMatch User dac\n  X11Forwarding no\n', 'PasswordAuthentication', 'no'))
       .toBe('Port 8822\nPasswordAuthentication no\nMatch User dac\n  X11Forwarding no\n')
+  })
+
+  test('replaces the Key=value form sshd also accepts', () => {
+    // Left in place, a stale `=`-form directive earlier in the file would win
+    // over an appended one, since sshd takes the first occurrence.
+    expect(applied('PasswordAuthentication=yes\n', 'PasswordAuthentication', 'no'))
+      .toBe('PasswordAuthentication no\n')
+  })
+
+  test('replaces a commented Key=value directive', () => {
+    expect(applied('#PermitEmptyPasswords=yes\n', 'PermitEmptyPasswords', 'no'))
+      .toBe('PermitEmptyPasswords no\n')
   })
 
   test('leaves the directive name in prose alone', () => {


### PR DESCRIPTION
## The bug

`scripts/install`'s optional SSH-setup block appended the user's public key to a hardcoded `/root/.ssh/authorized_keys` and, in the same pass, set `PasswordAuthentication no`. Those two halves are individually defensible and jointly a lockout:

- **root's home on this Yocto image is `/home/root`**, not `/root` (poky convention — the same assumption is already baked into `scripts/install:965`, `scripts/bin/sp-maintenance:75`, `scripts/pod/capabilities:90`). sshd resolves the default `AuthorizedKeysFile .ssh/authorized_keys` to `/home/root/.ssh/authorized_keys` and never looks at `/root/.ssh`.
- **free-sleep's `setup_ssh.sh` pins an absolute `AuthorizedKeysFile /home/root/ssh/authorized_keys`.** That directive survives the installer's `sed` edits, so even the corrected relative default would be ignored on a pod that has seen free-sleep.

Either way the key lands somewhere sshd ignores while password auth is switched off. Port 8822 is the pod's only remote entry point, so the result is an unrecoverable lockout — `Permission denied (publickey)` for every user, with recovery requiring a serial console and a U-Boot `init=/bin/bash` boot (or a hardware firmware reset, which wipes the install).

Found the hard way on a real pod: full TCP sweep showed only 111/5355/8822 open, sshd offering `publickey` only, rejecting a known-good key at the offer stage.

## The fix

- **`scripts/lib/ssh-helpers`** (new) — `resolve_authorized_keys_path` asks sshd where it actually reads keys: `sshd -T` first (so an `AuthorizedKeysFile` set in an `Include`d file still wins), then the raw config, then sshd's compiled-in default. Expands `%h`/`%u`, takes the first entry of a list, and resolves relative paths against root's real home from `getent`. Plus `install_authorized_key` (idempotent, StrictModes-safe ownership and modes) and `migrate_stranded_authorized_keys`, which folds keys left behind in `/root/.ssh` by an earlier install into the real file — so re-running the installer *repairs* an existing lockout instead of recreating it.
- **`scripts/install`** — sources the helper (same pattern as `scripts/pod/detect` and `scripts/lib/relocation-helpers`, both already sourced from `$INSTALL_DIR` at that point). Sets `Port` up front, but applies `PermitRootLogin prohibit-password` / `PasswordAuthentication no` / `PermitEmptyPasswords no` **only after a key is verifiably installed**. No valid key means auth settings are left untouched with an explanatory message; a missing helper aborts before touching them.
- **`tests/ssh-helpers.test.ts`** (new, 32 tests) — runs the helper under `bash` with `getent`/`sshd` stubbed to look like a pod, pinning each resolution rule and the migration behaviour.
- **`scripts/README.md`** — documents the real path and the "confirm key auth works before disabling passwords" ordering.

## Notes for review

The tests earned their keep immediately: the first version of the helper aborted the whole installer under `set -euo pipefail` whenever `getent` or `sshd -T` returned non-zero. Hence the explicit `|| true` guards, which are commented as load-bearing.

This is the repo's first shell-level test. It shells out to `bash` from vitest rather than introducing bats; happy to restructure if you'd prefer a different harness.

## Verification

`pnpm tsc` clean; `pnpm lint` clean (one pre-existing warning in `stryker.config.mjs`); `pnpm test` 3321 passed / 1 skipped across 137 files; `bash -n` clean on both scripts.

Not exercised end-to-end on a pod — the pod I found this on is currently locked out by the very bug being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SSH setup detects the effective authorized-keys location, including `/home/root` layouts.
  * Existing keys in legacy locations are migrated automatically without duplication.
  * Key installation validates formatting, enforces secure permissions, and verifies persistence.
  * SSH configuration is validated before restart, with port 8822 applied consistently.
  * Password authentication is disabled only after successful key verification, helping prevent lockouts.
  * Installation and manual setup documentation include path checks, authentication verification, and recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->