### PR TITLE
perf(web): reduce status latency and defer diagnostics charts

### DIFF
--- a/docs/performance/web-service-2026-09-06.md
+++ b/docs/performance/web-service-2026-09-06.md
@@ -1,0 +1,137 @@
+# Pod web-service measurements — 2026-09-06 UTC
+
+Measured on Pod `192.168.1.88` (aarch64, approximately 2 GiB RAM, Node
+22.17.0, Next.js 16.3.3). The previous installation was `e2c45c8`; the
+performance changes were first deployed as `40fab93`, then the coverage
+cleanup was deployed as `38e0695`. Package and lockfile hashes matched the
+previous installation, allowing its ARM-native dependencies to be reused.
+
+## Results
+
+The settled final build reduced median status latency from **99.43 to
+40.06 ms (60%)**, concurrent status p95 from **366.33 to 121.57 ms (67%)**,
+and diagnostics initial JavaScript from **1,279,395 to 783,209 decoded bytes
+(39%)**. Next.js remains in use.
+
+| Metric | Before (`e2c45c8`) | Final, settled (`38e0695`) |
+| --- | ---: | ---: |
+| Status median (60 requests) | 99.43 ms | 40.06 ms |
+| Status p95 | 106.52 ms | 45.94 ms |
+| Status maximum | 143.69 ms | 51.28 ms |
+| Four concurrent status reads: median (48 requests) | 246.64 ms | 82.04 ms |
+| Four concurrent status reads: p95 | 366.33 ms | 121.57 ms |
+| Health probe during those bursts: median (12 requests) | 96.05 ms | 131.78 ms |
+| CPU during 2 Hz status reads (% of one core) | 25.18 % | 20.25 % |
+| Idle CPU (% of one core) | 13.52 % | 13.65 % |
+| RSS at end of serial status phase | 178.15 MiB | 186.34 MiB |
+| Temperature page HTML median (10 requests) | 44.44 ms | 45.4 ms |
+| Diagnostics HTML median (10 requests) | 35.02 ms | 34.13 ms |
+| Diagnostics initial JavaScript | 1,279,395 bytes | 783,209 bytes |
+| Diagnostics initial script count | 16  | 12  |
+
+CPU during the status polling phase was about 20% lower in the settled final
+run. Idle CPU and HTML response medians were broadly unchanged; these data
+do not demonstrate a memory reduction. The lightweight health request
+issued alongside each status burst became slower (96.05 to 131.78 ms median),
+so this is not an improvement across every endpoint under contention.
+
+Raw measurements: [baseline](web-service-2026-09-06/before.json),
+[initial performance build](web-service-2026-09-06/initial-after.json),
+[initial build after warming](web-service-2026-09-06/warm-after.json),
+[final build including startup](web-service-2026-09-06/final-after.json), and
+[final settled build](web-service-2026-09-06/final-warm-after.json). The two
+initial performance runs had median status times of 44.36 and 39.11 ms.
+The final settled run's WebSocket status frames continued approximately
+once per second (1,035.98 ms p95 gap).
+
+
+## Method
+
+The [benchmark script](web-service-2026-09-06/benchmark.mjs) runs on the Pod
+against `http://127.0.0.1:3000`. Times include receipt of the complete HTTP
+response. These measurements exclude Wi-Fi round trips and browser parsing,
+hydration, painting, and interaction latency.
+
+Each run samples 15 seconds without its own WebSocket, then connects one
+read-only `deviceStatus` subscription on port 3001. After three warmup reads,
+it makes 60 serial `device.getStatus` tRPC requests, at least 500 ms apart
+start-to-start. Next come 12 bursts, each containing four concurrent status
+requests plus one `health/dac-monitor` request. This keeps the hardware
+monitor in its normal active-client polling mode while measuring reads.
+
+Each page receives one warmup and ten timed HTML requests. The script then
+fetches the distinct JavaScript URLs in the HTML's script elements. The byte
+counts are decoded source bytes, including the polyfill script; they are
+neither compressed transfer bytes nor all the code that later navigation
+might load. Asset-fetch duration is a loopback HTTP measurement, not page
+rendering time. Settings receive 20 additional serial reads.
+
+CPU is the change in the web server process's user/system ticks from
+`/proc/PID/stat`; `SC_CLK_TCK=100` was verified on this Pod. Percentages refer
+to one CPU core. RSS comes from `/proc/PID/status`, not the systemd cgroup's
+memory total. Background processing and normal app services stay active.
+
+The initial post-deployment run includes startup activity in its idle sample;
+the second run of `40fab93` checks behavior after warming. Two final complete
+runs verify the deployed coverage cleanup, including a run after sensor
+startup completed. One baseline and these short
+post-deployment runs cannot establish long-term resource use or isolate every
+source of variation. Deployment also moved the application to `/persistent`
+because root had only 141 MB free; its dependencies remain in their previous
+location.
+
+The first `38e0695` run included a 723.48 ms status request around
+00:36:12 UTC. At that time the journal recorded `no NATS server after 60s`
+and the switch to RAW-file input. This is a temporal correlation, not a
+profile proving causation. The sample is retained in
+[final-after.json](web-service-2026-09-06/final-after.json); it is not removed
+from that run's statistics. The additional settled run separates this startup
+phase from ordinary polling. No NATS configuration or sensor service was
+changed to improve the benchmark.
+
+## Reproduce
+
+Copy the benchmark to the Pod, close test browser tabs, and wait for
+`/api/health/dac-monitor` to report `running`. On this Pod, run:
+
+```sh
+/usr/local/bin/node benchmark.mjs http://127.0.0.1:3000 sample /persistent/sample.json
+```
+
+Use Node 22 or newer. The script reads the `sleepypod` systemd service's PID
+and assumes Linux with 100 clock ticks per second for its CPU calculation.
+Keep the existing services and workload consistent between runs. It performs
+HTTP queries and a sensor subscription; it does not send temperature, power,
+or other control commands.
+
+## Deployment and verification
+
+The exact successful push-workflow artifacts were used: [initial build
+33994517223](https://github.com/sleepypod/core/actions/runs/33994517223) and
+[coverage follow-up 34001504070](https://github.com/sleepypod/core/actions/runs/34001504070).
+Build caches were omitted from deployment. The current application path
+points to `/persistent/sleepypod-releases/38e0695`; the original installation
+is retained at `/home/dac/sleepypod-core.before-web-perf-40fab93` and supplies
+the shared `node_modules`. Keep that directory while either release depends
+on it. The previous performance release remains available at
+`/persistent/sleepypod-releases/40fab93`.
+
+The database paths, service configuration, and environment were preserved.
+Only the web service was restarted. Hardware reconnected, all 356 scheduled
+jobs loaded, and frank plus all five biometrics/sensor sidecars stayed active.
+System health reported an intact firewall and no schedule drift. The live
+browser smoke check loaded Overview, Thermal, Biometrics, and Sensors; the
+deferred charts rendered, live sensors updated, and no browser console
+errors appeared. That browser check used `40fab93`; the follow-up only
+simplifies equivalent server cache branches and adds regression coverage.
+
+The subagent reproduced the Codecov findings, removed a redundant outer
+Wi-Fi catch (all probe helpers already catch failures), and consolidated the
+status fallback into one branch so V8 records it correctly. It also added a
+regression test for requests before the monitor starts. The focused suite
+passed 125 tests; Wi-Fi coverage and device-router branch coverage both
+reached 100%. The [linked Codecov
+report](https://github.com/sleepypod/core/pull/693#issuecomment-5555069198)
+now reports all modified, coverable lines covered. CI tests, lint,
+TypeScript, both production builds, and local pre-push gates passed for
+`38e0695`.

--- a/docs/performance/web-service-2026-09-06/before.json
+++ b/docs/performance/web-service-2026-09-06/before.json
@@ -1,0 +1,160 @@
+{
+  "label": "before",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T00:20:27.927Z",
+  "node": "v22.17.0",
+  "pid": "397",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.",
+  "idle": {
+    "durationSec": 15.02,
+    "cpuPercentOneCore": 13.52,
+    "rssMiBStart": 168.6,
+    "rssMiBEnd": 171.61
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 99.43,
+    "p95Ms": 106.52,
+    "maxMs": 143.69,
+    "meanMs": 100.74
+  },
+  "statusSamplesMs": [
+    95.65,
+    105.08,
+    143.69,
+    105.87,
+    104.89,
+    102.7,
+    104.97,
+    103.78,
+    96.32,
+    99.07,
+    106.52,
+    102.48,
+    102.47,
+    102.67,
+    112.22,
+    99.68,
+    99.97,
+    103.82,
+    98.13,
+    99.16,
+    96.75,
+    100.32,
+    97.02,
+    100.12,
+    102.59,
+    103.98,
+    102.6,
+    103.26,
+    103.53,
+    106.37,
+    97.67,
+    99.96,
+    95.38,
+    98.75,
+    99.57,
+    98.37,
+    98.98,
+    98.49,
+    93.69,
+    96.95,
+    93.53,
+    96.74,
+    95.13,
+    98.28,
+    103.79,
+    98.27,
+    96.55,
+    94.12,
+    99.43,
+    94.48,
+    97.78,
+    100.78,
+    96.54,
+    96.35,
+    103.14,
+    108.8,
+    92.9,
+    104.86,
+    92.39,
+    97.26
+  ],
+  "active": {
+    "durationSec": 30.02,
+    "cpuPercentOneCore": 25.18,
+    "rssMiBStart": 168.14,
+    "rssMiBEnd": 178.15
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 246.64,
+    "p95Ms": 366.33,
+    "maxMs": 375.52,
+    "meanMs": 257.44
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 96.05,
+    "p95Ms": 162.89,
+    "maxMs": 162.89,
+    "meanMs": 101.49
+  },
+  "burst": {
+    "durationSec": 7.88,
+    "cpuPercentOneCore": 62.2,
+    "rssMiBStart": 178.15,
+    "rssMiBEnd": 193.11
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 44.44,
+        "p95Ms": 84.5,
+        "maxMs": 84.5,
+        "meanMs": 48.26
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 729457,
+      "fetchAllInitialJsMs": 407.11
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 35.02,
+        "p95Ms": 40.3,
+        "maxMs": 40.3,
+        "meanMs": 35.94
+      },
+      "htmlBytes": 24660,
+      "initialJsFiles": 16,
+      "initialJsDecodedBytes": 1279395,
+      "fetchAllInitialJsMs": 374.48
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 30.8,
+    "p95Ms": 36.38,
+    "maxMs": 41.84,
+    "meanMs": 31.59
+  },
+  "websocket": {
+    "frames": 43,
+    "gaps": {
+      "n": 42,
+      "medianMs": 1000.12,
+      "p95Ms": 1193.83,
+      "maxMs": 1299.78,
+      "meanMs": 1003.78
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "finishedAt": "2026-09-06T00:21:27.136Z"
+}

--- a/docs/performance/web-service-2026-09-06/benchmark.mjs
+++ b/docs/performance/web-service-2026-09-06/benchmark.mjs
@@ -1,0 +1,105 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const [base = 'http://127.0.0.1:3000', label = 'sample', destination] = process.argv.slice(2)
+const pid = process.env.APP_PID || (base.includes('127.0.0.1') ? execFileSync('systemctl', ['show', 'sleepypod', '-p', 'MainPID', '--value'], { encoding: 'utf8' }).trim() : null)
+const round = n => Math.round(n * 100) / 100
+const stats = (values) => {
+  const sorted = [...values].sort((a, b) => a - b)
+  return { n: values.length, medianMs: round(sorted[Math.ceil(sorted.length * 0.5) - 1]), p95Ms: round(sorted[Math.ceil(sorted.length * 0.95) - 1]), maxMs: round(sorted.at(-1)), meanMs: round(values.reduce((a, b) => a + b, 0) / values.length) }
+}
+function resource() {
+  if (!pid) return null
+  const fields = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ')
+  const status = readFileSync(`/proc/${pid}/status`, 'utf8')
+  return { t: performance.now(), cpuTicks: Number(fields[11]) + Number(fields[12]), rssKiB: Number(status.match(/VmRSS:\s+(\d+)/)[1]) }
+}
+function usage(a, b) {
+  return a && b ? { durationSec: round((b.t - a.t) / 1000), cpuPercentOneCore: round((b.cpuTicks - a.cpuTicks) * 1000 / (b.t - a.t)), rssMiBStart: round(a.rssKiB / 1024), rssMiBEnd: round(b.rssKiB / 1024) } : null
+}
+async function request(path, json = false, extra = {}) {
+  const start = performance.now()
+  const response = await fetch(base + path, { signal: AbortSignal.timeout(20000), ...extra })
+  const headersMs = performance.now() - start
+  const body = await response.text()
+  if (!response.ok) throw new Error(`${path}: HTTP ${response.status}: ${body.slice(0, 200)}`)
+  if (json && JSON.parse(body).error) throw new Error(`${path}: returned tRPC error`)
+  return { ms: performance.now() - start, headersMs, body }
+}
+const statusPath = '/api/trpc/device.getStatus?input=' + encodeURIComponent(JSON.stringify({ json: { unit: 'F' } }))
+const settingsPath = '/api/trpc/settings.getAll?input=' + encodeURIComponent(JSON.stringify({ json: {} }))
+const healthPath = '/api/health/dac-monitor'
+const result = { label, base, startedAt: new Date().toISOString(), node: process.version, pid, methodology: '15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.' }
+console.log(JSON.stringify({ event: 'start', label, pid }))
+const idleStart = resource()
+await delay(15000)
+result.idle = usage(idleStart, resource())
+console.log(JSON.stringify({ event: 'idle', ...result.idle }))
+const socketUrl = new URL(base)
+socketUrl.protocol = 'ws:'
+socketUrl.port = '3001'
+const socket = new WebSocket(socketUrl)
+const frames = []
+socket.addEventListener('message', (event) => {
+  const data = JSON.parse(event.data)
+  if (data.type === 'deviceStatus') frames.push(performance.now())
+})
+await Promise.race([
+  new Promise((resolve, reject) => {
+    socket.addEventListener('open', resolve, { once: true })
+    socket.addEventListener('error', reject, { once: true })
+  }),
+  delay(10000).then(() => { throw new Error('WebSocket connect timed out') }),
+])
+socket.send(JSON.stringify({ type: 'subscribe', sensors: ['deviceStatus'] }))
+try {
+  await delay(2500)
+  for (let i = 0; i < 3; i++) {
+    await request(statusPath, true)
+    await request(settingsPath, true)
+  }
+  const activeStart = resource()
+  const serial = []
+  for (let i = 0; i < 60; i++) {
+    const start = performance.now()
+    serial.push((await request(statusPath, true)).ms)
+    await delay(Math.max(0, 500 - (performance.now() - start)))
+  }
+  result.status = stats(serial)
+  result.statusSamplesMs = serial.map(round)
+  result.active = usage(activeStart, resource())
+  console.log(JSON.stringify({ event: 'serial', ...result.status, ...result.active }))
+  const concurrent = [], health = []
+  const burstStart = resource()
+  for (let i = 0; i < 12; i++) {
+    const rows = await Promise.all([request(statusPath, true), request(statusPath, true), request(statusPath, true), request(statusPath, true), request(healthPath, true)])
+    concurrent.push(...rows.slice(0, 4).map(row => row.ms))
+    health.push(rows[4].ms)
+    await delay(300)
+  }
+  result.concurrentStatus = stats(concurrent)
+  result.concurrentHealth = stats(health)
+  result.burst = usage(burstStart, resource())
+  result.pages = {}
+  for (const path of ['/en', '/en/debug']) {
+    await request(path)
+    const rows = []
+    for (let i = 0; i < 10; i++) rows.push(await request(path))
+    const scripts = [...new Set([...rows.at(-1).body.matchAll(/<script\b[^>]*\bsrc="([^" ]+\.js(?:\?[^" ]*)?)"/g)].map(m => m[1]))]
+    const assetStart = performance.now()
+    const sizes = await Promise.all(scripts.map(async path => Buffer.byteLength((await request(path)).body)))
+    result.pages[path] = { html: stats(rows.map(row => row.ms)), htmlBytes: Buffer.byteLength(rows.at(-1).body), initialJsFiles: scripts.length, initialJsDecodedBytes: sizes.reduce((a, b) => a + b, 0), fetchAllInitialJsMs: round(performance.now() - assetStart) }
+  }
+  const settings = []
+  for (let i = 0; i < 20; i++) settings.push((await request(settingsPath, true)).ms)
+  result.settings = stats(settings)
+  result.websocket = { frames: frames.length, gaps: frames.length > 1 ? stats(frames.slice(1).map((t, i) => t - frames[i])) : null }
+  result.health = JSON.parse((await request(healthPath, true)).body)
+  result.finishedAt = new Date().toISOString()
+  if (destination) writeFileSync(destination, JSON.stringify(result, null, 2) + '\n')
+  console.log(JSON.stringify({ event: 'complete', ...result }))
+}
+finally {
+  socket.close()
+}

--- a/docs/performance/web-service-2026-09-06/final-after.json
+++ b/docs/performance/web-service-2026-09-06/final-after.json
@@ -1,0 +1,160 @@
+{
+  "label": "final-38e0695",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T00:35:30.755Z",
+  "node": "v22.17.0",
+  "pid": "3035",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.",
+  "idle": {
+    "durationSec": 15.01,
+    "cpuPercentOneCore": 9.99,
+    "rssMiBStart": 173.54,
+    "rssMiBEnd": 158.91
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 45.05,
+    "p95Ms": 75.05,
+    "maxMs": 723.48,
+    "meanMs": 60.09
+  },
+  "statusSamplesMs": [
+    48.02,
+    60.44,
+    80.28,
+    60.58,
+    54.21,
+    56.62,
+    48.08,
+    46.91,
+    50.36,
+    43.7,
+    39.66,
+    48.29,
+    50.08,
+    50.96,
+    47.99,
+    45.2,
+    49.2,
+    44.62,
+    41.36,
+    44.12,
+    42.02,
+    44.08,
+    43.35,
+    45.05,
+    44.32,
+    43.93,
+    44.14,
+    46.3,
+    44.91,
+    44.45,
+    48.13,
+    44.86,
+    49.15,
+    48.37,
+    43.59,
+    43.19,
+    44.28,
+    47.73,
+    46.91,
+    43.88,
+    45.18,
+    47.49,
+    48.16,
+    43.34,
+    45.98,
+    43.59,
+    47.57,
+    723.48,
+    136.8,
+    37.91,
+    44.32,
+    43.93,
+    44.47,
+    43.61,
+    43.56,
+    43.92,
+    44.49,
+    46.18,
+    43.24,
+    75.05
+  ],
+  "active": {
+    "durationSec": 30.25,
+    "cpuPercentOneCore": 24.03,
+    "rssMiBStart": 158.86,
+    "rssMiBEnd": 173.98
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 88.11,
+    "p95Ms": 137.19,
+    "maxMs": 152.68,
+    "meanMs": 89.04
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 144.66,
+    "p95Ms": 173.17,
+    "maxMs": 173.17,
+    "meanMs": 149.65
+  },
+  "burst": {
+    "durationSec": 5.53,
+    "cpuPercentOneCore": 61.5,
+    "rssMiBStart": 173.98,
+    "rssMiBEnd": 181.15
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 54.73,
+        "p95Ms": 94.2,
+        "maxMs": 94.2,
+        "meanMs": 61.22
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 282.36
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 35.49,
+        "p95Ms": 60.92,
+        "maxMs": 60.92,
+        "meanMs": 38.46
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 228.2
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 30.38,
+    "p95Ms": 38.79,
+    "maxMs": 53.28,
+    "meanMs": 32.35
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 1001.2,
+      "p95Ms": 1109.48,
+      "maxMs": 1816.36,
+      "meanMs": 1019
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "finishedAt": "2026-09-06T00:36:27.549Z"
+}

--- a/docs/performance/web-service-2026-09-06/final-warm-after.json
+++ b/docs/performance/web-service-2026-09-06/final-warm-after.json
@@ -1,0 +1,160 @@
+{
+  "label": "final-warm-38e0695",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T00:38:08.017Z",
+  "node": "v22.17.0",
+  "pid": "3035",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.",
+  "idle": {
+    "durationSec": 15.02,
+    "cpuPercentOneCore": 13.65,
+    "rssMiBStart": 185.08,
+    "rssMiBEnd": 186.4
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 40.06,
+    "p95Ms": 45.94,
+    "maxMs": 51.28,
+    "meanMs": 40.82
+  },
+  "statusSamplesMs": [
+    34.74,
+    44.6,
+    51.28,
+    49.09,
+    38.9,
+    41.31,
+    43.28,
+    45.58,
+    41.25,
+    42.12,
+    33.58,
+    44.59,
+    49.96,
+    41.82,
+    38.89,
+    43.35,
+    41.15,
+    39.37,
+    42.19,
+    35.08,
+    42.53,
+    41.22,
+    39.1,
+    40.23,
+    42.24,
+    39.92,
+    41.21,
+    39.67,
+    41.2,
+    43.47,
+    38.02,
+    40.04,
+    39.3,
+    39.7,
+    40.76,
+    39.32,
+    40.05,
+    39.98,
+    38.32,
+    36.88,
+    39.22,
+    38.6,
+    40.57,
+    45.94,
+    42.23,
+    40.3,
+    38.82,
+    37.7,
+    40.06,
+    42.68,
+    39.28,
+    39.21,
+    44.31,
+    40.29,
+    38.17,
+    39.42,
+    39.21,
+    42.2,
+    37.49,
+    38.12
+  ],
+  "active": {
+    "durationSec": 30.02,
+    "cpuPercentOneCore": 20.25,
+    "rssMiBStart": 186.63,
+    "rssMiBEnd": 186.34
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 82.04,
+    "p95Ms": 121.57,
+    "maxMs": 151.79,
+    "meanMs": 79.87
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 131.78,
+    "p95Ms": 168.32,
+    "maxMs": 168.32,
+    "meanMs": 133.51
+  },
+  "burst": {
+    "durationSec": 5.33,
+    "cpuPercentOneCore": 52.31,
+    "rssMiBStart": 186.34,
+    "rssMiBEnd": 186.29
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 45.4,
+        "p95Ms": 50.29,
+        "maxMs": 50.29,
+        "meanMs": 45.69
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 428.3
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 34.13,
+        "p95Ms": 46.39,
+        "maxMs": 46.39,
+        "meanMs": 35.64
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 274.13
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 29.33,
+    "p95Ms": 36.12,
+    "maxMs": 38.16,
+    "meanMs": 30.36
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 1000.55,
+      "p95Ms": 1035.98,
+      "maxMs": 1058.62,
+      "meanMs": 1004.34
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "finishedAt": "2026-09-06T00:39:03.868Z"
+}

--- a/docs/performance/web-service-2026-09-06/initial-after.json
+++ b/docs/performance/web-service-2026-09-06/initial-after.json
@@ -1,0 +1,160 @@
+{
+  "label": "after",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T00:23:51.866Z",
+  "node": "v22.17.0",
+  "pid": "2288",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.",
+  "idle": {
+    "durationSec": 15.02,
+    "cpuPercentOneCore": 23.31,
+    "rssMiBStart": 153.62,
+    "rssMiBEnd": 170.3
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 44.36,
+    "p95Ms": 52.95,
+    "maxMs": 83.07,
+    "meanMs": 46.26
+  },
+  "statusSamplesMs": [
+    48.21,
+    48.83,
+    83.07,
+    52.95,
+    55.47,
+    52.6,
+    51.1,
+    49.31,
+    48.45,
+    44.34,
+    52.29,
+    45.29,
+    44.36,
+    48.54,
+    46.47,
+    44.42,
+    44.17,
+    45.1,
+    74.56,
+    43.14,
+    47.7,
+    46.94,
+    43.93,
+    43.65,
+    44.31,
+    46.93,
+    44.38,
+    44.52,
+    42.61,
+    41.78,
+    42.98,
+    42.61,
+    45.87,
+    41.65,
+    42.27,
+    41.97,
+    43.85,
+    49.92,
+    42.66,
+    42.4,
+    44.04,
+    48.13,
+    41.99,
+    42.19,
+    48.18,
+    42.16,
+    43.68,
+    46.3,
+    41.47,
+    43.18,
+    42.75,
+    42.52,
+    42.59,
+    44.87,
+    45.58,
+    35.83,
+    45.66,
+    42.55,
+    44.58,
+    41.66
+  ],
+  "active": {
+    "durationSec": 30.01,
+    "cpuPercentOneCore": 16.06,
+    "rssMiBStart": 172.94,
+    "rssMiBEnd": 176.82
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 91.8,
+    "p95Ms": 158.59,
+    "maxMs": 186.19,
+    "meanMs": 89.06
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 141.7,
+    "p95Ms": 203.07,
+    "maxMs": 203.07,
+    "meanMs": 151.41
+  },
+  "burst": {
+    "durationSec": 5.55,
+    "cpuPercentOneCore": 59.51,
+    "rssMiBStart": 176.82,
+    "rssMiBEnd": 176.72
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 44,
+        "p95Ms": 75.69,
+        "maxMs": 75.69,
+        "meanMs": 48.4
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 265.43
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 35.81,
+        "p95Ms": 55,
+        "maxMs": 55,
+        "meanMs": 38.57
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 265.36
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 31.3,
+    "p95Ms": 35,
+    "maxMs": 42.73,
+    "meanMs": 31.95
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 999.94,
+      "p95Ms": 1045.88,
+      "maxMs": 1126.11,
+      "meanMs": 1004.27
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "finishedAt": "2026-09-06T00:24:48.289Z"
+}

--- a/docs/performance/web-service-2026-09-06/warm-after.json
+++ b/docs/performance/web-service-2026-09-06/warm-after.json
@@ -1,0 +1,160 @@
+{
+  "label": "after-warm",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T00:25:27.977Z",
+  "node": "v22.17.0",
+  "pid": "2288",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering.",
+  "idle": {
+    "durationSec": 15.02,
+    "cpuPercentOneCore": 13.78,
+    "rssMiBStart": 190.27,
+    "rssMiBEnd": 192.19
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 39.11,
+    "p95Ms": 45.06,
+    "maxMs": 51.96,
+    "meanMs": 39.85
+  },
+  "statusSamplesMs": [
+    38.14,
+    51.96,
+    45.06,
+    43.39,
+    39.39,
+    42.58,
+    44.47,
+    38.95,
+    40.03,
+    41.63,
+    42.82,
+    44.85,
+    46.78,
+    42.41,
+    39.19,
+    41.97,
+    38.98,
+    39.01,
+    39.74,
+    38.26,
+    50.87,
+    39.13,
+    39.53,
+    39.45,
+    36.41,
+    38.25,
+    38.92,
+    39.16,
+    39.09,
+    39.11,
+    38.63,
+    38.32,
+    38.82,
+    37.99,
+    36.37,
+    39.41,
+    38.38,
+    41.65,
+    38.38,
+    37.55,
+    36.18,
+    37.4,
+    36.76,
+    37.27,
+    40.49,
+    39.22,
+    44.59,
+    37.58,
+    37.96,
+    34.85,
+    37.18,
+    38.5,
+    36.54,
+    35.96,
+    35.37,
+    39.49,
+    39.88,
+    39.39,
+    41.07,
+    40.38
+  ],
+  "active": {
+    "durationSec": 30.01,
+    "cpuPercentOneCore": 20.79,
+    "rssMiBStart": 191.02,
+    "rssMiBEnd": 191.71
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 78,
+    "p95Ms": 123,
+    "maxMs": 176.02,
+    "meanMs": 80.01
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 129.97,
+    "p95Ms": 192.93,
+    "maxMs": 192.93,
+    "meanMs": 135.29
+  },
+  "burst": {
+    "durationSec": 5.36,
+    "cpuPercentOneCore": 49.3,
+    "rssMiBStart": 191.71,
+    "rssMiBEnd": 190.96
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 40.43,
+        "p95Ms": 54.15,
+        "maxMs": 54.15,
+        "meanMs": 41.84
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 243.26
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 32.65,
+        "p95Ms": 41.67,
+        "maxMs": 41.67,
+        "meanMs": 34.39
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 232.74
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 28.41,
+    "p95Ms": 33.92,
+    "maxMs": 34.46,
+    "meanMs": 29.47
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 1000.67,
+      "p95Ms": 1047.49,
+      "maxMs": 1059.22,
+      "meanMs": 1003.4
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "finishedAt": "2026-09-06T00:26:23.504Z"
+}

--- a/src/components/diagnostics/DiagnosticsConsole.tsx
+++ b/src/components/diagnostics/DiagnosticsConsole.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
 import { usePathname } from 'next/navigation'
 import {
   Activity,
@@ -27,8 +28,6 @@ import { useSideNames } from '@/src/hooks/useSideNames'
 import { useWeekNavigator } from '@/src/hooks/useWeekNavigator'
 import { DataTable, type Column } from '@/src/ui/data-table'
 import { useTrendBuffer } from '@/src/hooks/useTrendBuffer'
-import { ThermalTrendChart } from '@/src/components/diagnostics/ThermalTrendChart'
-import { BiometricsTrendChart } from '@/src/components/diagnostics/BiometricsTrendChart'
 import {
   fmtF, fmtAge, fmtMs, fmtNum, fmtRel, fmtClock, fmtDayLabel,
   VERDICT_STYLES, buildWeekLanes, jobTone, fmtJobValue, biometricsFlowStatus, thermalTrendPoints,
@@ -40,7 +39,22 @@ import { InternetToggleCard } from '@/src/components/status/InternetToggleCard'
 import { UpdateCard } from '@/src/components/status/UpdateCard'
 import { SystemLogViewer } from '@/src/components/status/SystemLogViewer'
 import { FirmwareLogConsole } from '@/src/components/Sensors/FirmwareLogConsole'
-import { SensorsScreen } from '@/src/components/Sensors/SensorsScreen'
+
+// These panels are hidden on the initial Overview tab. Load their chart and
+// sensor dependencies only when the corresponding section is opened.
+const ThermalTrendChart = dynamic(() => import('./ThermalTrendChart').then(m => m.ThermalTrendChart), {
+  loading: PanelLoading,
+})
+const BiometricsTrendChart = dynamic(() => import('./BiometricsTrendChart').then(m => m.BiometricsTrendChart), {
+  loading: PanelLoading,
+})
+const SensorsScreen = dynamic(() => import('../Sensors/SensorsScreen').then(m => m.SensorsScreen), {
+  loading: PanelLoading,
+})
+
+function PanelLoading() {
+  return <div role="status" className="flex min-h-48 items-center justify-center text-xs text-zinc-500">Loading…</div>
+}
 
 // Formatting, scheduler-lane, and biometrics/thermal derivations live in
 // ./diagnosticsLogic so they can be unit-tested without React/tRPC.

--- a/src/hardware/dacMonitor.ts
+++ b/src/hardware/dacMonitor.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { HardwareClient } from './client'
 import { type DeviceStatus, type GestureData, type Side } from './types'
+import { getStatusRevision } from './statusRevision'
 
 export type DacMonitorStatus = 'stopped' | 'starting' | 'running' | 'degraded'
 
@@ -60,6 +61,8 @@ export class DacMonitor extends EventEmitter {
   private intervalHandle: ReturnType<typeof setInterval> | null = null
   private monitorStatus: DacMonitorStatus = 'stopped'
   private lastStatus: DeviceStatus | null = null
+  private lastPollStartedAt: number | null = null
+  private lastStatusRevision: number | null = null
   private lastGestures: GestureData | null = null
   private isFirstPoll = true
   private isPollInFlight = false
@@ -75,6 +78,15 @@ export class DacMonitor extends EventEmitter {
   getStatus = (): DacMonitorStatus => this.monitorStatus
 
   getLastStatus = (): DeviceStatus | null => this.lastStatus
+
+  /** Only reuse a recent, healthy observation with no intervening hardware writes. */
+  getFreshStatus = (maxAgeMs: number): DeviceStatus | null => {
+    if (this.monitorStatus !== 'running' || !this.client?.isConnected() || this.lastPollStartedAt === null) return null
+    const age = Date.now() - this.lastPollStartedAt
+    if (age < 0 || age >= maxAgeMs) return null
+    if (this.lastStatusRevision === null || this.lastStatusRevision !== getStatusRevision()) return null
+    return this.lastStatus
+  }
 
   /** Change the poll interval while running. Restarts the interval timer. */
   setPollInterval = (ms: number): void => {
@@ -102,6 +114,8 @@ export class DacMonitor extends EventEmitter {
     if (this.monitorStatus !== 'stopped') return
 
     this.monitorStatus = 'starting'
+    this.lastPollStartedAt = null
+    this.lastStatusRevision = null
     this.isFirstPoll = true
     this.lastGestures = null
     this.isPollInFlight = false
@@ -158,6 +172,10 @@ export class DacMonitor extends EventEmitter {
     if (!client || this.monitorStatus === 'stopped') return
 
     try {
+      // Capture before awaiting: a slow read or one overlapping a write must
+      // not be stamped as a fresh post-write observation when it completes.
+      const startedAt = Date.now()
+      const revision = getStatusRevision()
       const status = await client.getDeviceStatus()
 
       // Discard results if stop() ran while we were awaiting.
@@ -172,6 +190,8 @@ export class DacMonitor extends EventEmitter {
       }
 
       this.lastStatus = status
+      this.lastPollStartedAt = startedAt
+      this.lastStatusRevision = revision
       this.emit('status:updated', status)
 
       if (status.gestures) {

--- a/src/hardware/dacTransport.ts
+++ b/src/hardware/dacTransport.ts
@@ -293,9 +293,9 @@ class DacTransport {
     if (!this.socket.destroyed) this.socket.destroy()
   }
 
-  public static fromSocket(socket: Socket) {
+  public static fromSocket(socket: Socket, sequentialQueue: SequentialQueue) {
     const messageStream = new MessageStream(socket, SEPARATOR)
-    return new DacTransport(socket, messageStream, new SequentialQueue())
+    return new DacTransport(socket, messageStream, sequentialQueue)
   }
 
   private async write(data: Buffer) {
@@ -312,10 +312,10 @@ class DacServer {
     await this.listener.close()
   }
 
-  public async waitForConnection(): Promise<DacTransport> {
+  public async waitForConnection(sequentialQueue: SequentialQueue): Promise<DacTransport> {
     const socket = await this.listener.waitForConnection()
     console.log('[DAC] frankenfirmware connected')
-    return DacTransport.fromSocket(socket)
+    return DacTransport.fromSocket(socket, sequentialQueue)
   }
 
   public static async start(path: string) {
@@ -395,14 +395,24 @@ function withTimeout<T>(promise: Promise<T>, onTimeout: () => Error): Promise<T>
   })
 }
 
-// ─── Module-level state ──────────────────────────────────────────────────────
+// ─── Process-wide state ──────────────────────────────────────────────────────
 
-let dacServer: DacServer | undefined
-let transport: DacTransport | undefined
-let connectPromise: Promise<DacTransport> | undefined
+interface DacState {
+  dacServer?: DacServer
+  transport?: DacTransport
+  connectPromise?: Promise<DacTransport>
+  sequentialQueue: SequentialQueue
+}
+
+// Next.js can evaluate this module separately for instrumentation and routes.
+// Share ownership of the listener, connection, and queue across those bundles.
+const g = globalThis as Record<string, unknown>
+const state = (g.__sp_dac_transport__ ??= {
+  sequentialQueue: new SequentialQueue(),
+}) as DacState
 
 function waitWithTimeout(server: DacServer) {
-  return withTimeout(server.waitForConnection(), () => {
+  return withTimeout(server.waitForConnection(state.sequentialQueue), () => {
     console.warn(`[DAC] restarting after ${connectionTimeoutMs() / 1_000}s timeout`)
     return new ConnectionTimeoutError()
   })
@@ -411,11 +421,11 @@ function waitWithTimeout(server: DacServer) {
 async function shutdown() {
   // A snapshot from the old connection must not survive a reconnect.
   beginStatusChange()()
-  transport?.close()
-  transport = undefined
-  if (dacServer) {
-    await dacServer.close()
-    dacServer = undefined
+  state.transport?.close()
+  state.transport = undefined
+  if (state.dacServer) {
+    await state.dacServer.close()
+    state.dacServer = undefined
   }
 }
 
@@ -426,23 +436,23 @@ async function shutdown() {
  * Retries with server recreation on timeout.
  */
 export async function connectDac(socketPath: string): Promise<void> {
-  if (transport) return
-  if (connectPromise) {
-    await connectPromise
+  if (state.transport) return
+  if (state.connectPromise) {
+    await state.connectPromise
     return
   }
 
-  connectPromise = (async () => {
+  state.connectPromise = (async () => {
     let timeoutAttempts = 0
     while (true) {
-      if (!dacServer) {
-        dacServer = await DacServer.start(socketPath)
+      if (!state.dacServer) {
+        state.dacServer = await DacServer.start(socketPath)
       }
 
       try {
-        transport = await waitWithTimeout(dacServer)
+        state.transport = await waitWithTimeout(state.dacServer)
         console.log('[DAC] connected')
-        return transport
+        return state.transport
       }
       catch (error) {
         if (error instanceof ConnectionTimeoutError) {
@@ -464,10 +474,10 @@ export async function connectDac(socketPath: string): Promise<void> {
   })()
 
   try {
-    await connectPromise
+    await state.connectPromise
   }
   finally {
-    connectPromise = undefined
+    state.connectPromise = undefined
   }
 }
 
@@ -479,7 +489,7 @@ export async function connectDac(socketPath: string): Promise<void> {
  * @returns Raw response string from firmware
  */
 export async function sendCommand(command: string, arg?: string): Promise<string> {
-  if (!transport) {
+  if (!state.transport) {
     throw new Error('[DAC] not connected — call connectDac() first')
   }
 
@@ -488,8 +498,8 @@ export async function sendCommand(command: string, arg?: string): Promise<string
   const finish = command === '0' || command === '14' ? undefined : beginStatusChange()
   try {
     return await (arg === undefined || arg === ''
-      ? transport.sendMessage(command)
-      : transport.callFunction(command, arg))
+      ? state.transport.sendMessage(command)
+      : state.transport.callFunction(command, arg))
   }
   finally {
     finish?.()
@@ -500,7 +510,7 @@ export async function sendCommand(command: string, arg?: string): Promise<string
  * Disconnect and tear down.
  */
 export async function disconnectDac(): Promise<void> {
-  connectPromise = undefined
+  state.connectPromise = undefined
   await shutdown()
 }
 
@@ -508,5 +518,5 @@ export async function disconnectDac(): Promise<void> {
  * Check if frankenfirmware is currently connected.
  */
 export function isDacConnected(): boolean {
-  return transport !== undefined
+  return state.transport !== undefined
 }

--- a/src/hardware/dacTransport.ts
+++ b/src/hardware/dacTransport.ts
@@ -17,6 +17,7 @@ import { unlink } from 'fs/promises'
 import { createServer, type Server, type Socket } from 'net'
 import split from 'binary-split'
 import type { Transform } from 'stream'
+import { beginStatusChange } from './statusRevision'
 
 // ─── Utilities ───────────────────────────────────────────────────────────────
 
@@ -408,6 +409,8 @@ function waitWithTimeout(server: DacServer) {
 }
 
 async function shutdown() {
+  // A snapshot from the old connection must not survive a reconnect.
+  beginStatusChange()()
   transport?.close()
   transport = undefined
   if (dacServer) {
@@ -480,11 +483,17 @@ export async function sendCommand(command: string, arg?: string): Promise<string
     throw new Error('[DAC] not connected — call connectDac() first')
   }
 
-  if (arg === undefined || arg === '') {
-    return transport.sendMessage(command)
+  // HELLO and DEVICE_STATUS are read-only. Invalidate for every other command,
+  // including raw commands and writes from HomeKit, gestures, and the scheduler.
+  const finish = command === '0' || command === '14' ? undefined : beginStatusChange()
+  try {
+    return await (arg === undefined || arg === ''
+      ? transport.sendMessage(command)
+      : transport.callFunction(command, arg))
   }
-
-  return transport.callFunction(command, arg)
+  finally {
+    finish?.()
+  }
 }
 
 /**

--- a/src/hardware/dacTransport.ts
+++ b/src/hardware/dacTransport.ts
@@ -445,9 +445,8 @@ export async function connectDac(socketPath: string): Promise<void> {
   state.connectPromise = (async () => {
     let timeoutAttempts = 0
     while (true) {
-      if (!state.dacServer) {
-        state.dacServer = await DacServer.start(socketPath)
-      }
+      // Failed attempts close their listener before retrying.
+      state.dacServer = await DacServer.start(socketPath)
 
       try {
         state.transport = await waitWithTimeout(state.dacServer)

--- a/src/hardware/sharedClient.ts
+++ b/src/hardware/sharedClient.ts
@@ -140,11 +140,8 @@ class DacHardwareClient {
     return isDacConnected()
   }
 
-  // DEBUG passthrough for device.execute. Lives on the client (not as a
-  // free function) so the call binds to the same `dacTransport` module
-  // instance that owns the live `transport` singleton — importing
-  // sendCommand directly into a route handler can resolve to a separate
-  // Next.js bundle whose `transport` is undefined.
+  // DEBUG passthrough for device.execute. Keep connection setup and raw
+  // commands on the shared client, alongside the typed hardware operations.
   async sendRaw(command: string, args?: string): Promise<string> {
     if (!isDacConnected()) {
       await connectDac(DAC_SOCK_PATH)

--- a/src/hardware/statusRevision.ts
+++ b/src/hardware/statusRevision.ts
@@ -1,0 +1,24 @@
+/** Shared across Next.js bundles so every hardware writer invalidates cached reads. */
+const g = globalThis as Record<string, unknown>
+const KEY = '__sp_status_revision__'
+
+function state(): { revision: number, pending: number } {
+  return (g[KEY] ??= { revision: 0, pending: 0 }) as { revision: number, pending: number }
+}
+
+/** A null revision means a write is queued or running: no snapshot is reusable. */
+export function getStatusRevision(): number | null {
+  const s = state()
+  return s.pending === 0 ? s.revision : null
+}
+
+/** Invalidate before and after a write, including failed/partially applied writes. */
+export function beginStatusChange(): () => void {
+  const s = state()
+  s.pending++
+  s.revision++
+  return () => {
+    s.pending--
+    s.revision++
+  }
+}

--- a/src/hardware/tests/dacMonitor.cache.test.ts
+++ b/src/hardware/tests/dacMonitor.cache.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DacMonitor } from '../dacMonitor'
+import type { HardwareClient } from '../client'
+import { parseDeviceStatus } from '../responseParser'
+import { DEVICE_STATUS_POD4 } from './fixtures'
+import { beginStatusChange } from '../statusRevision'
+
+const status = parseDeviceStatus(DEVICE_STATUS_POD4)
+
+describe('DacMonitor cached observations', () => {
+  const client = {
+    connect: vi.fn(), disconnect: vi.fn(), isConnected: vi.fn(), getDeviceStatus: vi.fn(),
+  }
+  let monitor: DacMonitor
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    client.connect.mockResolvedValue(undefined)
+    client.isConnected.mockReturnValue(true)
+    client.getDeviceStatus.mockReset().mockResolvedValue(status)
+    monitor = new DacMonitor({
+      socketPath: '/unused', pollIntervalMs: 100,
+      hardwareClient: client as unknown as HardwareClient,
+    })
+    monitor.on('error', () => {})
+    await monitor.start()
+  })
+
+  afterEach(() => {
+    monitor.stop()
+    vi.useRealTimers()
+  })
+
+  it('only returns observations younger than the requested age', async () => {
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    await vi.advanceTimersByTimeAsync(100)
+    const observedAt = Date.now()
+    expect(monitor.getFreshStatus(2_000)).toEqual(status)
+    vi.setSystemTime(observedAt + 1_999)
+    expect(monitor.getFreshStatus(2_000)).toEqual(status)
+    vi.setSystemTime(observedAt + 2_000)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    vi.setSystemTime(observedAt - 1)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+  })
+
+  it('rejects snapshots while disconnected, degraded, stopped, or restarting', async () => {
+    await vi.advanceTimersByTimeAsync(100)
+    client.isConnected.mockReturnValue(false)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    client.isConnected.mockReturnValue(true)
+    client.getDeviceStatus.mockRejectedValueOnce(new Error('socket lost'))
+    await vi.advanceTimersByTimeAsync(100)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(monitor.getFreshStatus(2_000)).toEqual(status)
+    monitor.stop()
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    await monitor.start()
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+  })
+
+  it('invalidates for overlapping writes and waits for a new observation afterwards', async () => {
+    await vi.advanceTimersByTimeAsync(100)
+    const finishFirst = beginStatusChange()
+    const finishSecond = beginStatusChange()
+    try {
+      expect(monitor.getFreshStatus(2_000)).toBeNull()
+      // A poll during a write is never a reusable snapshot.
+      await vi.advanceTimersByTimeAsync(100)
+      expect(monitor.getFreshStatus(2_000)).toBeNull()
+    }
+    finally {
+      finishFirst()
+      expect(monitor.getFreshStatus(2_000)).toBeNull()
+      finishSecond()
+    }
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(monitor.getFreshStatus(2_000)).toEqual(status)
+  })
+
+  it('does not restamp a slow read that overlaps a completed write', async () => {
+    let finishRead: (value: typeof status) => void = () => {}
+    client.getDeviceStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      finishRead = resolve
+    }))
+    await vi.advanceTimersByTimeAsync(100)
+    beginStatusChange()()
+    finishRead(status)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(monitor.getFreshStatus(2_000)).toEqual(status)
+  })
+
+  it('measures age from the beginning of a slow read', async () => {
+    let finishRead: (value: typeof status) => void = () => {}
+    client.getDeviceStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      finishRead = resolve
+    }))
+    await vi.advanceTimersByTimeAsync(100)
+    vi.setSystemTime(Date.now() + 2_000)
+    finishRead(status)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(monitor.getFreshStatus(2_000)).toBeNull()
+  })
+})

--- a/src/hardware/tests/dacTransport.test.ts
+++ b/src/hardware/tests/dacTransport.test.ts
@@ -11,7 +11,7 @@
  * 4. Reconnection: server recreates on timeout, accepts new connections
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { Socket } from 'net'
+import { Server, Socket } from 'net'
 import { getStatusRevision } from '../statusRevision'
 import { promises as fs } from 'fs'
 import {
@@ -427,6 +427,58 @@ describe('dacTransport', () => {
   })
 
   describe('connectDac re-entry', () => {
+    test('shares the listener, pending connection, and command queue across module instances', async () => {
+      vi.resetModules()
+      const duplicate = await import('../dacTransport')
+      expect(duplicate.connectDac).not.toBe(connectDac)
+      const listen = vi.spyOn(Server.prototype, 'listen')
+
+      const firstConnection = connectDac(socketPath)
+      const secondConnection = duplicate.connectDac(socketPath)
+      await vi.waitFor(() => fs.access(socketPath), { interval: 5 })
+      mockFranken = await connectAsFrankenfirmware(socketPath)
+      const franken = mockFranken
+      const requests: string[] = []
+      let buffer = ''
+      franken.on('data', (chunk) => {
+        buffer += chunk.toString('utf-8')
+        while (buffer.includes('\n\n')) {
+          const index = buffer.indexOf('\n\n')
+          requests.push(buffer.substring(0, index))
+          buffer = buffer.substring(index + 2)
+          // Hold the first response so a competing queue would send the
+          // second command while the first is still waiting for its reply.
+          if (requests.length > 1) franken.write('SECOND\n\n')
+        }
+      })
+      await Promise.all([firstConnection, secondConnection])
+      expect(listen).toHaveBeenCalledOnce()
+      expect(isDacConnected()).toBe(true)
+      expect(duplicate.isDacConnected()).toBe(true)
+      await duplicate.connectDac(socketPath)
+      expect(listen).toHaveBeenCalledOnce()
+
+      const firstWrite = sendCommand('11', '50')
+      await vi.waitFor(() => expect(requests).toEqual(['11\n50']), { interval: 5 })
+      const secondWrite = duplicate.sendCommand('12', '-30')
+      try {
+        // Give socket writes time to arrive while the first response is held.
+        await new Promise(resolve => setTimeout(resolve, 50))
+        expect(requests).toEqual(['11\n50'])
+      }
+      finally {
+        franken.write('FIRST\n\n')
+        await expect(firstWrite).resolves.toBe('FIRST')
+        await expect(secondWrite).resolves.toBe('SECOND')
+      }
+      expect(requests).toEqual(['11\n50', '12\n-30'])
+
+      await duplicate.disconnectDac()
+      expect(duplicate.isDacConnected()).toBe(false)
+      expect(isDacConnected()).toBe(false)
+      await expect(sendCommand('14')).rejects.toThrow('not connected')
+    })
+
     test('returns immediately when already connected', async () => {
       const connectPromise = connectDac(socketPath)
       await new Promise(r => setTimeout(r, 200))

--- a/src/hardware/tests/dacTransport.test.ts
+++ b/src/hardware/tests/dacTransport.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { Socket } from 'net'
+import { getStatusRevision } from '../statusRevision'
 import { promises as fs } from 'fs'
 import {
   connectDac,
@@ -138,6 +139,31 @@ describe('dacTransport', () => {
     const response = await sendCommand('14')
     expect(response).toContain('tgHeatLevelR=10')
     expect(response).toContain('sensorLabel=H00-test')
+  })
+
+  test('invalidates snapshots for writes but keeps read-only commands reusable', async () => {
+    const connecting = connectDac(socketPath)
+    await vi.waitFor(() => fs.access(socketPath), { interval: 5 })
+    mockFranken = await connectAsFrankenfirmware(socketPath)
+    handleCommands(mockFranken)
+    await connecting
+    const initial = getStatusRevision()
+    await sendCommand('14')
+    await sendCommand('0')
+    expect(getStatusRevision()).toBe(initial)
+
+    const write = sendCommand('11', '-24')
+    expect(getStatusRevision()).toBeNull()
+    await write
+    expect(getStatusRevision()).not.toBeNull()
+    expect(getStatusRevision()).not.toBe(initial)
+    const written = getStatusRevision()
+    // No-argument commands such as priming also invalidate the cache.
+    await sendCommand('13')
+    expect(getStatusRevision()).not.toBe(written)
+    const beforeDisconnect = getStatusRevision()
+    await disconnectDac()
+    expect(getStatusRevision()).not.toBe(beforeDisconnect)
   })
 
   test('sends command with argument', async () => {
@@ -268,6 +294,19 @@ describe('dacTransport', () => {
         name: 'MessageResponseTimeoutError',
         message: 'Timed out after 150ms waiting for firmware response',
       })
+    })
+
+    test('failed writes invalidate old observations without leaving reads permanently blocked', async () => {
+      const connecting = connectDac(socketPath)
+      await vi.waitFor(() => fs.access(socketPath), { interval: 5 })
+      mockFranken = await connectAsFrankenfirmware(socketPath)
+      await connecting
+      const initial = getStatusRevision()
+      const write = sendCommand('11', '-24')
+      expect(getStatusRevision()).toBeNull()
+      await expect(write).rejects.toBeInstanceOf(MessageResponseTimeoutError)
+      expect(getStatusRevision()).not.toBeNull()
+      expect(getStatusRevision()).not.toBe(initial)
     })
 
     test('queue drains after timeout — next command succeeds (no deadlock)', async () => {

--- a/src/hardware/tests/wifi.test.ts
+++ b/src/hardware/tests/wifi.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 /**
- * Tests for the wifi info reader. Mocks fs.readFileSync and child_process.spawnSync
+ * Tests for the wifi info reader. Mocks fs.readFile and child_process.execFileAsync
  * so we can drive every branch without touching the host's network stack.
  *
  * Primary source is `iw dev <iface> link` (Pod 5 has iw but not iwgetid, and
@@ -11,22 +11,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
  */
 
 const mocks = vi.hoisted(() => ({
-  readFileSync: vi.fn(),
-  spawnSync: vi.fn(),
+  readFile: vi.fn(),
+  execFileAsync: vi.fn(),
 }))
 
-vi.mock('fs', () => ({
-  readFileSync: mocks.readFileSync,
-  default: { readFileSync: mocks.readFileSync },
+vi.mock('fs/promises', () => ({
+  readFile: mocks.readFile,
+  default: { readFile: mocks.readFile },
 }))
-vi.mock('child_process', () => ({
-  spawnSync: mocks.spawnSync,
-  default: { spawnSync: mocks.spawnSync },
-}))
-import { getWifiInfo } from '@/src/hardware/wifi'
+vi.mock('child_process', () => {
+  const execFile = Object.assign(vi.fn(), {
+    [Symbol.for('nodejs.util.promisify.custom')]: mocks.execFileAsync,
+  })
+  return { execFile, default: { execFile } }
+})
+import { getWifiInfo, readWifiInfo } from '@/src/hardware/wifi'
 
-const readFileSyncMock = mocks.readFileSync
-const spawnSyncMock = mocks.spawnSync
+const readFileMock = mocks.readFile
+const execFileAsyncMock = mocks.execFileAsync
 
 const IW_DEV_OUTPUT = `phy#0
 \tInterface wlan0
@@ -46,47 +48,48 @@ function iwLink(ssid: string, signalDbm: number): string {
 }
 
 function mockSpawn(impl: (cmd: string, args: string[]) => { stdout?: string }) {
-  spawnSyncMock.mockImplementation((cmd: string, args: string[]) => impl(cmd, args) as any)
+  execFileAsyncMock.mockImplementation((cmd: string, args: string[]) => impl(cmd, args) as any)
 }
 
 beforeEach(() => {
-  readFileSyncMock.mockReset()
-  spawnSyncMock.mockReset()
+  readFileMock.mockReset()
+  execFileAsyncMock.mockReset()
+  delete (globalThis as Record<string, unknown>).__sp_wifi_info__
 })
 
 describe('getWifiInfo — iw primary path (Pod 5)', () => {
-  it('parses signal (dBm) and SSID from `iw dev <iface> link`', () => {
+  it('parses signal (dBm) and SSID from `iw dev <iface> link`', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') return { stdout: iwLink('my-ssid', -67) }
       return {}
     })
 
-    const info = getWifiInfo()
+    const info = (await readWifiInfo())
     // -67 dBm → 2 * (-67 + 100) = 66
     expect(info.wifiStrength).toBe(66)
     expect(info.wifiSSID).toBe('my-ssid')
   })
 
-  it('clamps signal strength to 0..100', () => {
+  it('clamps signal strength to 0..100', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') return { stdout: iwLink('s', -30) } // very strong
       return {}
     })
-    expect(getWifiInfo().wifiStrength).toBe(100)
+    expect((await readWifiInfo()).wifiStrength).toBe(100)
   })
 
-  it('clamps very weak signal to 0', () => {
+  it('clamps very weak signal to 0', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') return { stdout: iwLink('s', -120) }
       return {}
     })
-    expect(getWifiInfo().wifiStrength).toBe(0)
+    expect((await readWifiInfo()).wifiStrength).toBe(0)
   })
 
-  it('accepts protocol whitespace but rejects prefixed lookalike fields', () => {
+  it('accepts protocol whitespace but rejects prefixed lookalike fields', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) {
         return { stdout: 'phy#0\n\tInterface   wlan-long0\n' }
@@ -104,8 +107,8 @@ describe('getWifiInfo — iw primary path (Pod 5)', () => {
       return {}
     })
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 66, wifiSSID: 'living room wifi' })
-    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 66, wifiSSID: 'living room wifi' })
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       'iw',
       ['dev', 'wlan-long0', 'link'],
@@ -117,27 +120,27 @@ describe('getWifiInfo — iw primary path (Pod 5)', () => {
     )
   })
 
-  it('parses a positive signed signal value', () => {
+  it('parses a positive signed signal value', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[2] === 'link') return { stdout: 'signal: 1 dBm\nSSID: lab' }
       return {}
     })
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 100, wifiSSID: 'lab' })
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 100, wifiSSID: 'lab' })
   })
 
-  it('accepts compact signal and SSID fields without optional whitespace', () => {
+  it('accepts compact signal and SSID fields without optional whitespace', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[2] === 'link') return { stdout: 'signal:-67dBm\nSSID:lab' }
       return {}
     })
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 66, wifiSSID: 'lab' })
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 66, wifiSSID: 'lab' })
   })
 
-  it('does not let later prefixed lookalike fields overwrite valid fields', () => {
+  it('does not let later prefixed lookalike fields overwrite valid fields', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[2] === 'link') {
@@ -153,28 +156,28 @@ describe('getWifiInfo — iw primary path (Pod 5)', () => {
       return {}
     })
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 66, wifiSSID: 'primary' })
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 66, wifiSSID: 'primary' })
   })
 })
 
 describe('getWifiInfo — fallback to /proc/net/wireless and iwgetid', () => {
-  it('uses /proc + iwgetid when `iw dev` lists no interface', () => {
+  it('uses /proc + iwgetid when `iw dev` lists no interface', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: '' }
       if (cmd === 'iwgetid') return { stdout: 'legacy-ssid\n' }
       return {}
     })
-    readFileSyncMock.mockReturnValue(
+    readFileMock.mockReturnValue(
       'Inter-|   sta-|   Quality        |   Discarded packets\n'
       + ' face | tus  | link level noise |  nwid crypt frag retry misc\n'
       + ' wlan0: 0000   35.  -75.  -256        0      0      0      0      0\n',
     )
-    const info = getWifiInfo()
+    const info = (await readWifiInfo())
     // 35/70 * 100 = 50
     expect(info.wifiStrength).toBe(50)
     expect(info.wifiSSID).toBe('legacy-ssid')
-    expect(readFileSyncMock).toHaveBeenCalledWith('/proc/net/wireless', 'utf-8')
-    expect(spawnSyncMock).toHaveBeenCalledWith(
+    expect(readFileMock).toHaveBeenCalledWith('/proc/net/wireless', 'utf-8')
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
       'iwgetid',
       ['-r'],
       expect.objectContaining({
@@ -185,19 +188,19 @@ describe('getWifiInfo — fallback to /proc/net/wireless and iwgetid', () => {
     )
   })
 
-  it('uses /proc + iwgetid when `iw dev <iface> link` says "Not connected"', () => {
+  it('uses /proc + iwgetid when `iw dev <iface> link` says "Not connected"', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') return { stdout: 'Not connected.' }
       if (cmd === 'iwgetid') return { stdout: 'legacy-ssid' }
       return {}
     })
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
-    expect(getWifiInfo().wifiSSID).toBe('legacy-ssid')
-    expect(getWifiInfo().wifiStrength).toBe(50)
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
+    expect((await readWifiInfo()).wifiSSID).toBe('legacy-ssid')
+    expect((await readWifiInfo()).wifiStrength).toBe(50)
   })
 
-  it('treats a not-connected prefix as authoritative even if stale fields follow it', () => {
+  it('treats a not-connected prefix as authoritative even if stale fields follow it', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') {
@@ -206,12 +209,12 @@ describe('getWifiInfo — fallback to /proc/net/wireless and iwgetid', () => {
       if (cmd === 'iwgetid') return { stdout: 'fallback-ssid' }
       return {}
     })
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 50, wifiSSID: 'fallback-ssid' })
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 50, wifiSSID: 'fallback-ssid' })
   })
 
-  it('trims leading whitespace before recognizing a not-connected response', () => {
+  it('trims leading whitespace before recognizing a not-connected response', async () => {
     mockSpawn((cmd, args) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT }
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') {
@@ -220,9 +223,9 @@ describe('getWifiInfo — fallback to /proc/net/wireless and iwgetid', () => {
       if (cmd === 'iwgetid') return { stdout: 'fallback-ssid' }
       return {}
     })
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
 
-    expect(getWifiInfo()).toEqual({ wifiStrength: 50, wifiSSID: 'fallback-ssid' })
+    expect((await readWifiInfo())).toEqual({ wifiStrength: 50, wifiSSID: 'fallback-ssid' })
   })
 })
 
@@ -231,76 +234,134 @@ describe('getWifiInfo — signal-strength fallback branches', () => {
     mockSpawn(() => ({})) // no iw output → all fallbacks
   })
 
-  it('returns -1 when /proc/net/wireless has no interface line', () => {
-    readFileSyncMock.mockReturnValue('Inter-|\n face |\n')
-    expect(getWifiInfo().wifiStrength).toBe(-1)
+  it('returns -1 when /proc/net/wireless has no interface line', async () => {
+    readFileMock.mockReturnValue('Inter-|\n face |\n')
+    expect((await readWifiInfo()).wifiStrength).toBe(-1)
   })
 
-  it('returns -1 when link column is not a number', () => {
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   abc   -50.  -256\n')
-    expect(getWifiInfo().wifiStrength).toBe(-1)
+  it('returns -1 when link column is not a number', async () => {
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   abc   -50.  -256\n')
+    expect((await readWifiInfo()).wifiStrength).toBe(-1)
   })
 
-  it('returns -1 when readFileSync throws (no /proc/net/wireless)', () => {
-    readFileSyncMock.mockImplementation(() => {
+  it('returns -1 when readFile throws (no /proc/net/wireless)', async () => {
+    readFileMock.mockImplementation(() => {
       throw new Error('ENOENT')
     })
-    expect(getWifiInfo().wifiStrength).toBe(-1)
+    expect((await readWifiInfo()).wifiStrength).toBe(-1)
   })
 
-  it('clamps /proc link quality to 100', () => {
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   200.  -50.  -256\n')
-    expect(getWifiInfo().wifiStrength).toBe(100)
+  it('clamps /proc link quality to 100', async () => {
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   200.  -50.  -256\n')
+    expect((await readWifiInfo()).wifiStrength).toBe(100)
   })
 })
 
 describe('getWifiInfo — SSID fallback branches', () => {
   beforeEach(() => {
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0 35. -50. -256\n')
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0 35. -50. -256\n')
   })
 
-  it('returns unknown when iwgetid stdout is empty', () => {
+  it('returns unknown when iwgetid stdout is empty', async () => {
     mockSpawn(cmd => (cmd === 'iwgetid' ? { stdout: '' } : {}))
-    expect(getWifiInfo().wifiSSID).toBe('unknown')
+    expect((await readWifiInfo()).wifiSSID).toBe('unknown')
   })
 
-  it('returns unknown when iwgetid stdout is missing', () => {
+  it('returns unknown when iwgetid stdout is missing', async () => {
     mockSpawn(cmd => (cmd === 'iwgetid' ? {} : {}))
-    expect(getWifiInfo().wifiSSID).toBe('unknown')
+    expect((await readWifiInfo()).wifiSSID).toBe('unknown')
   })
 
-  it('returns unknown when spawnSync for iwgetid throws', () => {
-    spawnSyncMock.mockImplementation((cmd: string) => {
+  it('returns unknown when execFileAsync for iwgetid throws', async () => {
+    execFileAsyncMock.mockImplementation((cmd: string) => {
       if (cmd === 'iwgetid') throw new Error('iwgetid missing')
       return {} as any
     })
-    expect(getWifiInfo().wifiSSID).toBe('unknown')
+    expect((await readWifiInfo()).wifiSSID).toBe('unknown')
   })
 })
 
 describe('getWifiInfo — robustness', () => {
-  it('falls through to /proc + iwgetid when `iw dev` itself throws', () => {
-    spawnSyncMock.mockImplementation((cmd: string) => {
+  it('falls through to /proc + iwgetid when `iw dev` itself throws', async () => {
+    execFileAsyncMock.mockImplementation((cmd: string) => {
       if (cmd === 'iw') throw new Error('iw missing')
       if (cmd === 'iwgetid') return { stdout: 'legacy' } as any
       return {} as any
     })
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
-    const info = getWifiInfo()
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
+    const info = (await readWifiInfo())
     expect(info.wifiStrength).toBe(50)
     expect(info.wifiSSID).toBe('legacy')
   })
 
-  it('falls through to /proc + iwgetid when the link probe throws (iface detect ok)', () => {
-    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+  it('falls through to /proc + iwgetid when the link probe throws (iface detect ok)', async () => {
+    execFileAsyncMock.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'iw' && args[0] === 'dev' && args.length === 1) return { stdout: IW_DEV_OUTPUT } as any
       if (cmd === 'iw' && args[0] === 'dev' && args[2] === 'link') throw new Error('boom')
       if (cmd === 'iwgetid') return { stdout: 'legacy' } as any
       return {} as any
     })
-    readFileSyncMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
-    const info = getWifiInfo()
+    readFileMock.mockReturnValue('hdr\nhdr\n wlan0: 0000   35.  -50.  -256\n')
+    const info = (await readWifiInfo())
     expect(info.wifiStrength).toBe(50)
     expect(info.wifiSSID).toBe('legacy')
+  })
+})
+
+describe('getWifiInfo background cache', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function finishRefresh() {
+    const cache = (globalThis as Record<string, unknown>).__sp_wifi_info__ as { pending: Promise<void> | null }
+    await cache.pending
+  }
+
+  it('returns immediately and shares one slow refresh across concurrent readers', async () => {
+    let finish: (value: { stdout: string }) => void = () => {}
+    execFileAsyncMock.mockImplementationOnce(() => new Promise((resolve) => {
+      finish = resolve
+    }))
+    mockSpawn(() => ({ stdout: iwLink('home', -67) }))
+
+    for (let i = 0; i < 20; i++) {
+      expect(getWifiInfo()).toEqual({ wifiStrength: -1, wifiSSID: 'unknown' })
+    }
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
+    // Even a scheduled event can run while the diagnostic command is pending.
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+    finish({ stdout: IW_DEV_OUTPUT })
+    await finishRefresh()
+    expect(getWifiInfo()).toEqual({ wifiStrength: 66, wifiSSID: 'home' })
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes after 30s, keeps the last value during refresh, and retries failures', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    mockSpawn((cmd, args) => ({ stdout: args.length === 1 ? IW_DEV_OUTPUT : iwLink('home', -67) }))
+    getWifiInfo()
+    await finishRefresh()
+    execFileAsyncMock.mockClear()
+    vi.advanceTimersByTime(29_999)
+    expect(getWifiInfo().wifiSSID).toBe('home')
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+
+    execFileAsyncMock.mockRejectedValue(new Error('command timeout'))
+    readFileMock.mockRejectedValue(new Error('ENOENT'))
+    vi.advanceTimersByTime(1)
+    expect(getWifiInfo().wifiSSID).toBe('home')
+    await finishRefresh()
+    expect(getWifiInfo()).toEqual({ wifiStrength: -1, wifiSSID: 'unknown' })
+    const calls = execFileAsyncMock.mock.calls.length
+    getWifiInfo()
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(calls)
+
+    vi.advanceTimersByTime(30_000)
+    mockSpawn((cmd, args) => ({ stdout: args.length === 1 ? IW_DEV_OUTPUT : iwLink('reconnected', -50) }))
+    getWifiInfo()
+    await finishRefresh()
+    expect(getWifiInfo()).toEqual({ wifiStrength: 100, wifiSSID: 'reconnected' })
   })
 })

--- a/src/hardware/wifi.ts
+++ b/src/hardware/wifi.ts
@@ -32,8 +32,6 @@ export function getWifiInfo(): WifiInfo {
   if (!cache.pending && (age < 0 || age >= CACHE_MS)) {
     cache.pending = readWifiInfo().then((value) => {
       cache.value = value
-    }).catch(() => {
-      cache.value = { wifiStrength: -1, wifiSSID: 'unknown' }
     }).finally(() => {
       cache.updatedAt = Date.now()
       cache.pending = null

--- a/src/hardware/wifi.ts
+++ b/src/hardware/wifi.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'fs'
-import { spawnSync } from 'child_process'
+import { readFile } from 'fs/promises'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 
 export interface WifiInfo {
   wifiStrength: number
@@ -10,25 +11,55 @@ export interface WifiInfo {
 // /usr/sbin on Pod 5. Broaden lookup paths for any spawned wifi binary so
 // the process resolves regardless of how the unit's PATH is configured.
 const SPAWN_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-const SPAWN_OPTS = { encoding: 'utf-8' as const, timeout: 2000, env: { ...process.env, PATH: SPAWN_PATH } }
+const execFileAsync = promisify(execFile)
+const SPAWN_OPTS = { encoding: 'utf-8' as const, timeout: 2000, killSignal: 'SIGKILL' as const, env: { ...process.env, PATH: SPAWN_PATH } }
 
+const CACHE_MS = 30_000
+interface WifiCache {
+  value: WifiInfo
+  updatedAt: number | null
+  pending: Promise<void> | null
+}
+const g = globalThis as Record<string, unknown>
+const CACHE_KEY = '__sp_wifi_info__'
+
+/** Return immediately; at most one asynchronous refresh runs every 30 seconds. */
 export function getWifiInfo(): WifiInfo {
+  const cache = (g[CACHE_KEY] ??= {
+    value: { wifiStrength: -1, wifiSSID: 'unknown' }, updatedAt: null, pending: null,
+  }) as WifiCache
+  const age = cache.updatedAt === null ? Infinity : Date.now() - cache.updatedAt
+  if (!cache.pending && (age < 0 || age >= CACHE_MS)) {
+    cache.pending = readWifiInfo().then((value) => {
+      cache.value = value
+    }).catch(() => {
+      cache.value = { wifiStrength: -1, wifiSSID: 'unknown' }
+    }).finally(() => {
+      cache.updatedAt = Date.now()
+      cache.pending = null
+    })
+  }
+  return { ...cache.value }
+}
+
+/** Probe the current Wi-Fi state without blocking the Node event loop. */
+export async function readWifiInfo(): Promise<WifiInfo> {
   // Pod 5 (J55) ships `iw` but not `iwgetid`, and its /proc/net/wireless
   // header has no data row — so try `iw dev … link` first; it provides
   // both signal (dBm) and SSID in one call. Fall back to the legacy
   // /proc + iwgetid pair for older pods that ship neither tool the same way.
-  const fromIw = parseIwLink()
+  const fromIw = await parseIwLink()
   return {
-    wifiStrength: fromIw.wifiStrength ?? parseProcWirelessLink(),
-    wifiSSID: fromIw.wifiSSID ?? parseIwgetidSSID(),
+    wifiStrength: fromIw.wifiStrength ?? await parseProcWirelessLink(),
+    wifiSSID: fromIw.wifiSSID ?? await parseIwgetidSSID(),
   }
 }
 
-function parseIwLink(): { wifiStrength: number | null, wifiSSID: string | null } {
+async function parseIwLink(): Promise<{ wifiStrength: number | null, wifiSSID: string | null }> {
   try {
-    const iface = detectWirelessIface()
+    const iface = await detectWirelessIface()
     if (!iface) return { wifiStrength: null, wifiSSID: null }
-    const result = spawnSync('iw', ['dev', iface, 'link'], SPAWN_OPTS)
+    const result = await execFileAsync('iw', ['dev', iface, 'link'], SPAWN_OPTS)
     const out = result.stdout?.trim()
     if (!out || out.startsWith('Not connected')) return { wifiStrength: null, wifiSSID: null }
 
@@ -48,9 +79,9 @@ function parseIwLink(): { wifiStrength: number | null, wifiSSID: string | null }
   }
 }
 
-function detectWirelessIface(): string | null {
+async function detectWirelessIface(): Promise<string | null> {
   try {
-    const result = spawnSync('iw', ['dev'], SPAWN_OPTS)
+    const result = await execFileAsync('iw', ['dev'], SPAWN_OPTS)
     const match = result.stdout?.match(/Interface\s+(\S+)/)
     return match ? match[1] : null
   }
@@ -64,9 +95,9 @@ function dbmToPercent(dbm: number): number {
   return Math.max(0, Math.min(100, Math.round(2 * (dbm + 100))))
 }
 
-function parseProcWirelessLink(): number {
+async function parseProcWirelessLink(): Promise<number> {
   try {
-    const raw = readFileSync('/proc/net/wireless', 'utf-8')
+    const raw = await readFile('/proc/net/wireless', 'utf-8')
     const lines = raw.trim().split('\n')
     const dataLine = lines.find(l => l.includes(':'))
     if (!dataLine) return -1
@@ -80,9 +111,9 @@ function parseProcWirelessLink(): number {
   }
 }
 
-function parseIwgetidSSID(): string {
+async function parseIwgetidSSID(): Promise<string> {
   try {
-    const result = spawnSync('iwgetid', ['-r'], SPAWN_OPTS)
+    const result = await execFileAsync('iwgetid', ['-r'], SPAWN_OPTS)
     return result.stdout?.trim() || 'unknown'
   }
   catch {

--- a/src/providers/TRPCProvider.tsx
+++ b/src/providers/TRPCProvider.tsx
@@ -1,24 +1,13 @@
 'use client'
 
-import { transformer } from '@/src/utils/transformer'
 import { trpc } from '@/src/utils/trpc'
-import { getBaseUrl } from '@/src/utils/url'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { httpBatchLink } from '@trpc/client'
+import { createWebQueryClient, createWebTRPCClient } from '@/src/utils/webClients'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
 
 export const TRPCProvider = ({ children }: { children: React.ReactNode }) => {
-  const [queryClient] = useState(() => new QueryClient())
-  const [trpcClient] = useState(() =>
-    trpc.createClient({
-      links: [
-        httpBatchLink({
-          url: getBaseUrl() + '/api/trpc',
-          transformer,
-        }),
-      ],
-    }),
-  )
+  const [queryClient] = useState(createWebQueryClient)
+  const [trpcClient] = useState(createWebTRPCClient)
 
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -25,6 +25,7 @@ import {
 } from '@/src/server/validation-schemas'
 import { toC, centiDegreesToC, centiPercentToPercent } from '@/src/lib/tempUtils'
 import { getWifiInfo } from '@/src/hardware/wifi'
+import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 
 // ---------------------------------------------------------------------------
 // Command name → HardwareCommand mapping for the raw execute endpoint
@@ -113,20 +114,11 @@ export const deviceRouter = router({
    * Get current device status directly from hardware.
    *
    * Queries the Pod hardware controller for current temperature, power state,
-   * and alarm status. Use this when you need authoritative real-time data.
-   * For less critical reads, query device_state table instead to avoid
-   * hardware connection overhead.
-   *
-   * Behavior:
-   * - Connects to hardware, reads status, disconnects
-   * - Updates database with current readings
-   * - Connection has ~25s timeout (hardware may be slow to respond)
-   * - Safe to poll every ~5-10 seconds (hardware controller can handle it)
-   *
-   * Database Sync:
-   * - Uses separate updates per side (not bulk insert) to handle primary key
-   *   constraint (side) correctly with onConflictDoUpdate
-   * - If database update fails, hardware read still succeeds but state isn't cached
+   * and alarm status. Reuses a healthy monitor observation younger than 2s,
+   * provided no hardware write has started since that observation began.
+   * Otherwise reads through the shared hardware connection and syncs the DB.
+   * Cached observations are already persisted by DeviceStateSync.
+   * Wi-Fi enrichment is cached separately and refreshes without blocking reads.
    *
    * @throws {TRPCError} INTERNAL_SERVER_ERROR if hardware connection fails
    * @throws {TRPCError} INTERNAL_SERVER_ERROR if hardware doesn't respond within timeout
@@ -200,10 +192,14 @@ export const deviceRouter = router({
       }),
     }))
     .query(async ({ input }) => {
-      return withHardwareClient(async (client) => {
-        const status = await client.getDeviceStatus()
+      const cachedStatus = getDacMonitorIfRunning()?.getFreshStatus(2_000)
+      const status = cachedStatus ?? await withHardwareClient(
+        client => client.getDeviceStatus(), 'Failed to get device status',
+      )
 
-        // Best-effort DB sync — next getStatus() call will re-sync if this fails
+      if (!cachedStatus) {
+        // The monitor already persists cached observations. Preserve the fallback
+        // sync only when a hardware read was necessary.
         try {
           await db
             .insert(deviceState)
@@ -246,66 +242,66 @@ export const deviceRouter = router({
         catch (dbError) {
           console.error('Failed to sync device status to DB:', dbError)
         }
+      }
 
-        const primeCompletedAt = getPrimeCompletedAt()
-        const stallNotices = getAllPumpStallNotices()
-        const leftSnooze = getSnoozeStatus('left')
-        const rightSnooze = getSnoozeStatus('right')
+      const primeCompletedAt = getPrimeCompletedAt()
+      const stallNotices = getAllPumpStallNotices()
+      const leftSnooze = getSnoozeStatus('left')
+      const rightSnooze = getSnoozeStatus('right')
 
-        const convertTemp = (f: number | null) =>
-          f == null ? null : (input.unit === 'C' ? Math.round(toC(f) * 10) / 10 : f)
+      const convertTemp = (f: number | null) =>
+        f == null ? null : (input.unit === 'C' ? Math.round(toC(f) * 10) / 10 : f)
 
-        // Best-effort enrichment — nulls on failure
-        let wifiStrength: number = -1
-        let wifiSSID: string = 'unknown'
-        let roomClimate: { temperatureC: number | null, humidity: number | null, timestamp: number | null } = { temperatureC: null, humidity: null, timestamp: null }
-        let waterLevelRaw: { raw: number | null, calibratedEmpty: number | null, calibratedFull: number | null, timestamp: number | null } = { raw: null, calibratedEmpty: null, calibratedFull: null, timestamp: null }
-        try {
-          const wifi = getWifiInfo()
-          wifiStrength = wifi.wifiStrength
-          wifiSSID = wifi.wifiSSID
+      // Best-effort enrichment — nulls on failure
+      let wifiStrength: number = -1
+      let wifiSSID: string = 'unknown'
+      let roomClimate: { temperatureC: number | null, humidity: number | null, timestamp: number | null } = { temperatureC: null, humidity: null, timestamp: null }
+      let waterLevelRaw: { raw: number | null, calibratedEmpty: number | null, calibratedFull: number | null, timestamp: number | null } = { raw: null, calibratedEmpty: null, calibratedFull: null, timestamp: null }
+      try {
+        const wifi = getWifiInfo()
+        wifiStrength = wifi.wifiStrength
+        wifiSSID = wifi.wifiSSID
 
-          const [latestBed] = await biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1)
-          if (latestBed) {
-            roomClimate = {
-              temperatureC: latestBed.ambientTemp !== null ? centiDegreesToC(latestBed.ambientTemp) : null,
-              humidity: latestBed.humidity !== null ? centiPercentToPercent(latestBed.humidity) : null,
-              timestamp: latestBed.timestamp ? latestBed.timestamp.getTime() : null,
-            }
-          }
-          const [latestWater] = await biometricsDb.select().from(waterLevelReadings).orderBy(desc(waterLevelReadings.timestamp)).limit(1)
-          if (latestWater) {
-            waterLevelRaw = {
-              raw: latestWater.raw ?? null,
-              calibratedEmpty: latestWater.calibratedEmpty ?? null,
-              calibratedFull: latestWater.calibratedFull ?? null,
-              timestamp: latestWater.timestamp ? latestWater.timestamp.getTime() : null,
-            }
+        const [latestBed] = await biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1)
+        if (latestBed) {
+          roomClimate = {
+            temperatureC: latestBed.ambientTemp !== null ? centiDegreesToC(latestBed.ambientTemp) : null,
+            humidity: latestBed.humidity !== null ? centiPercentToPercent(latestBed.humidity) : null,
+            timestamp: latestBed.timestamp ? latestBed.timestamp.getTime() : null,
           }
         }
-        catch { /* enrichment is best-effort */ }
-
-        return {
-          ...status,
-          leftSide: {
-            ...status.leftSide,
-            currentTemperature: convertTemp(status.leftSide.currentTemperature),
-            targetTemperature: convertTemp(status.leftSide.targetTemperature),
-          },
-          rightSide: {
-            ...status.rightSide,
-            currentTemperature: convertTemp(status.rightSide.currentTemperature),
-            targetTemperature: convertTemp(status.rightSide.targetTemperature),
-          },
-          ...(primeCompletedAt && { primeCompletedNotification: { timestamp: primeCompletedAt } }),
-          ...((stallNotices.left || stallNotices.right) && { pumpStallNotifications: stallNotices }),
-          snooze: { left: leftSnooze, right: rightSnooze },
-          wifiStrength,
-          wifiSSID,
-          roomClimate,
-          waterLevelRaw,
+        const [latestWater] = await biometricsDb.select().from(waterLevelReadings).orderBy(desc(waterLevelReadings.timestamp)).limit(1)
+        if (latestWater) {
+          waterLevelRaw = {
+            raw: latestWater.raw ?? null,
+            calibratedEmpty: latestWater.calibratedEmpty ?? null,
+            calibratedFull: latestWater.calibratedFull ?? null,
+            timestamp: latestWater.timestamp ? latestWater.timestamp.getTime() : null,
+          }
         }
-      }, 'Failed to get device status')
+      }
+      catch { /* enrichment is best-effort */ }
+
+      return {
+        ...status,
+        leftSide: {
+          ...status.leftSide,
+          currentTemperature: convertTemp(status.leftSide.currentTemperature),
+          targetTemperature: convertTemp(status.leftSide.targetTemperature),
+        },
+        rightSide: {
+          ...status.rightSide,
+          currentTemperature: convertTemp(status.rightSide.currentTemperature),
+          targetTemperature: convertTemp(status.rightSide.targetTemperature),
+        },
+        ...(primeCompletedAt && { primeCompletedNotification: { timestamp: primeCompletedAt } }),
+        ...((stallNotices.left || stallNotices.right) && { pumpStallNotifications: stallNotices }),
+        snooze: { left: leftSnooze, right: rightSnooze },
+        wifiStrength,
+        wifiSSID,
+        roomClimate,
+        waterLevelRaw,
+      }
     }),
 
   /**

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -192,12 +192,12 @@ export const deviceRouter = router({
       }),
     }))
     .query(async ({ input }) => {
-      const cachedStatus = getDacMonitorIfRunning()?.getFreshStatus(2_000)
-      const status = cachedStatus ?? await withHardwareClient(
-        client => client.getDeviceStatus(), 'Failed to get device status',
-      )
+      let status = getDacMonitorIfRunning()?.getFreshStatus(2_000)
 
-      if (!cachedStatus) {
+      if (!status) {
+        status = await withHardwareClient(
+          client => client.getDeviceStatus(), 'Failed to get device status',
+        )
         // The monitor already persists cached observations. Preserve the fallback
         // sync only when a hardware read was necessary.
         try {

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -43,6 +43,8 @@ const broadcastMock = vi.hoisted(() => ({
   broadcastMutationStatus: vi.fn(),
 }))
 
+const monitorMock = vi.hoisted(() => ({ getFreshStatus: vi.fn() }))
+
 const transportMock = vi.hoisted(() => ({
   sendCommand: vi.fn(),
   isDacConnected: vi.fn(() => true),
@@ -149,6 +151,7 @@ vi.mock('@/src/hardware/primeNotification', () => primeMock)
 vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
 vi.mock('@/src/hardware/dacTransport', () => transportMock)
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({ getDacMonitorIfRunning: () => monitorMock }))
 vi.mock('@/src/hardware/sharedClient', () => ({ getSharedHardwareClient: sharedClientMock.getSharedHardwareClient }))
 vi.mock('@/src/hardware/deviceStateSync', () => stateSyncMock)
 vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
@@ -196,6 +199,8 @@ beforeEach(() => {
   snoozeMock.getSnoozeStatus.mockReset().mockReturnValue({ active: false, snoozeUntil: null })
   broadcastMock.broadcastMutationStatus.mockReset()
   transportMock.sendCommand.mockReset()
+  transportMock.isDacConnected.mockReturnValue(true)
+  monitorMock.getFreshStatus.mockReset().mockReturnValue(null)
   sharedClientMock.sendRaw.mockReset()
   stateSyncMock.markSideMutated.mockReset()
   pumpStallMock.shouldBlock.mockReset().mockReturnValue(false)
@@ -213,6 +218,29 @@ beforeEach(() => {
 })
 
 describe('device.getStatus', () => {
+  it('serves monitor status without another hardware read or duplicate DB writes', async () => {
+    const cached = await helpersMock.client.getDeviceStatus()
+    helpersMock.client.getDeviceStatus.mockClear()
+    monitorMock.getFreshStatus.mockReturnValue(cached)
+    primeMock.getPrimeCompletedAt.mockReturnValue(1700000000000)
+    const result = await caller.getStatus({ unit: 'C' })
+    expect(result.leftSide.currentTemperature).toBeCloseTo(26.7, 1)
+    expect(result.primeCompletedNotification?.timestamp).toBe(1700000000000)
+    expect(monitorMock.getFreshStatus).toHaveBeenCalledWith(2_000)
+    expect(helpersMock.withHardwareClient).not.toHaveBeenCalled()
+    expect(helpersMock.client.getDeviceStatus).not.toHaveBeenCalled()
+    expect(dbMock.insert).not.toHaveBeenCalled()
+    // Conversion must not mutate the snapshot shared with other readers.
+    expect(cached.leftSide.currentTemperature).toBe(80)
+  })
+
+  it('reads hardware when the monitor has no reusable observation', async () => {
+    monitorMock.getFreshStatus.mockReturnValue(null)
+    await caller.getStatus({})
+    expect(helpersMock.client.getDeviceStatus).toHaveBeenCalledOnce()
+    expect(dbMock.insert).toHaveBeenCalledTimes(2)
+  })
+
   it('returns status with snooze block and converts to F by default', async () => {
     primeMock.getPrimeCompletedAt.mockReturnValue(1700000000000)
     snoozeMock.getSnoozeStatus.mockReturnValueOnce({ active: true, snoozeUntil: 1700001000000 })

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -43,7 +43,10 @@ const broadcastMock = vi.hoisted(() => ({
   broadcastMutationStatus: vi.fn(),
 }))
 
-const monitorMock = vi.hoisted(() => ({ getFreshStatus: vi.fn() }))
+const monitorMock = vi.hoisted(() => ({
+  getFreshStatus: vi.fn(),
+  getDacMonitorIfRunning: vi.fn(),
+}))
 
 const transportMock = vi.hoisted(() => ({
   sendCommand: vi.fn(),
@@ -151,7 +154,7 @@ vi.mock('@/src/hardware/primeNotification', () => primeMock)
 vi.mock('@/src/hardware/snoozeManager', () => snoozeMock)
 vi.mock('@/src/streaming/broadcastMutationStatus', () => broadcastMock)
 vi.mock('@/src/hardware/dacTransport', () => transportMock)
-vi.mock('@/src/hardware/dacMonitor.instance', () => ({ getDacMonitorIfRunning: () => monitorMock }))
+vi.mock('@/src/hardware/dacMonitor.instance', () => ({ getDacMonitorIfRunning: monitorMock.getDacMonitorIfRunning }))
 vi.mock('@/src/hardware/sharedClient', () => ({ getSharedHardwareClient: sharedClientMock.getSharedHardwareClient }))
 vi.mock('@/src/hardware/deviceStateSync', () => stateSyncMock)
 vi.mock('@/src/hardware/pumpStallGuard', () => pumpStallMock)
@@ -201,6 +204,7 @@ beforeEach(() => {
   transportMock.sendCommand.mockReset()
   transportMock.isDacConnected.mockReturnValue(true)
   monitorMock.getFreshStatus.mockReset().mockReturnValue(null)
+  monitorMock.getDacMonitorIfRunning.mockReset().mockReturnValue(monitorMock)
   sharedClientMock.sendRaw.mockReset()
   stateSyncMock.markSideMutated.mockReset()
   pumpStallMock.shouldBlock.mockReset().mockReturnValue(false)
@@ -237,6 +241,17 @@ describe('device.getStatus', () => {
   it('reads hardware when the monitor has no reusable observation', async () => {
     monitorMock.getFreshStatus.mockReturnValue(null)
     await caller.getStatus({})
+    expect(helpersMock.client.getDeviceStatus).toHaveBeenCalledOnce()
+    expect(dbMock.insert).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads hardware and persists status before the monitor is running', async () => {
+    monitorMock.getDacMonitorIfRunning.mockReturnValue(null)
+
+    const result = await caller.getStatus({})
+
+    expect(result.leftSide.currentTemperature).toBe(80)
+    expect(monitorMock.getFreshStatus).not.toHaveBeenCalled()
     expect(helpersMock.client.getDeviceStatus).toHaveBeenCalledOnce()
     expect(dbMock.insert).toHaveBeenCalledTimes(2)
   })

--- a/src/utils/tests/webClients.test.ts
+++ b/src/utils/tests/webClients.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { initTRPC, TRPCError } from '@trpc/server'
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
+import { getQueryKey } from '@trpc/react-query'
+import { createWebQueryClient, createWebTRPCClient } from '../webClients'
+import { transformer } from '../transformer'
+import { trpc } from '../trpc'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('web clients', () => {
+  it('streams a fast result before a slow query in the same HTTP batch completes', async () => {
+    const t = initTRPC.create({ transformer })
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const timestamp = new Date('2026-09-05T12:00:00Z')
+    const router = t.router({
+      settings: t.router({ getAll: t.procedure.query(() => ({ timestamp })) }),
+      schedules: t.router({ getAll: t.procedure.query(async () => {
+        await gate
+        throw new TRPCError({ code: 'TIMEOUT', message: 'hardware unavailable' })
+      }) }),
+    })
+    const fetchMock = vi.fn((url: string, init: RequestInit) => fetchRequestHandler({
+      endpoint: '/api/trpc', req: new Request(url, init), router, createContext: () => ({}),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const client = createWebTRPCClient()
+    let fastResult: unknown
+    let slowError: unknown
+    const fast = client.settings.getAll.query({}).then((value) => {
+      fastResult = value
+    })
+    const slow = client.schedules.getAll.query({ side: 'left' }).catch((error: unknown) => {
+      slowError = error
+    })
+    try {
+      await vi.waitFor(() => {
+        expect(fastResult).toEqual({ timestamp })
+      })
+      expect(slowError).toBeUndefined()
+      expect(fetchMock).toHaveBeenCalledOnce()
+      expect(fetchMock.mock.calls[0]?.[0]).toContain('settings.getAll,schedules.getAll')
+    }
+    finally {
+      release()
+      await Promise.all([fast, slow])
+    }
+    expect(slowError).toMatchObject({ message: 'hardware unavailable', data: { code: 'TIMEOUT' } })
+  })
+
+  it('reuses settings and schedules until invalidated, without caching live status', async () => {
+    const client = createWebQueryClient()
+    try {
+      for (const queryKey of [
+        getQueryKey(trpc.settings.getAll, {}, 'query'),
+        getQueryKey(trpc.schedules.getAll, { side: 'left' }, 'query'),
+      ]) {
+        const queryFn = vi.fn(async () => ({ version: 1 }))
+        await client.fetchQuery({ queryKey, queryFn })
+        await client.fetchQuery({ queryKey, queryFn })
+        expect(queryFn).toHaveBeenCalledOnce()
+        await client.invalidateQueries({ queryKey })
+        await client.fetchQuery({ queryKey, queryFn })
+        expect(queryFn).toHaveBeenCalledTimes(2)
+      }
+      const queryKey = getQueryKey(trpc.device.getStatus, {}, 'query')
+      const queryFn = vi.fn(async () => ({}))
+      await client.fetchQuery({ queryKey, queryFn })
+      await client.fetchQuery({ queryKey, queryFn })
+      expect(queryFn).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      client.clear()
+    }
+  })
+})

--- a/src/utils/webClients.ts
+++ b/src/utils/webClients.ts
@@ -1,0 +1,24 @@
+import { QueryClient } from '@tanstack/react-query'
+import { httpBatchStreamLink } from '@trpc/client'
+import { getQueryKey } from '@trpc/react-query'
+import { trpc } from './trpc'
+import { transformer } from './transformer'
+import { getBaseUrl } from './url'
+
+export function createWebQueryClient(): QueryClient {
+  const client = new QueryClient()
+  // Mutations already invalidate these queries. Live device/sensor queries
+  // retain their own freshness policies, including refetch on reconnect.
+  client.setQueryDefaults(getQueryKey(trpc.settings.getAll), { staleTime: 30_000 })
+  client.setQueryDefaults(getQueryKey(trpc.schedules), { staleTime: 30_000 })
+  return client
+}
+
+export function createWebTRPCClient() {
+  return trpc.createClient({
+    links: [
+      // Deliver fast queries even while hardware/history queries are pending.
+      httpBatchStreamLink({ url: getBaseUrl() + '/api/trpc', transformer }),
+    ],
+  })
+}


### PR DESCRIPTION
Device status requests waited for hardware, synchronous Wi-Fi probes, and duplicate SQLite writes. This change reuses recent monitor observations, refreshes Wi-Fi diagnostics asynchronously, and streams fast tRPC results while slower queries are pending.

- Reuse healthy status observations younger than two seconds, invalidating them for hardware writes, failed writes, raw commands, and reconnects. Preserve direct reads and database synchronization when no snapshot qualifies.
- Share the DAC listener, connection, pending connection promise, and command queue across Next.js module instances, so duplicated bundles cannot create competing listeners or interleave commands.
- Cache Wi-Fi probes for 30 seconds with one background refresh. Give settings and schedules a 30-second query cache with mutation invalidation.
- Load diagnostics charts and the sensor panel when their section opens.

On-Pod measurements at `38e0695`: status median fell from 99.43 to 40.06 ms; four-concurrent-request p95 fell from 366.33 to 121.57 ms; diagnostics initial decoded JavaScript fell from 1,279,395 to 783,209 bytes. Polling CPU was about 20% lower in the settled sample. Idle CPU was unchanged, no memory reduction was established, and a concurrent health probe remained slower. [Reproducible benchmark, raw samples, and startup-spike analysis](https://github.com/sleepypod/core/blob/8b983e451863d4288c490f026ef5b2b6749ed253/docs/performance/web-service-2026-09-06.md).

Validation covers cold/stalled Wi-Fi probes, cache expiration, overlapping/failed writes, stale monitor reads, monitor startup, query invalidation, streaming mixed-speed batches, and duplicated module imports sharing a real socket and serial command queue. The full CI suite passes 3,583 tests (one skipped). CI TypeScript, ESLint, both production builds, and local Drizzle/pre-push gates pass. Production browser smoke checks exercised Overview, Thermal, Biometrics, and Sensors with no console errors. The singleton follow-up is validated by the socket regression test; the recorded Pod measurements predate that follow-up.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update perf/web-service-latency
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/perf/web-service-latency/scripts/install \
  | sudo bash -s -- --branch perf/web-service-latency
```

🎯 **Pin to this exact build** ([run 34003006850](https://github.com/sleepypod/core/actions/runs/34003006850) · `a0033c8`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/a0033c8d41dcac07890c3fae0767a5ea724f6998/scripts/install \
  | sudo bash -s -- \
      --branch perf/web-service-latency \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/34003006850/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/34003006850/artifacts/9980067202) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Device status checks now reuse recent, valid observations for faster responses.
  - Wi‑Fi information loads asynchronously, keeping the interface responsive while refreshing data in the background.
  - Diagnostics charts and sensor views now display a loading indicator while opening.

- **Bug Fixes**
  - Device readings are no longer reused after hardware changes, failed reads, disconnects, or reconnects.
  - Status updates now remain accurate during overlapping or timed-out hardware commands.
  - Web data requests now refresh reliably and avoid unnecessary caching of live device status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->




