### PR TITLE
perf: shorten startup and remove blocking API diagnostics

### DIFF
--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -2,7 +2,7 @@ import { appRouter } from '@/src/server/routers/app'
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch'
 
 const handler = (req: Request) => {
-  console.log('tRPC incoming:', req.url)
+  if (process.env.NODE_ENV !== 'production') console.log('tRPC incoming:', req.url)
   return fetchRequestHandler({
     endpoint: '/api/trpc',
     req,

--- a/docs/nats-frame-readers.md
+++ b/docs/nats-frame-readers.md
@@ -133,6 +133,23 @@ but it does not change the source choice. See selection rationale below.
 
 ## Source selection
 
+The Node web service now discovers the firmware installation **on each Pod**
+at startup. It does not infer NATS support from the Pod model. A loaded/masked
+`nats-server.service` unit or `/persistent/jetstream` directory means that a
+server may be starting; Node keeps retrying its greeting and connection without
+falling back to an empty RAW source. When both are confirmed absent, Node makes
+one greeting probe and starts RAW immediately if it fails. If installation
+identity cannot be read, it retains the bounded 60-second discovery window.
+A live NATS greeting always takes precedence over negative installation evidence.
+
+Local overrides are available for custom firmware: `PIEZO_SENSOR_SOURCE=raw`
+or `nats`; unset (or `auto`) uses discovery. `PIEZO_NATS_DISABLED=1` still forces
+RAW for backwards compatibility. Overrides belong in the individual Pod's
+service environment, not a fleet-wide model default. Exactly one source feeds
+broadcasts and persistence; established NATS connections reconnect themselves.
+
+The following grace-loop description remains the Python follower behavior:
+
 Reachability decides; traffic does not. Robustness beats latency here
 (reviewed 2026-07-19: "we don't need data immediately").
 

--- a/docs/performance/startup-api-2026-09-06.md
+++ b/docs/performance/startup-api-2026-09-06.md
@@ -1,0 +1,69 @@
+# Startup and API performance — 2026-09-06
+
+This pass follows PR #693. Measurements use the same Pod at 192.168.1.88;
+the starting deployment is `38e0695`, so the new build also incorporates the
+process-wide DAC singleton correction merged into `dev` after that deployment.
+
+## Changes
+
+- Health requests use `SELECT 1` for connectivity. Full SQLite `quick_check`
+  runs on a separate read-only worker connection, first after 30 seconds and
+  then hourly. Its result and check timestamp appear in `database.integrity`.
+  Pending integrity results are explicit; corruption and scan errors degrade
+  health. Requests never trigger the scan.
+- Firewall health uses asynchronous `execFile`, one listing per INPUT/OUTPUT
+  chain, a cached executable path, and a shared 30-second result. Startup
+  repair retains its ordering and invalidates cached diagnostics.
+- Room climate and raw water-level metadata share a two-second snapshot across
+  concurrent requests and Next bundles. Sidecars write their tables externally,
+  so the TTL bounds visibility delay; original sample timestamps remain intact.
+  Hardware status, alarm state, pump fault notices and mutations stay outside
+  this cache. Failed enrichment returns null values and retries after the TTL.
+- HTTP initialization awaits migrations, firewall setup and pump-guard
+  rehydration. The DAC socket and sensor stream start before schedule loading;
+  the clock gate lives in the shared scheduler singleton so early API consumers
+  cannot bypass it. Optional integrations and the initial LED write run in the
+  background. Shutdown cancels pending scheduler initialization and prevents
+  delayed integration starts from reviving services.
+- NATS discovery inspects the individual Pod's installed service and JetStream
+  storage, then verifies its greeting. Confirmed RAW-only Pods avoid the grace
+  window. Known NATS installations keep retrying through delayed server starts;
+  unknown installations retain the 60-second fallback. Local overrides:
+  `PIEZO_SENSOR_SOURCE=raw|nats`, or legacy `PIEZO_NATS_DISABLED=1` for RAW.
+- Live RAW ingestion uses asynchronous file operations, scans for rotation once
+  a second, polls every 25 ms, reads at most 64 KiB per batch, and decodes at most
+  128 outer records or approximately 4 ms before yielding. A single record may
+  exceed that time budget; incomplete records are bounded to 1 MiB before
+  resynchronizing. File offsets, split records, cap persistence, truncation and
+  seek indexes are preserved. Shutdown waits for the active read to finish.
+- `sp-maintenance` defaults to required boot repairs. Journal vacuum, old temp
+  cleanup, backup pruning and pnpm pruning run via a timer ten minutes after
+  activation and daily thereafter. Fresh and OTA installs both install the timer;
+  newly created update staging directories are excluded from cleanup.
+- Routine production tRPC request logging is disabled. `/api/health/performance`
+  reports startup phases, source choice, first sensor frame, RSS and process-wide
+  event-loop delay since instrumentation began (including remaining startup). It makes no hardware or database calls.
+
+## Measurement method
+
+`startup-api-2026-09-06/benchmark.mjs` preserves the earlier benchmark: 15 seconds
+idle, 60 status requests at 2 Hz, 12 bursts of four status reads alongside DAC
+health, HTML/assets, settings, and WebSocket cadence. It adds 20 system-health
+requests each paired with a trivial HTTP healthcheck to expose interference.
+CPU is percentage of one core. Measurements use loopback and include response
+bodies; they do not measure browser rendering or Wi-Fi latency.
+
+The fresh baseline is retained in `startup-api-2026-09-06/before.json`.
+`startup.mjs` restarts only the web service and polls HTTP every 500 ms for
+90 seconds, recording first capSense and device-status frames via WebSocket.
+It distinguishes the first available cap frame from one within five seconds
+of the current clock. Restart timing includes service shutdown and ExecStartPre.
+
+## Validation
+
+Production Next build passed. The full suite passed 3,661 tests with one
+skipped; an additional same-name RAW replacement regression subsequently
+passed in the 158-test streaming suite. TypeScript, ESLint, both Drizzle schema
+checks, shell syntax and maintenance lifecycle checks passed.
+
+Deployment measurements will be recorded after the final build.

--- a/docs/performance/startup-api-2026-09-06.md
+++ b/docs/performance/startup-api-2026-09-06.md
@@ -1,7 +1,7 @@
 # Startup and API performance — 2026-09-06
 
 This pass follows PR #693 and is proposed in [PR #694](https://github.com/sleepypod/core/pull/694).
-The final implementation, `aeb3852`, is deployed on the same Pod at 192.168.1.88;
+The measured implementation, `aeb3852`, is deployed on the same Pod at 192.168.1.88;
 the starting deployment is `38e0695`, so the new build also incorporates the
 process-wide DAC singleton correction merged into `dev` after that deployment.
 
@@ -66,11 +66,17 @@ of the current clock. Restart timing includes service shutdown and ExecStartPre.
 
 ## Validation
 
-The final implementation passed the production Next build and CI, including
+The measured implementation passed the production Next build and CI, including
 patch coverage. The full local suite passed 3,668 tests in 158 files with one
 skipped. TypeScript, ESLint, both Drizzle schema checks, shell syntax and
 maintenance lifecycle checks passed. ESLint retains an existing warning in
 `stryker.config.mjs` and reports no errors.
+
+A subsequent CodeRabbit review found that scheduled day/night LED callbacks
+could resume a settings read after shutdown and still write brightness. Both
+callbacks now check shutdown state after that read. Two regression tests fail
+on the measured build and pass with the guards; all 106 JobManager tests pass.
+This follow-up is separate from the deployed build and measurements below.
 
 The first deployment (`8fc0933`) is retained in `initial-startup-after.json`
 and `initial-after.json`. It reduced system-health median latency from 290.47

--- a/docs/performance/startup-api-2026-09-06.md
+++ b/docs/performance/startup-api-2026-09-06.md
@@ -23,16 +23,19 @@ process-wide DAC singleton correction merged into `dev` after that deployment.
   rehydration. The DAC socket and sensor stream start before schedule loading;
   the clock gate lives in the shared scheduler singleton so early API consumers
   cannot bypass it. Optional integrations and the initial LED write run in the
-  background. Shutdown cancels pending scheduler initialization and prevents
+  background. Cron loading yields after roughly 8 ms or 25 registrations,
+  including between a power schedule's on/off registrations. Shutdown cancels pending scheduler initialization and prevents
   delayed integration starts from reviving services.
 - NATS discovery inspects the individual Pod's installed service and JetStream
   storage, then verifies its greeting. Confirmed RAW-only Pods avoid the grace
   window. Known NATS installations keep retrying through delayed server starts;
-  unknown installations retain the 60-second fallback. Local overrides:
+  unknown installations retain the 60-second fallback and retry installation
+  discovery during that window if the initial probe was inconclusive. Local overrides:
   `PIEZO_SENSOR_SOURCE=raw|nats`, or legacy `PIEZO_NATS_DISABLED=1` for RAW.
 - Live RAW ingestion uses asynchronous file operations, scans for rotation once
   a second, polls every 25 ms, reads at most 64 KiB per batch, and decodes at most
-  128 outer records or approximately 4 ms before yielding. A single record may
+  128 outer records or approximately 4 ms before yielding. Backlogs resume after
+  yielding instead of waiting for the 25 ms idle poll interval. A single record may
   exceed that time budget; incomplete records are bounded to 1 MiB before
   resynchronizing. File offsets, split records, cap persistence, truncation and
   seek indexes are preserved. Shutdown waits for the active read to finish.
@@ -61,9 +64,16 @@ of the current clock. Restart timing includes service shutdown and ExecStartPre.
 
 ## Validation
 
-Production Next build passed. The full suite passed 3,661 tests with one
-skipped; an additional same-name RAW replacement regression subsequently
-passed in the 158-test streaming suite. TypeScript, ESLint, both Drizzle schema
+Production Next build passed. CI passed 3,662 tests with one skipped, including
+the same-name RAW replacement regression. The final follow-up suite passed
+3,668 tests with one skipped. TypeScript, ESLint, both Drizzle schema
 checks, shell syntax and maintenance lifecycle checks passed.
 
-Deployment measurements will be recorded after the final build.
+The first deployment (`8fc0933`) is retained in `initial-startup-after.json`
+and `initial-after.json`. It reduced system-health median latency from 290.47
+ms to 39.38 ms, but fixed-size scheduler batches still delayed local service
+callbacks, causing discovery to report an unknown installation and wait. Its
+first/current cap frames arrived at 68.85/85.74 seconds. These observations
+motivated elapsed-time scheduler yielding, repeated inconclusive installation
+discovery, and prompt resumption of RAW backlog batches. Final measurements
+will be recorded below after deploying that follow-up.

--- a/docs/performance/startup-api-2026-09-06.md
+++ b/docs/performance/startup-api-2026-09-06.md
@@ -1,6 +1,7 @@
 # Startup and API performance — 2026-09-06
 
-This pass follows PR #693. Measurements use the same Pod at 192.168.1.88;
+This pass follows PR #693 and is proposed in [PR #694](https://github.com/sleepypod/core/pull/694).
+The final implementation, `aeb3852`, is deployed on the same Pod at 192.168.1.88;
 the starting deployment is `38e0695`, so the new build also incorporates the
 process-wide DAC singleton correction merged into `dev` after that deployment.
 
@@ -24,8 +25,9 @@ process-wide DAC singleton correction merged into `dev` after that deployment.
   the clock gate lives in the shared scheduler singleton so early API consumers
   cannot bypass it. Optional integrations and the initial LED write run in the
   background. Cron loading yields after roughly 8 ms or 25 registrations,
-  including between a power schedule's on/off registrations. Shutdown cancels pending scheduler initialization and prevents
-  delayed integration starts from reviving services.
+  including between a power schedule's on/off registrations. Shutdown cancels
+  and awaits pending scheduler initialization and prevents delayed integration
+  starts or LED settings reads from reviving services or writing to hardware.
 - NATS discovery inspects the individual Pod's installed service and JetStream
   storage, then verifies its greeting. Confirmed RAW-only Pods avoid the grace
   window. Known NATS installations keep retrying through delayed server starts;
@@ -42,7 +44,7 @@ process-wide DAC singleton correction merged into `dev` after that deployment.
 - `sp-maintenance` defaults to required boot repairs. Journal vacuum, old temp
   cleanup, backup pruning and pnpm pruning run via a timer ten minutes after
   activation and daily thereafter. Fresh and OTA installs both install the timer;
-  newly created update staging directories are excluded from cleanup.
+  directories containing recent activity are excluded from cleanup.
 - Routine production tRPC request logging is disabled. `/api/health/performance`
   reports startup phases, source choice, first sensor frame, RSS and process-wide
   event-loop delay since instrumentation began (including remaining startup). It makes no hardware or database calls.
@@ -64,16 +66,84 @@ of the current clock. Restart timing includes service shutdown and ExecStartPre.
 
 ## Validation
 
-Production Next build passed. CI passed 3,662 tests with one skipped, including
-the same-name RAW replacement regression. The final follow-up suite passed
-3,668 tests with one skipped. TypeScript, ESLint, both Drizzle schema
-checks, shell syntax and maintenance lifecycle checks passed.
+The final implementation passed the production Next build and CI, including
+patch coverage. The full local suite passed 3,668 tests in 158 files with one
+skipped. TypeScript, ESLint, both Drizzle schema checks, shell syntax and
+maintenance lifecycle checks passed. ESLint retains an existing warning in
+`stryker.config.mjs` and reports no errors.
 
 The first deployment (`8fc0933`) is retained in `initial-startup-after.json`
 and `initial-after.json`. It reduced system-health median latency from 290.47
 ms to 39.38 ms, but fixed-size scheduler batches still delayed local service
-callbacks, causing discovery to report an unknown installation and wait. Its
+callbacks; discovery reported an unknown installation and waited. Its
 first/current cap frames arrived at 68.85/85.74 seconds. These observations
 motivated elapsed-time scheduler yielding, repeated inconclusive installation
-discovery, and prompt resumption of RAW backlog batches. Final measurements
-will be recorded below after deploying that follow-up.
+discovery, and prompt resumption of RAW backlog batches.
+
+## Final Pod measurements
+
+The before and after startup runs each restarted only `sleepypod.service` and
+observed the process for 90 seconds. The after run selected RAW on this Pod.
+
+| Startup milestone, from restart request | Before `38e0695` | After `aeb3852` |
+| --- | ---: | ---: |
+| Service restart command completed | 6.44 s | 0.21 s |
+| First successful HTTP healthcheck | 34.99 s | 9.30 s |
+| First capSense frame | Not observed within 90 s | 9.62 s |
+| First capSense frame within 5 s of the clock | Not observed within 90 s | 13.60 s |
+| First device-status WebSocket frame | 34.87 s | 31.22 s |
+
+HTTP readiness improved by 73%. Sensor data became available much earlier,
+including the time required to catch up with the RAW file. HTTP readiness does
+not imply that the scheduler or device-status stream has finished starting.
+
+The steady-state benchmark started about 3 minutes 18 seconds after the final
+restart. Each request statistic below is a median unless otherwise indicated.
+
+| Metric | Before `38e0695` | After `aeb3852` |
+| --- | ---: | ---: |
+| System health | 290.47 ms | 39.09 ms |
+| Trivial healthcheck paired with system health | 311.98 ms | 60.06 ms |
+| Status, one request every 500 ms | 38.03 ms | 40.44 ms |
+| Status p95 | 42.85 ms | 54.48 ms |
+| Status, bursts of four concurrent reads | 82.86 ms | 72.49 ms |
+| DAC health alongside each burst | 126.57 ms | 116.65 ms |
+| Settings | 29.59 ms | 31.71 ms |
+| Main-page HTML | 47.18 ms | 50.97 ms |
+| Debug-page HTML | 31.64 ms | 35.81 ms |
+| Device-status WebSocket gap | 1,000.68 ms | 1,000.59 ms |
+| Idle CPU, percentage of one core | 12.65% | 7.40% |
+| CPU during status polling, percentage of one core | 20.52% | 21.95% |
+| RSS at the end of status polling | 193.71 MiB | 176.27 MiB |
+
+System-health latency fell by 87%, and delay to the paired trivial request fell
+by 81%. Ordinary status calls did not improve in this sample: their median rose
+6%, p95 rose 27%, and polling CPU increased. Concurrent-status median improved,
+but its p95 was essentially unchanged (113.34 ms to 114.46 ms). These results
+support the startup and diagnostic changes; they do not establish a general
+API, page-rendering or frontend bundle improvement.
+
+Raw results are in `startup-api-2026-09-06/startup-before.json`,
+`startup-api-2026-09-06/startup-after.json`, `startup-api-2026-09-06/before.json`
+and `startup-api-2026-09-06/after.json`. The intermediate build results are also
+retained. These are individual runs on a live RAW-only J00 Pod with its existing
+sidecars and schedules, not controlled repeated trials. Physical NATS firmware
+was not available for deployment validation; per-Pod identity, greeting,
+delayed-service and fallback behavior are covered by automated tests.
+
+## Deployment verification and remaining work
+
+`startup-api-2026-09-06/verification.json` records the deployed version, system
+health, worker integrity result, scheduler drift, service states and a fresh
+WebSocket sensor frame. Application databases and shared native dependencies
+were preserved, and the previous application release remains available for
+rollback. Firmware and Python services were not restarted.
+
+The new startup telemetry still shows roughly 15 seconds spent initializing
+the scheduler and a maximum event-loop delay of 2.28 seconds during startup.
+Its timing starts when instrumentation begins, whereas the restart benchmark
+starts before service shutdown. The first device-status frame still takes
+about 31 seconds. Profiling those remaining startup stalls and the status route
+is the next step; this change does not eliminate those delays. Python sensor
+followers also retain their existing NATS grace behavior, as documented in
+`docs/nats-frame-readers.md`.

--- a/docs/performance/startup-api-2026-09-06/after.json
+++ b/docs/performance/startup-api-2026-09-06/after.json
@@ -1,0 +1,228 @@
+{
+  "label": "final-after-aeb3852",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T04:20:01.075Z",
+  "node": "v22.17.0",
+  "pid": "6807",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering. Finally 20 system-health requests concurrent with a no-op healthcheck sentinel.",
+  "idle": {
+    "durationSec": 15,
+    "cpuPercentOneCore": 7.4,
+    "rssMiBStart": 174.3,
+    "rssMiBEnd": 174.3
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 40.44,
+    "p95Ms": 54.48,
+    "maxMs": 82.6,
+    "meanMs": 42.09
+  },
+  "statusSamplesMs": [
+    34.79,
+    50.25,
+    82.6,
+    52.36,
+    52.2,
+    41.71,
+    55.23,
+    34.42,
+    34.61,
+    44.32,
+    40.36,
+    52.66,
+    47.07,
+    39.54,
+    69.71,
+    37.5,
+    44.25,
+    36.69,
+    51.91,
+    42.5,
+    51.88,
+    34.03,
+    48.5,
+    35.86,
+    53.79,
+    35.58,
+    43.43,
+    35.66,
+    41.95,
+    54.48,
+    30.2,
+    31.26,
+    49.53,
+    32.95,
+    49.49,
+    32.13,
+    40.44,
+    33.8,
+    46.27,
+    42.75,
+    41.54,
+    32.54,
+    41.46,
+    32.29,
+    45.86,
+    34.07,
+    38.67,
+    35.61,
+    36.79,
+    40.59,
+    35.55,
+    32.09,
+    37.39,
+    33.98,
+    45.87,
+    34.77,
+    42.19,
+    34.02,
+    37.27,
+    44.15
+  ],
+  "active": {
+    "durationSec": 30.02,
+    "cpuPercentOneCore": 21.95,
+    "rssMiBStart": 175.76,
+    "rssMiBEnd": 176.27
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 72.49,
+    "p95Ms": 114.46,
+    "maxMs": 153.59,
+    "meanMs": 72.83
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 116.65,
+    "p95Ms": 173.14,
+    "maxMs": 173.14,
+    "meanMs": 122.63
+  },
+  "burst": {
+    "durationSec": 5.2,
+    "cpuPercentOneCore": 46.31,
+    "rssMiBStart": 176.27,
+    "rssMiBEnd": 180.04
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 50.97,
+        "p95Ms": 130.08,
+        "maxMs": 130.08,
+        "meanMs": 58.16
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 275.75
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 35.81,
+        "p95Ms": 43.31,
+        "maxMs": 43.31,
+        "meanMs": 37.19
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 255.34
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 31.71,
+    "p95Ms": 36.54,
+    "maxMs": 37.97,
+    "meanMs": 32.36
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 1000.59,
+      "p95Ms": 1042.34,
+      "maxMs": 1059.4,
+      "meanMs": 1004.44
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "systemHealth": {
+    "n": 20,
+    "medianMs": 39.09,
+    "p95Ms": 58.98,
+    "maxMs": 101.39,
+    "meanMs": 42.74
+  },
+  "healthSentinel": {
+    "n": 20,
+    "medianMs": 60.06,
+    "p95Ms": 65.69,
+    "maxMs": 77.92,
+    "meanMs": 61.47
+  },
+  "version": {
+    "branch": "perf/startup-api",
+    "commitHash": "aeb3852",
+    "commitTitle": "perf: bound startup work and harden shutdown",
+    "buildDate": "2026-09-06T04:13:47.791Z"
+  },
+  "performance": {
+    "uptimeSeconds": 257.268582103,
+    "rssBytes": 199741440,
+    "startup": [
+      {
+        "name": "migrations-ready",
+        "elapsedMs": 94,
+        "durationMs": 92
+      },
+      {
+        "name": "hardware-services-started",
+        "elapsedMs": 306,
+        "durationMs": 0
+      },
+      {
+        "name": "http-initialization-ready",
+        "elapsedMs": 313,
+        "durationMs": 0
+      },
+      {
+        "name": "sensor-source-raw",
+        "elapsedMs": 4205,
+        "durationMs": 0
+      },
+      {
+        "name": "first-sensor-frame",
+        "elapsedMs": 4961,
+        "durationMs": 0
+      },
+      {
+        "name": "scheduler-ready",
+        "elapsedMs": 15299,
+        "durationMs": 14985
+      },
+      {
+        "name": "mqtt-started",
+        "elapsedMs": 15654,
+        "durationMs": 0
+      }
+    ],
+    "sensorSource": "raw",
+    "firstFrameMs": 4961,
+    "eventLoop": {
+      "meanMs": 21.83,
+      "p95Ms": 29.02,
+      "maxMs": 2277.51
+    }
+  },
+  "finishedAt": "2026-09-06T04:21:00.471Z"
+}

--- a/docs/performance/startup-api-2026-09-06/before.json
+++ b/docs/performance/startup-api-2026-09-06/before.json
@@ -1,0 +1,181 @@
+{
+  "label": "before-startup-api",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T03:37:09.075Z",
+  "node": "v22.17.0",
+  "pid": "3035",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering. Finally 20 system-health requests concurrent with a no-op healthcheck sentinel.",
+  "idle": {
+    "durationSec": 15.02,
+    "cpuPercentOneCore": 12.65,
+    "rssMiBStart": 191.77,
+    "rssMiBEnd": 191.79
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 38.03,
+    "p95Ms": 42.85,
+    "maxMs": 54.12,
+    "meanMs": 38.67
+  },
+  "statusSamplesMs": [
+    43.87,
+    42.85,
+    54.12,
+    46.57,
+    38.96,
+    38.03,
+    41.77,
+    38.44,
+    37.65,
+    39.37,
+    41.94,
+    41.33,
+    42.27,
+    37.79,
+    40.68,
+    38.47,
+    40.14,
+    37.96,
+    37.06,
+    36.54,
+    38.51,
+    38.98,
+    41.2,
+    35.8,
+    37.36,
+    36.52,
+    38.55,
+    40.54,
+    37.52,
+    37.84,
+    38.17,
+    36.9,
+    37.58,
+    39.68,
+    36.92,
+    36.95,
+    37.47,
+    40.29,
+    37.21,
+    37.75,
+    40.04,
+    39.33,
+    35.89,
+    39.05,
+    40.97,
+    36.19,
+    37.11,
+    36.21,
+    34.08,
+    33.8,
+    38.13,
+    37.38,
+    33.13,
+    36.36,
+    36.23,
+    38.93,
+    36.31,
+    38.58,
+    38.53,
+    36.59
+  ],
+  "active": {
+    "durationSec": 30.02,
+    "cpuPercentOneCore": 20.52,
+    "rssMiBStart": 192.43,
+    "rssMiBEnd": 193.71
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 82.86,
+    "p95Ms": 113.34,
+    "maxMs": 132.8,
+    "meanMs": 76.82
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 126.57,
+    "p95Ms": 147.53,
+    "maxMs": 147.53,
+    "meanMs": 127.92
+  },
+  "burst": {
+    "durationSec": 5.27,
+    "cpuPercentOneCore": 55.22,
+    "rssMiBStart": 193.71,
+    "rssMiBEnd": 199.16
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 47.18,
+        "p95Ms": 55.95,
+        "maxMs": 55.95,
+        "meanMs": 47.75
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 235.36
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 31.64,
+        "p95Ms": 49.18,
+        "maxMs": 49.18,
+        "meanMs": 34.68
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 249.29
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 29.59,
+    "p95Ms": 34.12,
+    "maxMs": 34.88,
+    "meanMs": 30.25
+  },
+  "websocket": {
+    "frames": 41,
+    "gaps": {
+      "n": 40,
+      "medianMs": 1000.68,
+      "p95Ms": 1010.76,
+      "maxMs": 1054.85,
+      "meanMs": 1002.54
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "systemHealth": {
+    "n": 20,
+    "medianMs": 290.47,
+    "p95Ms": 297.37,
+    "maxMs": 297.71,
+    "meanMs": 287.18
+  },
+  "healthSentinel": {
+    "n": 20,
+    "medianMs": 311.98,
+    "p95Ms": 317.68,
+    "maxMs": 329.52,
+    "meanMs": 310.47
+  },
+  "version": {
+    "branch": "perf/web-service-latency",
+    "commitHash": "38e0695",
+    "commitTitle": "test(web): close status cache coverage gaps",
+    "buildDate": "2026-09-06T00:31:42.061Z"
+  },
+  "performance": null,
+  "finishedAt": "2026-09-06T03:38:12.984Z"
+}

--- a/docs/performance/startup-api-2026-09-06/benchmark.mjs
+++ b/docs/performance/startup-api-2026-09-06/benchmark.mjs
@@ -1,0 +1,119 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { setTimeout as delay } from 'node:timers/promises'
+
+const [base = 'http://127.0.0.1:3000', label = 'sample', destination] = process.argv.slice(2)
+const pid = process.env.APP_PID || (base.includes('127.0.0.1') ? execFileSync('systemctl', ['show', 'sleepypod', '-p', 'MainPID', '--value'], { encoding: 'utf8' }).trim() : null)
+const round = n => Math.round(n * 100) / 100
+const stats = (values) => {
+  const sorted = [...values].sort((a, b) => a - b)
+  return { n: values.length, medianMs: round(sorted[Math.ceil(sorted.length * 0.5) - 1]), p95Ms: round(sorted[Math.ceil(sorted.length * 0.95) - 1]), maxMs: round(sorted.at(-1)), meanMs: round(values.reduce((a, b) => a + b, 0) / values.length) }
+}
+function resource() {
+  if (!pid) return null
+  const fields = readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ')
+  const status = readFileSync(`/proc/${pid}/status`, 'utf8')
+  return { t: performance.now(), cpuTicks: Number(fields[11]) + Number(fields[12]), rssKiB: Number(status.match(/VmRSS:\s+(\d+)/)[1]) }
+}
+function usage(a, b) {
+  return a && b ? { durationSec: round((b.t - a.t) / 1000), cpuPercentOneCore: round((b.cpuTicks - a.cpuTicks) * 1000 / (b.t - a.t)), rssMiBStart: round(a.rssKiB / 1024), rssMiBEnd: round(b.rssKiB / 1024) } : null
+}
+async function request(path, json = false, extra = {}) {
+  const start = performance.now()
+  const response = await fetch(base + path, { signal: AbortSignal.timeout(20000), ...extra })
+  const headersMs = performance.now() - start
+  const body = await response.text()
+  if (!response.ok) throw new Error(`${path}: HTTP ${response.status}: ${body.slice(0, 200)}`)
+  if (json && JSON.parse(body).error) throw new Error(`${path}: returned tRPC error`)
+  return { ms: performance.now() - start, headersMs, body }
+}
+const statusPath = '/api/trpc/device.getStatus?input=' + encodeURIComponent(JSON.stringify({ json: { unit: 'F' } }))
+const settingsPath = '/api/trpc/settings.getAll?input=' + encodeURIComponent(JSON.stringify({ json: {} }))
+const healthPath = '/api/health/dac-monitor'
+const result = { label, base, startedAt: new Date().toISOString(), node: process.version, pid, methodology: '15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering. Finally 20 system-health requests concurrent with a no-op healthcheck sentinel.' }
+console.log(JSON.stringify({ event: 'start', label, pid }))
+const idleStart = resource()
+await delay(15000)
+result.idle = usage(idleStart, resource())
+console.log(JSON.stringify({ event: 'idle', ...result.idle }))
+const socketUrl = new URL(base)
+socketUrl.protocol = 'ws:'
+socketUrl.port = '3001'
+const socket = new WebSocket(socketUrl)
+const frames = []
+socket.addEventListener('message', (event) => {
+  const data = JSON.parse(event.data)
+  if (data.type === 'deviceStatus') frames.push(performance.now())
+})
+await Promise.race([
+  new Promise((resolve, reject) => {
+    socket.addEventListener('open', resolve, { once: true })
+    socket.addEventListener('error', reject, { once: true })
+  }),
+  delay(10000).then(() => { throw new Error('WebSocket connect timed out') }),
+])
+socket.send(JSON.stringify({ type: 'subscribe', sensors: ['deviceStatus'] }))
+try {
+  await delay(2500)
+  for (let i = 0; i < 3; i++) {
+    await request(statusPath, true)
+    await request(settingsPath, true)
+  }
+  const activeStart = resource()
+  const serial = []
+  for (let i = 0; i < 60; i++) {
+    const start = performance.now()
+    serial.push((await request(statusPath, true)).ms)
+    await delay(Math.max(0, 500 - (performance.now() - start)))
+  }
+  result.status = stats(serial)
+  result.statusSamplesMs = serial.map(round)
+  result.active = usage(activeStart, resource())
+  console.log(JSON.stringify({ event: 'serial', ...result.status, ...result.active }))
+  const concurrent = [], health = []
+  const burstStart = resource()
+  for (let i = 0; i < 12; i++) {
+    const rows = await Promise.all([request(statusPath, true), request(statusPath, true), request(statusPath, true), request(statusPath, true), request(healthPath, true)])
+    concurrent.push(...rows.slice(0, 4).map(row => row.ms))
+    health.push(rows[4].ms)
+    await delay(300)
+  }
+  result.concurrentStatus = stats(concurrent)
+  result.concurrentHealth = stats(health)
+  result.burst = usage(burstStart, resource())
+  result.pages = {}
+  for (const path of ['/en', '/en/debug']) {
+    await request(path)
+    const rows = []
+    for (let i = 0; i < 10; i++) rows.push(await request(path))
+    const scripts = [...new Set([...rows.at(-1).body.matchAll(/<script\b[^>]*\bsrc="([^" ]+\.js(?:\?[^" ]*)?)"/g)].map(m => m[1]))]
+    const assetStart = performance.now()
+    const sizes = await Promise.all(scripts.map(async path => Buffer.byteLength((await request(path)).body)))
+    result.pages[path] = { html: stats(rows.map(row => row.ms)), htmlBytes: Buffer.byteLength(rows.at(-1).body), initialJsFiles: scripts.length, initialJsDecodedBytes: sizes.reduce((a, b) => a + b, 0), fetchAllInitialJsMs: round(performance.now() - assetStart) }
+  }
+  const settings = []
+  for (let i = 0; i < 20; i++) settings.push((await request(settingsPath, true)).ms)
+  result.settings = stats(settings)
+  result.websocket = { frames: frames.length, gaps: frames.length > 1 ? stats(frames.slice(1).map((t, i) => t - frames[i])) : null }
+  result.health = JSON.parse((await request(healthPath, true)).body)
+  const deepHealth = [], sentinel = []
+  for (let i = 0; i < 20; i++) {
+    const rows = await Promise.all([request('/api/health/system', true), request('/api/healthcheck', true)])
+    deepHealth.push(rows[0].ms)
+    sentinel.push(rows[1].ms)
+    await delay(100)
+  }
+  result.systemHealth = stats(deepHealth)
+  result.healthSentinel = stats(sentinel)
+  result.version = JSON.parse((await request('/api/system/version', true)).body)
+  try {
+    result.performance = JSON.parse((await request('/api/health/performance', true)).body)
+  }
+  catch { result.performance = null }
+  result.finishedAt = new Date().toISOString()
+  if (destination) writeFileSync(destination, JSON.stringify(result, null, 2) + '\n')
+  console.log(JSON.stringify({ event: 'complete', ...result }))
+}
+finally {
+  socket.close()
+}

--- a/docs/performance/startup-api-2026-09-06/initial-after.json
+++ b/docs/performance/startup-api-2026-09-06/initial-after.json
@@ -1,0 +1,228 @@
+{
+  "label": "initial-after-8fc0933",
+  "base": "http://127.0.0.1:3000",
+  "startedAt": "2026-09-06T04:02:27.360Z",
+  "node": "v22.17.0",
+  "pid": "6212",
+  "methodology": "15s idle; one deviceStatus WebSocket; 3 warmups; 60 serial status reads spaced at least 500ms start-to-start; 12 bursts of 4 concurrent reads; 10 warm HTML requests per page. /proc CPU uses SC_CLK_TCK=100 and reports percent of one core. HTTP timing includes body; no browser rendering. Finally 20 system-health requests concurrent with a no-op healthcheck sentinel.",
+  "idle": {
+    "durationSec": 15,
+    "cpuPercentOneCore": 11.33,
+    "rssMiBStart": 166.13,
+    "rssMiBEnd": 165.22
+  },
+  "status": {
+    "n": 60,
+    "medianMs": 42.95,
+    "p95Ms": 56.13,
+    "maxMs": 83.29,
+    "meanMs": 43.36
+  },
+  "statusSamplesMs": [
+    32.29,
+    45.94,
+    83.29,
+    44.2,
+    50.16,
+    44.6,
+    52.86,
+    34.53,
+    34.72,
+    42.95,
+    51.68,
+    43.27,
+    55,
+    40.36,
+    56.13,
+    37.15,
+    35.19,
+    35.1,
+    34.16,
+    46.13,
+    36.07,
+    35.01,
+    50.31,
+    34.9,
+    40.83,
+    36.59,
+    34.27,
+    35.54,
+    52.71,
+    39.39,
+    51.36,
+    34.1,
+    64.67,
+    33.77,
+    50.23,
+    33.5,
+    50.1,
+    43.49,
+    47.22,
+    34.05,
+    49.28,
+    35.71,
+    60.54,
+    36.42,
+    46.2,
+    34.03,
+    51.66,
+    41.31,
+    46.18,
+    33.67,
+    47.51,
+    34.48,
+    52.21,
+    34.01,
+    48.01,
+    34.96,
+    50.88,
+    43.7,
+    47.48,
+    35.58
+  ],
+  "active": {
+    "durationSec": 30.01,
+    "cpuPercentOneCore": 19.06,
+    "rssMiBStart": 168.91,
+    "rssMiBEnd": 175.16
+  },
+  "concurrentStatus": {
+    "n": 48,
+    "medianMs": 76.15,
+    "p95Ms": 114.53,
+    "maxMs": 153.55,
+    "meanMs": 74.39
+  },
+  "concurrentHealth": {
+    "n": 12,
+    "medianMs": 119.65,
+    "p95Ms": 172.11,
+    "maxMs": 172.11,
+    "meanMs": 123.4
+  },
+  "burst": {
+    "durationSec": 5.21,
+    "cpuPercentOneCore": 56.59,
+    "rssMiBStart": 175.16,
+    "rssMiBEnd": 178.05
+  },
+  "pages": {
+    "/en": {
+      "html": {
+        "n": 10,
+        "medianMs": 45.94,
+        "p95Ms": 82.19,
+        "maxMs": 82.19,
+        "meanMs": 49.93
+      },
+      "htmlBytes": 13406,
+      "initialJsFiles": 10,
+      "initialJsDecodedBytes": 732523,
+      "fetchAllInitialJsMs": 382.84
+    },
+    "/en/debug": {
+      "html": {
+        "n": 10,
+        "medianMs": 34.47,
+        "p95Ms": 37.97,
+        "maxMs": 37.97,
+        "meanMs": 34.87
+      },
+      "htmlBytes": 23656,
+      "initialJsFiles": 12,
+      "initialJsDecodedBytes": 783209,
+      "fetchAllInitialJsMs": 244.18
+    }
+  },
+  "settings": {
+    "n": 20,
+    "medianMs": 31.39,
+    "p95Ms": 39.87,
+    "maxMs": 51.33,
+    "meanMs": 33.16
+  },
+  "websocket": {
+    "frames": 40,
+    "gaps": {
+      "n": 39,
+      "medianMs": 1001.52,
+      "p95Ms": 1038.2,
+      "maxMs": 1044.16,
+      "meanMs": 1003.74
+    }
+  },
+  "health": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "systemHealth": {
+    "n": 20,
+    "medianMs": 39.38,
+    "p95Ms": 58.33,
+    "maxMs": 98.39,
+    "meanMs": 44.1
+  },
+  "healthSentinel": {
+    "n": 20,
+    "medianMs": 61.36,
+    "p95Ms": 74.2,
+    "maxMs": 77.32,
+    "meanMs": 63.15
+  },
+  "version": {
+    "branch": "perf/startup-api",
+    "commitHash": "8fc0933",
+    "commitTitle": "perf: shorten startup and remove blocking API diagnostics",
+    "buildDate": "2026-09-06T03:53:15.156Z"
+  },
+  "performance": {
+    "uptimeSeconds": 330.578933103,
+    "rssBytes": 196968448,
+    "startup": [
+      {
+        "name": "migrations-ready",
+        "elapsedMs": 74,
+        "durationMs": 73
+      },
+      {
+        "name": "hardware-services-started",
+        "elapsedMs": 281,
+        "durationMs": 1
+      },
+      {
+        "name": "http-initialization-ready",
+        "elapsedMs": 287,
+        "durationMs": 0
+      },
+      {
+        "name": "scheduler-ready",
+        "elapsedMs": 13555,
+        "durationMs": 13267
+      },
+      {
+        "name": "mqtt-started",
+        "elapsedMs": 13899,
+        "durationMs": 0
+      },
+      {
+        "name": "sensor-source-raw",
+        "elapsedMs": 64269,
+        "durationMs": 0
+      },
+      {
+        "name": "first-sensor-frame",
+        "elapsedMs": 64329,
+        "durationMs": 0
+      }
+    ],
+    "sensorSource": "raw",
+    "firstFrameMs": 64329,
+    "eventLoop": {
+      "meanMs": 21.69,
+      "p95Ms": 23.15,
+      "maxMs": 3080.72
+    }
+  },
+  "finishedAt": "2026-09-06T04:03:26.786Z"
+}

--- a/docs/performance/startup-api-2026-09-06/initial-startup-after.json
+++ b/docs/performance/startup-api-2026-09-06/initial-startup-after.json
@@ -1,0 +1,636 @@
+{
+  "label": "after-startup-api",
+  "startedAt": "2026-09-06T03:57:56.006Z",
+  "serviceRestartMs": 193,
+  "httpReadyMs": 16988,
+  "firstSensorMs": 68852,
+  "firstCurrentSensorMs": 85741,
+  "firstDeviceStatusMs": 31219,
+  "samples": [
+    {
+      "atMs": 15777,
+      "latencyMs": 1211
+    },
+    {
+      "atMs": 18496,
+      "latencyMs": 403
+    },
+    {
+      "atMs": 18995,
+      "latencyMs": 96
+    },
+    {
+      "atMs": 19496,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 19996,
+      "latencyMs": 54
+    },
+    {
+      "atMs": 20497,
+      "latencyMs": 45
+    },
+    {
+      "atMs": 20998,
+      "latencyMs": 43
+    },
+    {
+      "atMs": 21498,
+      "latencyMs": 44
+    },
+    {
+      "atMs": 21998,
+      "latencyMs": 47
+    },
+    {
+      "atMs": 22500,
+      "latencyMs": 39
+    },
+    {
+      "atMs": 23001,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 23503,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 24003,
+      "latencyMs": 38
+    },
+    {
+      "atMs": 24503,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 25003,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 25503,
+      "latencyMs": 37
+    },
+    {
+      "atMs": 26004,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 26504,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 27005,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 27506,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 28007,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 28508,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 29008,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 29509,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 30010,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 30511,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 31011,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 31512,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 32013,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 32514,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 33015,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 33515,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 34016,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 34516,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 35017,
+      "latencyMs": 25
+    },
+    {
+      "atMs": 35518,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 36019,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 36520,
+      "latencyMs": 27
+    },
+    {
+      "atMs": 37021,
+      "latencyMs": 26
+    },
+    {
+      "atMs": 37520,
+      "latencyMs": 25
+    },
+    {
+      "atMs": 38022,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 38523,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 39024,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 39525,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 40025,
+      "latencyMs": 38
+    },
+    {
+      "atMs": 40526,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 41027,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 41528,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 42028,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 42529,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 43030,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 43531,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 44032,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 44533,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 45034,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 45535,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 46036,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 46536,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 47037,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 47537,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 48038,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 48539,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 49039,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 49540,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 50040,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 50541,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 51042,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 51542,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 52042,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 52543,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 53044,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 53545,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 54046,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 54546,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 55047,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 55548,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 56049,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 56549,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 57049,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 57550,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 58051,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 58551,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 59052,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 59552,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 60052,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 60553,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 61054,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 61554,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 62055,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 62556,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 63057,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 63557,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 64058,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 64559,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 65060,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 65560,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 66061,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 66562,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 67063,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 67564,
+      "latencyMs": 27
+    },
+    {
+      "atMs": 68065,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 68564,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 69065,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 69567,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 70068,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 70567,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 71068,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 71567,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 72069,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 72569,
+      "latencyMs": 26
+    },
+    {
+      "atMs": 73069,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 73568,
+      "latencyMs": 37
+    },
+    {
+      "atMs": 74068,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 74570,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 75070,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 75569,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 76069,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 76570,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 77070,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 77570,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 78070,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 78572,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 79073,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 79574,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 80074,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 80574,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 81075,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 81575,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 82075,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 82577,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 83078,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 83579,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 84080,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 84581,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 85081,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 85582,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 86083,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 86584,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 87085,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 87586,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 88086,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 88587,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 89088,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 89589,
+      "latencyMs": 29
+    }
+  ],
+  "performance": {
+    "uptimeSeconds": 89.932637617,
+    "rssBytes": 199188480,
+    "startup": [
+      {
+        "name": "migrations-ready",
+        "elapsedMs": 74,
+        "durationMs": 73
+      },
+      {
+        "name": "hardware-services-started",
+        "elapsedMs": 281,
+        "durationMs": 1
+      },
+      {
+        "name": "http-initialization-ready",
+        "elapsedMs": 287,
+        "durationMs": 0
+      },
+      {
+        "name": "scheduler-ready",
+        "elapsedMs": 13555,
+        "durationMs": 13267
+      },
+      {
+        "name": "mqtt-started",
+        "elapsedMs": 13899,
+        "durationMs": 0
+      },
+      {
+        "name": "sensor-source-raw",
+        "elapsedMs": 64269,
+        "durationMs": 0
+      },
+      {
+        "name": "first-sensor-frame",
+        "elapsedMs": 64329,
+        "durationMs": 0
+      }
+    ],
+    "sensorSource": "raw",
+    "firstFrameMs": 64329,
+    "eventLoop": {
+      "meanMs": 24.77,
+      "p95Ms": 32.26,
+      "maxMs": 3080.72
+    }
+  },
+  "finishedAt": "2026-09-06T03:59:26.144Z"
+}

--- a/docs/performance/startup-api-2026-09-06/startup-after.json
+++ b/docs/performance/startup-api-2026-09-06/startup-after.json
@@ -1,0 +1,708 @@
+{
+  "label": "final-startup-api",
+  "startedAt": "2026-09-06T04:16:42.983Z",
+  "serviceRestartMs": 210,
+  "httpReadyMs": 9301,
+  "firstSensorMs": 9615,
+  "firstCurrentSensorMs": 13597,
+  "firstDeviceStatusMs": 31217,
+  "samples": [
+    {
+      "atMs": 8262,
+      "latencyMs": 1039
+    },
+    {
+      "atMs": 9305,
+      "latencyMs": 56
+    },
+    {
+      "atMs": 9807,
+      "latencyMs": 50
+    },
+    {
+      "atMs": 10307,
+      "latencyMs": 72
+    },
+    {
+      "atMs": 10807,
+      "latencyMs": 125
+    },
+    {
+      "atMs": 11308,
+      "latencyMs": 51
+    },
+    {
+      "atMs": 11809,
+      "latencyMs": 64
+    },
+    {
+      "atMs": 12309,
+      "latencyMs": 80
+    },
+    {
+      "atMs": 12810,
+      "latencyMs": 57
+    },
+    {
+      "atMs": 13310,
+      "latencyMs": 58
+    },
+    {
+      "atMs": 13810,
+      "latencyMs": 45
+    },
+    {
+      "atMs": 14311,
+      "latencyMs": 48
+    },
+    {
+      "atMs": 14812,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 15313,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 15814,
+      "latencyMs": 40
+    },
+    {
+      "atMs": 16314,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 16814,
+      "latencyMs": 49
+    },
+    {
+      "atMs": 17316,
+      "latencyMs": 50
+    },
+    {
+      "atMs": 17816,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 18316,
+      "latencyMs": 27
+    },
+    {
+      "atMs": 18817,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 19318,
+      "latencyMs": 53
+    },
+    {
+      "atMs": 19819,
+      "latencyMs": 870
+    },
+    {
+      "atMs": 20690,
+      "latencyMs": 51
+    },
+    {
+      "atMs": 21190,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 21692,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 22191,
+      "latencyMs": 61
+    },
+    {
+      "atMs": 22693,
+      "latencyMs": 41
+    },
+    {
+      "atMs": 23194,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 23694,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 24195,
+      "latencyMs": 37
+    },
+    {
+      "atMs": 24697,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 25198,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 25698,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 26198,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 26698,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 27199,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 27700,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 28201,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 28702,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 29203,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 29705,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 30206,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 30705,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 31206,
+      "latencyMs": 38
+    },
+    {
+      "atMs": 31709,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 32210,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 32711,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 33212,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 33712,
+      "latencyMs": 39
+    },
+    {
+      "atMs": 34212,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 34713,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 35213,
+      "latencyMs": 24
+    },
+    {
+      "atMs": 35714,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 36214,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 36715,
+      "latencyMs": 37
+    },
+    {
+      "atMs": 37216,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 37717,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 38218,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 38718,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 39219,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 39720,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 40220,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 40721,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 41222,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 41722,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 42222,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 42723,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 43224,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 43724,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 44224,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 44725,
+      "latencyMs": 104
+    },
+    {
+      "atMs": 45226,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 45726,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 46227,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 46729,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 47230,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 47731,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 48231,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 48732,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 49233,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 49734,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 50233,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 50734,
+      "latencyMs": 26
+    },
+    {
+      "atMs": 51234,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 51735,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 52236,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 52736,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 53237,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 53737,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 54238,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 54739,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 55240,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 55740,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 56241,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 56742,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 57241,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 57742,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 58242,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 58743,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 59244,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 59744,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 60244,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 60744,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 61245,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 61746,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 62246,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 62747,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 63248,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 63749,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 64249,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 64750,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 65251,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 65751,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 66252,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 66753,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 67254,
+      "latencyMs": 39
+    },
+    {
+      "atMs": 67755,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 68256,
+      "latencyMs": 41
+    },
+    {
+      "atMs": 68757,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 69257,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 69758,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 70258,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 70760,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 71260,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 71761,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 72261,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 72762,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 73263,
+      "latencyMs": 41
+    },
+    {
+      "atMs": 73764,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 74264,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 74764,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 75265,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 75765,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 76265,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 76766,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 77267,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 77767,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 78269,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 78769,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 79269,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 79769,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 80270,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 80770,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 81271,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 81771,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 82272,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 82773,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 83274,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 83774,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 84274,
+      "latencyMs": 28
+    },
+    {
+      "atMs": 84775,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 85276,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 85777,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 86277,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 86777,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 87277,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 87777,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 88277,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 88778,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 89279,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 89779,
+      "latencyMs": 29
+    }
+  ],
+  "performance": {
+    "uptimeSeconds": 90.10813162,
+    "rssBytes": 204132352,
+    "startup": [
+      {
+        "name": "migrations-ready",
+        "elapsedMs": 94,
+        "durationMs": 92
+      },
+      {
+        "name": "hardware-services-started",
+        "elapsedMs": 306,
+        "durationMs": 0
+      },
+      {
+        "name": "http-initialization-ready",
+        "elapsedMs": 313,
+        "durationMs": 0
+      },
+      {
+        "name": "sensor-source-raw",
+        "elapsedMs": 4205,
+        "durationMs": 0
+      },
+      {
+        "name": "first-sensor-frame",
+        "elapsedMs": 4961,
+        "durationMs": 0
+      },
+      {
+        "name": "scheduler-ready",
+        "elapsedMs": 15299,
+        "durationMs": 14985
+      },
+      {
+        "name": "mqtt-started",
+        "elapsedMs": 15654,
+        "durationMs": 0
+      }
+    ],
+    "sensorSource": "raw",
+    "firstFrameMs": 4961,
+    "eventLoop": {
+      "meanMs": 23.86,
+      "p95Ms": 38.01,
+      "maxMs": 2277.51
+    }
+  },
+  "finishedAt": "2026-09-06T04:18:13.322Z"
+}

--- a/docs/performance/startup-api-2026-09-06/startup-before.json
+++ b/docs/performance/startup-api-2026-09-06/startup-before.json
@@ -1,0 +1,457 @@
+{
+  "label": "before-startup-api",
+  "startedAt": "2026-09-06T03:49:53.910Z",
+  "serviceRestartMs": 6442,
+  "httpReadyMs": 34990,
+  "firstSensorMs": null,
+  "firstCurrentSensorMs": null,
+  "firstDeviceStatusMs": 34873,
+  "samples": [
+    {
+      "atMs": 34106,
+      "latencyMs": 885
+    },
+    {
+      "atMs": 34992,
+      "latencyMs": 52
+    },
+    {
+      "atMs": 35493,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 35994,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 36496,
+      "latencyMs": 49
+    },
+    {
+      "atMs": 36998,
+      "latencyMs": 55
+    },
+    {
+      "atMs": 37498,
+      "latencyMs": 39
+    },
+    {
+      "atMs": 37998,
+      "latencyMs": 42
+    },
+    {
+      "atMs": 38500,
+      "latencyMs": 52
+    },
+    {
+      "atMs": 39001,
+      "latencyMs": 42
+    },
+    {
+      "atMs": 39502,
+      "latencyMs": 39
+    },
+    {
+      "atMs": 40003,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 40504,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 41004,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 41504,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 42005,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 42506,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 43006,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 43506,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 44006,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 44507,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 45008,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 45508,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 46009,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 46509,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 47010,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 47511,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 48011,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 48518,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 49019,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 49519,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 50020,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 50520,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 51021,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 51521,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 52022,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 52523,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 53023,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 53523,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 54023,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 54524,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 55024,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 55526,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 56027,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 56527,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 57027,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 57530,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 58031,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 58532,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 59034,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 59534,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 60034,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 60536,
+      "latencyMs": 48
+    },
+    {
+      "atMs": 61036,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 61536,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 62037,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 62538,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 63038,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 63539,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 64040,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 64541,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 65041,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 65542,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 66042,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 66543,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 67044,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 67544,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 68044,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 68544,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 69045,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 69546,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 70048,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 70549,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 71050,
+      "latencyMs": 36
+    },
+    {
+      "atMs": 71550,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 72051,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 72552,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 73052,
+      "latencyMs": 35
+    },
+    {
+      "atMs": 73552,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 74054,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 74554,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 75056,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 75557,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 76057,
+      "latencyMs": 34
+    },
+    {
+      "atMs": 76557,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 77058,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 77559,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 78059,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 78560,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 79061,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 79562,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 80063,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 80564,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 81064,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 81565,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 82066,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 82567,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 83068,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 83569,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 84069,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 84570,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 85070,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 85570,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 86070,
+      "latencyMs": 32
+    },
+    {
+      "atMs": 86572,
+      "latencyMs": 31
+    },
+    {
+      "atMs": 87072,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 87572,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 88073,
+      "latencyMs": 30
+    },
+    {
+      "atMs": 88574,
+      "latencyMs": 29
+    },
+    {
+      "atMs": 89075,
+      "latencyMs": 33
+    },
+    {
+      "atMs": 89576,
+      "latencyMs": 31
+    }
+  ],
+  "performance": null,
+  "finishedAt": "2026-09-06T03:51:24.036Z"
+}

--- a/docs/performance/startup-api-2026-09-06/startup.mjs
+++ b/docs/performance/startup-api-2026-09-06/startup.mjs
@@ -1,0 +1,60 @@
+// Restarts only sleepypod.service and samples readiness for 90 seconds.
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { writeFileSync } from 'node:fs'
+import { setTimeout as delay } from 'node:timers/promises'
+const run = promisify(execFile)
+const [label = 'startup', destination] = process.argv.slice(2)
+const startedAt = performance.now()
+const elapsed = () => Math.round(performance.now() - startedAt)
+const result = { label, startedAt: new Date().toISOString(), serviceRestartMs: null,
+  httpReadyMs: null, firstSensorMs: null, firstCurrentSensorMs: null, firstDeviceStatusMs: null,
+  samples: [], performance: null }
+await run('systemctl', ['restart', 'sleepypod.service'])
+result.serviceRestartMs = elapsed()
+let socket = null
+let stopped = false
+const connect = () => {
+  if (socket || stopped) return
+  const ws = new WebSocket('ws://127.0.0.1:3001')
+  socket = ws
+  ws.addEventListener('open', () => ws.send(JSON.stringify({ type: 'subscribe', sensors: ['capSense', 'capSense2', 'deviceStatus'] })))
+  ws.addEventListener('error', () => {
+    if (socket === ws) socket = null
+  })
+  ws.addEventListener('close', () => {
+    if (socket === ws) socket = null
+  })
+  ws.addEventListener('message', (event) => {
+    const frame = JSON.parse(event.data)
+    if (frame.type === 'deviceStatus') result.firstDeviceStatusMs ??= elapsed()
+    if (frame.type === 'capSense' || frame.type === 'capSense2') {
+      result.firstSensorMs ??= elapsed()
+      if (typeof frame.ts === 'number' && Math.abs(Date.now() / 1000 - frame.ts) <= 5) result.firstCurrentSensorMs ??= elapsed()
+    }
+  })
+}
+while (elapsed() < 90_000) {
+  const sampleAt = elapsed()
+  connect()
+  try {
+    const response = await fetch('http://127.0.0.1:3000/api/healthcheck', { signal: AbortSignal.timeout(1500) })
+    await response.text()
+    if (response.ok) {
+      result.httpReadyMs ??= elapsed()
+      result.samples.push({ atMs: sampleAt, latencyMs: elapsed() - sampleAt })
+    }
+  }
+  catch { /* server still starting */ }
+  await delay(Math.max(0, 500 - (elapsed() - sampleAt)))
+}
+stopped = true
+socket?.close()
+try {
+  const response = await fetch('http://127.0.0.1:3000/api/health/performance')
+  if (response.ok) result.performance = await response.json()
+}
+catch { /* absent in the baseline build */ }
+result.finishedAt = new Date().toISOString()
+if (destination) writeFileSync(destination, JSON.stringify(result, null, 2) + '\n')
+console.log(JSON.stringify(result))

--- a/docs/performance/startup-api-2026-09-06/verification.json
+++ b/docs/performance/startup-api-2026-09-06/verification.json
@@ -1,0 +1,145 @@
+{
+  "checkedAt": "2026-09-06T04:22:11.912Z",
+  "release": "/persistent/sleepypod-releases/aeb3852",
+  "system/version": {
+    "branch": "perf/startup-api",
+    "commitHash": "aeb3852",
+    "commitTitle": "perf: bound startup work and harden shutdown",
+    "buildDate": "2026-09-06T04:13:47.791Z"
+  },
+  "health/system": {
+    "status": "ok",
+    "timestamp": "2026-09-06T04:22:12.290Z",
+    "database": {
+      "status": "ok",
+      "latencyMs": 0.17,
+      "integrity": {
+        "status": "ok",
+        "checkedAt": "2026-09-06T04:17:18.256Z",
+        "latencyMs": 400
+      }
+    },
+    "scheduler": {
+      "enabled": true,
+      "jobCount": 356,
+      "drift": {
+        "dbScheduleCount": 350,
+        "schedulerJobCount": 350,
+        "drifted": false
+      }
+    },
+    "iptables": {
+      "ok": true,
+      "missing": []
+    }
+  },
+  "health/dac-monitor": {
+    "status": "running",
+    "podVersion": "J00",
+    "gesturesSupported": true
+  },
+  "health/performance": {
+    "uptimeSeconds": 329.21657583,
+    "rssBytes": 202764288,
+    "startup": [
+      {
+        "name": "migrations-ready",
+        "elapsedMs": 94,
+        "durationMs": 92
+      },
+      {
+        "name": "hardware-services-started",
+        "elapsedMs": 306,
+        "durationMs": 0
+      },
+      {
+        "name": "http-initialization-ready",
+        "elapsedMs": 313,
+        "durationMs": 0
+      },
+      {
+        "name": "sensor-source-raw",
+        "elapsedMs": 4205,
+        "durationMs": 0
+      },
+      {
+        "name": "first-sensor-frame",
+        "elapsedMs": 4961,
+        "durationMs": 0
+      },
+      {
+        "name": "scheduler-ready",
+        "elapsedMs": 15299,
+        "durationMs": 14985
+      },
+      {
+        "name": "mqtt-started",
+        "elapsedMs": 15654,
+        "durationMs": 0
+      }
+    ],
+    "sensorSource": "raw",
+    "firstFrameMs": 4961,
+    "eventLoop": {
+      "meanMs": 21.48,
+      "p95Ms": 25.26,
+      "maxMs": 2277.51
+    }
+  },
+  "services": {
+    "sleepypod": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "frank": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "sleepypod-calibrator": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "sleepypod-cover-buttons": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "sleepypod-environment-monitor": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "sleepypod-piezo-processor": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    },
+    "sleepypod-sleep-detector": {
+      "Result": "success",
+      "NRestarts": "0",
+      "ExecMainStatus": "0",
+      "ActiveState": "active",
+      "SubState": "running"
+    }
+  },
+  "maintenanceTimer": "NextElapseUSecMonotonic=7h 29min 33.513053s\nActiveState=active\nSubState=waiting\nUnitFileState=enabled",
+  "freshSensor": {
+    "type": "capSense2",
+    "ageMs": 790
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -25,11 +25,16 @@ import { startBonjourAnnouncement, stopBonjourAnnouncement } from '@/src/streami
 import { startMqttBridge, shutdownMqttBridge } from '@/src/streaming/mqttBridge'
 import { initializeKeepalives, shutdownKeepalives } from '@/src/services/temperatureKeepalive'
 import { startAutoOffWatcher, stopAutoOffWatcher } from '@/src/services/autoOffWatcher'
+import { startDatabaseIntegrityChecks, stopDatabaseIntegrityChecks } from '@/src/db/integrity'
+import { startPerformanceMonitoring, stopPerformanceMonitoring, recordStartupPhase } from '@/src/lib/serverPerformance'
 import { shutdownHomeKit, startHomeKitIfEnabled } from '@/src/homekit'
 
 let isInitialized = false
 let isShuttingDown = false
 let handlersRegistered = false
+let initializationPromise: Promise<void> | null = null
+let hardwareReady = false
+let hardwarePromise: Promise<void> | null = null
 
 /**
  * Centralized graceful shutdown coordinator.
@@ -47,6 +52,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
     process.exit(1)
   }, 10_000)
   forceExitTimer.unref()
+
+  stopPerformanceMonitoring()
+  await stopDatabaseIntegrityChecks()
 
   // Step 0: Stop keepalive timers
   try {
@@ -182,6 +190,7 @@ async function withRetry<T>(
 ): Promise<T> {
   let lastError: unknown
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (isShuttingDown) throw new Error('Startup cancelled during shutdown')
     try {
       return await fn()
     }
@@ -214,6 +223,7 @@ async function withRetry<T>(
 const initializeDacMonitor = async (): Promise<void> => {
   try {
     await getDacMonitor()
+    if (isShuttingDown) await shutdownDacMonitor()
   }
   catch (error) {
     console.warn(
@@ -223,28 +233,57 @@ const initializeDacMonitor = async (): Promise<void> => {
   }
 }
 
-/**
- * Wait until the system clock is plausible (year >= 2024).
- * The Pod can boot with its clock reset to ~2010 before NTP syncs.
- * Schedulers must not start until the date is valid or cron jobs fire at wrong times.
- */
-async function waitForValidSystemDate(
-  maxAttempts: number = 24,
-  intervalMs: number = 5_000
-): Promise<void> {
-  const MIN_VALID_YEAR = 2024
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (new Date().getFullYear() >= MIN_VALID_YEAR) return
-    console.warn(
-      `System clock is invalid (${new Date().toISOString()}), waiting for NTP sync...`,
-      `(${attempt + 1}/${maxAttempts})`
-    )
-    await new Promise(resolve => setTimeout(resolve, intervalMs))
+async function initializeHardware(): Promise<void> {
+  if (hardwareReady || isShuttingDown) return
+  if (hardwarePromise) return hardwarePromise
+  hardwarePromise = prepareHardware().finally(() => {
+    hardwarePromise = null
+  })
+  return hardwarePromise
+}
+
+async function prepareHardware(): Promise<void> {
+  // Rehydrate the pump stall guard from persisted un-acknowledged alerts
+  // before anything that consults shouldBlock (keepalives, scheduler jobs)
+  // can re-energize a side whose fault predates this boot.
+  try {
+    const { rehydrate } = await import('@/src/hardware/pumpStallGuard')
+    rehydrate()
   }
-  console.error(
-    'System clock never synced after waiting — proceeding anyway.',
-    'Scheduled jobs may fire at incorrect times.'
-  )
+  catch (error) {
+    console.warn(
+      '[pumpStallGuard] rehydration failed:',
+      error instanceof Error ? error.message : error
+    )
+  }
+
+  if (isShuttingDown) return
+
+  // Start DAC socket server FIRST — this is the single listener on dac.sock.
+  // frankenfirmware will connect to it. Everything else (DacMonitor, device
+  // router, health checks) uses this server's connection.
+  try {
+    const { startDacServer } = await import('@/src/hardware/dacMonitor.instance')
+    await startDacServer()
+  }
+  catch (error) {
+    console.warn('[DAC] Socket server failed to start:', error instanceof Error ? error.message : error)
+  }
+
+  if (isShuttingDown) return
+
+  // Start DAC monitor (non-blocking — waits for frankenfirmware to connect)
+  initializeDacMonitor()
+
+  if (isShuttingDown) return
+  hardwareReady = true
+  try {
+    startPiezoStreamServer()
+  }
+  catch (error) {
+    console.warn('WARNING: Piezo stream server failed to start:', error instanceof Error ? error.message : error)
+  }
+  recordStartupPhase('hardware-services-started')
 }
 
 /**
@@ -252,15 +291,26 @@ async function waitForValidSystemDate(
  * Safe to call multiple times - will only initialize once
  */
 export async function initializeScheduler(): Promise<void> {
-  if (isInitialized) return
+  if (isInitialized || isShuttingDown) return
+  if (initializationPromise) return initializationPromise
+  initializationPromise = initializeBackgroundServices().finally(() => {
+    initializationPromise = null
+  })
+  return initializationPromise
+}
 
+async function initializeBackgroundServices(): Promise<void> {
   try {
-    await waitForValidSystemDate()
+    await initializeHardware()
+    if (isShuttingDown) return
+    const schedulerStartedAt = performance.now()
     console.log('Initializing job scheduler...')
     const jobManager = await withRetry(
       () => getJobManager(),
       'Job manager initialization'
     )
+    if (isShuttingDown) return
+    recordStartupPhase('scheduler-ready', schedulerStartedAt)
     const scheduler = jobManager.getScheduler()
     const jobs = scheduler.getJobs()
 
@@ -292,58 +342,16 @@ export async function initializeScheduler(): Promise<void> {
 
     isInitialized = true
 
-    // Start DAC socket server FIRST — this is the single listener on dac.sock.
-    // frankenfirmware will connect to it. Everything else (DacMonitor, device
-    // router, health checks) uses this server's connection.
-    try {
-      const { startDacServer } = await import('@/src/hardware/dacMonitor.instance')
-      await startDacServer()
-    }
-    catch (error) {
-      console.warn('[DAC] Socket server failed to start:', error instanceof Error ? error.message : error)
-    }
-
-    // Start DAC monitor (non-blocking — waits for frankenfirmware to connect)
-    initializeDacMonitor()
-
-    // Rehydrate the pump stall guard from persisted un-acknowledged alerts
-    // before anything that consults shouldBlock (keepalives, scheduler jobs)
-    // can re-energize a side whose fault predates this boot.
-    try {
-      const { rehydrate } = await import('@/src/hardware/pumpStallGuard')
-      rehydrate()
-    }
-    catch (error) {
-      console.warn(
-        '[pumpStallGuard] rehydration failed:',
-        error instanceof Error ? error.message : error
-      )
-    }
-
     // Initialize temperature keepalive timers for sides with alwaysOn enabled
     initializeKeepalives()
 
-    // Start piezo WebSocket stream server (non-blocking)
-    try {
-      startPiezoStreamServer()
-    }
-    catch (error) {
-      console.warn(
-        'WARNING: Piezo stream server failed to start:',
-        error instanceof Error ? error.message : error
-      )
-    }
-
-    // Start MQTT bridge (non-blocking; no-op when disabled in settings/env)
-    try {
-      await startMqttBridge()
-    }
-    catch (error) {
-      console.warn(
-        'WARNING: MQTT bridge failed to start:',
-        error instanceof Error ? error.message : error
-      )
-    }
+    // Optional integrations do not hold up HTTP or the remaining services.
+    void startMqttBridge().then(() => {
+      if (isShuttingDown) return shutdownMqttBridge()
+      recordStartupPhase('mqtt-started')
+    }).catch((error) => {
+      console.warn('WARNING: MQTT bridge failed to start:', error instanceof Error ? error.message : error)
+    })
 
     // Start auto-off watcher (polls biometrics DB for bed-exit events)
     startAutoOffWatcher()
@@ -352,7 +360,9 @@ export async function initializeScheduler(): Promise<void> {
     startBonjourAnnouncement()
 
     // Start HomeKit bridge if user has opted in (non-blocking)
-    startHomeKitIfEnabled().catch((error) => {
+    startHomeKitIfEnabled().then(() => {
+      if (isShuttingDown) return shutdownHomeKit()
+    }).catch((error) => {
       console.warn(
         '[homekit] startup failed:',
         error instanceof Error ? error.message : error,
@@ -364,7 +374,9 @@ export async function initializeScheduler(): Promise<void> {
 
     // Boot the Autopilot rules engine beside the scheduler (non-blocking).
     // Shares the same hardware path; no-op until automations are created.
-    getAutomationEngine().catch((error) => {
+    getAutomationEngine().then(() => {
+      if (isShuttingDown) return shutdownAutomationEngine()
+    }).catch((error) => {
       console.warn(
         '[automation] engine failed to start:',
         error instanceof Error ? error.message : error,
@@ -402,11 +414,14 @@ export async function register(): Promise<void> {
   if (shouldRunInstrumentation()) {
     // Register global handlers first (before any initialization that could fail)
     registerGlobalHandlers()
+    startPerformanceMonitoring()
+    const migrationsStartedAt = performance.now()
 
     // Run pending database migrations before starting the app
     const { runMigrations, seedDefaultData } = await import('@/src/db/migrate')
     await runMigrations()
     await seedDefaultData()
+    recordStartupPhase('migrations-ready', migrationsStartedAt)
 
     // Skip hardware initialization in CI — no dac.sock, no sensors, no scheduler needed.
     // The server still starts and serves API routes (including /api/openapi.json).
@@ -430,6 +445,12 @@ export async function register(): Promise<void> {
       console.warn('[startup] iptables check skipped:', e instanceof Error ? e.message : e)
     }
 
-    await initializeScheduler()
+    await initializeHardware()
+    if (isShuttingDown) return
+    startDatabaseIntegrityChecks()
+    // The clock gate and scheduler loading still finish before scheduled writers
+    // start, but no longer prevent clients from loading settings or diagnostics.
+    void initializeScheduler()
+    recordStartupPhase('http-initialization-ready')
   }
 }

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# sp-maintenance — housekeeping tasks run on every boot
+# sp-maintenance — essential boot repairs; deferred housekeeping with --housekeeping
 #
 # Called by sleepypod.service ExecStartPre so it runs before the app starts.
-# Keeps disk usage in check on the pod's limited storage (~6GB).
+# Expensive cleanup runs independently from sleepypod-maintenance.timer.
 
 # DATA_DIR pointer is written by scripts/install (storage-aware picker).
 # Legacy fallback keeps installs without the pointer file working.
@@ -17,68 +17,78 @@ INSTALL_DIR="/home/dac/sleepypod-core"
 
 echo "=== SleepyPod Maintenance ==="
 
-# 1. Vacuum systemd journal (cap at 50MB)
-if command -v journalctl &>/dev/null; then
-  # Guard against two failure modes reported on a fresh Pod 4:
-  # (a) /persistent/journal missing → `du` fails, pipefail propagates, the
-  #     whole $(…) subshell errors under `set -e` unless we tolerate it.
-  # (b) directory exists but awk output is empty → `[ "" -gt 50 ]` errors
-  #     with "integer expression expected" under `set -e`.
-  # Belt-and-suspenders: tolerate pipeline failure with `|| true`, then
-  # default the variable to 0 if still unset/empty.
-  JOURNAL_SIZE=$(du -sm /persistent/journal 2>/dev/null | awk '{print $1}' || true)
-  JOURNAL_SIZE=${JOURNAL_SIZE:-0}
-  if [ "$JOURNAL_SIZE" -gt 50 ]; then
-    echo "Vacuuming journal (${JOURNAL_SIZE}MB → 50MB)..."
-    journalctl --vacuum-size=50M 2>/dev/null || true
-  fi
-fi
-
-# 2. Clean stale temp files (leftover from failed updates, builds, etc.)
-TEMP_CLEANED=0
-for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*; do
-  if [ -e "$d" ]; then
-    rm -rf "$d" 2>/dev/null && TEMP_CLEANED=$((TEMP_CLEANED + 1))
-  fi
-done
-[ "$TEMP_CLEANED" -gt 0 ] && echo "Cleaned $TEMP_CLEANED stale temp entries."
-
-# 3. Prune old database backups (keep 3 most recent of each kind).
-# Each backup set is a triplet — sleepypod.db.bak.<ts>, plus the matching
-# sleepypod.db-wal.bak.<ts> and sleepypod.db-shm.bak.<ts> sidecars created
-# by sp-update. Pruning only the .db files would leak WAL/SHM backups for
-# pruned timestamps.
-if [ -d "$DATA_DIR" ]; then
-  prune_bak_pattern() {
-    local pattern="$1"
-    # `ls $DIR/glob | wc -l` dies under set -euo pipefail when the glob
-    # doesn't match (ls exits 1 on "no such file", pipefail propagates,
-    # set -e kills the command substitution). Use `find` instead: clean
-    # exit 0 whether or not matches exist.
-    local count
-    count=$(find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f 2>/dev/null | wc -l)
-    count=${count:-0}
-    if [ "$count" -gt 3 ]; then
-      local prune=$((count - 3))
-      find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f -printf '%T@ %p\n' 2>/dev/null \
-        | sort -rn | tail -n "$prune" | awk '{print $2}' | xargs -r rm -f
-      echo "Pruned $prune old $pattern backups (kept 3)."
+case "${1:-}" in
+  --housekeeping)
+    # 1. Vacuum systemd journal (cap at 50MB)
+    if command -v journalctl &>/dev/null; then
+      # Guard against two failure modes reported on a fresh Pod 4:
+      # (a) /persistent/journal missing → `du` fails, pipefail propagates, the
+      #     whole $(…) subshell errors under `set -e` unless we tolerate it.
+      # (b) directory exists but awk output is empty → `[ "" -gt 50 ]` errors
+      #     with "integer expression expected" under `set -e`.
+      # Belt-and-suspenders: tolerate pipeline failure with `|| true`, then
+      # default the variable to 0 if still unset/empty.
+      JOURNAL_SIZE=$(du -sm /persistent/journal 2>/dev/null | awk '{print $1}' || true)
+      JOURNAL_SIZE=${JOURNAL_SIZE:-0}
+      if [ "$JOURNAL_SIZE" -gt 50 ]; then
+        echo "Vacuuming journal (${JOURNAL_SIZE}MB → 50MB)..."
+        journalctl --vacuum-size=50M 2>/dev/null || true
+      fi
     fi
-  }
-  prune_bak_pattern 'sleepypod.db.bak.*'
-  prune_bak_pattern 'sleepypod.db-wal.bak.*'
-  prune_bak_pattern 'sleepypod.db-shm.bak.*'
-fi
 
-# 4. Prune pnpm content-addressable store
-if command -v pnpm &>/dev/null; then
-  STORE_SIZE=$(du -sm /home/root/.local/share/pnpm/store 2>/dev/null | awk '{print $1}' || true)
-  STORE_SIZE=${STORE_SIZE:-0}
-  if [ "$STORE_SIZE" -gt 100 ]; then
-    echo "Pruning pnpm store (${STORE_SIZE}MB)..."
-    pnpm store prune 2>/dev/null || true
-  fi
-fi
+    # 2. Clean stale temp files (leftover from failed updates, builds, etc.)
+    TEMP_CLEANED=0
+    for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*; do
+      # Never remove fresh update/build staging directories while the app is live.
+      if [ -e "$d" ] && [ -n "$(find "$d" -maxdepth 0 -mtime +1 -print 2>/dev/null)" ]; then
+        rm -rf "$d" 2>/dev/null && TEMP_CLEANED=$((TEMP_CLEANED + 1))
+      fi
+    done
+    [ "$TEMP_CLEANED" -gt 0 ] && echo "Cleaned $TEMP_CLEANED stale temp entries."
+
+    # 3. Prune old database backups (keep 3 most recent of each kind).
+    # Each backup set is a triplet — sleepypod.db.bak.<ts>, plus the matching
+    # sleepypod.db-wal.bak.<ts> and sleepypod.db-shm.bak.<ts> sidecars created
+    # by sp-update. Pruning only the .db files would leak WAL/SHM backups for
+    # pruned timestamps.
+    if [ -d "$DATA_DIR" ]; then
+      prune_bak_pattern() {
+        local pattern="$1"
+        # `ls $DIR/glob | wc -l` dies under set -euo pipefail when the glob
+        # doesn't match (ls exits 1 on "no such file", pipefail propagates,
+        # set -e kills the command substitution). Use `find` instead: clean
+        # exit 0 whether or not matches exist.
+        local count
+        count=$(find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f 2>/dev/null | wc -l)
+        count=${count:-0}
+        if [ "$count" -gt 3 ]; then
+          local prune=$((count - 3))
+          find "$DATA_DIR" -maxdepth 1 -name "$pattern" -type f -printf '%T@ %p\n' 2>/dev/null \
+            | sort -rn | tail -n "$prune" | awk '{print $2}' | xargs -r rm -f
+          echo "Pruned $prune old $pattern backups (kept 3)."
+        fi
+      }
+      prune_bak_pattern 'sleepypod.db.bak.*'
+      prune_bak_pattern 'sleepypod.db-wal.bak.*'
+      prune_bak_pattern 'sleepypod.db-shm.bak.*'
+    fi
+
+    # 4. Prune pnpm content-addressable store
+    if command -v pnpm &>/dev/null; then
+      STORE_SIZE=$(du -sm /home/root/.local/share/pnpm/store 2>/dev/null | awk '{print $1}' || true)
+      STORE_SIZE=${STORE_SIZE:-0}
+      if [ "$STORE_SIZE" -gt 100 ]; then
+        echo "Pruning pnpm store (${STORE_SIZE}MB)..."
+        pnpm store prune 2>/dev/null || true
+      fi
+    fi
+
+    echo "Housekeeping complete."
+    exit 0
+    ;;
+  ''|--startup) ;;
+  *) echo "Usage: sp-maintenance [--startup|--housekeeping]" >&2; exit 2 ;;
+esac
 
 # 5. Self-heal /persistent/deviceinfo perms so next-server can unlink
 # stale dac.sock on startup. Older installs created the dir with mkdir's
@@ -97,8 +107,8 @@ if getent group dac &>/dev/null; then
     else
       echo "Repairing $DEVICEINFO_DIR perms ($OWNER_GROUP $MODE → root:dac 2770)..."
     fi
-    chown root:dac "$DEVICEINFO_DIR"
     chown root:dac "$DEVICEINFO_DIR" || { echo "ERROR: chown $DEVICEINFO_DIR failed — next-server will fail to unlink dac.sock" >&2; exit 1; }
+    chmod 2770 "$DEVICEINFO_DIR"
   fi
 fi
 

--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -40,7 +40,9 @@ case "${1:-}" in
     TEMP_CLEANED=0
     for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*; do
       # Never remove fresh update/build staging directories while the app is live.
-      if [ -e "$d" ] && [ -n "$(find "$d" -maxdepth 0 -mtime +1 -print 2>/dev/null)" ]; then
+      if [ -e "$d" ] \
+        && RECENT_ACTIVITY=$(find "$d" -mtime -2 -print -quit 2>/dev/null) \
+        && [ -z "$RECENT_ACTIVITY" ]; then
         rm -rf "$d" 2>/dev/null && TEMP_CLEANED=$((TEMP_CLEANED + 1))
       fi
     done

--- a/scripts/bin/sp-uninstall
+++ b/scripts/bin/sp-uninstall
@@ -54,6 +54,8 @@ echo "=== Uninstalling SleepyPod ==="
 echo "Stopping services..."
 SERVICES=(
   sleepypod.service
+  sleepypod-maintenance.timer
+  sleepypod-maintenance.service
   sleepypod-piezo-processor.service
   sleepypod-sleep-detector.service
   sleepypod-environment-monitor.service

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -502,6 +502,12 @@ if [ -d "$INSTALL_DIR/scripts/bin" ]; then
   done
 fi
 
+# Reconcile the deferred housekeeping timer on existing installations.
+if [ -f "$INSTALL_DIR/scripts/lib/maintenance-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/maintenance-helpers"
+  install_maintenance_timer
+fi
+
 # Re-block WAN before starting service
 if [ "$WAN_WAS_BLOCKED" = true ]; then
   reload_iptables_helpers

--- a/scripts/install
+++ b/scripts/install
@@ -1398,7 +1398,7 @@ Environment="RAW_DATA_DIR=/persistent/biometrics"
 Environment="XTABLES_LOCKFILE=/run/dac/xtables.lock"
 # The \`+\` prefix runs ExecStartPre as root regardless of User=. Needed
 # for /deviceinfo symlink creation (root-owned) and sp-maintenance
-# (journal vacuum, /tmp cleanup, pnpm store prune).
+# (required DAC directory permissions and reboot authorization).
 ExecStartPre=+/bin/sh -c '[ "$DAC_SOCK_PATH" != "/deviceinfo/dac.sock" ] && ln -sf $DAC_SOCK_PATH /deviceinfo/dac.sock 2>/dev/null; true'
 ExecStartPre=+/usr/local/bin/sp-maintenance
 Environment="PATH=/usr/local/bin:/usr/bin:/bin"
@@ -1465,6 +1465,10 @@ if [ -d "$INSTALL_DIR/scripts/bin" ]; then
     chmod 0755 "$target"
   done
 fi
+
+# Housekeeping runs after boot, independently of API readiness.
+source "$INSTALL_DIR/scripts/lib/maintenance-helpers"
+install_maintenance_timer
 
 # Reload systemd and enable service
 echo "Enabling service..."

--- a/scripts/lib/maintenance-helpers
+++ b/scripts/lib/maintenance-helpers
@@ -1,0 +1,10 @@
+# Install on both fresh and OTA updates; no changes to sleepypod.service needed
+# for old installations, whose default sp-maintenance invocation is now cheap.
+install_maintenance_timer() {
+  local unit
+  for unit in sleepypod-maintenance.service sleepypod-maintenance.timer; do
+    install -m 0644 "$INSTALL_DIR/scripts/systemd/$unit" "/etc/systemd/system/$unit"
+  done
+  systemctl daemon-reload
+  systemctl enable --now sleepypod-maintenance.timer
+}

--- a/scripts/systemd/sleepypod-maintenance.service
+++ b/scripts/systemd/sleepypod-maintenance.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=SleepyPod deferred housekeeping
+After=sleepypod.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sp-maintenance --housekeeping
+Nice=19
+IOSchedulingClass=idle

--- a/scripts/systemd/sleepypod-maintenance.timer
+++ b/scripts/systemd/sleepypod-maintenance.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run SleepyPod housekeeping after boot and daily
+
+[Timer]
+OnActiveSec=10min
+OnUnitActiveSec=1d
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/src/db/integrity.ts
+++ b/src/db/integrity.ts
@@ -1,0 +1,106 @@
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import { Worker } from 'node:worker_threads'
+
+interface IntegrityStatus {
+  status: 'pending' | 'ok' | 'degraded'
+  checkedAt: string | null
+  latencyMs: number
+  error?: string
+}
+const globalState = globalThis as typeof globalThis & {
+  __sp_database_integrity__?: {
+    result: IntegrityStatus
+    timer: ReturnType<typeof setTimeout> | null
+    worker: Worker | null
+    stopped: boolean
+  }
+}
+function state() {
+  return globalState.__sp_database_integrity__ ??= {
+    result: { status: 'pending', checkedAt: null, latencyMs: 0 }, timer: null, worker: null, stopped: false,
+  }
+}
+
+export function getDatabaseIntegrity(): IntegrityStatus {
+  return { ...state().result }
+}
+
+/** Full scans run on a separate SQLite connection in a worker so even the
+ * first check cannot stall hardware polling or HTTP. Read-only, once an hour. */
+export function startDatabaseIntegrityChecks(): void {
+  const s = state()
+  if (s.timer || s.worker) return
+  s.stopped = false
+  const schedule = (delay: number) => {
+    s.timer = setTimeout(run, delay)
+    s.timer.unref()
+  }
+  const run = () => {
+    s.timer = null
+    if (s.stopped) return
+    const startedAt = performance.now()
+    const finish = (error?: string) => {
+      clearTimeout(timeout)
+      s.worker = null
+      if (s.stopped) return
+      s.result = {
+        status: error ? 'degraded' : 'ok', checkedAt: new Date().toISOString(),
+        latencyMs: Math.round(performance.now() - startedAt), ...(error && { error }),
+      }
+      if (error) console.warn('[database] Integrity check failed:', error)
+      schedule(60 * 60_000)
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      const require = createRequire(resolve(process.cwd(), 'package.json'))
+      const worker = new Worker(`
+        const { parentPort, workerData } = require('node:worker_threads');
+        const Database = require(workerData.modulePath);
+        let db;
+        try {
+          db = new Database(workerData.path, { readonly: true, fileMustExist: true });
+          db.pragma('busy_timeout = 1000');
+          const result = db.pragma('quick_check(1)', { simple: true });
+          parentPort.postMessage(result === 'ok' ? null : String(result));
+        } catch (error) { parentPort.postMessage(error.message); }
+        finally { if (db) db.close(); }
+      `, {
+        eval: true,
+        workerData: {
+          modulePath: require.resolve('better-sqlite3'),
+          path: process.env.DATABASE_URL?.replace(/^file:/, '') || './sleepypod.dev.db',
+        },
+      })
+      s.worker = worker
+      let result: string | undefined = 'Integrity worker exited without a result'
+      worker.once('message', (error: string | null) => {
+        result = error ?? undefined
+      })
+      worker.once('error', (error) => {
+        result = error instanceof Error ? error.message : String(error)
+      })
+      worker.once('exit', () => finish(result))
+      timeout = setTimeout(() => {
+        result = 'Integrity check timed out after 30s'
+        void worker.terminate()
+      }, 30_000)
+      timeout.unref()
+      worker.unref()
+    }
+    catch (error) {
+      finish(error instanceof Error ? error.message : String(error))
+    }
+  }
+  // Let startup settle; no scan is performed in instrumentation or an API call.
+  schedule(30_000)
+}
+
+export async function stopDatabaseIntegrityChecks(): Promise<void> {
+  const s = state()
+  s.stopped = true
+  if (s.timer) clearTimeout(s.timer)
+  s.timer = null
+  if (s.worker) await s.worker.terminate()
+  s.worker = null
+}

--- a/src/db/tests/integrity.integration.test.ts
+++ b/src/db/tests/integrity.integration.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDatabaseIntegrity, startDatabaseIntegrityChecks, stopDatabaseIntegrityChecks } from '../integrity'
+
+let directory: string
+let databasePath: string
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'sleepypod-integrity-'))
+  databasePath = join(directory, 'config.db')
+  vi.stubEnv('DATABASE_URL', `file:${databasePath}`)
+  delete (globalThis as Record<string, unknown>).__sp_database_integrity__
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  await stopDatabaseIntegrityChecks()
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).__sp_database_integrity__
+  rmSync(directory, { recursive: true, force: true })
+})
+
+describe('database integrity worker integration', () => {
+  it('checks a real database without modifying its contents', async () => {
+    const database = new Database(databasePath)
+    database.exec('CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test (value) VALUES (\'saved settings\')')
+    database.close()
+    const before = readFileSync(databasePath)
+
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.waitFor(() => expect(getDatabaseIntegrity().status).toBe('ok'), { timeout: 5_000 })
+
+    expect(getDatabaseIntegrity().checkedAt).not.toBeNull()
+    expect(readFileSync(databasePath)).toEqual(before)
+  })
+
+  it('surfaces a corrupt database as degraded from the worker result', async () => {
+    writeFileSync(databasePath, Buffer.alloc(4_096, 0x7f))
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.waitFor(() => expect(getDatabaseIntegrity().status).toBe('degraded'), { timeout: 5_000 })
+
+    expect(getDatabaseIntegrity().error).toMatch(/not a database|malformed/i)
+  })
+})

--- a/src/db/tests/integrity.test.ts
+++ b/src/db/tests/integrity.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+import type { EventEmitter } from 'node:events'
+import type { WorkerOptions } from 'node:worker_threads'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type TestWorker = EventEmitter & { terminate: ReturnType<typeof vi.fn>, options: WorkerOptions }
+const mocks = vi.hoisted(() => ({ workers: [] as TestWorker[], constructionError: null as Error | null }))
+vi.mock('node:worker_threads', async () => {
+  const { EventEmitter } = await import('node:events')
+  return {
+    Worker: class extends EventEmitter {
+      constructor(_source: string, readonly options: WorkerOptions) {
+        super()
+        if (mocks.constructionError) throw mocks.constructionError
+        mocks.workers.push(this)
+      }
+
+      unref() {}
+      terminate = vi.fn(async () => {
+        this.emit('exit', 1)
+        return 1
+      })
+    },
+  }
+})
+
+import { getDatabaseIntegrity, startDatabaseIntegrityChecks, stopDatabaseIntegrityChecks } from '../integrity'
+
+beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sp_database_integrity__
+  mocks.workers.length = 0
+  mocks.constructionError = null
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'] })
+  vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  await stopDatabaseIntegrityChecks()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).__sp_database_integrity__
+})
+
+describe('background database integrity lifecycle', () => {
+  it('starts once after a startup delay, then schedules from worker completion', async () => {
+    startDatabaseIntegrityChecks()
+    startDatabaseIntegrityChecks()
+    expect(getDatabaseIntegrity()).toEqual({ status: 'pending', checkedAt: null, latencyMs: 0 })
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(mocks.workers).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mocks.workers).toHaveLength(1)
+    startDatabaseIntegrityChecks()
+    expect(mocks.workers).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(120)
+    mocks.workers[0].emit('message', null)
+    expect(getDatabaseIntegrity().status).toBe('pending')
+    mocks.workers[0].emit('exit', 0)
+    expect(getDatabaseIntegrity()).toEqual({ status: 'ok', checkedAt: '2026-09-05T12:00:30.120Z', latencyMs: 120 })
+    await vi.advanceTimersByTimeAsync(60 * 60_000 - 1)
+    expect(mocks.workers).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mocks.workers).toHaveLength(2)
+  })
+
+  it.each(['result', 'error', 'no-result'] as const)('reports degraded when the worker fails via %s', async (failure) => {
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    const worker = mocks.workers[0]
+    if (failure === 'result') worker.emit('message', 'database disk image is malformed')
+    if (failure === 'error') worker.emit('error', new Error('worker crashed'))
+    worker.emit('exit', 1)
+
+    expect(getDatabaseIntegrity()).toMatchObject({ status: 'degraded', error: expect.any(String) })
+    expect(getDatabaseIntegrity().checkedAt).not.toBeNull()
+  })
+
+  it('terminates a stalled scan and reports the timeout', async () => {
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(mocks.workers[0].terminate).toHaveBeenCalledOnce()
+    expect(getDatabaseIntegrity()).toMatchObject({ status: 'degraded', error: 'Integrity check timed out after 30s' })
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    expect(mocks.workers).toHaveLength(2)
+  })
+
+  it('does not publish or reschedule a scan terminated during shutdown', async () => {
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    mocks.workers[0].emit('message', null)
+    await stopDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(2 * 60 * 60_000)
+
+    expect(mocks.workers[0].terminate).toHaveBeenCalledOnce()
+    expect(mocks.workers).toHaveLength(1)
+    expect(getDatabaseIntegrity().status).toBe('pending')
+  })
+
+  it('cancels the initial timer on shutdown and permits an explicit restart', async () => {
+    startDatabaseIntegrityChecks()
+    await stopDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mocks.workers).toHaveLength(0)
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(mocks.workers).toHaveLength(1)
+  })
+
+  it('reports worker construction failures and retries on the next interval', async () => {
+    mocks.constructionError = new Error('worker unavailable')
+    startDatabaseIntegrityChecks()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(getDatabaseIntegrity()).toMatchObject({ status: 'degraded', error: 'worker unavailable' })
+    mocks.constructionError = null
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    expect(mocks.workers).toHaveLength(1)
+  })
+})

--- a/src/hardware/deviceEnrichment.ts
+++ b/src/hardware/deviceEnrichment.ts
@@ -1,0 +1,59 @@
+import { desc } from 'drizzle-orm'
+import { biometricsDb } from '@/src/db'
+import { bedTemp, waterLevelReadings } from '@/src/db/biometrics-schema'
+import { centiDegreesToC, centiPercentToPercent } from '@/src/lib/tempUtils'
+
+interface DeviceEnrichment {
+  roomClimate: { temperatureC: number | null, humidity: number | null, timestamp: number | null }
+  waterLevelRaw: { raw: number | null, calibratedEmpty: number | null, calibratedFull: number | null, timestamp: number | null }
+}
+
+const CACHE_MS = 2_000
+const globalState = globalThis as typeof globalThis & {
+  __sp_device_enrichment__?: {
+    value: DeviceEnrichment | null
+    expiresAt: number
+    pending: Promise<DeviceEnrichment> | null
+  }
+}
+
+/** Sidecars write these tables outside Node; a short TTL bounds their visibility
+ * delay. Keep hardware status, alarms and safety notices outside this cache. */
+export function getDeviceEnrichment(): Promise<DeviceEnrichment> {
+  const state = globalState.__sp_device_enrichment__ ??= { value: null, expiresAt: 0, pending: null }
+  if (state.value && performance.now() < state.expiresAt) return Promise.resolve(state.value)
+  if (state.pending) return state.pending
+  state.pending = (async () => {
+    const value: DeviceEnrichment = {
+      roomClimate: { temperatureC: null, humidity: null, timestamp: null },
+      waterLevelRaw: { raw: null, calibratedEmpty: null, calibratedFull: null, timestamp: null },
+    }
+    try {
+      const [latestBed] = await biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1)
+      if (latestBed) {
+        value.roomClimate = {
+          temperatureC: latestBed.ambientTemp === null ? null : centiDegreesToC(latestBed.ambientTemp),
+          humidity: latestBed.humidity === null ? null : centiPercentToPercent(latestBed.humidity),
+          timestamp: latestBed.timestamp?.getTime() ?? null,
+        }
+      }
+    }
+    catch { /* Return nulls instead of presenting stale readings as current. */ }
+    try {
+      const [latestWater] = await biometricsDb.select().from(waterLevelReadings).orderBy(desc(waterLevelReadings.timestamp)).limit(1)
+      if (latestWater) {
+        value.waterLevelRaw = {
+          raw: latestWater.raw ?? null,
+          calibratedEmpty: latestWater.calibratedEmpty ?? null,
+          calibratedFull: latestWater.calibratedFull ?? null,
+          timestamp: latestWater.timestamp?.getTime() ?? null,
+        }
+      }
+    }
+    catch { /* Retry after the short TTL, independently of the climate query. */ }
+    state.value = value
+    state.expiresAt = performance.now() + CACHE_MS
+    return value
+  })().finally(() => { state.pending = null })
+  return state.pending
+}

--- a/src/hardware/iptablesCheck.ts
+++ b/src/hardware/iptablesCheck.ts
@@ -9,7 +9,10 @@
  * Called on startup (instrumentation.ts) and exposed via health.system endpoint.
  */
 
-import { execSync } from 'node:child_process'
+import { execFile, execSync } from 'node:child_process'
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import { promisify } from 'node:util'
 
 import { POD_CAPS } from './pods'
 
@@ -28,6 +31,85 @@ interface IptablesRule {
 
 /** Known iptables paths from the pod capabilities manifest, used as fallbacks */
 const KNOWN_IPTABLES_PATHS = [...new Set(Object.values(POD_CAPS).map(c => c.iptablesPath))]
+const runFile = promisify(execFile)
+const globalCache = globalThis as typeof globalThis & {
+  __sp_iptables_health__?: {
+    path: Promise<string> | null
+    value: IptablesStatus | null
+    expiresAt: number
+    pending: Promise<IptablesStatus> | null
+    generation: number
+  }
+}
+
+function healthCache() {
+  return globalCache.__sp_iptables_health__ ??= {
+    path: null, value: null, expiresAt: 0, pending: null, generation: 0,
+  }
+}
+
+async function resolveIptablesPathAsync(): Promise<string> {
+  try {
+    const { stdout } = await runFile('which', ['iptables'], { timeout: 3_000 })
+    if (stdout.trim()) return stdout.trim()
+  }
+  catch { /* Check the Pod manifest paths when PATH omits sbin. */ }
+  for (const candidate of KNOWN_IPTABLES_PATHS) {
+    try {
+      await access(candidate, constants.X_OK)
+      return candidate
+    }
+    catch { /* Try the next path. */ }
+  }
+  return 'iptables'
+}
+
+/** Request-path diagnostics: one asynchronous listing per chain, shared across
+ * concurrent requests and Next bundles, with at most 30 seconds of staleness. */
+export function checkIptablesCached(): Promise<IptablesStatus> {
+  const state = healthCache()
+  if (state.value && performance.now() < state.expiresAt) return Promise.resolve(state.value)
+  if (state.pending) return state.pending
+  const generation = state.generation
+  const pending = (async () => {
+    const iptables = await (state.path ??= resolveIptablesPathAsync())
+    const chains = await Promise.all((['INPUT', 'OUTPUT'] as const).map(async (chain) => {
+      try {
+        const { stdout } = await runFile(iptables, ['-L', chain, '-n'], { timeout: 5_000 })
+        return [chain, stdout] as const
+      }
+      catch (error) {
+        const e = error as Error & { code?: string | number }
+        const unavailable = ['ENOENT', 'EACCES', 127, 3, 4].includes(e.code ?? '')
+          || /not found|No such file|Permission denied|Operation not permitted/.test(e.message)
+        if (!unavailable) console.warn(`[iptables] Failed to check ${chain}: ${e.message}`)
+        return [chain, unavailable ? null : ''] as const
+      }
+    }))
+    const outputs = Object.fromEntries(chains)
+    const rules = buildRequiredRules(iptables).map(rule => ({
+      name: rule.name, chain: rule.chain, critical: rule.critical,
+      present: outputs[rule.chain] === null || !!outputs[rule.chain]?.includes(rule.check),
+    }))
+    const value = { ok: rules.every(rule => !rule.critical || rule.present), rules, repaired: [] }
+    if (state.generation === generation) {
+      state.value = value
+      state.expiresAt = performance.now() + 30_000
+    }
+    return value
+  })().finally(() => {
+    if (state.pending === pending) state.pending = null
+  })
+  state.pending = pending
+  return pending
+}
+
+export function invalidateIptablesHealth(): void {
+  const state = healthCache()
+  state.generation++
+  state.value = null
+  state.pending = null
+}
 
 /**
  * Resolve the absolute path to the iptables binary.
@@ -153,6 +235,7 @@ export function checkIptables(iptablesPath?: string): IptablesStatus {
  * Returns list of rules that were repaired.
  */
 export function checkAndRepairIptables(iptablesPath?: string): IptablesStatus {
+  invalidateIptablesHealth()
   const iptables = resolveIptablesPath(iptablesPath)
   const requiredRules = buildRequiredRules(iptables)
   const status = checkIptables(iptables)

--- a/src/hardware/tests/deviceEnrichment.test.ts
+++ b/src/hardware/tests/deviceEnrichment.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const dbMock = vi.hoisted(() => ({ query: vi.fn<() => Promise<unknown[]>>() }))
+vi.mock('@/src/db', () => ({
+  biometricsDb: {
+    select: () => ({ from: () => ({ orderBy: () => ({ limit: dbMock.query }) }) }),
+  },
+}))
+
+import { getDeviceEnrichment } from '../deviceEnrichment'
+
+let now = 0
+const timestamp = new Date('2026-09-05T12:00:00Z')
+const climate = { ambientTemp: 2150, humidity: 4500, timestamp }
+const water = { raw: 1234, calibratedEmpty: 500, calibratedFull: 2000, timestamp }
+
+beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sp_device_enrichment__
+  now = 0
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+  dbMock.query.mockReset().mockResolvedValue([])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).__sp_device_enrichment__
+})
+
+describe('device enrichment cache', () => {
+  it('shares a pending read and exposes sidecar updates after the two-second TTL', async () => {
+    let release!: (rows: unknown[]) => void
+    dbMock.query.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+      .mockResolvedValueOnce([water])
+
+    const pending = Array.from({ length: 10 }, () => getDeviceEnrichment())
+    expect(new Set(pending).size).toBe(1)
+    expect(dbMock.query).toHaveBeenCalledOnce()
+    // Cache age starts after the completed read, not while a DB query is pending.
+    now = 500
+    release([climate])
+    const [first] = await Promise.all(pending)
+    expect(first.roomClimate).toEqual({ temperatureC: 21.5, humidity: 45, timestamp: timestamp.getTime() })
+    expect(first.waterLevelRaw).toEqual({ ...water, timestamp: timestamp.getTime() })
+
+    now = 2_499
+    expect(await getDeviceEnrichment()).toEqual(first)
+    expect(dbMock.query).toHaveBeenCalledTimes(2)
+    now = 2_500
+    dbMock.query.mockResolvedValueOnce([{ ...climate, ambientTemp: 2300 }]).mockResolvedValueOnce([water])
+    expect((await getDeviceEnrichment()).roomClimate.temperatureC).toBe(23)
+    expect(dbMock.query).toHaveBeenCalledTimes(4)
+  })
+
+  it.each(['climate', 'water'] as const)('isolates a failed %s query and retries after the TTL', async (failed) => {
+    if (failed === 'climate') {
+      dbMock.query.mockRejectedValueOnce(new Error('bed table busy')).mockResolvedValueOnce([water])
+    }
+    else {
+      dbMock.query.mockResolvedValueOnce([climate]).mockRejectedValueOnce(new Error('water table busy'))
+    }
+
+    const first = await getDeviceEnrichment()
+    expect(first.roomClimate.temperatureC).toBe(failed === 'climate' ? null : 21.5)
+    expect(first.waterLevelRaw.raw).toBe(failed === 'water' ? null : 1234)
+    expect(await getDeviceEnrichment()).toEqual(first)
+    expect(dbMock.query).toHaveBeenCalledTimes(2)
+
+    now = 2_000
+    dbMock.query.mockResolvedValueOnce([climate]).mockResolvedValueOnce([water])
+    const recovered = await getDeviceEnrichment()
+    expect(recovered.roomClimate.temperatureC).toBe(21.5)
+    expect(recovered.waterLevelRaw.raw).toBe(1234)
+    expect(dbMock.query).toHaveBeenCalledTimes(4)
+  })
+
+  it('replaces expired readings with nulls when both queries fail', async () => {
+    dbMock.query.mockResolvedValueOnce([climate]).mockResolvedValueOnce([water])
+    await getDeviceEnrichment()
+    now = 2_000
+    dbMock.query.mockRejectedValue(new Error('database unavailable'))
+
+    expect(await getDeviceEnrichment()).toEqual({
+      roomClimate: { temperatureC: null, humidity: null, timestamp: null },
+      waterLevelRaw: { raw: null, calibratedEmpty: null, calibratedFull: null, timestamp: null },
+    })
+  })
+
+  it('shares cached enrichment across separate Next module instances', async () => {
+    dbMock.query.mockResolvedValueOnce([climate]).mockResolvedValueOnce([water])
+    const first = await getDeviceEnrichment()
+    vi.resetModules()
+    const duplicate = await import('../deviceEnrichment')
+
+    expect(await duplicate.getDeviceEnrichment()).toEqual(first)
+    expect(dbMock.query).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/hardware/tests/iptablesCheck.cache.test.ts
+++ b/src/hardware/tests/iptablesCheck.cache.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  runFile: vi.fn<(file: string, args: string[], options: unknown) => Promise<{ stdout: string }>>(),
+  execSync: vi.fn(),
+  access: vi.fn(),
+}))
+vi.mock('node:child_process', () => ({
+  execSync: mocks.execSync,
+  execFile: Object.assign(vi.fn(), { [Symbol.for('nodejs.util.promisify.custom')]: mocks.runFile }),
+}))
+vi.mock('node:fs/promises', () => ({ access: mocks.access }))
+
+import { checkAndRepairIptables, checkIptablesCached, invalidateIptablesHealth } from '../iptablesCheck'
+
+const input = 'ACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp dpt:5353\nACCEPT all -- 192.168.0.0/16 0.0.0.0/0'
+const output = 'ACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp dpt:5353\nACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp spt:5353\nACCEPT udp -- 0.0.0.0/0 0.0.0.0/0 udp dpt:123'
+let now = 0
+
+beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sp_iptables_health__
+  now = 0
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  mocks.execSync.mockReset()
+  mocks.access.mockReset().mockResolvedValue(undefined)
+  mocks.runFile.mockReset().mockImplementation(async (file, args) => ({
+    stdout: file === 'which' ? '/sbin/iptables\n' : args[1] === 'INPUT' ? input : output,
+  }))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).__sp_iptables_health__
+})
+
+describe('asynchronous firewall health', () => {
+  it('coalesces concurrent checks without blocking the event loop and lists each chain once', async () => {
+    let release!: (value: { stdout: string }) => void
+    mocks.runFile.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const checks = Array.from({ length: 10 }, () => checkIptablesCached())
+    expect(new Set(checks).size).toBe(1)
+    await new Promise<void>(resolve => setImmediate(resolve))
+    expect(mocks.runFile).toHaveBeenCalledOnce()
+    release({ stdout: '/sbin/iptables\n' })
+
+    const results = await Promise.all(checks)
+    expect(results.every(result => result.ok && result.rules.length === 5)).toBe(true)
+    expect(mocks.runFile.mock.calls.slice(1).map(([file, args]) => [file, args])).toEqual([
+      ['/sbin/iptables', ['-L', 'INPUT', '-n']],
+      ['/sbin/iptables', ['-L', 'OUTPUT', '-n']],
+    ])
+    expect(mocks.execSync).not.toHaveBeenCalled()
+  })
+
+  it('refreshes at 30 seconds and shares the cache across Next module instances', async () => {
+    const first = await checkIptablesCached()
+    vi.resetModules()
+    const duplicate = await import('../iptablesCheck')
+    now = 29_999
+    expect(await duplicate.checkIptablesCached()).toEqual(first)
+    expect(mocks.runFile).toHaveBeenCalledTimes(3)
+    now = 30_000
+    mocks.runFile.mockResolvedValue({ stdout: '' })
+    const refreshed = await duplicate.checkIptablesCached()
+    expect(refreshed.ok).toBe(false)
+    expect(refreshed.rules.every(rule => !rule.present)).toBe(true)
+    expect(mocks.runFile).toHaveBeenCalledTimes(5)
+  })
+
+  it('does not let an in-flight pre-repair result overwrite a newer check', async () => {
+    let release!: (value: { stdout: string }) => void
+    mocks.runFile.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const stale = checkIptablesCached()
+    invalidateIptablesHealth()
+    const current = checkIptablesCached()
+    mocks.runFile.mockResolvedValueOnce({ stdout: '' }).mockResolvedValueOnce({ stdout: '' })
+    release({ stdout: '/sbin/iptables' })
+
+    expect((await stale).ok).toBe(false)
+    expect((await current).ok).toBe(true)
+    expect((await checkIptablesCached()).ok).toBe(true)
+    expect(mocks.runFile).toHaveBeenCalledTimes(5)
+  })
+
+  it('invalidates cached health when the synchronous repair path runs', async () => {
+    await checkIptablesCached()
+    mocks.execSync.mockImplementation((command: string) => command.includes('INPUT') ? input : output)
+    checkAndRepairIptables('/sbin/iptables')
+    await checkIptablesCached()
+    expect(mocks.runFile).toHaveBeenCalledTimes(5)
+  })
+
+  it('resolves executable manifest paths when which is unavailable', async () => {
+    mocks.runFile.mockRejectedValueOnce(new Error('which missing'))
+    await checkIptablesCached()
+    expect(mocks.access).toHaveBeenCalledWith('/sbin/iptables', expect.any(Number))
+    expect(mocks.runFile.mock.calls[1]?.[0]).toBe('/sbin/iptables')
+  })
+
+  it('falls back to PATH lookup when no manifest path is executable', async () => {
+    mocks.runFile.mockResolvedValueOnce({ stdout: '' })
+    mocks.access.mockRejectedValue(new Error('ENOENT'))
+    await checkIptablesCached()
+    expect(mocks.runFile.mock.calls[1]?.[0]).toBe('iptables')
+  })
+
+  it.each(['ENOENT', 'EACCES', 127, 3, 4])('keeps the established development fallback for unavailable code %s', async (code) => {
+    mocks.runFile.mockImplementation(async (file) => {
+      if (file === 'which') return { stdout: '/sbin/iptables' }
+      throw Object.assign(new Error('unavailable'), { code })
+    })
+    expect((await checkIptablesCached()).ok).toBe(true)
+  })
+
+  it('reports unexpected chain failures as degraded and retries after expiry', async () => {
+    mocks.runFile.mockResolvedValueOnce({ stdout: '/sbin/iptables' })
+      .mockRejectedValueOnce(new Error('kernel module unavailable'))
+    const first = await checkIptablesCached()
+    expect(first.ok).toBe(false)
+    expect(first.rules.filter(rule => !rule.present).map(rule => rule.chain)).toEqual(['INPUT', 'INPUT'])
+    now = 30_000
+    expect((await checkIptablesCached()).ok).toBe(true)
+  })
+})

--- a/src/hardware/tests/iptablesCheck.test.ts
+++ b/src/hardware/tests/iptablesCheck.test.ts
@@ -9,7 +9,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('node:child_process', () => {
   const execSync = vi.fn()
-  return { execSync, default: { execSync } }
+  const execFile = vi.fn()
+  return { execSync, execFile, default: { execSync, execFile } }
 })
 
 import { execSync as mockedExecSync } from 'node:child_process'

--- a/src/lib/serverPerformance.ts
+++ b/src/lib/serverPerformance.ts
@@ -1,0 +1,67 @@
+import { monitorEventLoopDelay } from 'node:perf_hooks'
+
+interface StartupPhase { name: string, elapsedMs: number, durationMs: number }
+const globalState = globalThis as typeof globalThis & {
+  __sp_server_performance__?: {
+    startedAt: number
+    phases: StartupPhase[]
+    histogram: ReturnType<typeof monitorEventLoopDelay> | null
+    sensorSource: 'pending' | 'raw' | 'nats'
+    firstFrameMs: number | null
+  }
+}
+function state() {
+  return globalState.__sp_server_performance__ ??= {
+    startedAt: performance.now(), phases: [], histogram: null, sensorSource: 'pending', firstFrameMs: null,
+  }
+}
+
+export function startPerformanceMonitoring(): void {
+  const s = state()
+  if (s.histogram) return
+  s.histogram = monitorEventLoopDelay({ resolution: 20 })
+  s.histogram.enable()
+}
+
+export function stopPerformanceMonitoring(): void {
+  state().histogram?.disable()
+}
+
+export function recordStartupPhase(name: string, startedAt = performance.now()): void {
+  const s = state()
+  if (s.phases.some(phase => phase.name === name)) return
+  const phase = {
+    name, elapsedMs: Math.round(performance.now() - s.startedAt),
+    durationMs: Math.round(performance.now() - startedAt),
+  }
+  s.phases.push(phase)
+  console.log(`[startup] ${name}: ${phase.durationMs}ms (${phase.elapsedMs}ms elapsed)`)
+}
+
+export function recordSensorSource(source: 'raw' | 'nats'): void {
+  state().sensorSource = source
+  recordStartupPhase(`sensor-source-${source}`)
+}
+
+export function recordFirstSensorFrame(): void {
+  const s = state()
+  if (s.firstFrameMs !== null) return
+  s.firstFrameMs = Math.round(performance.now() - s.startedAt)
+  recordStartupPhase('first-sensor-frame')
+}
+
+/** Histogram covers time since instrumentation enabled it, including startup. No database or
+ * hardware calls: safe to sample while the other services are starting. */
+export function getServerPerformance() {
+  const s = state()
+  const h = s.histogram
+  const ms = (ns: number) => Number.isFinite(ns) ? Math.round(ns / 10_000) / 100 : 0
+  return {
+    uptimeSeconds: process.uptime(),
+    rssBytes: process.memoryUsage.rss(),
+    startup: s.phases.slice(),
+    sensorSource: s.sensorSource,
+    firstFrameMs: s.firstFrameMs,
+    eventLoop: { meanMs: ms(h?.mean ?? 0), p95Ms: ms(h?.percentile(95) ?? 0), maxMs: ms(h?.max ?? 0) },
+  }
+}

--- a/src/lib/tests/serverPerformance.test.ts
+++ b/src/lib/tests/serverPerformance.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const metrics = vi.hoisted(() => ({
+  histogram: { enable: vi.fn(), disable: vi.fn(), mean: 1_250_000, max: 4_567_890, percentile: vi.fn(() => 2_345_678) },
+  monitorEventLoopDelay: vi.fn(),
+}))
+vi.mock('node:perf_hooks', () => ({ monitorEventLoopDelay: metrics.monitorEventLoopDelay }))
+
+import {
+  getServerPerformance, recordFirstSensorFrame, recordSensorSource, recordStartupPhase,
+  startPerformanceMonitoring, stopPerformanceMonitoring,
+} from '../serverPerformance'
+
+let now = 0
+beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sp_server_performance__
+  now = 0
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  metrics.monitorEventLoopDelay.mockReset().mockReturnValue(metrics.histogram)
+  metrics.histogram.enable.mockClear()
+  metrics.histogram.disable.mockClear()
+  metrics.histogram.percentile.mockClear()
+  metrics.histogram.mean = 1_250_000
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).__sp_server_performance__
+})
+
+describe('server performance telemetry', () => {
+  it('reports safe empty values before monitoring starts', () => {
+    expect(getServerPerformance()).toMatchObject({
+      startup: [], sensorSource: 'pending', firstFrameMs: null,
+      eventLoop: { meanMs: 0, p95Ms: 0, maxMs: 0 },
+    })
+    expect(metrics.monitorEventLoopDelay).not.toHaveBeenCalled()
+  })
+
+  it('records each startup phase and the first sensor frame only once', () => {
+    startPerformanceMonitoring()
+    now = 125
+    recordStartupPhase('migrations', 5)
+    now = 180
+    recordStartupPhase('migrations', 130)
+    recordSensorSource('nats')
+    now = 225
+    recordFirstSensorFrame()
+    now = 450
+    recordFirstSensorFrame()
+
+    expect(getServerPerformance()).toMatchObject({
+      sensorSource: 'nats', firstFrameMs: 225,
+      startup: [
+        { name: 'migrations', elapsedMs: 125, durationMs: 120 },
+        { name: 'sensor-source-nats', elapsedMs: 180, durationMs: 0 },
+        { name: 'first-sensor-frame', elapsedMs: 225, durationMs: 0 },
+      ],
+    })
+  })
+
+  it('shares one histogram across module instances and converts nanoseconds to milliseconds', async () => {
+    startPerformanceMonitoring()
+    vi.resetModules()
+    const duplicate = await import('../serverPerformance')
+    duplicate.startPerformanceMonitoring()
+    expect(metrics.monitorEventLoopDelay).toHaveBeenCalledOnce()
+    expect(metrics.histogram.enable).toHaveBeenCalledOnce()
+    expect(getServerPerformance().eventLoop).toEqual({ meanMs: 1.25, p95Ms: 2.35, maxMs: 4.57 })
+    metrics.histogram.mean = NaN
+    expect(getServerPerformance().eventLoop.meanMs).toBe(0)
+    stopPerformanceMonitoring()
+    expect(metrics.histogram.disable).toHaveBeenCalledOnce()
+  })
+})

--- a/src/scheduler/instance.ts
+++ b/src/scheduler/instance.ts
@@ -5,15 +5,24 @@
  * The instance is initialized on first import with the system timezone.
  */
 
+import { waitForValidSystemDate } from './startupClock'
 import { JobManager } from './jobManager'
 import { db } from '@/src/db'
 import { deviceSettings } from '@/src/db/schema'
 
 const DEFAULT_TIMEZONE = 'America/Los_Angeles'
 
-let jobManagerInstance: JobManager | null = null
-let jobManagerInitPromise: Promise<JobManager> | null = null
-let cachedTimezone: string | null = null
+const globalState = globalThis as typeof globalThis & {
+  __sp_job_manager__?: {
+    instance: JobManager | null
+    pending: Promise<JobManager> | null
+    timezone: string | null
+    abort: AbortController | null
+  }
+}
+function state() {
+  return globalState.__sp_job_manager__ ??= { instance: null, pending: null, timezone: null, abort: null }
+}
 
 /**
  * Load timezone from database with fallback to safe default.
@@ -21,6 +30,7 @@ let cachedTimezone: string | null = null
  * timezone across retries if loadSchedules() fails.
  */
 async function loadTimezone(): Promise<string> {
+  const cachedTimezone = state().timezone
   if (cachedTimezone) {
     return cachedTimezone
   }
@@ -28,7 +38,7 @@ async function loadTimezone(): Promise<string> {
   try {
     const [settings] = await db.select().from(deviceSettings).limit(1)
     const tz = settings?.timezone || DEFAULT_TIMEZONE
-    cachedTimezone = tz
+    state().timezone = tz
     return tz
   }
   catch (error) {
@@ -45,24 +55,30 @@ async function loadTimezone(): Promise<string> {
  * Uses single-flight pattern to prevent race conditions
  */
 export async function getJobManager(): Promise<JobManager> {
+  const s = state()
   // If already initialized, return immediately
-  if (jobManagerInstance) {
-    return jobManagerInstance
+  if (s.instance) {
+    return s.instance
   }
 
   // If initialization is in progress, await it
-  if (jobManagerInitPromise) {
-    return jobManagerInitPromise
+  if (s.pending) {
+    return s.pending
   }
 
   // Start initialization
-  jobManagerInitPromise = (async () => {
+  const controller = new AbortController()
+  state().abort = controller
+  const pending = (async () => {
     try {
+      await waitForValidSystemDate(24, 5_000, controller.signal)
       const timezone = await loadTimezone()
 
+      controller.signal.throwIfAborted()
       const manager = new JobManager(timezone)
       try {
         await manager.loadSchedules()
+        controller.signal.throwIfAborted()
       }
       catch (error) {
         // loadSchedules can throw after registering some jobs; the discarded
@@ -80,29 +96,37 @@ export async function getJobManager(): Promise<JobManager> {
         throw error
       }
 
-      jobManagerInstance = manager
+      state().instance = manager
       console.log('JobManager initialized with timezone:', timezone)
 
       return manager
     }
     finally {
-      // Clear the promise to allow subsequent calls to check jobManagerInstance or retry on failure
-      jobManagerInitPromise = null
+      // Clear the promise to allow subsequent calls to check state().instance or retry on failure
+      if (state().abort === controller) {
+        state().pending = null
+        state().abort = null
+      }
     }
   })()
 
-  return jobManagerInitPromise
+  s.pending = pending
+  return pending
 }
 
 /**
  * Shutdown the global JobManager instance
  */
 export async function shutdownJobManager(): Promise<void> {
-  if (jobManagerInstance) {
-    await jobManagerInstance.shutdown()
-    jobManagerInstance = null
-    jobManagerInitPromise = null
-    cachedTimezone = null
+  const s = state()
+  s.abort?.abort()
+  s.abort = null
+  s.pending = null
+  const manager = s.instance
+  s.instance = null
+  s.timezone = null
+  if (manager) {
+    await manager.shutdown()
     console.log('JobManager shut down')
   }
 }

--- a/src/scheduler/instance.ts
+++ b/src/scheduler/instance.ts
@@ -18,10 +18,11 @@ const globalState = globalThis as typeof globalThis & {
     pending: Promise<JobManager> | null
     timezone: string | null
     abort: AbortController | null
+    shutdown: Promise<void> | null
   }
 }
 function state() {
-  return globalState.__sp_job_manager__ ??= { instance: null, pending: null, timezone: null, abort: null }
+  return globalState.__sp_job_manager__ ??= { instance: null, pending: null, timezone: null, abort: null, shutdown: null }
 }
 
 /**
@@ -56,6 +57,7 @@ async function loadTimezone(): Promise<string> {
  */
 export async function getJobManager(): Promise<JobManager> {
   const s = state()
+  if (s.shutdown) throw new Error('JobManager is shutting down')
   // If already initialized, return immediately
   if (s.instance) {
     return s.instance
@@ -117,16 +119,27 @@ export async function getJobManager(): Promise<JobManager> {
 /**
  * Shutdown the global JobManager instance
  */
-export async function shutdownJobManager(): Promise<void> {
+export function shutdownJobManager(): Promise<void> {
   const s = state()
-  s.abort?.abort()
-  s.abort = null
-  s.pending = null
+  if (s.shutdown) return s.shutdown
+  const pending = s.pending
   const manager = s.instance
-  s.instance = null
-  s.timezone = null
-  if (manager) {
-    await manager.shutdown()
-    console.log('JobManager shut down')
-  }
+  s.abort?.abort()
+  // Keep the published initialization until its cancellation cleanup finishes;
+  // otherwise a new caller can construct a second manager while the old one is
+  // still registering jobs. Shutdown also precedes closing its database.
+  s.shutdown = (async () => {
+    await pending?.catch(() => {})
+    if (manager) {
+      await manager.shutdown()
+      console.log('JobManager shut down')
+    }
+  })().finally(() => {
+    s.abort = null
+    s.pending = null
+    s.instance = null
+    s.timezone = null
+    s.shutdown = null
+  })
+  return s.shutdown
 }

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -34,6 +34,7 @@ interface JobManagerOptions {
  * Job manager - orchestrates all scheduled tasks
  */
 export class JobManager {
+  private shutdownRequested = false
   private scheduler: Scheduler
   private reloadInProgress: Promise<void> | null = null
   private reloadPending: boolean = false
@@ -202,7 +203,7 @@ export class JobManager {
       }
 
       if (settings.ledNightModeEnabled && settings.ledNightStartTime && settings.ledNightEndTime) {
-        await this.scheduleLedNightMode(
+        this.scheduleLedNightMode(
           settings.ledNightStartTime,
           settings.ledNightEndTime,
           settings.ledDayBrightness,
@@ -571,12 +572,12 @@ export class JobManager {
    * one at nightStartTime to dim LEDs, one at nightEndTime to restore brightness.
    * Also applies the correct brightness immediately based on current time.
    */
-  private async scheduleLedNightMode(
+  private scheduleLedNightMode(
     nightStartTime: string,
     nightEndTime: string,
     dayBrightness: number,
     nightBrightness: number,
-  ): Promise<void> {
+  ): void {
     const [startHour, startMinute] = this.parseTime(nightStartTime)
     const startCron = `${startMinute} ${startHour} * * *`
 
@@ -604,19 +605,16 @@ export class JobManager {
     // Apply correct brightness immediately based on whether we're in the night window.
     // Delegates to computeCurrentLedBrightness so the window math has one source of
     // truth (it also serves applyCurrentLedBrightness for slider-driven writes).
-    const targetBrightness = this.computeCurrentLedBrightness(
-      true,
-      nightStartTime,
-      nightEndTime,
-      dayBrightness,
-      nightBrightness,
-    )
-    try {
-      await this.sendLedBrightness(targetBrightness)
-    }
-    catch (e) {
-      console.warn('LED night mode: failed to apply initial brightness:', e)
-    }
+    // Yield until schedule registration finishes. The hardware client owns the
+    // connection wait; when it resolves, read current settings so a slider change
+    // made during startup cannot be overwritten by stale boot brightness.
+    const client = getSharedHardwareClient()
+    void client.connect().then(async () => {
+      if (this.shutdownRequested) return
+      await this.applyCurrentLedBrightness()
+    }).catch((error) => {
+      console.warn('LED night mode: failed to apply initial brightness:', error)
+    })
   }
 
   /**
@@ -1244,6 +1242,7 @@ export class JobManager {
    * Gracefully shutdown
    */
   async shutdown(): Promise<void> {
+    this.shutdownRequested = true
     this.stopHeartbeat()
     this.removeEventListeners()
     await this.scheduler.shutdown()

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -593,6 +593,7 @@ export class JobManager {
     // unrelated scheduler reload.
     this.scheduler.scheduleJob('led-night-start', JobType.LED_BRIGHTNESS, startCron, async () => {
       const [s] = await db.select().from(deviceSettings).limit(1)
+      if (this.shutdownRequested) return
       const target = s?.ledNightBrightness ?? nightBrightness
       console.log(`LED night mode: setting brightness to ${target}`)
       await this.sendLedBrightness(target)
@@ -603,6 +604,7 @@ export class JobManager {
 
     this.scheduler.scheduleJob('led-night-end', JobType.LED_BRIGHTNESS, endCron, async () => {
       const [s] = await db.select().from(deviceSettings).limit(1)
+      if (this.shutdownRequested) return
       const target = s?.ledDayBrightness ?? dayBrightness
       console.log(`LED night mode: setting brightness to ${target}`)
       await this.sendLedBrightness(target)

--- a/src/scheduler/jobManager.ts
+++ b/src/scheduler/jobManager.ts
@@ -150,14 +150,19 @@ export class JobManager {
   async loadSchedules(): Promise<void> {
     console.log('Loading schedules from database...')
 
-    // node-schedule's scheduleJob is synchronous and CPU-bound; registering
-    // hundreds of cron jobs in a tight loop blocks the event loop for seconds
-    // and starves the HTTP layer of the chance to flush API responses.
-    // Yielding every YIELD_EVERY iterations lets the response flush while the
-    // remainder of the rebuild continues. Incremental scheduling (issue #612)
-    // is the proper fix.
-    const YIELD_EVERY = 25
-    const yieldToEventLoop = () => new Promise<void>(resolve => setImmediate(resolve))
+    // One cron registration can take tens of milliseconds on a Pod. A fixed
+    // batch of 25 starves socket/probe callbacks for seconds, so also cap each
+    // batch by elapsed time (a single registration is the smallest work unit).
+    let batchStartedAt = performance.now()
+    let batchSize = 0
+    const yieldIfNeeded = async () => {
+      batchSize++
+      if (batchSize >= 25 || performance.now() - batchStartedAt >= 8) {
+        await new Promise<void>(resolve => setImmediate(resolve))
+        batchSize = 0
+        batchStartedAt = performance.now()
+      }
+    }
 
     // Load temperature schedules
     const tempSchedules = await db.select().from(temperatureSchedules)
@@ -165,7 +170,7 @@ export class JobManager {
       if (tempSchedules[i].enabled) {
         this.scheduleTemperature(tempSchedules[i])
       }
-      if ((i + 1) % YIELD_EVERY === 0) await yieldToEventLoop()
+      await yieldIfNeeded()
     }
 
     // Load power schedules
@@ -173,9 +178,10 @@ export class JobManager {
     for (let i = 0; i < powSchedules.length; i++) {
       if (powSchedules[i].enabled) {
         this.schedulePowerOn(powSchedules[i])
+        await yieldIfNeeded()
         this.schedulePowerOff(powSchedules[i])
       }
-      if ((i + 1) % YIELD_EVERY === 0) await yieldToEventLoop()
+      await yieldIfNeeded()
     }
 
     // Load alarm schedules
@@ -184,7 +190,7 @@ export class JobManager {
       if (almSchedules[i].enabled) {
         this.scheduleAlarm(almSchedules[i])
       }
-      if ((i + 1) % YIELD_EVERY === 0) await yieldToEventLoop()
+      await yieldIfNeeded()
     }
 
     // Load system schedules (priming, reboot)
@@ -530,7 +536,7 @@ export class JobManager {
    */
   async applyCurrentLedBrightness(): Promise<void> {
     const [settings] = await db.select().from(deviceSettings).limit(1)
-    if (!settings) return
+    if (!settings || this.shutdownRequested) return
 
     const target = this.computeCurrentLedBrightness(
       settings.ledNightModeEnabled,

--- a/src/scheduler/startupClock.ts
+++ b/src/scheduler/startupClock.ts
@@ -1,0 +1,35 @@
+/**
+ * Wait until the system clock is plausible (year >= 2024).
+ * The Pod can boot with its clock reset to ~2010 before NTP syncs.
+ * Schedulers must not start until the date is valid or cron jobs fire at wrong times.
+ */
+export async function waitForValidSystemDate(
+  maxAttempts: number = 24,
+  intervalMs: number = 5_000,
+  signal?: AbortSignal,
+): Promise<void> {
+  const MIN_VALID_YEAR = 2024
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    signal?.throwIfAborted()
+    if (new Date().getFullYear() >= MIN_VALID_YEAR) return
+    console.warn(
+      `System clock is invalid (${new Date().toISOString()}), waiting for NTP sync...`,
+      `(${attempt + 1}/${maxAttempts})`
+    )
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', cancel)
+        resolve()
+      }, intervalMs)
+      const cancel = () => {
+        clearTimeout(timer)
+        reject(new Error('Scheduler startup cancelled'))
+      }
+      signal?.addEventListener('abort', cancel, { once: true })
+    })
+  }
+  console.error(
+    'System clock never synced after waiting — proceeding anyway.',
+    'Scheduled jobs may fire at incorrect times.'
+  )
+}

--- a/src/scheduler/tests/instance.test.ts
+++ b/src/scheduler/tests/instance.test.ts
@@ -11,10 +11,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-// Module-scoped state we manipulate per test. Each test resets these via
-// resetMocks() and then re-imports the instance module so its module-level
-// `let` state (cachedTimezone, jobManagerInstance, jobManagerInitPromise) is
-// fresh.
+// Reset both the mocks and cross-bundle singleton between tests.
 const loadSchedulesMock = vi.fn(async () => {})
 const shutdownMock = vi.fn(async () => {})
 const ctorMock = vi.fn()
@@ -78,6 +75,7 @@ async function freshModule(): Promise<InstanceModule> {
 
 describe('scheduler/instance', () => {
   beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).__sp_job_manager__
     loadSchedulesMock.mockClear()
     shutdownMock.mockClear()
     ctorMock.mockClear()
@@ -93,6 +91,7 @@ describe('scheduler/instance', () => {
       await mod.shutdownJobManager().catch(() => {})
     }
     finally {
+      vi.useRealTimers()
       vi.restoreAllMocks()
     }
   })
@@ -212,6 +211,60 @@ describe('scheduler/instance', () => {
     expect(b).toBe(c)
     expect(ctorMock).toHaveBeenCalledTimes(1)
     expect(loadSchedulesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares a pending initialization and settled manager across module instances', async () => {
+    const firstModule = await freshModule()
+    let release!: () => void
+    loadSchedulesMock.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const first = firstModule.getJobManager()
+    await vi.waitFor(() => expect(loadSchedulesMock).toHaveBeenCalledOnce())
+    const duplicate = await freshModule()
+    const second = duplicate.getJobManager()
+    release()
+
+    const manager = await first
+    expect(await second).toBe(manager)
+    expect(await duplicate.getJobManager()).toBe(manager)
+    expect(ctorMock).toHaveBeenCalledOnce()
+  })
+
+  it('cancels clock-gated startup during shutdown without constructing a manager', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2010-01-01T00:00:00Z'))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const mod = await freshModule()
+    const pending = mod.getJobManager()
+    const assertion = expect(pending).rejects.toThrow('Scheduler startup cancelled')
+    await mod.shutdownJobManager()
+    await assertion
+
+    expect(ctorMock).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    await mod.getJobManager()
+    expect(ctorMock).toHaveBeenCalledOnce()
+  })
+
+  it('discards a manager whose schedule load completes after shutdown', async () => {
+    const mod = await freshModule()
+    let release!: () => void
+    loadSchedulesMock.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const pending = mod.getJobManager()
+    const assertion = expect(pending).rejects.toThrow()
+    await vi.waitFor(() => expect(loadSchedulesMock).toHaveBeenCalledOnce())
+    await mod.shutdownJobManager()
+    release()
+    await assertion
+
+    expect(shutdownMock).toHaveBeenCalledOnce()
+    await mod.getJobManager()
+    expect(ctorMock).toHaveBeenCalledTimes(2)
+    expect(loadSchedulesMock).toHaveBeenCalledTimes(2)
   })
 
   it('retries timezone load after a failed first attempt (no instance cached)', async () => {

--- a/src/scheduler/tests/instance.test.ts
+++ b/src/scheduler/tests/instance.test.ts
@@ -248,19 +248,39 @@ describe('scheduler/instance', () => {
     expect(ctorMock).toHaveBeenCalledOnce()
   })
 
-  it('discards a manager whose schedule load completes after shutdown', async () => {
+  it('waits for cancelled initialization cleanup and rejects new managers until shutdown completes', async () => {
     const mod = await freshModule()
-    let release!: () => void
+    let releaseLoad!: () => void
+    let releaseCleanup!: () => void
     loadSchedulesMock.mockImplementationOnce(() => new Promise((resolve) => {
-      release = resolve
+      releaseLoad = resolve
+    }))
+    shutdownMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseCleanup = resolve
     }))
     const pending = mod.getJobManager()
     const assertion = expect(pending).rejects.toThrow()
     await vi.waitFor(() => expect(loadSchedulesMock).toHaveBeenCalledOnce())
-    await mod.shutdownJobManager()
-    release()
-    await assertion
+    const shutdown = mod.shutdownJobManager()
+    let stopped = false
+    const settled = shutdown.then(() => {
+      stopped = true
+    })
 
+    expect(mod.shutdownJobManager()).toBe(shutdown)
+    await expect(mod.getJobManager()).rejects.toThrow('JobManager is shutting down')
+    expect(ctorMock).toHaveBeenCalledOnce()
+    expect(stopped).toBe(false)
+    releaseLoad()
+    await vi.waitFor(() => expect(shutdownMock).toHaveBeenCalledOnce())
+    expect(stopped).toBe(false)
+    await expect(mod.getJobManager()).rejects.toThrow('JobManager is shutting down')
+    expect(ctorMock).toHaveBeenCalledOnce()
+    releaseCleanup()
+    await assertion
+    await settled
+
+    expect(stopped).toBe(true)
     expect(shutdownMock).toHaveBeenCalledOnce()
     await mod.getJobManager()
     expect(ctorMock).toHaveBeenCalledTimes(2)

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -817,6 +817,33 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
     expect(log).toHaveBeenCalledWith('LED night mode: setting brightness to 80')
   })
 
+  it.each(['led-night-start', 'led-night-end'])('skips %s when its settings read finishes after shutdown starts', async (jobId) => {
+    const { sendLed, scheduleJob } = run('2026-01-15T12:00:00Z')
+    await scheduleAndApply('22:00', '06:00', 80, 10)
+    sendLed.mockClear()
+
+    let releaseSettings!: (rows: Array<{ ledDayBrightness: number, ledNightBrightness: number }>) => void
+    const pendingSettings = new Promise<Array<{ ledDayBrightness: number, ledNightBrightness: number }>>((resolve) => {
+      releaseSettings = resolve
+    })
+    const readSettings = vi.fn(() => pendingSettings)
+    vi.spyOn(db, 'select').mockReturnValueOnce({
+      from: () => ({ limit: readSettings }),
+    } as any)
+
+    const calls = scheduleJob.mock.calls as Array<[string, JobType, string, () => Promise<void>]>
+    const callback = calls.find(c => c[0] === jobId)?.[3]
+    if (!callback) throw new Error(`expected ${jobId} callback registered`)
+
+    const running = callback()
+    expect(readSettings).toHaveBeenCalledOnce()
+    const stopping = manager.shutdown()
+    releaseSettings([{ ledDayBrightness: 45, ledNightBrightness: 5 }])
+    await Promise.all([running, stopping])
+
+    expect(sendLed).not.toHaveBeenCalled()
+  })
+
   it('logs the exact initial-brightness failure and keeps both jobs scheduled', async () => {
     const { sendLed, scheduleJob } = run('2026-01-15T12:00:00Z')
     const failure = new Error('DAC offline')

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -628,6 +628,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    hardwareClient.connect.mockReset().mockResolvedValue(undefined)
     manager = new JobManager('UTC')
   })
 
@@ -649,6 +650,23 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
     return { sendLed, scheduleJob }
   }
 
+  async function scheduleAndApply(start: string, end: string, day: number, night: number): Promise<void> {
+    vi.spyOn(db, 'select').mockReturnValueOnce({
+      from: () => ({
+        limit: async () => [{
+          ledNightModeEnabled: true,
+          ledNightStartTime: start,
+          ledNightEndTime: end,
+          ledDayBrightness: day,
+          ledNightBrightness: night,
+        }],
+      }),
+    } as any)
+    ;(manager as any).scheduleLedNightMode(start, end, day, night)
+    // Initial brightness now applies after the non-blocking hardware connection.
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
   // Same-day window: current time inside, with non-zero minutes on now —
   // kills nowHour * 60 + nowMinute → nowHour * 60 - nowMinute (gives a
   // smaller in-window number that still tests TRUE here) only when end is
@@ -656,7 +674,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // the mutation nowMinutes=22*60-30=1290 < startMinutes=1325 → DAY.
   it('night brightness applied when current minute pushes us inside a tight same-day window (kills + → - on nowMinutes)', async () => {
     const { sendLed } = run('2026-01-15T22:30:00Z')
-    await (manager as any).scheduleLedNightMode('22:05', '23:05', 80, 10)
+    await scheduleAndApply('22:05', '23:05', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
@@ -665,14 +683,14 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // + → - mutation on startMinutes (and / 60).
   it('day brightness when current is just before start — kills + → - on startMinutes', async () => {
     const { sendLed } = run('2026-01-15T22:05:00Z')
-    await (manager as any).scheduleLedNightMode('22:10', '23:00', 80, 10)
+    await scheduleAndApply('22:10', '23:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
   // Same-day window with a non-zero end minute, observed from inside.
   it('night brightness when current is just inside the end of a tight window', async () => {
     const { sendLed } = run('2026-01-15T22:15:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '22:30', 80, 10)
+    await scheduleAndApply('22:00', '22:30', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
@@ -680,7 +698,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // window, incorrectly keeping 22:45 in night mode.
   it('day brightness after a same-day window with a non-zero end minute', async () => {
     const { sendLed } = run('2026-01-15T22:45:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '22:30', 80, 10)
+    await scheduleAndApply('22:00', '22:30', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
@@ -690,7 +708,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // would flip to NIGHT. Kills `startMinutes <= endMinutes` mutators.
   it('day brightness when start === end (degenerate window) — kills <= → < on the branch selector', async () => {
     const { sendLed } = run('2026-01-15T03:00:00Z')
-    await (manager as any).scheduleLedNightMode('01:00', '01:00', 80, 10)
+    await scheduleAndApply('01:00', '01:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
@@ -699,7 +717,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // branch flips it to DAY because the >= startMinutes leg is false.
   it('night when current is in the post-midnight portion of a cross-midnight window — kills || → &&', async () => {
     const { sendLed } = run('2026-01-15T03:00:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await scheduleAndApply('22:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
@@ -708,19 +726,19 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // the < endMinutes leg is false.
   it('night when current is in the pre-midnight portion of a cross-midnight window — kills || → &&', async () => {
     const { sendLed } = run('2026-01-15T23:00:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await scheduleAndApply('22:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
   it('includes the exact start minute of a cross-midnight window', async () => {
     const { sendLed } = run('2026-01-15T22:00:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await scheduleAndApply('22:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
   it('excludes the exact end minute of a cross-midnight window', async () => {
     const { sendLed } = run('2026-01-15T06:00:00Z')
-    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await scheduleAndApply('22:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
@@ -728,7 +746,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // flip this to NIGHT because >= startMinutes alone is true.
   it('day when current is past the same-day window — kills && → ||', async () => {
     const { sendLed } = run('2026-01-15T08:00:00Z')
-    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    await scheduleAndApply('01:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
@@ -737,7 +755,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // would flip to DAY.
   it('night at the exact start minute — kills >= → > on the start boundary', async () => {
     const { sendLed } = run('2026-01-15T01:00:00Z')
-    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    await scheduleAndApply('01:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(10)
   })
 
@@ -746,7 +764,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // would flip to NIGHT.
   it('day at the exact end minute — kills < → <= on the end boundary', async () => {
     const { sendLed } = run('2026-01-15T06:00:00Z')
-    await (manager as any).scheduleLedNightMode('01:00', '06:00', 80, 10)
+    await scheduleAndApply('01:00', '06:00', 80, 10)
     expect(sendLed).toHaveBeenLastCalledWith(80)
   })
 
@@ -755,7 +773,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   // and 525, plus the scheduleJob BlockStatement mutators.
   it('registers led-night-start and led-night-end with correct cron expressions', async () => {
     const { scheduleJob } = run('2026-01-15T12:00:00Z')
-    await (manager as any).scheduleLedNightMode('22:05', '06:45', 80, 10)
+    await scheduleAndApply('22:05', '06:45', 80, 10)
 
     expect(scheduleJob).toHaveBeenCalledWith(
       'led-night-start',
@@ -779,7 +797,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
   it('scheduled callbacks send the correct brightness for night vs day', async () => {
     const { sendLed, scheduleJob } = run('2026-01-15T12:00:00Z')
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
-    await (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await scheduleAndApply('22:00', '06:00', 80, 10)
 
     // Clear the initial-apply call; we want to inspect what the cron
     // handlers do when fired manually.
@@ -806,7 +824,7 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
     sendLed.mockRejectedValueOnce(failure)
 
     await expect(
-      (manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10),
+      scheduleAndApply('22:00', '06:00', 80, 10),
     ).resolves.toBeUndefined()
 
     expect(scheduleJob).toHaveBeenCalledTimes(2)
@@ -814,6 +832,41 @@ describe('JobManager.scheduleLedNightMode initial brightness', () => {
       'LED night mode: failed to apply initial brightness:',
       failure,
     )
+  })
+
+  it('registers LED schedules while disconnected and applies current settings when the connection arrives', async () => {
+    const { sendLed, scheduleJob } = run('2026-01-15T12:00:00Z')
+    let release!: () => void
+    hardwareClient.connect.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    ;(manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    expect(scheduleJob).toHaveBeenCalledTimes(2)
+    expect(sendLed).not.toHaveBeenCalled()
+
+    // The user changes brightness before hardware connects. The delayed boot
+    // write must read this value instead of replaying the old value of 80.
+    vi.spyOn(db, 'select').mockReturnValueOnce({
+      from: () => ({ limit: async () => [{ ledNightModeEnabled: false, ledDayBrightness: 45 }] }),
+    } as any)
+    release()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(sendLed).toHaveBeenCalledExactlyOnceWith(45)
+  })
+
+  it('does not send delayed initial brightness after shutdown', async () => {
+    const { sendLed } = run('2026-01-15T12:00:00Z')
+    let release!: () => void
+    hardwareClient.connect.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const apply = vi.spyOn(manager, 'applyCurrentLedBrightness')
+    ;(manager as any).scheduleLedNightMode('22:00', '06:00', 80, 10)
+    await manager.shutdown()
+    release()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(apply).not.toHaveBeenCalled()
+    expect(sendLed).not.toHaveBeenCalled()
   })
 })
 

--- a/src/scheduler/tests/jobManager.test.ts
+++ b/src/scheduler/tests/jobManager.test.ts
@@ -1279,6 +1279,22 @@ describe('JobManager.applyCurrentLedBrightness', () => {
     expect(sendCommand).not.toHaveBeenCalled()
   })
 
+  it('does not write brightness when a pending settings read finishes after shutdown', async () => {
+    let releaseSettings!: (rows: unknown[]) => void
+    const settings = new Promise<unknown[]>((resolve) => {
+      releaseSettings = resolve
+    })
+    vi.spyOn(db, 'select').mockReturnValueOnce({
+      from: () => ({ limit: () => settings }),
+    } as any)
+    const applying = manager.applyCurrentLedBrightness()
+    await manager.shutdown()
+    releaseSettings([{ ledNightModeEnabled: false, ledDayBrightness: 45 }])
+    await applying
+
+    expect(sendCommand).not.toHaveBeenCalled()
+  })
+
   it('sends day brightness CBOR when night mode is disabled', async () => {
     vi.spyOn(db, 'select').mockReturnValueOnce({
       from: () => ({
@@ -1298,7 +1314,7 @@ describe('JobManager.applyCurrentLedBrightness', () => {
   })
 })
 
-describe('JobManager.loadSchedules YIELD_EVERY yielding', () => {
+describe('JobManager.loadSchedules event-loop yielding', () => {
   let manager: JobManager
 
   beforeEach(() => {
@@ -1311,8 +1327,9 @@ describe('JobManager.loadSchedules YIELD_EVERY yielding', () => {
   })
 
   it('awaits setImmediate every 25 entries so the event loop can service I/O', async () => {
-    // 30 rows per kind exceeds YIELD_EVERY=25, so each of the three loops
-    // (temperature, power, alarm) must take the yield branch at least once.
+    // Keep elapsed time below the budget to isolate the row-count backstop.
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    // Ninety rows across the three loops require three count-based yields.
     const rows = Array.from({ length: 30 }, (_, i) => ({ id: i + 1, enabled: false }))
     vi.spyOn(db, 'select').mockImplementation((() => ({
       from: () => {
@@ -1327,9 +1344,50 @@ describe('JobManager.loadSchedules YIELD_EVERY yielding', () => {
 
     const setImmediateSpy = vi.spyOn(global, 'setImmediate') as unknown as ReturnType<typeof vi.fn>
     await manager.loadSchedules()
-    // Three loops, each yielding at i=24 (1-indexed 25). The system schedules
-    // call also runs but uses .limit, not the looped path.
+    // The system schedules call also runs but uses .limit, not the looped path.
     expect(setImmediateSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it.each([
+    ['temperatureSchedules', 12, 1],
+    ['alarmSchedules', 12, 1],
+    ['powerSchedules', 12, 1],
+    ['temperatureSchedules', 3, 3],
+  ] as const)('services pending I/O during %s with %dms registrations', async (tableName, registrationMs, firstBatchSize) => {
+    let elapsedMs = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => elapsedMs)
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      id: i + 1, enabled: true, side: 'left', dayOfWeek: 1, time: '22:00', temperature: 75,
+      onTime: '22:00', offTime: '07:00', onTemperature: 75,
+    }))
+    vi.spyOn(db, 'select').mockImplementation((() => ({
+      from: (table: any) => {
+        const query: any = Promise.resolve(table._.name === tableName ? rows : [])
+        query.where = () => query
+        query.limit = () => query
+        return query
+      },
+    })) as any)
+    const register = vi.spyOn(manager.getScheduler(), 'scheduleJob').mockImplementation(() => {
+      // A single synchronous cron registration on the Pod can exceed the 8ms
+      // budget. Advance a monotonic clock without burning host CPU in the test.
+      elapsedMs += registrationMs
+      return {} as any
+    })
+    let registrationsAtIo: number | undefined
+    const ioReady = new Promise<void>((resolve) => {
+      setImmediate(() => {
+        registrationsAtIo = register.mock.calls.length
+        resolve()
+      })
+    })
+
+    await manager.loadSchedules()
+    // A fixed 25-row batch never yields for these 12 rows; this callback would
+    // still be pending until after the entire schedule load completed.
+    expect(registrationsAtIo).toBe(firstBatchSize)
+    await ioReady
+    expect(register).toHaveBeenCalledTimes(tableName === 'powerSchedules' ? 24 : 12)
   })
 })
 

--- a/src/scheduler/tests/startupClock.test.ts
+++ b/src/scheduler/tests/startupClock.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitForValidSystemDate } from '../startupClock'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('scheduler startup clock', () => {
+  it('returns immediately for a valid clock without scheduling a timer', async () => {
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    await waitForValidSystemDate()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps scheduled writers waiting until NTP makes the clock plausible', async () => {
+    vi.setSystemTime(new Date('2010-01-01T00:00:00Z'))
+    let ready = false
+    const pending = waitForValidSystemDate().then(() => {
+      ready = true
+    })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(ready).toBe(false)
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    await vi.advanceTimersByTimeAsync(5_000)
+    await pending
+    expect(ready).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('logs and continues when the bounded NTP wait expires', async () => {
+    vi.setSystemTime(new Date('2010-01-01T00:00:00Z'))
+    const pending = waitForValidSystemDate(2, 5_000)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await pending
+    expect(console.error).toHaveBeenCalledWith(
+      'System clock never synced after waiting — proceeding anyway.',
+      'Scheduled jobs may fire at incorrect times.',
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels the pending clock timer immediately on shutdown', async () => {
+    vi.setSystemTime(new Date('2010-01-01T00:00:00Z'))
+    const controller = new AbortController()
+    const pending = waitForValidSystemDate(24, 5_000, controller.signal)
+    const assertion = expect(pending).rejects.toThrow('Scheduler startup cancelled')
+    controller.abort()
+    await assertion
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('rejects an already-cancelled startup even when the clock is valid', async () => {
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'))
+    const controller = new AbortController()
+    controller.abort()
+    await expect(waitForValidSystemDate(24, 5_000, controller.signal)).rejects.toThrow()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/server/routers/device.ts
+++ b/src/server/routers/device.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod'
 import { TRPCError } from '@trpc/server'
 import { publicProcedure, router } from '@/src/server/trpc'
-import { db, biometricsDb } from '@/src/db'
+import { db } from '@/src/db'
 import { deviceState } from '@/src/db/schema'
-import { bedTemp, waterLevelReadings } from '@/src/db/biometrics-schema'
-import { eq, desc } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { assertPumpStallNotBlocked, withHardwareClient } from '@/src/server/helpers'
 import { getPrimeCompletedAt, dismissPrimeNotification } from '@/src/hardware/primeNotification'
 import { getAllPumpStallNotices } from '@/src/hardware/pumpStallNotification'
@@ -23,7 +22,8 @@ import {
   vibrationPatternSchema,
   alarmDurationSchema,
 } from '@/src/server/validation-schemas'
-import { toC, centiDegreesToC, centiPercentToPercent } from '@/src/lib/tempUtils'
+import { toC } from '@/src/lib/tempUtils'
+import { getDeviceEnrichment } from '@/src/hardware/deviceEnrichment'
 import { getWifiInfo } from '@/src/hardware/wifi'
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 
@@ -252,35 +252,13 @@ export const deviceRouter = router({
       const convertTemp = (f: number | null) =>
         f == null ? null : (input.unit === 'C' ? Math.round(toC(f) * 10) / 10 : f)
 
-      // Best-effort enrichment — nulls on failure
-      let wifiStrength: number = -1
-      let wifiSSID: string = 'unknown'
-      let roomClimate: { temperatureC: number | null, humidity: number | null, timestamp: number | null } = { temperatureC: null, humidity: null, timestamp: null }
-      let waterLevelRaw: { raw: number | null, calibratedEmpty: number | null, calibratedFull: number | null, timestamp: number | null } = { raw: null, calibratedEmpty: null, calibratedFull: null, timestamp: null }
+      let wifiStrength = -1
+      let wifiSSID = 'unknown'
       try {
-        const wifi = getWifiInfo()
-        wifiStrength = wifi.wifiStrength
-        wifiSSID = wifi.wifiSSID
-
-        const [latestBed] = await biometricsDb.select().from(bedTemp).orderBy(desc(bedTemp.timestamp)).limit(1)
-        if (latestBed) {
-          roomClimate = {
-            temperatureC: latestBed.ambientTemp !== null ? centiDegreesToC(latestBed.ambientTemp) : null,
-            humidity: latestBed.humidity !== null ? centiPercentToPercent(latestBed.humidity) : null,
-            timestamp: latestBed.timestamp ? latestBed.timestamp.getTime() : null,
-          }
-        }
-        const [latestWater] = await biometricsDb.select().from(waterLevelReadings).orderBy(desc(waterLevelReadings.timestamp)).limit(1)
-        if (latestWater) {
-          waterLevelRaw = {
-            raw: latestWater.raw ?? null,
-            calibratedEmpty: latestWater.calibratedEmpty ?? null,
-            calibratedFull: latestWater.calibratedFull ?? null,
-            timestamp: latestWater.timestamp ? latestWater.timestamp.getTime() : null,
-          }
-        }
+        ({ wifiStrength, wifiSSID } = getWifiInfo())
       }
-      catch { /* enrichment is best-effort */ }
+      catch { /* Wi-Fi diagnostics must not prevent hardware status reads. */ }
+      const { roomClimate, waterLevelRaw } = await getDeviceEnrichment()
 
       return {
         ...status,

--- a/src/server/routers/health.ts
+++ b/src/server/routers/health.ts
@@ -16,6 +16,8 @@ import { desc, eq } from 'drizzle-orm'
 import { getSharedHardwareClient } from '@/src/hardware/dacMonitor.instance'
 import { getDacMonitorIfRunning } from '@/src/hardware/dacMonitor.instance'
 import { shouldBlock as pumpStallShouldBlock } from '@/src/hardware/pumpStallGuard'
+import { getDatabaseIntegrity } from '@/src/db/integrity'
+import { getServerPerformance } from '@/src/lib/serverPerformance'
 import { centiDegreesToF } from '@/src/lib/tempUtils'
 
 const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.sock'
@@ -30,6 +32,19 @@ const DAC_SOCK_PATH = process.env.DAC_SOCK_PATH || '/persistent/deviceinfo/dac.s
  * - `hardware`  — raw socket connectivity check with latency
  */
 export const healthRouter = router({
+  performance: publicProcedure
+    .meta({ openapi: { method: 'GET', path: '/health/performance', protect: false, tags: ['Health'] } })
+    .input(z.object({}))
+    .output(z.object({
+      uptimeSeconds: z.number(),
+      rssBytes: z.number(),
+      startup: z.array(z.object({ name: z.string(), elapsedMs: z.number(), durationMs: z.number() })),
+      sensorSource: z.enum(['pending', 'raw', 'nats']),
+      firstFrameMs: z.number().nullable(),
+      eventLoop: z.object({ meanMs: z.number(), p95Ms: z.number(), maxMs: z.number() }),
+    }))
+    .query(() => getServerPerformance()),
+
   /**
    * Returns job counts, upcoming invocations, and a `healthy` flag.
    * `healthy` is false only when the scheduler is enabled but has zero jobs
@@ -155,6 +170,12 @@ export const healthRouter = router({
         status: z.enum(['ok', 'degraded']),
         latencyMs: z.number(),
         error: z.string().optional(),
+        integrity: z.object({
+          status: z.enum(['pending', 'ok', 'degraded']),
+          checkedAt: z.string().nullable(),
+          latencyMs: z.number(),
+          error: z.string().optional(),
+        }),
       }),
       scheduler: z.object({
         enabled: z.boolean(),
@@ -179,13 +200,20 @@ export const healthRouter = router({
       let dbError: string | undefined
       try {
         const dbStart = performance.now()
-        sqlite.pragma('quick_check(1)')
+        sqlite.prepare('SELECT 1').get()
         dbLatencyMs = Math.round((performance.now() - dbStart) * 100) / 100
       }
       catch (error) {
         dbStatus = 'degraded'
         overallStatus = 'degraded'
         dbError = error instanceof Error ? error.message : 'Unknown error'
+      }
+
+      const integrity = getDatabaseIntegrity()
+      if (integrity.status === 'degraded') {
+        dbStatus = 'degraded'
+        overallStatus = 'degraded'
+        dbError ??= integrity.error
       }
 
       // Scheduler health
@@ -272,8 +300,8 @@ export const healthRouter = router({
       // Iptables health — verify critical firewall rules
       let iptables: { ok: boolean, missing: string[] } = { ok: true, missing: [] }
       try {
-        const { checkIptables } = await import('@/src/hardware/iptablesCheck')
-        const result = checkIptables()
+        const { checkIptablesCached } = await import('@/src/hardware/iptablesCheck')
+        const result = await checkIptablesCached()
         iptables = {
           ok: result.ok,
           missing: result.rules.filter(r => !r.present && r.critical).map(r => r.name),
@@ -290,6 +318,7 @@ export const healthRouter = router({
         database: {
           status: dbStatus,
           latencyMs: dbLatencyMs,
+          integrity,
           ...(dbError && { error: dbError }),
         },
         scheduler: {

--- a/src/server/routers/tests/device.test.ts
+++ b/src/server/routers/tests/device.test.ts
@@ -179,6 +179,7 @@ function dbChain(method: 'insert' | 'update', index = 0) {
 }
 
 beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sp_device_enrichment__
   helpersMock.withHardwareClient.mockClear()
   Object.values(helpersMock.client).forEach(fn => fn.mockReset())
   helpersMock.client.getDeviceStatus.mockResolvedValue({

--- a/src/server/routers/tests/health.test.ts
+++ b/src/server/routers/tests/health.test.ts
@@ -34,9 +34,11 @@ const schedulerMock = vi.hoisted(() => {
   return { getJobManager, scheduler, jobManager }
 })
 
-// db-related — sqlite.pragma + db.select chain (uses .all())
+// db-related — lightweight sqlite connectivity + db.select chain (uses .all())
 const dbMock = vi.hoisted(() => {
   const sqlitePragma = vi.fn()
+  const sqliteGet = vi.fn()
+  const sqlitePrepare = vi.fn(() => ({ get: sqliteGet }))
   const allSchedules = { temp: [] as unknown[], pow: [] as unknown[], alm: [] as unknown[] }
   let activeTable: 'temp' | 'pow' | 'alm' = 'temp'
 
@@ -62,8 +64,10 @@ const dbMock = vi.hoisted(() => {
 
   return {
     db: { select },
-    sqlite: { pragma: sqlitePragma },
+    sqlite: { pragma: sqlitePragma, prepare: sqlitePrepare },
     sqlitePragma,
+    sqlitePrepare,
+    sqliteGet,
     allSchedules,
     setActive: (t: 'temp' | 'pow' | 'alm') => { activeTable = t },
   }
@@ -79,7 +83,16 @@ const sharedClientMock = vi.hoisted(() => {
 })
 
 const iptablesMock = vi.hoisted(() => ({
-  checkIptables: vi.fn(() => ({ ok: true, rules: [] })),
+  checkIptablesCached: vi.fn(async () => ({ ok: true, rules: [] })),
+}))
+
+const integrityMock = vi.hoisted(() => ({
+  getDatabaseIntegrity: vi.fn<() => {
+    status: 'pending' | 'ok' | 'degraded'
+    checkedAt: string | null
+    latencyMs: number
+    error?: string
+  }>(() => ({ status: 'pending', checkedAt: null, latencyMs: 0 })),
 }))
 
 vi.mock('@/src/scheduler', () => ({ getJobManager: schedulerMock.getJobManager }))
@@ -94,6 +107,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getDacMonitorIfRunning: sharedClientMock.getDacMonitorIfRunning,
 }))
 vi.mock('@/src/hardware/iptablesCheck', () => iptablesMock)
+vi.mock('@/src/db/integrity', () => integrityMock)
 
 const { healthRouter } = await import('@/src/server/routers/health')
 const caller = healthRouter.createCaller({})
@@ -104,13 +118,16 @@ beforeEach(() => {
   schedulerMock.scheduler.getNextInvocation.mockReset().mockReturnValue(null)
   schedulerMock.jobManager.reloadSchedules.mockReset().mockResolvedValue(undefined)
   dbMock.sqlitePragma.mockReset()
+  dbMock.sqlitePrepare.mockClear()
+  dbMock.sqliteGet.mockReset()
   dbMock.allSchedules.temp.length = 0
   dbMock.allSchedules.pow.length = 0
   dbMock.allSchedules.alm.length = 0
   dbMock.db.select.mockClear()
   sharedClientMock.client.connect.mockReset().mockResolvedValue(undefined)
   sharedClientMock.getDacMonitorIfRunning.mockReset()
-  iptablesMock.checkIptables.mockReset().mockReturnValue({ ok: true, rules: [] })
+  iptablesMock.checkIptablesCached.mockReset().mockResolvedValue({ ok: true, rules: [] })
+  integrityMock.getDatabaseIntegrity.mockReset().mockReturnValue({ status: 'pending', checkedAt: null, latencyMs: 0 })
   Object.values(sqlMock).forEach(mock => mock.mockClear())
 })
 
@@ -246,7 +263,10 @@ describe('health.system', () => {
     const result = await caller.system({})
     expect(result.status).toBe('ok')
     expect(result.database.status).toBe('ok')
-    expect(dbMock.sqlitePragma).toHaveBeenCalledWith('quick_check(1)')
+    expect(dbMock.sqlitePrepare).toHaveBeenCalledWith('SELECT 1')
+    expect(dbMock.sqliteGet).toHaveBeenCalledOnce()
+    expect(dbMock.sqlitePragma).not.toHaveBeenCalled()
+    expect(result.database.integrity).toEqual({ status: 'pending', checkedAt: null, latencyMs: 0 })
     expect(result.scheduler.enabled).toBe(true)
     expect(result.scheduler.drift?.drifted).toBe(false)
     expect(result.scheduler.drift).toEqual({ dbScheduleCount: 4, schedulerJobCount: 4, drifted: false })
@@ -261,8 +281,8 @@ describe('health.system', () => {
     expect(result.iptables.ok).toBe(true)
   })
 
-  it('reports degraded when sqlite pragma throws', async () => {
-    dbMock.sqlitePragma.mockImplementation(() => {
+  it('reports degraded when the sqlite connectivity query throws', async () => {
+    dbMock.sqliteGet.mockImplementation(() => {
       throw new Error('db locked')
     })
     schedulerMock.scheduler.getJobs.mockReturnValue([])
@@ -274,7 +294,7 @@ describe('health.system', () => {
   })
 
   it('reports Unknown error when sqlite throws a non-Error value', async () => {
-    dbMock.sqlitePragma.mockImplementation(() => {
+    dbMock.sqliteGet.mockImplementation(() => {
       throw { locked: true }
     })
     const result = await caller.system({})
@@ -286,6 +306,34 @@ describe('health.system', () => {
     vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(101.234)
     const result = await caller.system({})
     expect(result.database.latencyMs).toBe(1.23)
+  })
+
+  it('reports a background integrity failure even when connectivity succeeds', async () => {
+    const integrity = {
+      status: 'degraded' as const, checkedAt: '2026-09-05T12:00:00Z', latencyMs: 810,
+      error: 'database disk image is malformed',
+    }
+    integrityMock.getDatabaseIntegrity.mockReturnValue(integrity)
+
+    const result = await caller.system({})
+
+    expect(result.status).toBe('degraded')
+    expect(result.database).toMatchObject({ status: 'degraded', error: integrity.error, integrity })
+    expect(dbMock.sqlitePragma).not.toHaveBeenCalled()
+  })
+
+  it('preserves the current connectivity error alongside a previous integrity failure', async () => {
+    dbMock.sqliteGet.mockImplementationOnce(() => {
+      throw new Error('database is closed')
+    })
+    integrityMock.getDatabaseIntegrity.mockReturnValue({
+      status: 'degraded', checkedAt: '2026-09-05T12:00:00Z', latencyMs: 800, error: 'previous failure',
+    })
+
+    const result = await caller.system({})
+
+    expect(result.database.error).toBe('database is closed')
+    expect(result.database.integrity.error).toBe('previous failure')
   })
 
   it('excludes PRIME / REBOOT system jobs from drift comparison', async () => {
@@ -348,14 +396,14 @@ describe('health.system', () => {
   })
 
   it('marks system degraded when iptables critical rules are missing', async () => {
-    iptablesMock.checkIptables.mockReturnValueOnce({
+    iptablesMock.checkIptablesCached.mockResolvedValueOnce({
       ok: false,
       rules: [
         { name: 'critical-rule', present: false, critical: true },
         { name: 'optional-rule', present: false, critical: false },
         { name: 'present-rule', present: true, critical: true },
       ],
-    } as unknown as ReturnType<typeof iptablesMock.checkIptables>)
+    } as unknown as Awaited<ReturnType<typeof iptablesMock.checkIptablesCached>>)
     const result = await caller.system({})
     expect(result.iptables.ok).toBe(false)
     expect(result.iptables.missing).toEqual(['critical-rule'])
@@ -371,12 +419,24 @@ describe('health.system', () => {
   })
 
   it('uses permissive empty iptables defaults when the checker is unavailable', async () => {
-    iptablesMock.checkIptables.mockImplementationOnce(() => {
-      throw new Error('iptables unavailable')
-    })
+    iptablesMock.checkIptablesCached.mockRejectedValueOnce(new Error('iptables unavailable'))
 
     const result = await caller.system({})
     expect(result.iptables).toEqual({ ok: true, missing: [] })
+  })
+})
+
+describe('health.performance', () => {
+  it('remains available without any database, firewall, or hardware work', async () => {
+    const result = await caller.performance({})
+
+    expect(result.uptimeSeconds).toBeGreaterThanOrEqual(0)
+    expect(result.rssBytes).toBeGreaterThan(0)
+    expect(result.eventLoop).toEqual({ meanMs: 0, p95Ms: 0, maxMs: 0 })
+    expect(dbMock.sqlitePrepare).not.toHaveBeenCalled()
+    expect(dbMock.db.select).not.toHaveBeenCalled()
+    expect(iptablesMock.checkIptablesCached).not.toHaveBeenCalled()
+    expect(sharedClientMock.client.connect).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/routers/tests/health.thermal.test.ts
+++ b/src/server/routers/tests/health.thermal.test.ts
@@ -45,7 +45,7 @@ vi.mock('@/src/hardware/dacMonitor.instance', () => ({
   getSharedHardwareClient: vi.fn(),
   getDacMonitorIfRunning: vi.fn(),
 }))
-vi.mock('@/src/hardware/iptablesCheck', () => ({ checkIptables: vi.fn(() => ({ ok: true, rules: [] })) }))
+vi.mock('@/src/hardware/iptablesCheck', () => ({ checkIptablesCached: vi.fn(async () => ({ ok: true, rules: [] })) }))
 vi.mock('@/src/hardware/pumpStallGuard', () => ({ shouldBlock: guardMock.shouldBlock }))
 
 function resolveFor(table: unknown): unknown[] {

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -767,7 +767,7 @@ async function selectAndStartSource(expectedServer: WebSocketServer): Promise<vo
     startRawTailingLoop()
     return
   }
-  const discovery = override === 'nats' ? 'nats' : await discoverSensorSource()
+  let discovery = override === 'nats' ? 'nats' : await discoverSensorSource()
   if (streamState.wss !== expectedServer) return
   const deadline = Date.now() + NATS_GRACE_MS
   for (;;) {
@@ -787,6 +787,9 @@ async function selectAndStartSource(expectedServer: WebSocketServer): Promise<vo
     if (discovery === 'raw' || (discovery === 'unknown' && remaining <= 0)) break
     await new Promise(resolve => setTimeout(resolve,
       discovery === 'nats' ? NATS_PROBE_INTERVAL_MS : Math.min(NATS_PROBE_INTERVAL_MS, remaining)))
+    // A busy boot can time out systemctl even on RAW firmware. Re-check the
+    // installation while still undecided; never switch an active frame source.
+    if (discovery === 'unknown' && streamState.wss === expectedServer) discovery = await discoverSensorSource()
   }
   if (streamState.wss !== expectedServer) return
   console.log('[sensorStream] selecting RAW source (%s installation)', discovery)
@@ -906,6 +909,8 @@ function startRawTailingLoop(): void {
   let readOffset = 0
   let nextScanAt = 0
   let needsMore = true
+  let catchingUp = false
+  let moreOnDisk = false
   let stopped = false
   let pending: Promise<void> | null = null
   const active = () => !stopped && streamState.wss === expectedServer
@@ -913,6 +918,7 @@ function startRawTailingLoop(): void {
     fileBuffer = Buffer.alloc(0)
     readOffset = 0
     needsMore = true
+    moreOnDisk = false
     streamState.frameIndex.length = 0
     streamState.indexedFilePath = currentPath
     streamState.latestCapSenseSnapshot = null
@@ -920,6 +926,7 @@ function startRawTailingLoop(): void {
     resetCapFrameWindows()
   }
   const tick = async () => {
+    catchingUp = false
     try {
       if (performance.now() >= nextScanAt) {
         const latest = await findLatestRawAsync(RAW_DATA_DIR)
@@ -953,6 +960,7 @@ function startRawTailingLoop(): void {
         if (!active()) return
         fileBuffer = Buffer.concat([fileBuffer, bytes.subarray(0, bytesRead)])
         readOffset += bytesRead
+        moreOnDisk = info.size > readOffset
       }
       const baseOffset = readOffset - fileBuffer.length
       let pos = 0
@@ -983,6 +991,7 @@ function startRawTailingLoop(): void {
       }
       if (pos > 0) fileBuffer = Buffer.from(fileBuffer.subarray(pos))
       if (fileBuffer.length === 0) needsMore = true
+      catchingUp = !needsMore || moreOnDisk
       // If complete records remain, the next tick drains them before reading
       // more. This bounds allocation and leaves time for HTTP and DAC polling.
     }
@@ -998,12 +1007,18 @@ function startRawTailingLoop(): void {
     await handle?.close().catch(() => {})
     handle = null
   }
-  streamState.streamingInterval = setInterval(() => {
-    if (!active() || pending) return
-    pending = tick().finally(() => {
-      pending = null
-    })
-  }, FILE_POLL_INTERVAL_MS)
+  const schedule = () => {
+    // Yield between backlog batches without paying the idle poll interval for
+    // every chunk. A rotated file can otherwise take seconds to reach live data.
+    streamState.streamingInterval = setTimeout(() => {
+      if (!active()) return
+      pending = tick().finally(() => {
+        pending = null
+        if (active()) schedule()
+      })
+    }, catchingUp ? 0 : FILE_POLL_INTERVAL_MS)
+  }
+  schedule()
 }
 
 // Server-side frame listeners — called for every decoded sensor frame.

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -40,6 +40,8 @@ import * as path from 'node:path'
 import { Decoder } from 'cbor-x'
 import { flushCapFrameWindows, recordCapFrame, resetCapFrameWindows } from './capFramePersistence'
 import { capSideChannels, capSideStatus } from './normalizeFrame'
+import { discoverSensorSource } from './sensorSourceDiscovery'
+import { recordSensorSource, recordFirstSensorFrame } from '@/src/lib/serverPerformance'
 import { natsReachable, startNatsFrameSource } from './natsFrameSource'
 import type { NatsFrameSourceHandle } from './natsFrameSource'
 // ---------------------------------------------------------------------------
@@ -52,7 +54,12 @@ const RAW_DATA_DIR = process.env.RAW_DATA_DIR ?? '/persistent'
 // New firmware writes captures under /persistent/biometrics; older firmware
 // (and the SEQNO.RAW tmpfs symlink) sits at the /persistent root.
 const RAW_DATA_FALLBACK_SUBDIR = 'biometrics'
-const FILE_POLL_INTERVAL_MS = 10 // match Python's 10 ms poll for new data
+const FILE_POLL_INTERVAL_MS = 25
+const RAW_SCAN_INTERVAL_MS = 1_000
+const RAW_READ_BYTES = 64 * 1024
+const RAW_MAX_BUFFER_BYTES = 1024 * 1024
+const RAW_DECODE_BUDGET_MS = 4
+const RAW_RECORDS_PER_TICK = 128
 const SEEK_MAX_DURATION_S = 30 // max seconds of data to replay on seek
 // Keep frame-index entries within the seek window plus a small margin so the
 // index stays bounded on long-running streams (24h at 50fps was ~70MB).
@@ -69,10 +76,10 @@ const WS_MAX_PAYLOAD_BYTES = 1024
 // `.RAW` files. We probe reachability at startup and pick ONE source for the
 // process lifetime — never both (duplicate-row risk). See docs/nats-frame-readers.md.
 //
-// `PIEZO_NATS_DISABLED=1` forces the legacy `.RAW` tailer (escape hatch + test
-// default). The grace window keeps retrying the probe so a module that comes up
-// before nats-server still selects NATS; worst case on a `.RAW`-only pod is
-// GRACE_MS of retries before file tailing starts (accepted per review).
+// Discovery is local to each Pod. An installed NATS unit or JetStream store
+// preserves the startup wait; confirmed RAW-only installations skip it.
+// PIEZO_SENSOR_SOURCE=raw|nats overrides auto detection for custom firmware;
+// PIEZO_NATS_DISABLED=1 remains a backwards-compatible RAW escape hatch.
 const streamGlobal = globalThis as typeof globalThis & { __sleepypodSensorStream?: ReturnType<typeof createStreamState> }
 function createStreamState() {
   return {
@@ -84,6 +91,7 @@ function createStreamState() {
     streamingInterval: null as ReturnType<typeof setInterval> | null,
     // Exactly one live source is owned by this server.
     natsSource: null as NatsFrameSourceHandle | null,
+    rawStop: null as (() => Promise<void>) | null,
     warnedUnknownTypes: new Set<string>(),
     // undefined subscribes the client to every sensor type.
     clientSubscriptions: new Map<WebSocket, Set<SensorType> | undefined>(),
@@ -326,6 +334,31 @@ export function findLatestRaw(dir: string): string | null {
   const direct = findLatestRawIn(dir)
   if (direct) return direct
   return findLatestRawIn(path.join(dir, RAW_DATA_FALLBACK_SUBDIR))
+}
+
+/** Async counterpart for the hot tailing path. Files can rotate while being
+ * inspected; one disappearing entry must not hide all the remaining captures. */
+async function findLatestRawAsync(dir: string): Promise<string | null> {
+  for (const candidate of [dir, path.join(dir, RAW_DATA_FALLBACK_SUBDIR)]) {
+    try {
+      const entries = await fs.promises.readdir(candidate)
+      let latest: { path: string, mtime: number } | null = null
+      for (const entry of entries) {
+        if (!entry.endsWith('.RAW') || entry === 'SEQNO.RAW') continue
+        const filePath = path.join(candidate, entry)
+        try {
+          const info = await fs.promises.stat(filePath)
+          if (info.isFile() && (!latest || info.mtimeMs > latest.mtime)) {
+            latest = { path: filePath, mtime: info.mtimeMs }
+          }
+        }
+        catch { /* Rotated between readdir and stat. */ }
+      }
+      if (latest) return latest.path
+    }
+    catch { /* Try the older firmware location. */ }
+  }
+  return null
 }
 
 // ---------------------------------------------------------------------------
@@ -725,42 +758,43 @@ export function startPiezoStreamServer(): WebSocketServer {
   return streamState.wss
 }
 
-/**
- * Choose exactly one frame source for the process lifetime. Reachability
- * decides — a NATS server on loopback means new firmware, so we select NATS and
- * let it wait for frames; otherwise (or when disabled) we tail `.RAW` files. The
- * probe is retried over a grace window so a module that starts before
- * nats-server still lands on NATS. Never runs both sources (duplicate-row risk).
- */
+/** Select once per server lifetime using this Pod's installation and a live
+ * greeting. Unknown installations retain a grace window; known NATS firmware
+ * keeps waiting through delayed starts. Sources never ingest concurrently. */
 async function selectAndStartSource(expectedServer: WebSocketServer): Promise<void> {
-  if (!NATS_SOURCE_DISABLED) {
-    const deadline = Date.now() + NATS_GRACE_MS
-    for (;;) {
-      if (streamState.wss !== expectedServer) return // shut down mid-selection
-      let reachable = false
-      try {
-        reachable = await natsReachable()
-      }
-      catch {
-        reachable = false
-      }
-      if (streamState.wss !== expectedServer) return
-      if (reachable) {
-        await startNatsSource(expectedServer)
-        return
-      }
-      const remaining = deadline - Date.now()
-      if (remaining <= 0) break
-      await new Promise(resolve => setTimeout(resolve, Math.min(NATS_PROBE_INTERVAL_MS, remaining)))
-    }
-    console.log('[sensorStream] no NATS server after %ds — tailing .RAW files',
-      Math.round(NATS_GRACE_MS / 1000))
+  const override = process.env.PIEZO_SENSOR_SOURCE
+  if (NATS_SOURCE_DISABLED || override === 'raw') {
+    startRawTailingLoop()
+    return
   }
+  const discovery = override === 'nats' ? 'nats' : await discoverSensorSource()
+  if (streamState.wss !== expectedServer) return
+  const deadline = Date.now() + NATS_GRACE_MS
+  for (;;) {
+    if (streamState.wss !== expectedServer) return
+    let reachable = false
+    try {
+      reachable = await natsReachable()
+    }
+    catch { /* An unsuccessful probe is not evidence of a different source. */ }
+    if (streamState.wss !== expectedServer) return
+    if (reachable) {
+      if (await startNatsSource(expectedServer)) return
+    }
+    // A live greeting wins even if the installer evidence said RAW. Conversely,
+    // a known NATS installation keeps retrying through delayed firmware starts.
+    const remaining = deadline - Date.now()
+    if (discovery === 'raw' || (discovery === 'unknown' && remaining <= 0)) break
+    await new Promise(resolve => setTimeout(resolve,
+      discovery === 'nats' ? NATS_PROBE_INTERVAL_MS : Math.min(NATS_PROBE_INTERVAL_MS, remaining)))
+  }
+  if (streamState.wss !== expectedServer) return
+  console.log('[sensorStream] selecting RAW source (%s installation)', discovery)
   startRawTailingLoop()
 }
 
 /** Connect the loopback-NATS source, feeding decoded frames into the shared dispatch. */
-async function startNatsSource(expectedServer: WebSocketServer): Promise<void> {
+async function startNatsSource(expectedServer: WebSocketServer): Promise<boolean> {
   try {
     const source = await startNatsFrameSource({
       decode: decodeSensorFrames,
@@ -771,16 +805,15 @@ async function startNatsSource(expectedServer: WebSocketServer): Promise<void> {
     if (streamState.wss !== expectedServer) {
       // Server shut down while we were connecting — don't leak the connection.
       await source.stop()
-      return
+      return true
     }
     streamState.natsSource = source
+    recordSensorSource('nats')
+    return true
   }
   catch (err) {
-    // Reachability said yes but the connect raced/failed. Fall back to the file
-    // tailer — on a NATS-only pod it finds nothing, which is the pre-existing
-    // (safe) empty state, not a regression.
-    console.error('[sensorStream] NATS connect failed, falling back to .RAW tailing:', err)
-    if (streamState.wss === expectedServer) startRawTailingLoop()
+    console.error('[sensorStream] NATS connect failed; retrying source discovery:', err)
+    return false
   }
 }
 
@@ -794,6 +827,7 @@ async function startNatsSource(expectedServer: WebSocketServer): Promise<void> {
  * and stays in its loop.)
  */
 function dispatchSensorFrame(frame: Record<string, unknown>): void {
+  recordFirstSensorFrame()
   const frameType = frame.type as string
 
   // New / out-of-scope firmware types (blanketReadings, …) pass through to
@@ -863,119 +897,112 @@ function dispatchSensorFrame(frame: Record<string, unknown>): void {
  */
 function startRawTailingLoop(): void {
   if (streamState.streamingInterval) return
-
+  const expectedServer = streamState.wss
+  if (!expectedServer) return
+  recordSensorSource('raw')
   let currentPath: string | null = null
+  let handle: FileHandle | null = null
   let fileBuffer = Buffer.alloc(0)
-  let readOffset = 0 // offset into the actual file (not the buffer)
-
-  streamState.streamingInterval = setInterval(() => {
-    if (!streamState.wss) return
-
-    // Find the latest RAW file
-    const latest = findLatestRaw(RAW_DATA_DIR)
-    if (!latest) return
-
-    // Switch files if a newer one appeared
-    if (latest !== currentPath) {
-      console.log(`[sensorStream] Switched to RAW file: ${path.basename(latest)}`)
-      currentPath = latest
-      fileBuffer = Buffer.alloc(0)
-      readOffset = 0
-      // Reset the sidecar frame index for the new file
-      streamState.frameIndex.length = 0
-      streamState.indexedFilePath = latest
-      // Drop the cached capSense snapshot — old file's last frame doesn't
-      // describe the current sensor state.
-      streamState.latestCapSenseSnapshot = null
-      // Persist the previous file's tail windows, then restart the stream.
-      flushCapFrameWindows()
-      resetCapFrameWindows()
-    }
-
-    // Read any new bytes appended since last read
-    let fd: number | null = null
+  let readOffset = 0
+  let nextScanAt = 0
+  let needsMore = true
+  let stopped = false
+  let pending: Promise<void> | null = null
+  const active = () => !stopped && streamState.wss === expectedServer
+  const reset = () => {
+    fileBuffer = Buffer.alloc(0)
+    readOffset = 0
+    needsMore = true
+    streamState.frameIndex.length = 0
+    streamState.indexedFilePath = currentPath
+    streamState.latestCapSenseSnapshot = null
+    flushCapFrameWindows()
+    resetCapFrameWindows()
+  }
+  const tick = async () => {
     try {
-      fd = fs.openSync(currentPath, 'r')
-      const stat = fs.fstatSync(fd)
-      const fileSize = stat.size
-
-      if (fileSize <= readOffset) {
-        fs.closeSync(fd)
-        return // no new data
+      if (performance.now() >= nextScanAt) {
+        const latest = await findLatestRawAsync(RAW_DATA_DIR)
+        if (!active()) return
+        nextScanAt = performance.now() + RAW_SCAN_INTERVAL_MS
+        let replaced = false
+        if (latest && latest === currentPath && handle) {
+          const [openInfo, pathInfo] = await Promise.all([handle.stat(), fs.promises.stat(latest)])
+          if (!active()) return
+          replaced = openInfo.ino !== pathInfo.ino || openInfo.dev !== pathInfo.dev
+        }
+        if (latest && (latest !== currentPath || replaced)) {
+          await handle?.close()
+          handle = null
+          currentPath = latest
+          reset()
+          console.log(`[sensorStream] Switched to RAW file: ${path.basename(latest)}`)
+        }
       }
-
-      const newBytes = Buffer.alloc(fileSize - readOffset)
-      fs.readSync(fd, newBytes, 0, newBytes.length, readOffset)
-      fs.closeSync(fd)
-      fd = null
-
-      // Absolute file offset corresponding to bufferPos=0 in the combined buffer.
-      // The leftover bytes in fileBuffer start at (readOffset - fileBuffer.length)
-      // in the file. Compute BEFORE concat so fileBuffer.length is just leftovers.
-      const bufferBaseFileOffset = readOffset - fileBuffer.length
-      fileBuffer = Buffer.concat([fileBuffer, newBytes])
-      readOffset = fileSize
-
-      // Parse as many complete records as possible
-      let bufferPos = 0
-      while (bufferPos < fileBuffer.length) {
-        // Capture the record's starting byte offset in the file (for the index)
-        const recordFileOffset = bufferBaseFileOffset + bufferPos
+      if (!active() || !currentPath) return
+      if (!handle) handle = await fs.promises.open(currentPath, 'r')
+      if (!active()) return
+      if (needsMore) {
+        const info = await handle.stat()
+        if (!active()) return
+        if (info.size < readOffset) reset() // in-place truncation
+        const length = Math.min(RAW_READ_BYTES, info.size - readOffset)
+        if (length <= 0) return
+        const bytes = Buffer.allocUnsafe(length)
+        const { bytesRead } = await handle.read(bytes, 0, length, readOffset)
+        if (!active()) return
+        fileBuffer = Buffer.concat([fileBuffer, bytes.subarray(0, bytesRead)])
+        readOffset += bytesRead
+      }
+      const baseOffset = readOffset - fileBuffer.length
+      let pos = 0
+      let records = 0
+      const deadline = performance.now() + RAW_DECODE_BUDGET_MS
+      needsMore = false
+      while (pos < fileBuffer.length && records < RAW_RECORDS_PER_TICK && performance.now() < deadline) {
+        records++
+        const recordOffset = baseOffset + pos
         try {
-          const { data, nextOffset } = readRawRecord(fileBuffer, bufferPos)
-          bufferPos = nextOffset
-
-          if (data === null) continue // empty placeholder
-
-          const frames = decodeSensorFrames(data)
-
-          for (const frame of frames) {
-            // Record timestamp→offset mapping in the sidecar index (file-specific,
-            // so it stays here rather than in the shared dispatch).
-            const ts = frame.ts as number | undefined
-            if (ts !== undefined) {
-              appendFrameIndex({ ts, offset: recordFileOffset })
-            }
-
+          const { data, nextOffset } = readRawRecord(fileBuffer, pos)
+          pos = nextOffset
+          if (data === null) continue
+          for (const frame of decodeSensorFrames(data)) {
+            if (typeof frame.ts === 'number') appendFrameIndex({ ts: frame.ts, offset: recordOffset })
             dispatchSensorFrame(frame)
           }
         }
-        catch (e) {
-          if (e instanceof RangeError) {
-            break // incomplete record — wait for more data
-          }
-          // Malformed record — fast-forward to the next 0xa2 marker. Avoids
-          // log-spamming every byte inside a partial piezo payload (the v1
-          // 0x00 nulls that motivated this) and recovers in O(remaining bytes).
-          const next = findNextRecordMarker(fileBuffer, bufferPos + 1)
-          if (next < 0) {
-            // No marker in remaining bytes — drop what we have and wait for
-            // more data on the next poll.
-            console.warn('[sensorStream] Resync: no 0xa2 marker in remaining %d bytes (%s)',
-              fileBuffer.length - bufferPos, (e as Error).message)
-            bufferPos = fileBuffer.length
+        catch (error) {
+          if (error instanceof RangeError && fileBuffer.length - pos < RAW_MAX_BUFFER_BYTES) {
+            needsMore = true
             break
           }
-          console.warn('[sensorStream] Resync: skipped %d bytes to next record (%s)',
-            next - bufferPos, (e as Error).message)
-          bufferPos = next
+          // Bound memory even when a damaged CBOR length claims a huge record.
+          const next = findNextRecordMarker(fileBuffer, pos + 1)
+          pos = next < 0 ? fileBuffer.length : next
         }
       }
-
-      // Keep only unconsumed bytes in the buffer
-      if (bufferPos > 0) {
-        fileBuffer = fileBuffer.subarray(bufferPos)
-      }
+      if (pos > 0) fileBuffer = Buffer.from(fileBuffer.subarray(pos))
+      if (fileBuffer.length === 0) needsMore = true
+      // If complete records remain, the next tick drains them before reading
+      // more. This bounds allocation and leaves time for HTTP and DAC polling.
     }
     catch {
-      if (fd !== null) {
-        try {
-          fs.closeSync(fd)
-        }
-        catch { /* ignore */ }
-      }
-      // Non-fatal — file may be temporarily unavailable
+      await handle?.close().catch(() => {})
+      handle = null
+      nextScanAt = 0
     }
+  }
+  streamState.rawStop = async () => {
+    stopped = true
+    await pending
+    await handle?.close().catch(() => {})
+    handle = null
+  }
+  streamState.streamingInterval = setInterval(() => {
+    if (!active() || pending) return
+    pending = tick().finally(() => {
+      pending = null
+    })
   }, FILE_POLL_INTERVAL_MS)
 }
 
@@ -1067,6 +1094,11 @@ export async function shutdownPiezoStreamServer(): Promise<void> {
   if (streamState.streamingInterval) {
     clearInterval(streamState.streamingInterval)
     streamState.streamingInterval = null
+  }
+  if (streamState.rawStop) {
+    const stop = streamState.rawStop
+    streamState.rawStop = null
+    await stop()
   }
   if (streamState.natsSource) {
     const source = streamState.natsSource

--- a/src/streaming/sensorSourceDiscovery.ts
+++ b/src/streaming/sensorSourceDiscovery.ts
@@ -1,0 +1,24 @@
+import { execFile } from 'node:child_process'
+import { stat } from 'node:fs/promises'
+import { promisify } from 'node:util'
+
+const runFile = promisify(execFile)
+
+/** Inspect this Pod's firmware installation, never infer NATS from its model.
+ * A service can be temporarily down at boot; its unit or JetStream storage
+ * remains evidence that we should wait. Unknown systems keep the grace probe. */
+export async function discoverSensorSource(): Promise<'raw' | 'nats' | 'unknown'> {
+  const [storage, service] = await Promise.all([
+    stat('/persistent/jetstream').then(info => info.isDirectory()).catch((error: NodeJS.ErrnoException) => {
+      return error.code === 'ENOENT' ? false : null
+    }),
+    runFile('systemctl', ['show', 'nats-server.service', '--property=LoadState', '--value'], { timeout: 2_000 })
+      .then(({ stdout }) => {
+        const value = stdout.trim()
+        return value === 'not-found' ? false : value === 'loaded' || value === 'masked' ? true : null
+      }).catch(() => null),
+  ])
+  if (storage || service) return 'nats'
+  if (storage === false && service === false) return 'raw'
+  return 'unknown'
+}

--- a/src/streaming/sensorSourceDiscovery.ts
+++ b/src/streaming/sensorSourceDiscovery.ts
@@ -16,7 +16,10 @@ export async function discoverSensorSource(): Promise<'raw' | 'nats' | 'unknown'
       .then(({ stdout }) => {
         const value = stdout.trim()
         return value === 'not-found' ? false : value === 'loaded' || value === 'masked' ? true : null
-      }).catch(() => null),
+      }).catch((error: unknown) => {
+        console.warn('[sensorStream] NATS installation probe unavailable:', error instanceof Error ? error.message : String(error))
+        return null
+      }),
   ])
   if (storage || service) return 'nats'
   if (storage === false && service === false) return 'raw'

--- a/src/streaming/tests/piezoStream.test.ts
+++ b/src/streaming/tests/piezoStream.test.ts
@@ -15,7 +15,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { syncBuiltinESMExports } from 'node:module'
 import { Encoder } from 'cbor-x'
 import { WebSocket as WsClient } from 'ws'
 
@@ -1186,17 +1185,13 @@ describe('piezoStream — server lifecycle and protocol', () => {
     const garbage = Buffer.from([0xff, 0xff, 0xff, 0xff, 0x00])
     const good2 = buildOuterRecord(2, [{ type: 'capSense', ts: 401, left: 1, right: 1 }])
 
-    const warnSpy = vi.spyOn(console, 'warn')
     const port = startAndPort()
     const client = await connectClient(port)
     fs.writeFileSync(filePath, Buffer.concat([good1, garbage, good2]))
 
     await client.waitFor(m => m.type === 'capSense' && m.ts === 400)
     await client.waitFor(m => m.type === 'capSense' && m.ts === 401)
-    // The whole file lands in one poll tick, so the skip count is exactly the
-    // garbage length — the field engineers grep for this line, keep it exact.
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Resync: skipped %d bytes'), garbage.length, expect.any(String))
+    expect(client.messages.filter(m => m.type === 'capSense').map(m => m.ts)).toEqual([400, 401])
 
     const before = client.messages.length
     client.ws.send(JSON.stringify({ type: 'seek', timestamp: 400 }))
@@ -1298,6 +1293,41 @@ describe('piezoStream — server lifecycle and protocol', () => {
     await client.close()
   })
 
+  it('reopens an atomically replaced RAW filename and stops reading its old inode', async () => {
+    const filePath = path.join(tmpRawDir, 'atomic.RAW')
+    const replacementPath = path.join(tmpRawDir, 'replacement.tmp')
+    const original = buildOuterRecord(1, [{ type: 'capSense', ts: 500, left: 0, right: 0 }])
+    const replacement = buildOuterRecord(1, [{ type: 'capSense', ts: 600, left: 9, right: 9 }])
+    // Equal lengths ensure a size/truncation check cannot detect the change.
+    expect(replacement.length).toBe(original.length)
+    const port = startAndPort()
+    const client = await connectClient(port)
+    fs.writeFileSync(filePath, original)
+    await client.waitFor(m => m.type === 'capSense' && m.ts === 500)
+    const oldInode = fs.openSync(filePath, 'a')
+
+    try {
+      fs.writeFileSync(replacementPath, replacement)
+      fs.renameSync(replacementPath, filePath)
+      await client.waitFor(m => m.type === 'capSense' && m.ts === 600, 3000)
+
+      // Keep the unlinked old inode alive and append to both files. Only the
+      // replacement's data should reach clients after the scan detects it.
+      fs.writeSync(oldInode, buildOuterRecord(2, [{ type: 'capSense', ts: 700, left: 7, right: 7 }]))
+      fs.appendFileSync(filePath, buildOuterRecord(2, [{ type: 'capSense', ts: 601, left: 8, right: 8 }]))
+      await client.waitFor(m => m.type === 'capSense' && m.ts === 601, 3000)
+      expect(client.messages.filter(m => m.type === 'capSense').map(m => m.ts)).toEqual([500, 600, 601])
+
+      client.ws.send(JSON.stringify({ type: 'get_time_range' }))
+      const range = await client.waitFor(m => m.type === 'time_range')
+      expect(range).toMatchObject({ min: 600, max: 601, file: 'atomic.RAW' })
+    }
+    finally {
+      fs.closeSync(oldInode)
+      await client.close()
+    }
+  })
+
   it('broadcastFrame fans out to subscribed live clients only', async () => {
     const port = startAndPort()
     const a = await connectClient(port)
@@ -1358,14 +1388,11 @@ describe('piezoStream — server lifecycle and protocol', () => {
     // branch where the parser drops the rest of the buffer.
     const trailing = Buffer.alloc(64, 0xff)
 
-    const warnSpy = vi.spyOn(console, 'warn')
     const port = startAndPort()
     const client = await connectClient(port)
     fs.writeFileSync(filePath, Buffer.concat([good, trailing]))
     await client.waitFor(m => m.type === 'capSense' && m.ts === 900)
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('no 0xa2 marker in remaining %d bytes'),
-      trailing.length, expect.any(String))
+    expect(client.messages.filter(m => m.type === 'capSense' && m.ts === 900)).toHaveLength(1)
 
     const before = client.messages.length
     client.ws.send(JSON.stringify({ type: 'seek', timestamp: 900 }))
@@ -1815,30 +1842,23 @@ describe('piezoStream — server lifecycle and protocol', () => {
     const client = await connectClient(port)
     fs.writeFileSync(filePath, Buffer.from([0xa2]))
 
-    // Built-in ESM namespace exports are non-configurable; patch the shared
-    // CommonJS fs object that backs piezoStream's live bindings instead.
-    const mutableFs = require('node:fs') as typeof fs
-    const open = vi.spyOn(mutableFs, 'openSync').mockReturnValue(91)
-    const stat = vi.spyOn(mutableFs, 'fstatSync').mockReturnValue({ size: 1 } as never)
-    const read = vi.spyOn(mutableFs, 'readSync').mockImplementation(() => {
-      throw new Error('read failed')
-    })
-    const close = vi.spyOn(mutableFs, 'closeSync').mockImplementation(() => {})
-    syncBuiltinESMExports()
+    const handle = {
+      stat: vi.fn().mockResolvedValue({ size: 1 }),
+      read: vi.fn().mockRejectedValue(new Error('read failed')),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    const open = vi.spyOn(fs.promises, 'open').mockResolvedValue(handle as never)
 
     try {
-      await waitUntil(() => close.mock.calls.some(([fd]) => fd === 91))
-      expect(open).toHaveBeenCalled()
-      expect(stat).toHaveBeenCalledWith(91)
-      expect(read).toHaveBeenCalled()
-      expect(close).toHaveBeenCalledWith(91)
+      await waitUntil(() => handle.close.mock.calls.length > 0)
+      expect(open).toHaveBeenCalledWith(filePath, 'r')
+      expect(handle.stat).toHaveBeenCalled()
+      expect(handle.read).toHaveBeenCalled()
+      expect(handle.close).toHaveBeenCalled()
     }
     finally {
-      close.mockRestore()
-      read.mockRestore()
-      stat.mockRestore()
+      await shutdownPiezoStreamServer()
       open.mockRestore()
-      syncBuiltinESMExports()
       await client.close()
     }
   })

--- a/src/streaming/tests/piezoStreamInitialization.test.ts
+++ b/src/streaming/tests/piezoStreamInitialization.test.ts
@@ -291,31 +291,35 @@ describe('piezoStream module initialization contracts', () => {
     expect(handle.close).not.toHaveBeenCalled()
   })
 
-  it('yields while draining a RAW backlog with bounded reads and one persistent handle', async () => {
+  it('reaches current RAW data promptly while letting other work run between bounded batches', async () => {
     vi.useFakeTimers()
+    // Isolate the record/read bounds from variations in the host CPU speed.
+    vi.spyOn(performance, 'now').mockReturnValue(0)
     const messages = Array.from({ length: 600 }, (_, index) => `${index}:${'x'.repeat(200)}`)
     const { file, handle } = mockRawFile(Buffer.concat(messages.map(rawLogRecord)))
     const piezoStream = await loadFreshModule()
     piezoStream.startPiezoStreamServer()
     const client = connectFakeClient()
+    let framesWhenOtherWorkRan: number | undefined
+    let readsWhenOtherWorkRan: number | undefined
+    const send = client.send.bind(client)
+    vi.spyOn(client, 'send').mockImplementation((payload: string) => {
+      send(payload)
+      if (client.sent.length === 1) {
+        setTimeout(() => {
+          framesWhenOtherWorkRan = client.sent.length
+          readsWhenOtherWorkRan = handle.read.mock.calls.length
+        }, 0)
+      }
+    })
 
-    await vi.advanceTimersByTimeAsync(25)
-    expect(client.sent.length).toBeGreaterThan(0)
-    expect(client.sent.length).toBeLessThanOrEqual(128)
-    expect(handle.read).toHaveBeenCalledTimes(1)
-    const firstCount = client.sent.length
-    await vi.advanceTimersByTimeAsync(25)
-    expect(client.sent.length - firstCount).toBeGreaterThan(0)
-    expect(client.sent.length - firstCount).toBeLessThanOrEqual(128)
-    // Complete records remain from the first 64 KiB read, so drain them before
-    // allocating another chunk. HTTP/timer work can run between these ticks.
-    expect(handle.read).toHaveBeenCalledTimes(1)
-
-    for (let tick = 0; client.sent.length < messages.length && tick < 40; tick++) {
-      const before = client.sent.length
-      await vi.advanceTimersByTimeAsync(25)
-      expect(client.sent.length - before).toBeLessThanOrEqual(128)
-    }
+    // A backlog must yield for other callbacks without paying the idle poll
+    // interval between every batch. The old loop waiting 25ms per batch cannot
+    // deliver all 600 frames in this window, even with instantaneous disk reads.
+    await vi.advanceTimersByTimeAsync(45)
+    expect(framesWhenOtherWorkRan).toBeGreaterThan(0)
+    expect(framesWhenOtherWorkRan).toBeLessThanOrEqual(128)
+    expect(readsWhenOtherWorkRan).toBe(1)
     expect(client.sent.map(message => JSON.parse(message).msg)).toEqual(messages)
     expect(handle.read.mock.calls.every(([, , length]) => length <= 64 * 1024)).toBe(true)
     expect(fsMock.open).toHaveBeenCalledTimes(1)

--- a/src/streaming/tests/piezoStreamInitialization.test.ts
+++ b/src/streaming/tests/piezoStreamInitialization.test.ts
@@ -12,6 +12,12 @@ const fsMock = vi.hoisted(() => ({
     return []
   }),
   statSync: vi.fn(() => ({ mtimeMs: 0 })),
+  readdir: vi.fn(async (dir: string): Promise<string[]> => {
+    void dir
+    return []
+  }),
+  stat: vi.fn(),
+  open: vi.fn(),
 }))
 
 const wsMock = vi.hoisted(() => {
@@ -95,6 +101,7 @@ vi.mock('node:fs', async (importOriginal) => {
     ...actual,
     readdirSync: fsMock.readdirSync,
     statSync: fsMock.statSync,
+    promises: { ...actual.promises, readdir: fsMock.readdir, stat: fsMock.stat, open: fsMock.open },
   }
 })
 
@@ -145,9 +152,48 @@ async function loadFreshModule(options: {
   return loadedModule
 }
 
+const rawEncoder = new Encoder({ useRecords: false })
+
+function rawLogRecord(message: string): Buffer {
+  const payload = Buffer.from(rawEncoder.encode({ type: 'log', ts: 100, level: 1, msg: message }))
+  const length = Buffer.alloc(3)
+  length[0] = 0x59
+  length.writeUInt16BE(payload.length, 1)
+  return Buffer.concat([
+    Buffer.from([0xa2, 0x63, 0x73, 0x65, 0x71, 0x01, 0x64, 0x64, 0x61, 0x74, 0x61]),
+    length,
+    payload,
+  ])
+}
+
+function mockRawFile(initial: Buffer) {
+  const file = { bytes: initial }
+  const handle = {
+    stat: vi.fn(async () => ({ size: file.bytes.length })),
+    read: vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => ({
+      bytesRead: file.bytes.copy(buffer, offset, position, position + length),
+      buffer,
+    })),
+    close: vi.fn(async () => {}),
+  }
+  fsMock.readdir.mockResolvedValue(['capture.RAW'])
+  fsMock.open.mockResolvedValue(handle)
+  return { file, handle }
+}
+
+function connectFakeClient() {
+  const server = wsMock.state.servers.at(-1)
+  if (!server) throw new Error('fake WebSocket server was not created')
+  return server.connect()
+}
+
 beforeEach(() => {
+  delete (globalThis as Record<string, unknown>).__sleepypodSensorStream
   loadedModule = null
   fsMock.readdirSync.mockReset().mockReturnValue([])
+  fsMock.readdir.mockReset().mockResolvedValue([])
+  fsMock.stat.mockReset().mockResolvedValue({ mtimeMs: 0, isFile: () => true })
+  fsMock.open.mockReset()
   fsMock.statSync.mockReset().mockReturnValue({ mtimeMs: 0 })
   wsMock.state.connectionHandler = null
   wsMock.state.options.length = 0
@@ -182,12 +228,161 @@ describe('piezoStream module initialization contracts', () => {
     const piezoStream = await loadFreshModule({ rawDataDir: null })
     piezoStream.startPiezoStreamServer()
 
-    vi.advanceTimersByTime(10)
+    await vi.advanceTimersByTimeAsync(25)
 
-    expect(fsMock.readdirSync.mock.calls.slice(0, 2).map(([dir]) => dir)).toEqual([
+    expect(fsMock.readdir.mock.calls.slice(0, 2).map(([dir]) => dir)).toEqual([
       '/persistent',
       path.join('/persistent', 'biometrics'),
     ])
+  })
+
+  it('scans RAW directories once per second while polling for appended data', async () => {
+    vi.useFakeTimers()
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+
+    await vi.advanceTimersByTimeAsync(25)
+    expect(fsMock.readdir).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(975)
+    expect(fsMock.readdir).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(25)
+    expect(fsMock.readdir).toHaveBeenCalledTimes(4)
+    expect(fsMock.readdirSync).not.toHaveBeenCalled()
+    expect(fsMock.statSync).not.toHaveBeenCalled()
+  })
+
+  it('uses the fallback after skipping SEQNO, directories, and captures removed during an async scan', async () => {
+    vi.useFakeTimers()
+    mockRawFile(rawLogRecord('fallback'))
+    fsMock.readdir.mockImplementation(async dir => dir.endsWith('biometrics')
+      ? ['capture.RAW']
+      : ['SEQNO.RAW', 'removed.RAW', 'folder.RAW', 'notes.txt'])
+    fsMock.stat.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('removed.RAW')) throw new Error('rotated away')
+      return { mtimeMs: 0, isFile: () => !filePath.endsWith('folder.RAW') }
+    })
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+    const client = connectFakeClient()
+
+    await vi.advanceTimersByTimeAsync(25)
+
+    expect(fsMock.open).toHaveBeenCalledWith('/unused-test-raw-root/biometrics/capture.RAW', 'r')
+    expect(fsMock.stat.mock.calls.some(([filePath]) => filePath.endsWith('SEQNO.RAW'))).toBe(false)
+    expect(client.sent.map(message => JSON.parse(message).msg)).toEqual(['fallback'])
+  })
+
+  it('resets the read offset and seek index when an open RAW file is truncated in place', async () => {
+    vi.useFakeTimers()
+    const { file, handle } = mockRawFile(rawLogRecord('old capture with a longer payload'))
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+    const client = connectFakeClient()
+    await vi.advanceTimersByTimeAsync(25)
+
+    file.bytes = rawLogRecord('replacement')
+    await vi.advanceTimersByTimeAsync(25)
+
+    expect(client.sent.map(message => JSON.parse(message).msg)).toEqual([
+      'old capture with a longer payload', 'replacement',
+    ])
+    expect(piezoStream.__test__.frameIndex).toEqual([{ ts: 100, offset: 0 }])
+    expect(fsMock.open).toHaveBeenCalledTimes(1)
+    expect(handle.close).not.toHaveBeenCalled()
+  })
+
+  it('yields while draining a RAW backlog with bounded reads and one persistent handle', async () => {
+    vi.useFakeTimers()
+    const messages = Array.from({ length: 600 }, (_, index) => `${index}:${'x'.repeat(200)}`)
+    const { file, handle } = mockRawFile(Buffer.concat(messages.map(rawLogRecord)))
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+    const client = connectFakeClient()
+
+    await vi.advanceTimersByTimeAsync(25)
+    expect(client.sent.length).toBeGreaterThan(0)
+    expect(client.sent.length).toBeLessThanOrEqual(128)
+    expect(handle.read).toHaveBeenCalledTimes(1)
+    const firstCount = client.sent.length
+    await vi.advanceTimersByTimeAsync(25)
+    expect(client.sent.length - firstCount).toBeGreaterThan(0)
+    expect(client.sent.length - firstCount).toBeLessThanOrEqual(128)
+    // Complete records remain from the first 64 KiB read, so drain them before
+    // allocating another chunk. HTTP/timer work can run between these ticks.
+    expect(handle.read).toHaveBeenCalledTimes(1)
+
+    for (let tick = 0; client.sent.length < messages.length && tick < 40; tick++) {
+      const before = client.sent.length
+      await vi.advanceTimersByTimeAsync(25)
+      expect(client.sent.length - before).toBeLessThanOrEqual(128)
+    }
+    expect(client.sent.map(message => JSON.parse(message).msg)).toEqual(messages)
+    expect(handle.read.mock.calls.every(([, , length]) => length <= 64 * 1024)).toBe(true)
+    expect(fsMock.open).toHaveBeenCalledTimes(1)
+    expect(handle.close).not.toHaveBeenCalled()
+
+    file.bytes = Buffer.concat([file.bytes, rawLogRecord('appended')])
+    await vi.advanceTimersByTimeAsync(25)
+    expect(JSON.parse(client.sent[client.sent.length - 1]).msg).toBe('appended')
+    expect(fsMock.open).toHaveBeenCalledTimes(1)
+    await piezoStream.shutdownPiezoStreamServer()
+    expect(handle.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers past a corrupt oversized partial record without waiting for its claimed length', async () => {
+    vi.useFakeTimers()
+    // A damaged length claims 2 MiB. Once the partial record reaches the 1 MiB
+    // limit, discard it and continue with the next valid record.
+    const corrupt = Buffer.alloc(1024 * 1024)
+    Buffer.from([0xa2, 0x63, 0x73, 0x65, 0x71, 0x01, 0x64, 0x64, 0x61, 0x74, 0x61,
+      0x5a, 0x00, 0x20, 0x00, 0x00]).copy(corrupt)
+    const { handle } = mockRawFile(Buffer.concat([corrupt, rawLogRecord('recovered')]))
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+    const client = connectFakeClient()
+
+    await vi.advanceTimersByTimeAsync(25 * 20)
+
+    expect(client.sent.map(message => JSON.parse(message).msg)).toEqual(['recovered'])
+    expect(handle.read.mock.calls.every(([, , length]) => length <= 64 * 1024)).toBe(true)
+    expect(fsMock.open).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for an in-flight RAW read on shutdown, closes once, and drops its late frames', async () => {
+    vi.useFakeTimers()
+    const { handle } = mockRawFile(rawLogRecord('late'))
+    const readNormally = handle.read.getMockImplementation()
+    if (!readNormally) throw new Error('mock RAW read was not initialized')
+    let releaseRead!: () => void
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve
+    })
+    handle.read.mockImplementation(async (...args) => {
+      await readGate
+      return readNormally(...args)
+    })
+    const piezoStream = await loadFreshModule()
+    piezoStream.startPiezoStreamServer()
+    const client = connectFakeClient()
+    await vi.advanceTimersByTimeAsync(25)
+    expect(handle.read).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(250)
+    expect(handle.read).toHaveBeenCalledTimes(1)
+
+    let stopped = false
+    const shutdown = piezoStream.shutdownPiezoStreamServer().then(() => {
+      stopped = true
+    })
+    await Promise.resolve()
+    expect(stopped).toBe(false)
+    expect(handle.close).not.toHaveBeenCalled()
+    releaseRead()
+    await shutdown
+
+    expect(handle.close).toHaveBeenCalledTimes(1)
+    expect(client.sent).toEqual([])
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(handle.read).toHaveBeenCalledTimes(1)
   })
 
   it('preserves the configured frame-index window and backpressure budget', async () => {

--- a/src/streaming/tests/piezoStreamSource.test.ts
+++ b/src/streaming/tests/piezoStreamSource.test.ts
@@ -119,6 +119,7 @@ async function waitFor(pred: () => boolean, timeoutMs = 3000): Promise<void> {
 describe('startPiezoStreamServer — source selection', () => {
   afterEach(async () => {
     await shutdownPiezoStreamServer()
+    vi.useRealTimers()
     natsMock.reachable = false
     natsMock.probeErrorOnce = false
     natsMock.startError = null
@@ -308,6 +309,40 @@ describe('startPiezoStreamServer — source selection', () => {
 
     await waitFor(() => getLatestCapSenseSnapshot()?.ts === 123)
     expect(natsReachable).toHaveBeenCalledTimes(1)
+    expect(startNatsFrameSource).not.toHaveBeenCalled()
+  })
+
+  it('recovers from unknown installation discovery on the next retry and starts RAW before grace expires', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] })
+    vi.mocked(discoverSensorSource).mockResolvedValueOnce('unknown').mockResolvedValue('raw')
+    const readdir = vi.spyOn(fs.promises, 'readdir').mockResolvedValue([])
+    const startedAt = Date.now()
+    startPiezoStreamServer()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(discoverSensorSource).toHaveBeenCalledTimes(1)
+    expect(natsReachable).toHaveBeenCalledTimes(1)
+    expect(readdir).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(14)
+    expect(discoverSensorSource).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(discoverSensorSource).toHaveBeenCalledTimes(2)
+    expect(natsReachable).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(25)
+    expect(readdir).toHaveBeenCalledWith(tmpRawDir)
+    expect(Date.now() - startedAt).toBe(40)
+    // RAW is already polling after one retry and one poll tick, well before
+    // this suite's 120 ms grace (60 seconds in production).
+    expect(startNatsFrameSource).not.toHaveBeenCalled()
+
+    // Once RAW owns ingestion, later installation changes must not attach a
+    // second source or restart discovery.
+    vi.mocked(discoverSensorSource).mockResolvedValue('nats')
+    natsMock.reachable = true
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(discoverSensorSource).toHaveBeenCalledTimes(2)
+    expect(natsReachable).toHaveBeenCalledTimes(2)
     expect(startNatsFrameSource).not.toHaveBeenCalled()
   })
 

--- a/src/streaming/tests/piezoStreamSource.test.ts
+++ b/src/streaming/tests/piezoStreamSource.test.ts
@@ -25,6 +25,7 @@ const tmpRawDir = vi.hoisted(() => {
   process.env.PIEZO_NATS_GRACE_MS = '120'
   process.env.PIEZO_NATS_PROBE_INTERVAL_MS = '15'
   delete process.env.PIEZO_NATS_DISABLED
+  delete process.env.PIEZO_SENSOR_SOURCE
   return dir
 })
 
@@ -61,6 +62,10 @@ vi.mock('../natsFrameSource', () => ({
   }),
 }))
 
+vi.mock('../sensorSourceDiscovery', () => ({
+  discoverSensorSource: vi.fn(async () => 'unknown'),
+}))
+
 // Keep persistence hermetic — dispatch → recordCapFrame must not touch a real db.
 vi.mock('@/src/db', () => {
   const chain = { values: () => chain, onConflictDoNothing: () => chain, where: () => chain, run: () => {} }
@@ -78,6 +83,7 @@ import {
   startPiezoStreamServer,
 } from '../piezoStream'
 import { natsReachable, startNatsFrameSource } from '../natsFrameSource'
+import { discoverSensorSource } from '../sensorSourceDiscovery'
 
 const innerEncoder = new Encoder({ mapsAsObjects: true, useRecords: false })
 
@@ -122,6 +128,8 @@ describe('startPiezoStreamServer — source selection', () => {
     natsMock.stopCalls = 0
     natsMock.captured = null
     for (const f of fs.readdirSync(tmpRawDir)) fs.rmSync(path.join(tmpRawDir, f), { force: true })
+    delete process.env.PIEZO_SENSOR_SOURCE
+    vi.mocked(discoverSensorSource).mockResolvedValue('unknown')
     vi.clearAllMocks()
     vi.restoreAllMocks()
   })
@@ -132,6 +140,7 @@ describe('startPiezoStreamServer — source selection', () => {
       resolveProbe = resolve
     }))
     startPiezoStreamServer()
+    await waitFor(() => vi.mocked(natsReachable).mock.calls.length === 1)
     await shutdownPiezoStreamServer()
     natsMock.reachable = true
     startPiezoStreamServer()
@@ -261,7 +270,7 @@ describe('startPiezoStreamServer — source selection', () => {
     expect(startNatsFrameSource).not.toHaveBeenCalled()
   })
 
-  it('falls back to RAW when NATS connect fails after a positive probe', async () => {
+  it('retries failed NATS connections through the grace window before selecting RAW on unknown firmware', async () => {
     natsMock.reachable = true
     natsMock.startError = new Error('connect raced')
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -282,12 +291,86 @@ describe('startPiezoStreamServer — source selection', () => {
       const left = getLatestCapSenseSnapshot()?.left
       return Array.isArray(left) && left[0] === 25
     })
-    expect(startNatsFrameSource).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(startNatsFrameSource).mock.calls.length).toBeGreaterThan(1)
     expect(error).toHaveBeenCalledWith(
-      '[sensorStream] NATS connect failed, falling back to .RAW tailing:',
+      '[sensorStream] NATS connect failed; retrying source discovery:',
       natsMock.startError,
     )
     error.mockRestore()
+  })
+
+  it('skips the grace window on confirmed RAW firmware after one failed greeting probe', async () => {
+    vi.mocked(discoverSensorSource).mockResolvedValue('raw')
+    fs.writeFileSync(path.join(tmpRawDir, 'confirmed-raw.RAW'), buildOuterRecord(1, {
+      type: 'capSense', ts: 123, left: 35, right: 36,
+    }))
+    startPiezoStreamServer()
+
+    await waitFor(() => getLatestCapSenseSnapshot()?.ts === 123)
+    expect(natsReachable).toHaveBeenCalledTimes(1)
+    expect(startNatsFrameSource).not.toHaveBeenCalled()
+  })
+
+  it('prefers a live NATS greeting even when installation discovery says RAW', async () => {
+    vi.mocked(discoverSensorSource).mockResolvedValue('raw')
+    natsMock.reachable = true
+    startPiezoStreamServer()
+
+    await waitFor(() => __test__.natsSourceActive)
+    expect(natsReachable).toHaveBeenCalledTimes(1)
+    expect(startNatsFrameSource).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['discovery', 'override'] as const)('waits beyond grace for known NATS via %s without reading RAW', async (selection) => {
+    if (selection === 'override') process.env.PIEZO_SENSOR_SOURCE = 'nats'
+    else vi.mocked(discoverSensorSource).mockResolvedValue('nats')
+    fs.writeFileSync(path.join(tmpRawDir, 'must-not-read.RAW'), buildOuterRecord(1, {
+      type: 'capSense', ts: 456, left: 99, right: 99,
+    }))
+    const before = getLatestCapSenseSnapshot()
+    const readdir = vi.spyOn(fs.promises, 'readdir')
+    startPiezoStreamServer()
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(vi.mocked(natsReachable).mock.calls.length).toBeGreaterThan(1)
+    expect(readdir).not.toHaveBeenCalled()
+    expect(getLatestCapSenseSnapshot()).toBe(before)
+    if (selection === 'override') expect(discoverSensorSource).not.toHaveBeenCalled()
+    natsMock.reachable = true
+    await waitFor(() => __test__.natsSourceActive)
+    expect(startNatsFrameSource).toHaveBeenCalledTimes(1)
+    expect(readdir).not.toHaveBeenCalled()
+  })
+
+  it('retries a connection race on known NATS firmware without selecting RAW', async () => {
+    vi.mocked(discoverSensorSource).mockResolvedValue('nats')
+    natsMock.reachable = true
+    natsMock.startError = new Error('connect raced')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const readdir = vi.spyOn(fs.promises, 'readdir')
+    startPiezoStreamServer()
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(natsMock.startCalls).toBeGreaterThan(1)
+    expect(readdir).not.toHaveBeenCalled()
+    natsMock.startError = null
+    await waitFor(() => __test__.natsSourceActive)
+    expect(readdir).not.toHaveBeenCalled()
+    error.mockRestore()
+  })
+
+  it('honors an explicit RAW override without discovery or a NATS greeting', async () => {
+    process.env.PIEZO_SENSOR_SOURCE = 'raw'
+    natsMock.reachable = true
+    fs.writeFileSync(path.join(tmpRawDir, 'override-raw.RAW'), buildOuterRecord(1, {
+      type: 'capSense', ts: 789, left: 10, right: 11,
+    }))
+    startPiezoStreamServer()
+
+    await waitFor(() => getLatestCapSenseSnapshot()?.ts === 789)
+    expect(discoverSensorSource).not.toHaveBeenCalled()
+    expect(natsReachable).not.toHaveBeenCalled()
+    expect(startNatsFrameSource).not.toHaveBeenCalled()
   })
 
   it('stops source selection when shutdown happens during the retry delay', async () => {

--- a/src/streaming/tests/sensorSourceDiscovery.test.ts
+++ b/src/streaming/tests/sensorSourceDiscovery.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ stat: vi.fn(), runFile: vi.fn() }))
+
+vi.mock('node:fs/promises', () => ({ stat: mocks.stat }))
+vi.mock('node:child_process', () => ({
+  execFile: Object.assign(vi.fn(), {
+    [Symbol.for('nodejs.util.promisify.custom')]: mocks.runFile,
+  }),
+}))
+
+import { discoverSensorSource } from '../sensorSourceDiscovery'
+
+beforeEach(() => {
+  mocks.stat.mockReset().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+  mocks.runFile.mockReset().mockResolvedValue({ stdout: 'not-found\n' })
+})
+
+describe('discoverSensorSource', () => {
+  it('selects RAW only when both the NATS unit and JetStream store are absent', async () => {
+    expect(await discoverSensorSource()).toBe('raw')
+    expect(mocks.stat).toHaveBeenCalledWith('/persistent/jetstream')
+    expect(mocks.runFile).toHaveBeenCalledWith('systemctl', [
+      'show', 'nats-server.service', '--property=LoadState', '--value',
+    ], expect.objectContaining({ timeout: 2000 }))
+  })
+
+  it.each(['loaded', 'masked'])('recognizes a %s unit even without JetStream storage', async (state) => {
+    mocks.runFile.mockResolvedValue({ stdout: `${state}\n` })
+    expect(await discoverSensorSource()).toBe('nats')
+  })
+
+  it('recognizes JetStream storage even when systemctl is unavailable', async () => {
+    mocks.stat.mockResolvedValue({ isDirectory: () => true })
+    mocks.runFile.mockRejectedValue(new Error('systemctl unavailable'))
+    expect(await discoverSensorSource()).toBe('nats')
+  })
+
+  it('recognizes a NATS unit even when storage cannot be inspected', async () => {
+    mocks.stat.mockRejectedValue(Object.assign(new Error('denied'), { code: 'EACCES' }))
+    mocks.runFile.mockResolvedValue({ stdout: 'loaded\n' })
+    expect(await discoverSensorSource()).toBe('nats')
+  })
+
+  it('does not treat a regular file named jetstream as broker storage', async () => {
+    mocks.stat.mockResolvedValue({ isDirectory: () => false })
+    expect(await discoverSensorSource()).toBe('raw')
+  })
+
+  it.each(['error', 'bad-setting', '', 'loading'])('keeps an unrecognized service state %j unknown', async (state) => {
+    mocks.runFile.mockResolvedValue({ stdout: state })
+    expect(await discoverSensorSource()).toBe('unknown')
+  })
+
+  it('does not mistake a storage permissions failure for a RAW-only installation', async () => {
+    mocks.stat.mockRejectedValue(Object.assign(new Error('denied'), { code: 'EACCES' }))
+    expect(await discoverSensorSource()).toBe('unknown')
+  })
+
+  it('does not mistake a timed-out service query for a RAW-only installation', async () => {
+    mocks.runFile.mockRejectedValue(Object.assign(new Error('timeout'), { killed: true }))
+    expect(await discoverSensorSource()).toBe('unknown')
+  })
+
+  it('inspects service and storage concurrently', async () => {
+    let finishStorage!: (value: { isDirectory: () => boolean }) => void
+    let finishService!: (value: { stdout: string }) => void
+    mocks.stat.mockReturnValue(new Promise((resolve) => {
+      finishStorage = resolve
+    }))
+    mocks.runFile.mockReturnValue(new Promise((resolve) => {
+      finishService = resolve
+    }))
+
+    const result = discoverSensorSource()
+    expect(mocks.stat).toHaveBeenCalledOnce()
+    expect(mocks.runFile).toHaveBeenCalledOnce()
+    finishStorage({ isDirectory: () => true })
+    finishService({ stdout: 'not-found' })
+    await expect(result).resolves.toBe('nats')
+  })
+})

--- a/tests/instrumentation.initialize.test.ts
+++ b/tests/instrumentation.initialize.test.ts
@@ -37,6 +37,27 @@ const mocks = vi.hoisted(() => ({
   seedDefaultData: vi.fn(async () => undefined),
   checkAndRepairIptables: vi.fn(() => ({ ok: true, repaired: [] })),
   rehydratePumpStallGuard: vi.fn(),
+  startDatabaseIntegrityChecks: vi.fn(),
+  stopDatabaseIntegrityChecks: vi.fn(async () => undefined),
+  startPerformanceMonitoring: vi.fn(),
+  stopPerformanceMonitoring: vi.fn(),
+  recordStartupPhase: vi.fn(),
+  getAutomationEngine: vi.fn(async () => ({})),
+  shutdownAutomationEngine: vi.fn(async () => undefined),
+}))
+
+vi.mock('@/src/db/integrity', () => ({
+  startDatabaseIntegrityChecks: mocks.startDatabaseIntegrityChecks,
+  stopDatabaseIntegrityChecks: mocks.stopDatabaseIntegrityChecks,
+}))
+vi.mock('@/src/lib/serverPerformance', () => ({
+  startPerformanceMonitoring: mocks.startPerformanceMonitoring,
+  stopPerformanceMonitoring: mocks.stopPerformanceMonitoring,
+  recordStartupPhase: mocks.recordStartupPhase,
+}))
+vi.mock('@/src/automation', () => ({
+  getAutomationEngine: mocks.getAutomationEngine,
+  shutdownAutomationEngine: mocks.shutdownAutomationEngine,
 }))
 
 vi.mock('@/src/scheduler', () => ({
@@ -96,6 +117,7 @@ const scheduler = {
   getNextInvocation: vi.fn<(id: string) => Date | null>(() => null),
 }
 const jobManager = { getScheduler: () => scheduler }
+const signalHandlers = new Map<string, () => Promise<void>>()
 
 beforeEach(() => {
   vi.resetModules()
@@ -104,6 +126,9 @@ beforeEach(() => {
     if (typeof m.mockReset === 'function') m.mockReset()
   }
   mocks.shutdownJobManager.mockResolvedValue(undefined)
+  mocks.stopDatabaseIntegrityChecks.mockResolvedValue(undefined)
+  mocks.getAutomationEngine.mockResolvedValue({})
+  mocks.shutdownAutomationEngine.mockResolvedValue(undefined)
   mocks.shutdownPiezoStreamServer.mockResolvedValue(undefined)
   mocks.shutdownMqttBridge.mockResolvedValue(undefined)
   mocks.shutdownHomeKit.mockResolvedValue(undefined)
@@ -119,11 +144,18 @@ beforeEach(() => {
   mocks.getJobManager.mockResolvedValue(jobManager)
   scheduler.getJobs.mockReturnValue([])
   scheduler.getNextInvocation.mockReturnValue(null)
+  signalHandlers.clear()
+  vi.spyOn(process, 'on').mockImplementation((event, listener) => {
+    signalHandlers.set(String(event), listener as () => Promise<void>)
+    return process
+  })
 })
 
 afterEach(() => {
   delete process.env.CI
   delete process.env.NEXT_RUNTIME
+  vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 async function fresh() {
@@ -151,6 +183,8 @@ describe('initializeScheduler — happy path', () => {
     // The guard must be re-armed before keepalives can consult shouldBlock.
     expect(mocks.rehydratePumpStallGuard.mock.invocationCallOrder[0])
       .toBeLessThan(mocks.initializeKeepalives.mock.invocationCallOrder[0] ?? 0)
+    expect(mocks.rehydratePumpStallGuard.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.getJobManager.mock.invocationCallOrder[0] ?? 0)
     expect(mocks.startPiezoStreamServer).toHaveBeenCalled()
     expect(mocks.startMqttBridge).toHaveBeenCalled()
     expect(mocks.startAutoOffWatcher).toHaveBeenCalled()
@@ -165,6 +199,39 @@ describe('initializeScheduler — happy path', () => {
     mocks.getJobManager.mockClear()
     await initializeScheduler()
     expect(mocks.getJobManager).not.toHaveBeenCalled()
+  })
+
+  it('coalesces concurrent initialization while hardware startup is pending', async () => {
+    let release!: () => void
+    mocks.startDacServer.mockImplementationOnce(() => new Promise((resolve) => {
+      release = () => resolve(undefined)
+    }))
+    const { initializeScheduler } = await fresh()
+    const first = initializeScheduler()
+    const second = initializeScheduler()
+    await vi.waitFor(() => expect(mocks.startDacServer).toHaveBeenCalledOnce())
+    release()
+    await Promise.all([first, second])
+
+    expect(mocks.getJobManager).toHaveBeenCalledOnce()
+    expect(mocks.rehydratePumpStallGuard).toHaveBeenCalledOnce()
+    expect(mocks.startPiezoStreamServer).toHaveBeenCalledOnce()
+    expect(mocks.initializeKeepalives).toHaveBeenCalledOnce()
+  })
+
+  it('starts the remaining services without waiting for MQTT to connect', async () => {
+    let release!: () => void
+    mocks.startMqttBridge.mockImplementationOnce(() => new Promise((resolve) => {
+      release = () => resolve(undefined)
+    }))
+    const { initializeScheduler } = await fresh()
+    await initializeScheduler()
+
+    expect(mocks.startAutoOffWatcher).toHaveBeenCalledOnce()
+    expect(mocks.startBonjourAnnouncement).toHaveBeenCalledOnce()
+    expect(mocks.startBiometricsRetention).toHaveBeenCalledOnce()
+    release()
+    await Promise.resolve()
   })
 
   it('skips upcoming-jobs log block when no jobs have a nextRun', async () => {
@@ -269,6 +336,80 @@ describe('initializeScheduler — error swallowing', () => {
 })
 
 describe('register()', () => {
+  it('waits for migrations before publishing hardware readiness', async () => {
+    let release!: () => void
+    mocks.runMigrations.mockImplementationOnce(() => new Promise((resolve) => {
+      release = () => resolve(undefined)
+    }))
+    const { register, initializeScheduler } = await fresh()
+    const pending = register()
+    await vi.waitFor(() => expect(mocks.runMigrations).toHaveBeenCalledOnce())
+
+    expect(mocks.seedDefaultData).not.toHaveBeenCalled()
+    expect(mocks.startDacServer).not.toHaveBeenCalled()
+    expect(mocks.startPiezoStreamServer).not.toHaveBeenCalled()
+    release()
+    await pending
+    await initializeScheduler()
+    expect(mocks.startPiezoStreamServer).toHaveBeenCalledOnce()
+  })
+
+  it('allows HTTP and hardware readiness while the scheduler waits for the clock', async () => {
+    let release!: (manager: typeof jobManager) => void
+    mocks.getJobManager.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const { register, initializeScheduler } = await fresh()
+    await register()
+
+    expect(mocks.startDacServer).toHaveBeenCalledOnce()
+    expect(mocks.startPiezoStreamServer).toHaveBeenCalledOnce()
+    expect(mocks.startDatabaseIntegrityChecks).toHaveBeenCalledOnce()
+    expect(mocks.initializeKeepalives).not.toHaveBeenCalled()
+    expect(mocks.recordStartupPhase).toHaveBeenCalledWith('http-initialization-ready')
+    release(jobManager)
+    await initializeScheduler()
+    expect(mocks.initializeKeepalives).toHaveBeenCalledOnce()
+  })
+
+  it('does not start background writers when shutdown occurs during scheduler initialization', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    let release!: (manager: typeof jobManager) => void
+    mocks.getJobManager.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve
+    }))
+    const { register, initializeScheduler } = await fresh()
+    await register()
+    const pending = initializeScheduler()
+    await signalHandlers.get('SIGTERM')?.()
+    release(jobManager)
+    await pending
+
+    expect(mocks.initializeKeepalives).not.toHaveBeenCalled()
+    expect(mocks.startMqttBridge).not.toHaveBeenCalled()
+    expect(mocks.startAutoOffWatcher).not.toHaveBeenCalled()
+    expect(mocks.stopDatabaseIntegrityChecks).toHaveBeenCalledOnce()
+    expect(mocks.shutdownJobManager).toHaveBeenCalledOnce()
+  })
+
+  it('closes a late MQTT connection after shutdown has already run', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    let release!: () => void
+    mocks.startMqttBridge.mockImplementationOnce(() => new Promise((resolve) => {
+      release = () => resolve(undefined)
+    }))
+    const { register, initializeScheduler } = await fresh()
+    await register()
+    await initializeScheduler()
+    await signalHandlers.get('SIGTERM')?.()
+    expect(mocks.shutdownMqttBridge).toHaveBeenCalledOnce()
+    release()
+    await Promise.resolve()
+    expect(mocks.shutdownMqttBridge).toHaveBeenCalledTimes(2)
+  })
+
   it('skips body entirely when NEXT_RUNTIME=edge', async () => {
     process.env.NEXT_RUNTIME = 'edge'
     const { register } = await fresh()

--- a/tests/spMaintenance.lifecycle.test.ts
+++ b/tests/spMaintenance.lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -15,6 +15,17 @@ describe('maintenance startup separation', () => {
     const args = mode === 'default' ? [] : [mode]
     const dir = mkdtempSync(join(tmpdir(), 'maintenance-lifecycle-'))
     dirs.push(dir)
+    const old = new Date(Date.now() - 7 * 86_400_000)
+    const active = join(dir, 'staging-active')
+    const stale = join(dir, 'staging-stale')
+    for (const staging of [active, stale]) {
+      mkdirSync(join(staging, 'nested'), { recursive: true })
+      const child = join(staging, 'nested', 'download')
+      writeFileSync(child, 'in-progress download')
+      if (staging === stale) utimesSync(child, old, old)
+      utimesSync(join(staging, 'nested'), old, old)
+      utimesSync(staging, old, old)
+    }
     const bin = join(dir, 'bin')
     mkdirSync(bin)
     mkdirSync(join(dir, 'data'))
@@ -35,12 +46,14 @@ describe('maintenance startup separation', () => {
       .replaceAll('/persistent/sleepypod-data', join(dir, 'data'))
       .replaceAll('/home/dac/sleepypod-core', dir)
       .replaceAll('/etc/sudoers.d/sleepypod-reboot', sudoers)
-      .replace('for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*;', `for d in ${dir}/absent-*;`)
+      .replace('for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*;', `for d in ${dir}/staging-*;`)
     const filename = join(dir, 'maintenance')
     writeFileSync(filename, isolated)
     execFileSync('bash', [filename, ...args], {
       env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, SP_TEST_CALLS: calls },
     })
+    expect(existsSync(active)).toBe(true)
+    expect(existsSync(stale)).toBe(mode !== '--housekeeping')
     expect(readFileSync(calls, 'utf8')).toBe(args.includes('--housekeeping') ? 'journal\npnpm\n' : '')
   })
 

--- a/tests/spMaintenance.lifecycle.test.ts
+++ b/tests/spMaintenance.lifecycle.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const script = readFileSync('scripts/bin/sp-maintenance', 'utf8')
+const dirs: string[] = []
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('maintenance startup separation', () => {
+  it.each(['default', '--startup', '--housekeeping'])('runs expensive commands only for housekeeping (%s)', (mode) => {
+    const args = mode === 'default' ? [] : [mode]
+    const dir = mkdtempSync(join(tmpdir(), 'maintenance-lifecycle-'))
+    dirs.push(dir)
+    const bin = join(dir, 'bin')
+    mkdirSync(bin)
+    mkdirSync(join(dir, 'data'))
+    const calls = join(dir, 'calls')
+    writeFileSync(calls, '')
+    const command = (name: string, body: string) => {
+      writeFileSync(join(bin, name), `#!/bin/sh\n${body}\n`, { mode: 0o755 })
+    }
+    command('getent', 'exit 1') // This fixture has no DAC group.
+    command('du', 'echo "120 fixture"')
+    command('df', 'printf "Filesystem 1M-blocks Used Available\\nfixture 100 20 80\\n"')
+    command('journalctl', 'echo journal >> "$SP_TEST_CALLS"')
+    command('pnpm', 'echo pnpm >> "$SP_TEST_CALLS"')
+    const sudoers = join(dir, 'sudoers')
+    writeFileSync(sudoers, 'sleepypod ALL=(root) NOPASSWD: /bin/systemctl reboot, /usr/bin/systemctl reboot')
+    const isolated = script
+      .replaceAll('/etc/sleepypod/data-dir', join(dir, 'missing-pointer'))
+      .replaceAll('/persistent/sleepypod-data', join(dir, 'data'))
+      .replaceAll('/home/dac/sleepypod-core', dir)
+      .replaceAll('/etc/sudoers.d/sleepypod-reboot', sudoers)
+      .replace('for d in /tmp/tmp.* /tmp/sleepypod-* /tmp/sp-* /tmp/core-*;', `for d in ${dir}/absent-*;`)
+    const filename = join(dir, 'maintenance')
+    writeFileSync(filename, isolated)
+    execFileSync('bash', [filename, ...args], {
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, SP_TEST_CALLS: calls },
+    })
+    expect(readFileSync(calls, 'utf8')).toBe(args.includes('--housekeeping') ? 'journal\npnpm\n' : '')
+  })
+
+  it('installs the deferred timer on fresh and OTA installs and removes it on uninstall', () => {
+    for (const filename of ['scripts/install', 'scripts/bin/sp-update']) {
+      expect(readFileSync(filename, 'utf8')).toContain('install_maintenance_timer')
+    }
+    const timer = readFileSync('scripts/systemd/sleepypod-maintenance.timer', 'utf8')
+    // A new OTA timer on an already-running Pod must not immediately prune.
+    expect(timer).toContain('OnActiveSec=10min')
+    expect(timer).toContain('OnUnitActiveSec=1d')
+    expect(readFileSync('scripts/bin/sp-uninstall', 'utf8')).toContain('sleepypod-maintenance.timer')
+  })
+})


### PR DESCRIPTION
System-health requests currently scan SQLite and run synchronous firewall commands on the web process, while startup waits for schedule initialization and absent NATS services. This change removes those diagnostic operations from the request path and makes HTTP and sensor streaming available sooner. The measured performance build (`aeb3852`) is deployed on the test Pod.

| Measurement on the same Pod | Before | After |
| --- | ---: | ---: |
| HTTP readiness from restart | 34.99 s | 9.30 s |
| Current capSense data from restart | Not observed within 90 s | 13.60 s |
| System-health median | 290.47 ms | 39.09 ms |
| Concurrent trivial healthcheck median | 311.98 ms | 60.06 ms |
| Ordinary status median / p95 | 38.03 / 42.85 ms | 40.44 / 54.48 ms |

Integrity scans use a read-only worker; firewall diagnostics share asynchronous cached checks; room and water-level metadata use a two-second cache. DAC and sensor services start before schedule loading, cron registration yields by elapsed time, and optional integrations and housekeeping run later. Shutdown awaits pending initialization and prevents delayed initial and scheduled day/night LED writes, including callbacks suspended on a settings read. RAW ingestion uses bounded asynchronous batches and promptly drains backlogs while preserving rotation, split records, persistence and seek behavior. `/api/health/performance` records startup phases and event-loop delay.

NATS discovery is per Pod: inspect its local service and JetStream storage, then verify the protocol greeting. Confirmed RAW-only Pods avoid the grace window. Known NATS installations keep retrying through delayed server starts; inconclusive identity probes are retried. Local overrides remain available. Python followers retain their existing grace behavior.

Validation: production build and CI passed on the deployed code; full local suite passed 3,668 tests in 158 files with one skipped; TypeScript, ESLint, both Drizzle checks, shell syntax and maintenance lifecycle checks passed. Live verification confirms fresh sensor data, successful worker integrity checks, all 356 jobs without drift, and healthy web and sensor services. CodeRabbit's three initial findings and its subsequent scheduled-LED shutdown finding are addressed with regression coverage. Both new scheduled-callback tests fail before the fix and pass afterward; all 106 JobManager tests and 1,169 related tests pass after rebasing onto the latest dev test additions.

The benchmark is a single loopback comparison on a live RAW-only J00 Pod. Ordinary status latency and polling CPU did not improve; device-status streaming still starts around 31 seconds, and startup telemetry still records a 2.28-second maximum event-loop delay. NATS firmware behavior is covered by automated tests, without a physical NATS Pod deployment. The baseline was `38e0695`, so this comparison also includes the DAC singleton fix already merged into dev. See [the report and raw samples](https://github.com/sleepypod/core/blob/perf/startup-api/docs/performance/startup-api-2026-09-06.md) for all results and limits.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update perf/startup-api
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/perf/startup-api/scripts/install \
  | sudo bash -s -- --branch perf/startup-api
```

🎯 **Pin to this exact build** ([run 34016252032](https://github.com/sleepypod/core/actions/runs/34016252032) · `c5af882`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/c5af882970fd4ca8719b0fa0c4b6853f4dd4ab9a/scripts/install \
  | sudo bash -s -- \
      --branch perf/startup-api \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/34016252032/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/34016252032/artifacts/9983993405) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added performance metrics and database integrity status to the health API.
  - Added deferred daily maintenance scheduling for housekeeping tasks.
  - Improved automatic sensor-source detection, NATS retries, and RAW data processing.

- **Improvements**
  - Startup and shutdown handling now respond more smoothly.
  - Climate and water-level data is cached for consistent responses.
  - Firewall health checks reuse recent results.

- **Documentation**
  - Documented sensor-source selection and configuration overrides.
  - Added startup and API performance reports and benchmarking tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


