### PR TITLE
test: kill latest mutation-run survivors (#591 hit list)

### DIFF
--- a/src/hooks/tests/useSensorStream.test.ts
+++ b/src/hooks/tests/useSensorStream.test.ts
@@ -961,6 +961,27 @@ describe('useSensorStream — mutation boundaries and lifecycle contracts', () =
 })
 
 describe('useSensorFrame — listener lifecycle and dependencies', () => {
+  it('notifies only the listeners registered for an incoming sensor type', async () => {
+    const stream = renderHook(() => useSensorStream())
+    await waitFor(() => expect(wsMock.sockets.length).toBe(1))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+
+    const capSense = renderHook(() => useSensorFrame('capSense'))
+    const notify = vi.fn()
+    sensorSingleton.sensorListeners.get('capSense')?.add(notify)
+
+    act(() => ws.triggerMessage({ type: 'bedTemp', ts: 1 }))
+    expect(notify).not.toHaveBeenCalled()
+
+    act(() => ws.triggerMessage({ type: 'capSense', ts: 2, left: 1, right: 2 }))
+    expect(notify).toHaveBeenCalledOnce()
+
+    sensorSingleton.sensorListeners.get('capSense')?.delete(notify)
+    capSense.unmount()
+    stream.unmount()
+  })
+
   it('keeps both per-sensor listeners when two consumers use the same type', () => {
     const first = renderHook(() => useSensorFrame('capSense'))
     const second = renderHook(() => useSensorFrame('capSense'))

--- a/src/lib/tests/movement.mutation.test.ts
+++ b/src/lib/tests/movement.mutation.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadMovementBucketSizes() {
+  // These constants are evaluated at module load. Reload the module while a
+  // static Stryker mutant is active so arithmetic changes remain observable.
+  vi.resetModules()
+  const { MOVEMENT_BUCKET_DAY_SECONDS, MOVEMENT_BUCKET_WEEK_SECONDS } = await import('../movement')
+  return { MOVEMENT_BUCKET_DAY_SECONDS, MOVEMENT_BUCKET_WEEK_SECONDS }
+}
+
+describe('movement bucket mutation contract', () => {
+  it('pins both bucket sizes after a fresh module import', async () => {
+    await expect(loadMovementBucketSizes()).resolves.toEqual({
+      MOVEMENT_BUCKET_DAY_SECONDS: 300,
+      MOVEMENT_BUCKET_WEEK_SECONDS: 1800,
+    })
+  })
+})

--- a/src/services/tests/temperatureKeepalive.mutation.test.ts
+++ b/src/services/tests/temperatureKeepalive.mutation.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/src/db', () => {
+  const query = {
+    from: vi.fn(() => query),
+    where: vi.fn(() => query),
+    limit: vi.fn(() => query),
+    all: vi.fn(() => []),
+  }
+
+  return { db: { select: vi.fn(() => query) } }
+})
+
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({
+  getSharedHardwareClient: vi.fn(),
+}))
+
+vi.mock('@/src/hardware/pumpStallGuard', () => ({
+  shouldBlock: vi.fn(() => false),
+}))
+
+vi.mock('@/src/hardware/sideLock', () => ({
+  withSideLock: (_side: unknown, work: () => unknown) => work(),
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('temperature keepalive mutation contract', () => {
+  it('loads a fresh module and arms the firmware keepalive at exactly six hours', async () => {
+    // KEEPALIVE_INTERVAL_MS is evaluated at module load. Reload the service
+    // while each static Stryker mutant is active so arithmetic changes cannot
+    // hide behind the module instance collected before mutation activation.
+    vi.resetModules()
+    const { startKeepalive, shutdownKeepalives } = await import('../temperatureKeepalive')
+
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+    const interval = vi.spyOn(globalThis, 'setInterval')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    startKeepalive('left')
+
+    expect(interval).toHaveBeenCalledWith(expect.any(Function), 21_600_000)
+    shutdownKeepalives()
+  })
+})

--- a/src/streaming/tests/normalizeFrame.test.ts
+++ b/src/streaming/tests/normalizeFrame.test.ts
@@ -48,6 +48,12 @@ describe('capSideChannels', () => {
     expect(capSideChannels(null)).toBeNull()
     expect(capSideChannels('nope')).toBeNull()
   })
+
+  it('rejects callable values even when they carry sensor-like properties', () => {
+    const callable = Object.assign(() => undefined, { values: [1, 2, 3] })
+
+    expect(capSideChannels(callable)).toBeNull()
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reload module-scoped movement and keepalive constants while Stryker mutants are active
- reject callable sensor channel payloads even when they expose a values property
- verify sensor frames notify only the matching per-sensor listener registry
- add tests only; production code is unchanged

Targets the latest run tracked in #591: surviving mutants 851 and 1370, plus no-coverage mutants 999-1001 and 2041-2042.

## Validation

- manually applied all seven exact mutations and confirmed each new assertion fails
- pnpm test run --passWithNoTests (3,357 passed, 1 skipped before the final isolated keepalive test was added)
- focused keepalive suite (24 passed)
- pnpm tsc
- pnpm lint (one pre-existing stryker.config.mjs warning)
- both Drizzle schema checks
- pre-push changed-file suite (142 passed)

Relates to #591.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming sensor callbacks receive only matching sensor frames.
  * Added validation for movement time-bucket constants.
  * Added coverage for six-hour temperature keepalive scheduling and cleanup.
  * Added validation that invalid sensor side-channel values are normalized safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/mutation-run-31870088314
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/mutation-run-31870088314/scripts/install \
  | sudo bash -s -- --branch test/mutation-run-31870088314
```

🎯 **Pin to this exact build** ([run 31983027452](https://github.com/sleepypod/core/actions/runs/31983027452) · `461a255`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/461a255d6dfcf9e48adf9fba5ee5cc366ef31c57/scripts/install \
  | sudo bash -s -- \
      --branch test/mutation-run-31870088314 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/31983027452/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/31983027452/artifacts/9272930468) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
