### PR TITLE
test(hardware,server): kill dacTransport framing and device lock-routing mutants (#591 hit list)

### DIFF
--- a/src/hardware/tests/dacTransport.mutation.test.ts
+++ b/src/hardware/tests/dacTransport.mutation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Mutation-boundary tests for dacTransport.ts wire framing.
+ *
+ * `SEPARATOR` is evaluated at module load, so Stryker's static mutant on the
+ * '\n\n' literal never re-runs under a cached import and reports a false
+ * survivor. Re-import the module per test (vi.resetModules + dynamic import)
+ * so the initializer executes with the active mutant, then pin the exact
+ * bytes on the wire.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { Socket } from 'net'
+import { promises as fs } from 'fs'
+// Type-only: erased at compile time, so the module still loads fresh per test.
+import type * as DacTransportModule from '../dacTransport'
+
+function createTestSocketPath(): string {
+  return `/tmp/test-dac-mut-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`
+}
+
+function connectAsFrankenfirmware(socketPath: string): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket()
+    const timeout = setTimeout(() => {
+      socket.destroy()
+      reject(new Error('Mock frankenfirmware connection timeout'))
+    }, 5000)
+
+    socket.connect(socketPath, () => {
+      clearTimeout(timeout)
+      resolve(socket)
+    })
+
+    socket.on('error', (err: Error) => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+  })
+}
+
+describe('dacTransport wire framing (fresh import per mutant)', () => {
+  let socketPath = ''
+  let mockFranken: Socket | undefined
+  let mod: typeof DacTransportModule | undefined
+
+  afterEach(async () => {
+    try {
+      mockFranken?.destroy()
+      await mod?.disconnectDac()
+    }
+    finally {
+      mockFranken = undefined
+      mod = undefined
+      delete process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS
+      try {
+        await fs.unlink(socketPath)
+      }
+      catch { /* ignore */ }
+    }
+  })
+
+  test('frames every outbound command with the exact double-newline separator', async () => {
+    // Bound the mutant's failure mode: an unseparated request never earns a
+    // response, so without this the kill would surface as a slow suite timeout.
+    process.env.DAC_MESSAGE_RESPONSE_TIMEOUT_MS = '400'
+    socketPath = createTestSocketPath()
+    vi.resetModules()
+    mod = await import('../dacTransport')
+
+    const connectPromise = mod.connectDac(socketPath)
+    await vi.waitFor(() => fs.access(socketPath), { timeout: 5_000, interval: 5 })
+    mockFranken = await connectAsFrankenfirmware(socketPath)
+
+    // Like real firmware, only a fully separator-terminated request is answered.
+    const wire: string[] = []
+    let buffer = ''
+    mockFranken.on('data', (chunk) => {
+      const text = chunk.toString('utf-8')
+      wire.push(text)
+      buffer += text
+      while (buffer.includes('\n\n')) {
+        buffer = buffer.substring(buffer.indexOf('\n\n') + 2)
+        mockFranken?.write('ACK\n\n')
+      }
+    })
+
+    await connectPromise
+
+    await expect(mod.sendCommand('14')).resolves.toBe('ACK')
+    expect(wire.join('')).toBe('14\n\n')
+
+    // The argument path shares the separator; pin it too.
+    await expect(mod.sendCommand('11', '-24')).resolves.toBe('ACK')
+    expect(wire.join('')).toBe('14\n\n11\n-24\n\n')
+  })
+})

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -1135,6 +1135,18 @@ describe('device.execute (raw command)', () => {
       await rightHolder.catch(() => {})
     }
   })
+
+  it('re-checks both sides inside the nested locks before a both-sides raw write', async () => {
+    // Pre-flight passes for both sides (two checks); the trip lands while the
+    // command sits inside the nested locks — the in-lock loop must catch it.
+    pumpStallMock.shouldBlock
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true)
+    sharedClientMock.sendRaw.mockResolvedValue('ok')
+    await expect(caller.execute({ command: 'SET_TEMP', args: '50' })).rejects.toThrow(/Pump stall protection active/)
+    expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+  })
 })
 
 describe('device best-effort DB sync swallows errors', () => {

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TRPCError } from '@trpc/server'
 
 const helpersMock = vi.hoisted(() => {
   const client = {
@@ -658,6 +659,32 @@ describe('device.setTemperature', () => {
     }
   })
 
+  it('leaves the optimistic write in place when the failure is not a guard rejection', async () => {
+    vi.useFakeTimers()
+    try {
+      dbState.rowsQueue.push([{ isPowered: false, poweredOnAt: null }])
+      // A wrapped hardware failure is a TRPCError too — only the guard's
+      // PRECONDITION_FAILED code may trigger the parked-mirror restore.
+      helpersMock.withHardwareClient.mockRejectedValueOnce(
+        new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to set temperature' }),
+      )
+
+      const promise = caller.setTemperature({ side: 'left', temperature: 70 })
+      const caught = promise.catch((e: unknown) => e)
+      await vi.advanceTimersByTimeAsync(250)
+      const err = await caught
+
+      expect(err).toBeInstanceOf(TRPCError)
+      expect((err as TRPCError).code).toBe('INTERNAL_SERVER_ERROR')
+      // Single optimistic update, no compensating off-write, no off broadcast.
+      expect(dbMock.update).toHaveBeenCalledTimes(1)
+      expect(broadcastMock.broadcastMutationStatus).not.toHaveBeenCalledWith('left', { targetLevel: 0 })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('coalesces a second call into one hardware command (last value wins)', async () => {
     vi.useFakeTimers()
     try {
@@ -1029,6 +1056,83 @@ describe('device.execute (raw command)', () => {
     finally {
       releaseLeft()
       await holder.catch(() => {})
+    }
+  })
+
+  it('a non-energizing command never queues behind held side locks', async () => {
+    let releaseLeft!: () => void
+    let releaseRight!: () => void
+    const leftHolder = withSideLock('left', () => new Promise<void>((resolve) => {
+      releaseLeft = resolve
+    }))
+    const rightHolder = withSideLock('right', () => new Promise<void>((resolve) => {
+      releaseRight = resolve
+    }))
+    try {
+      sharedClientMock.sendRaw.mockResolvedValue('ok')
+      // Must complete while BOTH locks are held — routing a guard-free command
+      // through the side locks would serialize reads behind hardware writes.
+      const pending = caller.execute({ command: 'DEVICE_STATUS' })
+      const outcome = await Promise.race([
+        pending.then(() => 'completed'),
+        new Promise<string>(resolve => setTimeout(() => resolve('lock-blocked'), 200)),
+      ])
+      expect(outcome).toBe('completed')
+      expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('14', undefined)
+    }
+    finally {
+      releaseLeft()
+      releaseRight()
+      await leftHolder.catch(() => {})
+      await rightHolder.catch(() => {})
+    }
+  })
+
+  it('a single-side energizing write does not wait on the opposite side lock', async () => {
+    let releaseRight!: () => void
+    const rightHolder = withSideLock('right', () => new Promise<void>((resolve) => {
+      releaseRight = resolve
+    }))
+    try {
+      sharedClientMock.sendRaw.mockResolvedValue('ok')
+      // A left-side write needs only the left lock; taking both would let one
+      // side's slow hardware call stall the other side's commands.
+      const pending = caller.execute({ command: 'TEMP_LEVEL_LEFT', args: '50' })
+      const outcome = await Promise.race([
+        pending.then(() => 'completed'),
+        new Promise<string>(resolve => setTimeout(() => resolve('lock-blocked'), 200)),
+      ])
+      expect(outcome).toBe('completed')
+      expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('11', '50')
+    }
+    finally {
+      releaseRight()
+      await rightHolder.catch(() => {})
+    }
+  })
+
+  it('a both-sides raw write queues behind the right side lock too', async () => {
+    let releaseRight!: () => void
+    const rightHolder = withSideLock('right', () => new Promise<void>((resolve) => {
+      releaseRight = resolve
+    }))
+    try {
+      sharedClientMock.sendRaw.mockResolvedValue('ok')
+      // SET_TEMP energizes both sides, so it must hold both locks — collapsing
+      // to the first side's lock would let it re-energize a right side that a
+      // concurrent holder is parking.
+      const pending = caller.execute({ command: 'SET_TEMP', args: '50' })
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(sharedClientMock.sendRaw).not.toHaveBeenCalled()
+
+      releaseRight()
+      await rightHolder
+      await pending
+      expect(sharedClientMock.sendRaw).toHaveBeenCalledWith('1', '50')
+    }
+    finally {
+      releaseRight()
+      await rightHolder.catch(() => {})
     }
   })
 })


### PR DESCRIPTION
Works the top unclaimed survivors from mutation run [32557731949](https://github.com/sleepypod/core/actions/runs/32557731949) (issue #591, trigger commit `07f3856`). No source changes.

## What's killed

**`src/hardware/dacTransport.ts`** (10 surviving → target 1 killable)
- L221 `StringLiteral` on the `'\n\n'` SEPARATOR — a static module-init mutant. New `dacTransport.mutation.test.ts` follows the fresh-import pattern (`vi.resetModules()` + dynamic import, as in `types.mutation.test.ts`) and pins the exact wire bytes for both the bare-command and argument paths.

**`src/server/routers/device.ts`** (10 surviving → target 7 killable)
- L846 `ConditionalExpression`/`BlockStatement` on `guardedSides.length === 0` — new test proves a non-energizing command completes while both side locks are held.
- L853 `ConditionalExpression true/false`, `EqualityOperator !==`, `BlockStatement` on `guardedSides.length === 1` — two new tests prove a single-side energizing write does not wait on the opposite lock, and a both-sides `SET_TEMP` does queue behind the right lock.
- L421 `ConditionalExpression true` on the `error.code === 'PRECONDITION_FAILED'` clause — new test rejects with a non-guard `TRPCError` and asserts the optimistic write is not rolled back.

Each test was verified to FAIL with its mutation hand-applied to the source and pass on clean source.

## Audited equivalent (no test possible — details in the #591 comment)

- `src/lib/scheduleGrouping.ts` — all 11 (noon-split precheck subsumed by the >12h gap loop, exhaustively swept; comparator tiebreaker subsumed by stable-sort insertion order, 200k-case brute force).
- `src/lib/occupancy.ts` — all 9 (optional-chain/guard mutants inside try/catch that returns the identical fallback).
- `src/streaming/piezoStream.ts` L127–130 — all 10 new `appendFrameIndex` mutants (guard is a pure optimization; `splice(0,0)` no-op; monotonic ts bounds the loop).
- `src/hardware/dacTransport.ts` — remaining 9 (constant-fold `10 > 0`, no-match `replace` no-op, internal error text never escapes the instanceof-based retry classifier, always-truthy timeout handle, unreachable `!dacServer` false).
- `src/server/routers/device.ts` L277/L408 — best-effort-catch-masked enrichment guard and a discarded callback return value.

## Test plan
- [x] `pnpm exec vitest run src/hardware/tests/dacTransport.mutation.test.ts src/server/routers/tests/device.test.ts` — 70 passed
- [x] Each new test fails under its hand-applied mutation (5/5 verified locally)
- [x] `pnpm tsc && pnpm lint && pnpm test` — clean (one pre-existing warning in stryker.config.mjs)
- [ ] `mutation-test` label CI run confirms Survived → Killed for the 8 target mutants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded hardware communication coverage for command framing, response timeouts, and connection cleanup.
  * Added device-control scenarios covering hardware failures while preserving temperature state.
  * Added validation for raw-command locking, including independent side locks and non-energizing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/lib-mutants-591
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/lib-mutants-591/scripts/install \
  | sudo bash -s -- --branch test/lib-mutants-591
```

🎯 **Pin to this exact build** ([run 32669661162](https://github.com/sleepypod/core/actions/runs/32669661162) · `013c3d1`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/013c3d133e09a38fd77c1dc9c633156789c73cb0/scripts/install \
  | sudo bash -s -- \
      --branch test/lib-mutants-591 \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/32669661162/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/32669661162/artifacts/9501023476) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->

