### PR TITLE
fix(biometrics): persist frozen firmware heartbeat in tmpfs

### DIFF
--- a/modules/biometrics-archiver/sleepypod-tmpfs-prep
+++ b/modules/biometrics-archiver/sleepypod-tmpfs-prep
@@ -9,6 +9,7 @@
 # - settings/heat/vector/system-connections/free-sleep-data/deviceinfo/
 #   sleepypod-data: state directories the firmware reads (and rarely
 #   writes); symlinks transparently expose the on-disk content.
+# - frozen.heartbeat: persistent watchdog state used by frankenfirmware.
 # - alarm.cbr/uptime.log: misc small state files.
 #
 # Idempotent: safe to run on every frank.service start. Tmpfs is empty
@@ -34,7 +35,7 @@ done
 
 # State files that firmware reads/writes through cwd. Symlinks pass
 # writes through to eMMC.
-for name in SEQNO.RAW alarm.cbr uptime.log; do
+for name in SEQNO.RAW frozen.heartbeat alarm.cbr uptime.log; do
   src="$SOURCE_DIR/$name"
   dst="$TMPFS_DIR/$name"
   if [ -f "$src" ] && [ ! -L "$dst" ]; then


### PR DESCRIPTION
## Summary

- stage `frozen.heartbeat` alongside the other persistent frankenfirmware state files
- document that the file is watchdog state and must survive the biometrics tmpfs mount

## Why

On Pod 3, frankenfirmware reads `frozen.heartbeat` relative to its working directory. After the biometrics archiver moves that directory to `/persistent/biometrics`, omitting this symlink leaves a separate volatile heartbeat file in tmpfs.

That makes the frozen-controller watchdog appear expired approximately every 30 seconds. Each reload temporarily locks both TECs and leaks another descriptor for `firmware-frozen.bbin`, eventually ending in `Too many open files`.

Linking the tmpfs path back to `/persistent/frozen.heartbeat` keeps the watchdog state coherent while RAW data continues to use tmpfs.

## Validation

- `bash -n modules/biometrics-archiver/sleepypod-tmpfs-prep`
- `git diff --check`
- isolated temporary-directory test confirmed `/persistent/biometrics/frozen.heartbeat` is created as a symlink to the persistent source
- live Pod 3 A/B test: no recurring firmware reloads and frankenfirmware remained at 14 open FDs for 90 seconds with the symlink present

Fixes #690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved biometrics archive preparation by preserving the persistent watchdog heartbeat state alongside existing state files.
  * Updated documentation to clarify the role of the heartbeat state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->