### PR TITLE
test: audit coverage and fix calibration trigger ordering

### DIFF
--- a/.github/workflows/python-modules.yml
+++ b/.github/workflows/python-modules.yml
@@ -7,6 +7,7 @@ on:
       - 'modules/**/*.py'
       - 'modules/**/pyproject.toml'
       - 'modules/**/uv.lock'
+      - 'modules/.coveragerc'
       - '.github/workflows/python-modules.yml'
   pull_request:
     types: [opened, synchronize, reopened]
@@ -14,6 +15,7 @@ on:
       - 'modules/**/*.py'
       - 'modules/**/pyproject.toml'
       - 'modules/**/uv.lock'
+      - 'modules/.coveragerc'
       - '.github/workflows/python-modules.yml'
   workflow_dispatch:
 
@@ -110,6 +112,7 @@ jobs:
           # shellcheck source=/dev/null
           . .venv/bin/activate
           pytest ${{ matrix.module.target }} \
+            --cov-config=${{ github.workspace }}/modules/.coveragerc \
             --cov=${{ matrix.module.cov_source }} \
             --cov-report=xml:coverage.xml \
             --junit-xml=junit.xml \

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ node_modules
 # Testing
 test-results
 coverage
+.coverage
+.coverage.*
 .stryker-tmp
 reports/mutation
 

--- a/docs/testing/coverage-audit-2026-09-06.md
+++ b/docs/testing/coverage-audit-2026-09-06.md
@@ -39,7 +39,7 @@ the mounted SVG ref; the power button's remaining branch is the handler guard
 behind the disabled pending button. No private handlers are exposed to force
 these branches.
 
-**119 Python cases** across three new suites:
+**120 Python cases** across three new suites:
 
 - RAW parser: all supported integer and byte-length widths; every truncated
   prefix; empty markers; exact cursor position between consecutive records;
@@ -48,7 +48,8 @@ these branches.
   The private import explicitly avoids another suite's `sys.modules` stub.
 - Calibration triggers: temporary-file invisibility, non-destructive reads,
   oldest-file consumption, invalid JSON/non-object removal, same-millisecond
-  write uniqueness, and failed-rename isolation using real temporary files.
+  write uniqueness and FIFO across counter 9→10, and failed-rename isolation
+  using real temporary files.
 - Calibration algorithms: minimum usable samples; final quiet-window selection;
   6/8-channel capSense2 and optional reference channels; standard-deviation
   floors; signed piezo lists/bytes/bytearrays and trailing bytes; minimum and
@@ -99,7 +100,7 @@ need targeted failure-path work.
 
 | Python CI scope | Passing tests | Statements | Branches |
 | --- | ---: | ---: | ---: |
-| `common` | 193 | 698/886 | 242/308 |
+| `common` | 194 | 700/888 | 242/308 |
 | `cover-buttons` | 11 | 43/71 | 15/22 |
 | `environment-monitor` | 21 | 71/131 | 15/42 |
 | `calibrator` | 12 | 63/185 | 24/74 |
@@ -116,10 +117,12 @@ compatibility with Pod-specific services.
 ## Validation and reproduction
 
 - Full Vitest run: **3,828 passed, one existing skipped, 162 files passed**.
-- Full six-job Python matrix: **352 passed** under Python 3.10.
+- Full six-job Python matrix: **353 passed** under Python 3.10.
 - TypeScript typecheck and ESLint on all added TS/TSX tests passed.
-- Production runtime code is unchanged. Only tests, coverage configuration,
-  workflow coverage options, generated-artifact ignores, and this report change.
+- CodeRabbit follow-up: the strengthened FIFO assertions failed against the
+  original lexical queue ordering. Queue reads and deletion now share numeric
+  timestamp/PID/counter ordering, preserving existing unpadded filenames.
+  This is the only production runtime change in the audit PR.
 
 ```sh
 pnpm install --frozen-lockfile

--- a/docs/testing/coverage-audit-2026-09-06.md
+++ b/docs/testing/coverage-audit-2026-09-06.md
@@ -1,0 +1,141 @@
+# Test coverage audit — 2026-09-06
+
+Audited `dev` at `2e13b79` in an isolated worktree, using Node 24.16.0,
+pnpm 10.34.5, and Python 3.10.19. This is a unit-test audit; passing results do
+not establish real-Pod, browser-layout, or end-to-end correctness.
+
+## Measurement findings
+
+- The original Vitest run passed **3,780 tests in 158 files**, with one existing
+  skipped test. It reported **98.21% statements / 94.71% branches / 98.75% lines**.
+- That report omitted 113 unimported TypeScript files under `src/` (including
+  type-only files) and included some test helpers. It did not measure the whole
+  application. The new explicit include covers `src/`, `app/`, instrumentation,
+  and the proxy; test files, helpers, and declarations are excluded.
+- With the added tests and corrected denominator, coverage is **64.44%
+  statements / 53.09% branches / 65.49% lines**. The lower aggregate reflects
+  newly visible untested code; it is not a test-coverage regression. There is
+  deliberately no arbitrary global threshold imposed on the existing backlog.
+- Python CI previously counted test modules and measured only statements. The
+  shared `.coveragerc` excludes test code and enables branches for all six CI
+  module jobs. The prototype in piezo-processor remains visible in the report.
+
+## Tests added
+
+**48 TypeScript cases** across four suites, preserving all pre-existing tests:
+
+| Area | Behavioral checks | Final lines / branches |
+| --- | --- | --- |
+| Automation biometrics reader | Real SQLite ordering and side filters; null vs zero; Fahrenheit conversion; partial zones; exact 5m/15m/30s freshness boundaries; cap scalar/matrix/reference handling; partial and total DB failure | 100% / 100% |
+| Temperature dial | F/C keyboard steps in hardware units; 55–110°F clamps; pointer preview, deduplication, release/cancel, arc gap, scaled viewport; off-state inactivity; accessible values | 100% / 96.05% |
+| Power button | Selected/linked side commands; neutral power-on setpoint; power-off payload; optimistic timeout and server acknowledgement; pending state; partial linked failure recovery | 100% / 91.66% |
+| Diagnostic charts | Actual data sorting without mutation; downsampling keeps latest sample; missing values and precision; finite thermal domains and axis/tooltip formatting | 100% / 100% each |
+
+The reader previously had only 10.2% line / 0% branch coverage. The dial and
+power button were absent from the report. Both chart suites previously had
+71.42% line coverage, and their rendering tests did not assert data ordering.
+Remaining dial branches are defensive null fallbacks behind non-null props and
+the mounted SVG ref; the power button's remaining branch is the handler guard
+behind the disabled pending button. No private handlers are exposed to force
+these branches.
+
+**119 Python cases** across three new suites:
+
+- RAW parser: all supported integer and byte-length widths; every truncated
+  prefix; empty markers; exact cursor position between consecutive records;
+  real-file payload sizes crossing 4 KiB buffers; malformed framing and 1 MB
+  payload guard. `common/cbor_raw.py` reaches **100% lines and branches**.
+  The private import explicitly avoids another suite's `sys.modules` stub.
+- Calibration triggers: temporary-file invisibility, non-destructive reads,
+  oldest-file consumption, invalid JSON/non-object removal, same-millisecond
+  write uniqueness, and failed-rename isolation using real temporary files.
+- Calibration algorithms: minimum usable samples; final quiet-window selection;
+  6/8-channel capSense2 and optional reference channels; standard-deviation
+  floors; signed piezo lists/bytes/bytearrays and trailing bytes; minimum and
+  signal-scaled thresholds; inclusive HR/HRV/BR bounds; dynamic-bound flags;
+  missing vitals; calibration-age decay and signal-to-noise scoring. These
+  assert the existing algorithm contract, not clinical validity.
+
+`common/calibration.py` improves from **19% to 80% combined statement/branch
+coverage**. Its remaining areas include persistence, temperature calibration,
+legacy presence helpers, and exceptional filesystem paths.
+
+## Remaining coverage inventory
+
+This audit prioritizes untested control commands, sensor framing, calibration,
+and live automation inputs. It does not claim every coverage gap is closed.
+Many UI components have tested hooks/utilities but no component-level behavior
+tests. Reported coverage now makes that distinction explicit.
+
+| TypeScript area | Lines | Branches |
+| --- | ---: | ---: |
+| `app` | 91/182 (50.00%) | 56/106 (52.83%) |
+| `instrumentation.ts` | 148/168 (88.10%) | 57/86 (66.28%) |
+| `proxy.ts` | 0/19 (0.00%) | 0/9 (0.00%) |
+| `src/automation` | 610/614 (99.35%) | 561/572 (98.08%) |
+| `src/components` | 422/4573 (9.23%) | 418/4919 (8.50%) |
+| `src/db` | 197/197 (100.00%) | 59/67 (88.06%) |
+| `src/hardware` | 1616/1618 (99.88%) | 1000/1039 (96.25%) |
+| `src/homekit` | 539/539 (100.00%) | 224/236 (94.92%) |
+| `src/hooks` | 723/727 (99.45%) | 478/497 (96.18%) |
+| `src/lib` | 537/537 (100.00%) | 389/398 (97.74%) |
+| `src/locales` | 0/0 (100.00%) | 0/0 (100.00%) |
+| `src/modules` | 0/0 (100.00%) | 0/0 (100.00%) |
+| `src/providers` | 35/101 (34.65%) | 4/38 (10.53%) |
+| `src/scheduler` | 620/620 (100.00%) | 233/239 (97.49%) |
+| `src/server` | 1671/1673 (99.88%) | 1182/1212 (97.52%) |
+| `src/services` | 152/155 (98.06%) | 79/85 (92.94%) |
+| `src/streaming` | 984/987 (99.70%) | 732/771 (94.94%) |
+| `src/ui` | 0/37 (0.00%) | 0/37 (0.00%) |
+| `src/utils` | 12/12 (100.00%) | 6/6 (100.00%) |
+
+Highest-priority follow-ups are schedule/automation editors (mutation payloads,
+validation and failure recovery), device settings (save/revert and side scope),
+and VitalsPanel/PiezoWaveform (stream lifecycle and cleanup). Large uncovered
+presentation surfaces also include DiagnosticsConsole, VitalsChart,
+DualSideChart and SleepStagesCard. Hardware paths already have high statement
+coverage, but NATS lifecycle/probe branches and startup instrumentation still
+need targeted failure-path work.
+
+| Python CI scope | Passing tests | Statements | Branches |
+| --- | ---: | ---: | ---: |
+| `common` | 193 | 698/886 | 242/308 |
+| `cover-buttons` | 11 | 43/71 | 15/22 |
+| `environment-monitor` | 21 | 71/131 | 15/42 |
+| `calibrator` | 12 | 63/185 | 24/74 |
+| `piezo-processor` | 84 | 442/909 | 142/322 |
+| `sleep-detector` | 31 | 268/475 | 70/162 |
+
+Python follow-ups: common calibration persistence/temperature correction;
+calibrator orchestration; sleep-detector run-loop transitions; environment
+writer lifecycle; NATS reconnect/shutdown and RAW rotation. The piezo-processor
+scope includes the untested `prototype_v2.py`; its production `main.py` has
+76% combined statement/branch coverage. Unit stubs do not establish runtime
+compatibility with Pod-specific services.
+
+## Validation and reproduction
+
+- Full Vitest run: **3,828 passed, one existing skipped, 162 files passed**.
+- Full six-job Python matrix: **352 passed** under Python 3.10.
+- TypeScript typecheck and ESLint on all added TS/TSX tests passed.
+- Production runtime code is unchanged. Only tests, coverage configuration,
+  workflow coverage options, generated-artifact ignores, and this report change.
+
+```sh
+pnpm install --frozen-lockfile
+pnpm test run --coverage --maxWorkers=4
+pnpm tsc
+pnpm exec eslint src/automation/tests/biometricsSignalReader.test.ts \
+  src/components/TemperatureDial/tests/TemperatureDial.test.tsx \
+  src/components/PowerButton/tests/PowerButton.test.tsx \
+  src/components/diagnostics/tests/trendChartData.test.tsx
+
+# In modules/ (Python 3.10 with pytest, pytest-cov and cbor2):
+python -m pytest common --cov=common --cov-config=.coveragerc --cov-report=term-missing
+# In each module directory, with its test/runtime dependencies installed:
+python -m pytest . --cov=. --cov-config=../.coveragerc --cov-report=term-missing
+```
+
+The new Vitest `coverage/coverage-summary.json` and the existing lcov output
+provide machine-readable results; Python CI continues uploading coverage XML
+and JUnit for each module independently.

--- a/modules/.coveragerc
+++ b/modules/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+omit =
+    */test_*.py
+    */conftest.py

--- a/modules/common/calibration.py
+++ b/modules/common/calibration.py
@@ -800,6 +800,15 @@ def is_present_piezo_calibrated(
 
 # ── CalibrationWatcher ──
 
+def _trigger_sort_key(path: Path) -> tuple:
+    """Order timestamp/PID/counter numerically, including legacy queued files.
+
+    The bare legacy trigger has no numeric suffix and sorts first. Within a
+    writer's same-millisecond requests, counter 9 must precede counter 10.
+    """
+    return tuple(int(part) for part in path.name.split(".")[2:] if part.isdecimal())
+
+
 class CalibrationWatcher:
     """Watch for calibration trigger files written by tRPC.
 
@@ -813,7 +822,7 @@ class CalibrationWatcher:
         try:
             # Check for queued triggers (*.trigger files)
             trigger_dir = TRIGGER_PATH.parent
-            triggers = sorted(trigger_dir.glob(".calibrate-trigger*"))
+            triggers = sorted(trigger_dir.glob(".calibrate-trigger*"), key=_trigger_sort_key)
             triggers = [t for t in triggers if not t.suffix == ".tmp"]
             if not triggers:
                 return None
@@ -836,7 +845,7 @@ class CalibrationWatcher:
         """Delete the oldest trigger file after calibration completes."""
         try:
             trigger_dir = TRIGGER_PATH.parent
-            triggers = sorted(trigger_dir.glob(".calibrate-trigger*"))
+            triggers = sorted(trigger_dir.glob(".calibrate-trigger*"), key=_trigger_sort_key)
             triggers = [t for t in triggers if not t.suffix == ".tmp"]
             if triggers:
                 triggers[0].unlink(missing_ok=True)

--- a/modules/common/test_calibration_algorithms.py
+++ b/modules/common/test_calibration_algorithms.py
@@ -1,0 +1,146 @@
+"""Deterministic sensor baseline and validation contracts."""
+import struct
+from unittest.mock import Mock
+import pytest
+from common.calibration import CapCalibrator, CapSense2Calibrator, HRValidator, PiezoCalibrator
+
+
+def cap_records(count):
+    return [{"ts": 1000 + i, "left": {"out": 100, "cen": 200, "in": 300}} for i in range(count)]
+
+
+def cap2_records(count):
+    return [{"ts": 1000 + i, "right": {"values": [10, 12, 20, 22, 30, 32]}} for i in range(count)]
+
+
+@pytest.mark.parametrize("calibrator", [CapCalibrator, CapSense2Calibrator, PiezoCalibrator])
+def test_empty_input_rejected(calibrator):
+    with pytest.raises(ValueError, match="No .* records"):
+        calibrator().calibrate([], "left")
+
+
+@pytest.mark.parametrize("calibrator,records,side", [
+    (CapCalibrator, cap_records(59) + [{"right": {"out": 100}}], "left"),
+    (CapSense2Calibrator, cap2_records(59) + [{}, {"right": {"values": [1, 2]}}], "right"),
+    (PiezoCalibrator, [{"left1": [-1, 1]}] * 59 + [{}, {"left1": b""}, {"left1": []}, {"left1": "bad"}], "left"),
+])
+def test_minimum_counts_only_usable_samples_for_selected_side(calibrator, records, side):
+    with pytest.raises(ValueError, match="Insufficient .*59"):
+        calibrator().calibrate(records, side)
+
+
+def test_cap_baseline_scans_final_window_and_floors_std():
+    records = cap_records(301)
+    records[0]["left"] = {"out": 10000, "cen": 10000, "in": 10000}
+    result = CapCalibrator().calibrate(records, "left")
+    assert (result.window_start, result.window_end, result.samples_used) == (1001, 1300, 300)
+    assert result.quality_score == 1
+    assert result.params == {"threshold": 6.0, "channels": {
+        "out": {"mean": 100, "std": 5}, "cen": {"mean": 200, "std": 5}, "in": {"mean": 300, "std": 5},
+    }}
+
+
+@pytest.mark.parametrize("count", [60, 300])
+def test_capsense2_accepts_six_channel_firmware_and_short_quiet_windows(count):
+    result = CapSense2Calibrator().calibrate(cap2_records(count), "right")
+    assert (result.window_start, result.window_end, result.samples_used) == (1000, 999 + count, count)
+    assert result.quality_score == 1
+    assert result.params == {"format": "capSense2", "threshold": 6.0, "channels": {
+        "A": {"mean": 11, "std": .05}, "B": {"mean": 21, "std": .05}, "C": {"mean": 31, "std": .05},
+    }}
+
+
+def test_capsense2_uses_final_quiet_sensing_window_ignoring_ref_variance():
+    records = cap2_records(301)
+    records[0]["right"]["values"] = [1000] * 6
+    for i in range(1, 301):
+        records[i]["right"]["values"] = [10, 12, 20, 22, 30, 32, i, i + 2]
+    result = CapSense2Calibrator().calibrate(records, "right")
+    assert result.window_start == 1001
+    assert result.samples_used == 300
+    assert result.quality_score == 1
+    assert result.params["ref"] == {"mean": 151.5, "std": pytest.approx(86.6021)}
+
+
+def test_capsense2_mixed_reference_frames_keep_timestamp_alignment():
+    records = cap2_records(60)
+    records[-1]["right"]["values"] = [10, 12, 20, 22, 30, 32, 1.1, 1.3]
+    result = CapSense2Calibrator().calibrate(records, "right")
+    assert result.params["ref"] == {"mean": 1.2, "std": .001}
+    assert result.samples_used == 60
+
+
+@pytest.mark.parametrize("encoding", [list, bytes, bytearray])
+@pytest.mark.parametrize("amplitude,threshold,quality", [(100, 50000, .996), (10000, 120000, .833)])
+def test_piezo_signed_samples_threshold_floor_and_signal_scaled_quality(encoding, amplitude, threshold, quality):
+    samples = [-amplitude, 0, amplitude]
+    raw = samples if encoding is list else encoding(struct.pack("<3i", *samples) + b"\xff")
+    result = PiezoCalibrator().calibrate([{"ts": 1000 + i, "left1": raw} for i in range(60)], "left")
+    assert result.params == {
+        "noise_floor_rms": amplitude * 2, "presence_threshold": threshold, "baseline_mean_range": amplitude * 2,
+    }
+    assert result.quality_score == quality
+    assert (result.window_start, result.window_end, result.samples_used) == (1000, 1059, 60)
+
+
+def test_piezo_scans_last_quiet_window():
+    records = [{"ts": 1000 + i, "right1": [-100, 100]} for i in range(301)]
+    records[0]["right1"] = [-100000, 100000]
+    result = PiezoCalibrator().calibrate(records, "right")
+    assert (result.window_start, result.window_end, result.samples_used) == (1001, 1300, 300)
+    assert result.params["noise_floor_rms"] == 200
+
+
+@pytest.mark.parametrize("field,valid,invalid", [
+    ("hr", [30, 100], [29.99, 100.01]), ("hrv", [8, 100], [7.99, 100.01]), ("br", [6, 22], [5.99, 22.01]),
+])
+def test_validator_hard_bounds_are_inclusive_and_reject_without_clamping(field, valid, invalid):
+    for value in valid:
+        result = HRValidator().validate(**{"hr": None, field: value})
+        assert getattr(result, field + "_validated") == value
+        assert result.flags == []
+    for value in invalid:
+        result = HRValidator().validate(**{"hr": None, field: value})
+        assert getattr(result, field + "_validated") is None
+        assert result.flags == [field + "_out_of_bounds"]
+        if field == "hr":
+            assert result.hr_raw == value
+
+
+def test_validator_missing_data_does_not_invent_vitals():
+    result = HRValidator().validate(None)
+    assert (result.hr_validated, result.hrv_validated, result.br_validated, result.hr_raw) == (None,) * 4
+    assert result.flags == []
+    assert result.quality_score == .32
+
+
+def test_validator_dynamic_bounds_flag_but_retain_plausible_stage_transition():
+    validator = HRValidator()
+    for _ in range(30):
+        assert validator.validate(60).flags == []
+    assert validator.validate(67.5).flags == []
+    result = validator.validate(68)
+    assert result.hr_validated == 68
+    assert result.flags == ["hr_dynamic_bounds"]
+    assert result.quality_score == .47
+
+
+@pytest.mark.parametrize("age,quality", [(0, 1), (12, 1), (30, .925), (48, .85), (72, .85)])
+def test_validator_calibration_freshness_decays_between_12_and_48_hours(age, quality):
+    store = Mock()
+    store.get_active.return_value = {"parameters": '{"noise_floor_rms":100}'}
+    store.get_profile_age_hours.return_value = age
+    result = HRValidator(store, "right").validate(60, 40, 12, signal_rms=1000)
+    assert result.quality_score == quality
+    assert result.flags == []
+    store.get_active.assert_called_once_with("right", "piezo")
+
+
+@pytest.mark.parametrize("rms,flags,quality", [(200, ["low_signal"], .68), (300, [], .72), (2000, [], 1)])
+def test_validator_signal_to_noise_threshold_and_saturation(rms, flags, quality):
+    store = Mock()
+    store.get_active.return_value = {"parameters": {"noise_floor_rms": 100}}
+    store.get_profile_age_hours.return_value = 0
+    result = HRValidator(store).validate(60, 40, 12, signal_rms=rms)
+    assert result.flags == flags
+    assert result.quality_score == quality

--- a/modules/common/test_calibration_triggers.py
+++ b/modules/common/test_calibration_triggers.py
@@ -1,5 +1,6 @@
 """Calibration trigger queue contracts using a real temporary directory."""
 import json
+from itertools import count
 import pytest
 from common import calibration
 
@@ -19,8 +20,8 @@ def test_empty_queue_and_clear_are_idempotent(trigger_dir):
 
 
 def test_reads_oldest_without_consuming_and_ignores_incomplete_tmp_files(trigger_dir):
-    older = trigger_dir / ".calibrate-trigger.100"
-    newer = trigger_dir / ".calibrate-trigger.200"
+    older = trigger_dir / ".calibrate-trigger.9"
+    newer = trigger_dir / ".calibrate-trigger.10"
     incomplete = trigger_dir / ".calibrate-trigger.000.tmp"
     older.write_text(json.dumps({"side": "left", "sensor": "cap"}))
     newer.write_text(json.dumps({"side": "right", "sensor": "piezo"}))
@@ -38,8 +39,8 @@ def test_reads_oldest_without_consuming_and_ignores_incomplete_tmp_files(trigger
 
 @pytest.mark.parametrize("invalid", ['{"side":', '[]', 'null', '42', '"left"'])
 def test_discards_bad_trigger_then_allows_next_request(trigger_dir, invalid):
-    bad = trigger_dir / ".calibrate-trigger.100"
-    good = trigger_dir / ".calibrate-trigger.200"
+    bad = trigger_dir / ".calibrate-trigger.9"
+    good = trigger_dir / ".calibrate-trigger.10"
     bad.write_text(invalid)
     good.write_text('{"side":"right"}')
     watcher = calibration.CalibrationWatcher()
@@ -51,6 +52,7 @@ def test_discards_bad_trigger_then_allows_next_request(trigger_dir, invalid):
 
 def test_same_millisecond_writes_remain_distinct_and_leave_no_tmp_files(trigger_dir, monkeypatch):
     monkeypatch.setattr(calibration.time, "time", lambda: 1_000.125)
+    monkeypatch.setattr(calibration, "_trigger_seq", count(8))
     payloads = [{"side": "left", "request": n} for n in range(3)]
     for payload in payloads:
         calibration.write_trigger_atomic(payload)
@@ -63,7 +65,7 @@ def test_same_millisecond_writes_remain_distinct_and_leave_no_tmp_files(trigger_
     while (payload := watcher.check_trigger()) is not None:
         received.append(payload)
         watcher.clear_trigger()
-    assert sorted(received, key=lambda p: p["request"]) == payloads
+    assert received == payloads
     assert list(trigger_dir.iterdir()) == []
 
 
@@ -75,3 +77,21 @@ def test_failed_rename_is_never_visible_as_a_complete_request(trigger_dir, monke
         calibration.write_trigger_atomic({"side": "left"})
     assert calibration.CalibrationWatcher().check_trigger() is None
     assert all(path.suffix == ".tmp" for path in trigger_dir.iterdir())
+
+
+def test_mixed_legacy_and_sequenced_filenames_are_read_and_cleared_in_order(trigger_dir):
+    names = [
+        ".calibrate-trigger",
+        ".calibrate-trigger.9",
+        ".calibrate-trigger.10.1.000000008",
+        ".calibrate-trigger.10.1.9",
+        ".calibrate-trigger.10.1.10",
+    ]
+    for index, name in reversed(list(enumerate(names))):
+        (trigger_dir / name).write_text(json.dumps({"request": index}))
+    watcher = calibration.CalibrationWatcher()
+    for index, name in enumerate(names):
+        assert watcher.check_trigger() == {"request": index}
+        watcher.clear_trigger()
+        assert not (trigger_dir / name).exists()
+    assert watcher.check_trigger() is None

--- a/modules/common/test_calibration_triggers.py
+++ b/modules/common/test_calibration_triggers.py
@@ -1,0 +1,77 @@
+"""Calibration trigger queue contracts using a real temporary directory."""
+import json
+import pytest
+from common import calibration
+
+
+@pytest.fixture
+def trigger_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(calibration, "TRIGGER_PATH", tmp_path / ".calibrate-trigger")
+    return tmp_path
+
+
+def test_empty_queue_and_clear_are_idempotent(trigger_dir):
+    watcher = calibration.CalibrationWatcher()
+    assert watcher.check_trigger() is None
+    watcher.clear_trigger()
+    watcher.clear_trigger()
+    assert list(trigger_dir.iterdir()) == []
+
+
+def test_reads_oldest_without_consuming_and_ignores_incomplete_tmp_files(trigger_dir):
+    older = trigger_dir / ".calibrate-trigger.100"
+    newer = trigger_dir / ".calibrate-trigger.200"
+    incomplete = trigger_dir / ".calibrate-trigger.000.tmp"
+    older.write_text(json.dumps({"side": "left", "sensor": "cap"}))
+    newer.write_text(json.dumps({"side": "right", "sensor": "piezo"}))
+    incomplete.write_text('{"side":')
+    watcher = calibration.CalibrationWatcher()
+    assert watcher.check_trigger() == {"side": "left", "sensor": "cap"}
+    assert watcher.check_trigger() == {"side": "left", "sensor": "cap"}
+    assert older.exists()
+    watcher.clear_trigger()
+    assert watcher.check_trigger() == {"side": "right", "sensor": "piezo"}
+    watcher.clear_trigger()
+    assert watcher.check_trigger() is None
+    assert incomplete.exists()
+
+
+@pytest.mark.parametrize("invalid", ['{"side":', '[]', 'null', '42', '"left"'])
+def test_discards_bad_trigger_then_allows_next_request(trigger_dir, invalid):
+    bad = trigger_dir / ".calibrate-trigger.100"
+    good = trigger_dir / ".calibrate-trigger.200"
+    bad.write_text(invalid)
+    good.write_text('{"side":"right"}')
+    watcher = calibration.CalibrationWatcher()
+    assert watcher.check_trigger() is None
+    assert not bad.exists()
+    assert good.exists()
+    assert watcher.check_trigger() == {"side": "right"}
+
+
+def test_same_millisecond_writes_remain_distinct_and_leave_no_tmp_files(trigger_dir, monkeypatch):
+    monkeypatch.setattr(calibration.time, "time", lambda: 1_000.125)
+    payloads = [{"side": "left", "request": n} for n in range(3)]
+    for payload in payloads:
+        calibration.write_trigger_atomic(payload)
+    files = sorted(trigger_dir.iterdir())
+    assert len(files) == len(payloads)
+    assert all(path.suffix != ".tmp" for path in files)
+    assert sorted(json.loads(path.read_text())["request"] for path in files) == [0, 1, 2]
+    watcher = calibration.CalibrationWatcher()
+    received = []
+    while (payload := watcher.check_trigger()) is not None:
+        received.append(payload)
+        watcher.clear_trigger()
+    assert sorted(received, key=lambda p: p["request"]) == payloads
+    assert list(trigger_dir.iterdir()) == []
+
+
+def test_failed_rename_is_never_visible_as_a_complete_request(trigger_dir, monkeypatch):
+    def fail_rename(*args):
+        raise OSError("rename failed")
+    monkeypatch.setattr(calibration.Path, "rename", fail_rename)
+    with pytest.raises(OSError, match="rename failed"):
+        calibration.write_trigger_atomic({"side": "left"})
+    assert calibration.CalibrationWatcher().check_trigger() is None
+    assert all(path.suffix == ".tmp" for path in trigger_dir.iterdir())

--- a/modules/common/test_cbor_raw.py
+++ b/modules/common/test_cbor_raw.py
@@ -1,0 +1,86 @@
+"""Protocol tests for RAW framing, independent of follower tests' module stubs."""
+import importlib.util
+import io
+from pathlib import Path
+import pytest
+
+# Follower tests stub common.cbor_raw. Load the actual parser under a private
+# name so collection order cannot select the stub instead of production code.
+_spec = importlib.util.spec_from_file_location(
+    "_raw_parser_under_test", Path(__file__).with_name("cbor_raw.py")
+)
+_parser = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_parser)
+read_raw_record = _parser.read_raw_record
+
+SEQ_ENCODINGS = [
+    b"\x00", b"\x17", b"\x18\xff", b"\x19\x12\x34",
+    b"\x1a\x12\x34\x56\x78", b"\x1b\x01\x02\x03\x04\x05\x06\x07\x08",
+]
+LENGTH_ENCODINGS = [
+    b"\x43", b"\x58\x03", b"\x59\x00\x03",
+    b"\x5a\x00\x00\x00\x03", b"\x5b\x00\x00\x00\x00\x00\x00\x00\x03",
+]
+
+
+def record(seq=b"\x1a\x00\x00\x00\x01", length=b"\x43", payload=b"abc"):
+    return b"\xa2\x63seq" + seq + b"\x64data" + length + payload
+
+
+@pytest.mark.parametrize("seq", SEQ_ENCODINGS)
+@pytest.mark.parametrize("length", LENGTH_ENCODINGS)
+def test_accepts_unsigned_sequence_and_byte_string_length_widths(seq, length):
+    encoded = record(seq, length)
+    stream = io.BytesIO(encoded + record(payload=b"xyz"))
+    assert read_raw_record(stream) == b"abc"
+    assert stream.tell() == len(encoded)
+    assert read_raw_record(stream) == b"xyz"
+    assert stream.tell() == len(stream.getvalue())
+    with pytest.raises(EOFError):
+        read_raw_record(stream)
+
+
+@pytest.mark.parametrize("seq", SEQ_ENCODINGS)
+@pytest.mark.parametrize("length", LENGTH_ENCODINGS)
+def test_every_incomplete_prefix_is_retryable_eof(seq, length):
+    encoded = record(seq, length)
+    for end in range(len(encoded)):
+        with pytest.raises(EOFError):
+            read_raw_record(io.BytesIO(encoded[:end]))
+
+
+def test_placeholder_consumes_only_its_record():
+    placeholder = record(length=b"\x40", payload=b"")
+    stream = io.BytesIO(placeholder + record())
+    assert read_raw_record(stream) is None
+    assert stream.tell() == len(placeholder)
+    assert read_raw_record(stream) == b"abc"
+
+
+@pytest.mark.parametrize("size", [23, 24, 255, 256, 4096, 5000, 65536, 1_000_000])
+def test_real_file_cursor_does_not_skip_records_across_buffer_boundaries(tmp_path, size):
+    payload = bytes(range(256)) * (size // 256) + bytes(range(size % 256))
+    encoded = record(length=b"\x5a" + size.to_bytes(4, "big"), payload=payload)
+    path = tmp_path / "frame.RAW"
+    path.write_bytes(encoded + record())
+    with path.open("rb") as stream:
+        assert read_raw_record(stream) == payload
+        assert stream.tell() == len(encoded)
+        assert read_raw_record(stream) == b"abc"
+
+
+@pytest.mark.parametrize("encoded, message", [
+    (b"\xa1", "Expected outer map"),
+    (b"\xa2\x63bad", "Expected seq key"),
+    (record(seq=b"\x20"), "seq must be unsigned"),
+    (record(seq=b"\x1c"), "Unexpected seq encoding"),
+    (record(seq=b"\x1f"), "Unexpected seq encoding"),
+    (b"\xa2\x63seq\x00\x64oops", "Expected data key"),
+    (record(length=b"\x63"), "data must be a byte string"),
+    (record(length=b"\x5c"), "Unsupported data length encoding"),
+    (record(length=b"\x5f"), "Unsupported data length encoding"),
+    (record(length=b"\x5a" + (1_000_001).to_bytes(4, "big"), payload=b""), "Implausibly large"),
+])
+def test_rejects_malformed_structure_without_waiting_for_payload(encoded, message):
+    with pytest.raises(ValueError, match=message):
+        read_raw_record(io.BytesIO(encoded))

--- a/src/automation/tests/biometricsSignalReader.test.ts
+++ b/src/automation/tests/biometricsSignalReader.test.ts
@@ -1,0 +1,180 @@
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as schema from '@/src/db/biometrics-schema'
+import type { LatestCapSenseSnapshot } from '@/src/streaming/piezoStream'
+import { BiometricsSignalReader } from '../signals.biometrics'
+
+const state = vi.hoisted(() => ({
+  db: null as ReturnType<typeof drizzle<typeof schema>> | null,
+  cap: null as LatestCapSenseSnapshot | null,
+}))
+vi.mock('@/src/db', () => ({
+  get biometricsDb() {
+    return state.db
+  },
+}))
+vi.mock('@/src/streaming/piezoStream', () => ({ getLatestCapSenseSnapshot: () => state.cap }))
+
+const NOW = new Date('2026-09-06T12:00:00Z')
+const ago = (ms: number) => new Date(NOW.getTime() - ms)
+let raw: Database.Database
+let db: ReturnType<typeof drizzle<typeof schema>>
+const reader = new BiometricsSignalReader()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+  raw = new Database(':memory:')
+  db = drizzle(raw, { schema })
+  migrate(db, { migrationsFolder: path.resolve('src/db/biometrics-migrations') })
+  state.db = db
+  state.cap = null
+})
+afterEach(() => {
+  if (raw.open) raw.close()
+  state.db = null
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+function seedEnvironment(timestamp: Date) {
+  db.insert(schema.bedTemp).values({
+    timestamp, ambientTemp: 2000, humidity: 4500,
+    leftOuterTemp: 1000, leftCenterTemp: 2000, leftInnerTemp: 3000,
+    rightOuterTemp: 3000, rightCenterTemp: 2000, rightInnerTemp: 1000,
+  }).run()
+  db.insert(schema.freezerTemp).values({ timestamp, leftWaterTemp: 0, rightWaterTemp: 4000 }).run()
+  db.insert(schema.ambientLight).values({ timestamp, lux: 0 }).run()
+}
+
+const environment = {
+  'ambient.temperature': 68, 'ambient.humidity': 45, 'ambient.light': 0,
+  'left.surfaceTemp': 68, 'left.surfaceTemp.spread': 36, 'left.surfaceTemp.gradient': 36,
+  'right.surfaceTemp': 68, 'right.surfaceTemp.spread': 36, 'right.surfaceTemp.gradient': -36,
+  'left.waterTemp': 32, 'right.waterTemp': 104,
+}
+
+describe('BiometricsSignalReader', () => {
+  it('returns no signals before any samples arrive', () => {
+    expect(reader.read()).toEqual({})
+  })
+
+  it('selects the newest row independently for each side and source', () => {
+    // Insert older rows last: an unordered query must not accidentally pass.
+    for (const [side, heartRate, totalMovement] of [['left', 61, 0], ['right', 72, 15]] as const) {
+      db.insert(schema.vitals).values([
+        { side, timestamp: NOW, heartRate, hrv: 40, breathingRate: 12 },
+        { side, timestamp: ago(60_000), heartRate: 99, hrv: 99, breathingRate: 99 },
+      ]).run()
+      db.insert(schema.movement).values([
+        { side, timestamp: NOW, totalMovement },
+        { side, timestamp: ago(60_000), totalMovement: 99 },
+      ]).run()
+    }
+    expect(reader.read()).toEqual({
+      'left.heartRate': 61, 'left.hrv': 40, 'left.breathingRate': 12, 'left.movement': 0,
+      'right.heartRate': 72, 'right.hrv': 40, 'right.breathingRate': 12, 'right.movement': 15,
+    })
+  })
+
+  it('keeps zero vitals but does not resurrect missing values from older rows', () => {
+    db.insert(schema.vitals).values([
+      { side: 'left', timestamp: NOW, heartRate: 0, hrv: 0, breathingRate: 0 },
+      { side: 'right', timestamp: NOW },
+      { side: 'right', timestamp: ago(1000), heartRate: 65, hrv: 30, breathingRate: 14 },
+    ]).run()
+    expect(reader.read()).toEqual({ 'left.heartRate': 0, 'left.hrv': 0, 'left.breathingRate': 0 })
+  })
+
+  it.each([0, 1])('expires vitals and movement %i ms past their five-minute boundary', (extra) => {
+    db.insert(schema.vitals).values({ side: 'left', timestamp: ago(300_000), heartRate: 60 }).run()
+    db.insert(schema.movement).values({ side: 'right', timestamp: ago(300_000), totalMovement: 7 }).run()
+    vi.setSystemTime(NOW.getTime() + extra)
+    expect(reader.read()).toEqual(extra ? {} : { 'left.heartRate': 60, 'right.movement': 7 })
+  })
+
+  it.each([0, 1])('expires all environment sources %i ms past their fifteen-minute boundary', (extra) => {
+    seedEnvironment(ago(900_000))
+    vi.setSystemTime(NOW.getTime() + extra)
+    expect(reader.read()).toEqual(extra ? {} : environment)
+  })
+
+  it('uses the newest environment rows even when they contain missing readings', () => {
+    seedEnvironment(ago(1000))
+    db.insert(schema.bedTemp).values({ timestamp: NOW }).run()
+    db.insert(schema.freezerTemp).values({ timestamp: NOW }).run()
+    db.insert(schema.ambientLight).values({ timestamp: NOW }).run()
+    expect(reader.read()).toEqual({})
+  })
+
+  it('averages only available surface zones and requires both endpoints for a gradient', () => {
+    db.insert(schema.bedTemp).values({
+      timestamp: NOW, leftCenterTemp: 0, rightOuterTemp: 1000, rightCenterTemp: 3000,
+    }).run()
+    expect(reader.read()).toEqual({
+      'left.surfaceTemp': 32, 'right.surfaceTemp': 68, 'right.surfaceTemp.spread': 36,
+    })
+  })
+
+  it('computes a gradient when the center is missing and keeps independent nullable water readings', () => {
+    db.insert(schema.bedTemp).values({ timestamp: NOW, leftOuterTemp: 3000, leftInnerTemp: 1000 }).run()
+    db.insert(schema.freezerTemp).values({ timestamp: NOW, rightWaterTemp: 0 }).run()
+    expect(reader.read()).toEqual({
+      'left.surfaceTemp': 68, 'left.surfaceTemp.spread': 36, 'left.surfaceTemp.gradient': -36,
+      'right.waterTemp': 32,
+    })
+  })
+
+  it('drops stale sources without suppressing fresh sources on either side', () => {
+    seedEnvironment(ago(901_000))
+    db.insert(schema.vitals).values({ side: 'left', timestamp: ago(301_000), heartRate: 60 }).run()
+    db.insert(schema.vitals).values({ side: 'right', timestamp: NOW, heartRate: 70 }).run()
+    db.insert(schema.movement).values({ side: 'left', timestamp: NOW, totalMovement: 3 }).run()
+    expect(reader.read()).toEqual({ 'right.heartRate': 70, 'left.movement': 3 })
+  })
+
+  it('reduces capSense2 body channels without including the two reference channels', () => {
+    state.cap = {
+      type: 'capSense2', ts: 0, receivedAtMs: NOW.getTime(),
+      left: [1, 2, 3, 4, 5, 6, 999, -999], right: [10, 20, 30, 40, 50, 60, 9999, -9999],
+    }
+    expect(reader.read()).toEqual({
+      'left.cap.max': 6, 'left.cap.mean': 3.5, 'left.cap.spread': 5,
+      'right.cap.max': 60, 'right.cap.mean': 35, 'right.cap.spread': 50,
+    })
+  })
+
+  it.each([0, 1])('expires scalar capSense %i ms past receipt freshness, ignoring firmware time', (extra) => {
+    state.cap = { type: 'capSense', ts: 0, receivedAtMs: NOW.getTime() - 30_000, left: 0, right: 12 }
+    vi.setSystemTime(NOW.getTime() + extra)
+    expect(reader.read()).toEqual(extra
+      ? {}
+      : {
+          'left.cap.max': 0, 'left.cap.mean': 0, 'left.cap.spread': 0,
+          'right.cap.max': 12, 'right.cap.mean': 12, 'right.cap.spread': 0,
+        })
+  })
+
+  it('omits empty capacitive arrays independently by side', () => {
+    state.cap = { type: 'capSense2', ts: 0, receivedAtMs: NOW.getTime(), left: [], right: [4, 6] }
+    expect(reader.read()).toEqual({ 'right.cap.max': 6, 'right.cap.mean': 5, 'right.cap.spread': 2 })
+  })
+
+  it('warns and returns an empty snapshot if the database is unavailable', () => {
+    raw.close()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(reader.read()).toEqual({})
+    expect(warn).toHaveBeenCalledWith('[automation] BiometricsSignalReader.read failed:', expect.any(Error))
+  })
+
+  it('retains signals already read when a later source fails', () => {
+    db.insert(schema.vitals).values({ side: 'left', timestamp: NOW, heartRate: 63 }).run()
+    raw.exec('DROP TABLE movement')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(reader.read()).toEqual({ 'left.heartRate': 63 })
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/PowerButton/tests/PowerButton.test.tsx
+++ b/src/components/PowerButton/tests/PowerButton.test.tsx
@@ -1,0 +1,137 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PowerButton } from '../PowerButton'
+
+const state = vi.hoisted(() => ({
+  activeSides: ['left'] as Array<'left' | 'right'>,
+  primarySide: 'left' as 'left' | 'right',
+  status: null as { leftSide: { targetLevel: number }, rightSide: { targetLevel: number } } | null,
+  pending: false,
+  mutate: vi.fn<(input: { side: string, powered: boolean, temperature?: number }) => Promise<void>>(),
+  invalidate: vi.fn(),
+  onSuccess: () => {},
+}))
+vi.mock('@/src/providers/SideProvider', () => ({ useSide: () => state }))
+vi.mock('@/src/hooks/useDeviceStatus', () => ({ useDeviceStatus: () => ({ status: state.status }) }))
+vi.mock('@/src/utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({ device: { getStatus: { invalidate: state.invalidate } } }),
+    device: { setPower: { useMutation: (options: { onSuccess: () => void }) => {
+      state.onSuccess = options.onSuccess
+      return { isPending: state.pending, mutateAsync: state.mutate }
+    } } },
+  },
+}))
+
+function status() {
+  if (!state.status) throw new Error('Status fixture is absent')
+  return state.status
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  state.activeSides = ['left']
+  state.primarySide = 'left'
+  state.status = { leftSide: { targetLevel: 0 }, rightSide: { targetLevel: 0 } }
+  state.pending = false
+  state.invalidate.mockReset()
+  state.mutate.mockReset().mockImplementation(async () => {
+    state.onSuccess()
+  })
+})
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+async function click(name: 'Turn on' | 'Turn off') {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name }))
+  })
+}
+
+describe('PowerButton', () => {
+  it('turns on a selected side at the neutral setpoint and holds optimism across stale frames', async () => {
+    const { rerender } = render(<PowerButton />)
+    await click('Turn on')
+    expect(state.mutate).toHaveBeenCalledExactlyOnceWith({ side: 'left', powered: true, temperature: 75 })
+    expect(state.invalidate).toHaveBeenCalledOnce()
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeTruthy()
+    rerender(<PowerButton />)
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeTruthy()
+    act(() => vi.advanceTimersByTime(5999))
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeTruthy()
+    act(() => vi.advanceTimersByTime(1))
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeTruthy()
+  })
+
+  it('follows subsequent server changes once power has been acknowledged', async () => {
+    const { rerender } = render(<PowerButton />)
+    await click('Turn on')
+    status().leftSide.targetLevel = 1
+    rerender(<PowerButton />)
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeTruthy()
+    status().leftSide.targetLevel = 0
+    rerender(<PowerButton />)
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeTruthy()
+  })
+
+  it('uses the right primary side and powers it off without sending a temperature', async () => {
+    state.primarySide = 'right'
+    state.activeSides = ['right']
+    status().rightSide.targetLevel = -10
+    render(<PowerButton />)
+    await click('Turn off')
+    expect(state.mutate.mock.calls).toEqual([[{ side: 'right', powered: false }]])
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeTruthy()
+  })
+
+  it.each([true, false])('sends linked power=%s to both sides', async (powered) => {
+    state.activeSides = ['left', 'right']
+    status().leftSide.targetLevel = powered ? 0 : 10
+    render(<PowerButton />)
+    await click(powered ? 'Turn on' : 'Turn off')
+    expect(state.mutate.mock.calls).toEqual(powered
+      ? [[{ side: 'left', powered: true, temperature: 75 }], [{ side: 'right', powered: true, temperature: 75 }]]
+      : [[{ side: 'left', powered: false }], [{ side: 'right', powered: false }]])
+  })
+
+  it('reverts optimism and refetches after one linked-side mutation fails', async () => {
+    state.activeSides = ['left', 'right']
+    state.mutate.mockImplementation(async ({ side }) => {
+      if (side === 'right') throw new Error('right DAC rejected write')
+      state.onSuccess()
+    })
+    render(<PowerButton />)
+    await click('Turn on')
+    expect(state.mutate).toHaveBeenCalledTimes(2)
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeTruthy()
+    expect(state.invalidate).toHaveBeenCalledTimes(2) // success + recovery refetch
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('shows optimism while a mutation is unresolved and disables further clicks while pending', async () => {
+    let resolve!: () => void
+    state.mutate.mockImplementation(() => new Promise<void>((done) => {
+      resolve = done
+    }))
+    const { rerender } = render(<PowerButton />)
+    await click('Turn on')
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeTruthy()
+    state.pending = true
+    rerender(<PowerButton />)
+    const button = screen.getByRole('button', { name: 'Turn off' }) as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    fireEvent.click(button)
+    expect(state.mutate).toHaveBeenCalledOnce()
+    await act(async () => {
+      resolve()
+    })
+  })
+
+  it('starts off before the first status frame arrives', () => {
+    state.status = null
+    render(<PowerButton />)
+    expect(screen.getByRole('button', { name: 'Turn on' })).toBeTruthy()
+  })
+})

--- a/src/components/TemperatureDial/tests/TemperatureDial.test.tsx
+++ b/src/components/TemperatureDial/tests/TemperatureDial.test.tsx
@@ -1,0 +1,113 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TemperatureDial } from '../TemperatureDial'
+
+// JSDOM has no layout or pointer capture. Keep React event handling real while
+// supplying a scaled, offset SVG viewport, as a browser would.
+function setup(props: Partial<React.ComponentProps<typeof TemperatureDial>> = {}) {
+  const onTemperatureChange = vi.fn()
+  const onTemperatureCommit = vi.fn()
+  const view = render(<TemperatureDial currentTempF={75} targetTempF={75} isOn onTemperatureChange={onTemperatureChange} onTemperatureCommit={onTemperatureCommit} {...props} />)
+  const dial = screen.getByRole('slider')
+  const [, , width, height] = (dial.getAttribute('viewBox') ?? '').split(' ').map(Number)
+  vi.spyOn(dial, 'getBoundingClientRect').mockReturnValue({
+    left: 40, top: 20, width: width / 2, height: height / 2,
+    right: 40 + width / 2, bottom: 20 + height / 2, x: 40, y: 20, toJSON: () => ({}),
+  })
+  Object.assign(dial, { setPointerCapture: vi.fn(), releasePointerCapture: vi.fn() })
+  const at = (x: number, y: number) => ({ clientX: 40 + x / 2, clientY: 20 + y / 2, pointerId: 1 })
+  return { ...view, dial, at, onTemperatureChange, onTemperatureCommit }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('TemperatureDial', () => {
+  it.each([
+    ['ArrowUp', 75, 'F', 76], ['ArrowRight', 75, 'F', 76],
+    ['ArrowDown', 75, 'F', 74], ['ArrowLeft', 75, 'F', 74],
+    ['ArrowUp', 110, 'F', 110], ['ArrowDown', 55, 'F', 55],
+    ['ArrowUp', 68, 'C', 70], ['ArrowDown', 68, 'C', 66],
+    ['ArrowUp', 110, 'C', 110], ['ArrowDown', 55, 'C', 55],
+  ] as const)('%s at %i°F displayed in %s commits %i°F', (key, targetTempF, unit, expected) => {
+    const { dial, onTemperatureChange, onTemperatureCommit } = setup({ targetTempF, unit })
+    fireEvent.keyDown(dial, { key })
+    expect(onTemperatureChange).toHaveBeenCalledExactlyOnceWith(expected)
+    expect(onTemperatureCommit).toHaveBeenCalledExactlyOnceWith(expected)
+  })
+
+  it('exposes Fahrenheit bounds and a Celsius accessible value', () => {
+    const { dial } = setup({ targetTempF: 68, unit: 'C' })
+    expect(dial.getAttribute('aria-valuemin')).toBe('55')
+    expect(dial.getAttribute('aria-valuemax')).toBe('110')
+    expect(dial.getAttribute('aria-valuenow')).toBe('68')
+    expect(dial.getAttribute('aria-valuetext')).toBe('20°C')
+    expect(dial.getAttribute('tabindex')).toBe('0')
+  })
+
+  it('ignores unrelated keys, pointer moves, and releases before a drag', () => {
+    const { dial, at, onTemperatureChange, onTemperatureCommit } = setup()
+    fireEvent.keyDown(dial, { key: 'Enter' })
+    fireEvent.pointerMove(dial, at(302, 162))
+    fireEvent.pointerUp(dial, at(302, 162))
+    expect(onTemperatureChange).not.toHaveBeenCalled()
+    expect(onTemperatureCommit).not.toHaveBeenCalled()
+  })
+
+  it('previews drag changes once per temperature and commits only on release', () => {
+    const { dial, at, onTemperatureChange, onTemperatureCommit } = setup()
+    fireEvent.pointerDown(dial, at(162, 22)) // top of dial = midpoint, rounded to 83°F
+    expect(onTemperatureChange).toHaveBeenLastCalledWith(83)
+    expect(onTemperatureCommit).not.toHaveBeenCalled()
+    fireEvent.pointerMove(dial, at(302, 162)) // right of dial = 101°F
+    fireEvent.pointerMove(dial, at(302, 162))
+    expect(onTemperatureChange.mock.calls).toEqual([[83], [101]])
+    expect(onTemperatureCommit).not.toHaveBeenCalled()
+    fireEvent.pointerUp(dial, at(302, 162))
+    expect(onTemperatureCommit).toHaveBeenCalledExactlyOnceWith(101)
+    fireEvent.pointerMove(dial, at(22, 162))
+    fireEvent.pointerUp(dial, at(22, 162))
+    expect(onTemperatureChange).toHaveBeenCalledTimes(2)
+    expect(onTemperatureCommit).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores the bottom arc gap and commits the last valid preview on cancellation', () => {
+    const { dial, at, onTemperatureChange, onTemperatureCommit } = setup()
+    fireEvent.pointerDown(dial, at(162, 302))
+    expect(onTemperatureChange).not.toHaveBeenCalled()
+    fireEvent.pointerMove(dial, at(22, 162))
+    expect(onTemperatureChange).toHaveBeenCalledExactlyOnceWith(64)
+    fireEvent.pointerMove(dial, at(162, 302))
+    fireEvent.pointerCancel(dial, at(162, 302))
+    expect(onTemperatureCommit).toHaveBeenCalledExactlyOnceWith(64)
+  })
+
+  it('keeps all interactions inactive when power is off', () => {
+    const { dial, at, onTemperatureChange, onTemperatureCommit } = setup({ isOn: false })
+    expect(dial.getAttribute('tabindex')).toBe('-1')
+    fireEvent.keyDown(dial, { key: 'ArrowUp' })
+    fireEvent.pointerDown(dial, at(162, 22))
+    fireEvent.pointerMove(dial, at(302, 162))
+    fireEvent.pointerUp(dial, at(302, 162))
+    expect(onTemperatureChange).not.toHaveBeenCalled()
+    expect(onTemperatureCommit).not.toHaveBeenCalled()
+    expect(screen.queryByText('NOW')).toBeNull()
+  })
+
+  it.each([[70, 'WARMING'], [80, 'COOLING']] as const)('shows the direction from %i°F', (currentTempF, label) => {
+    setup({ currentTempF })
+    expect(screen.getByText(label)).toBeTruthy()
+  })
+
+  it('shows no direction at the target and supports preview-only consumers', () => {
+    const { dial, at, onTemperatureChange } = setup({ onTemperatureCommit: undefined })
+    expect(screen.queryByText('WARMING')).toBeNull()
+    expect(screen.queryByText('COOLING')).toBeNull()
+    fireEvent.keyDown(dial, { key: 'ArrowUp' })
+    fireEvent.pointerDown(dial, at(162, 22))
+    fireEvent.pointerUp(dial, at(162, 22))
+    expect(onTemperatureChange.mock.calls).toEqual([[76], [83]])
+  })
+})

--- a/src/components/diagnostics/tests/trendChartData.test.tsx
+++ b/src/components/diagnostics/tests/trendChartData.test.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BiometricsTrendChart, type VitalSample } from '../BiometricsTrendChart'
+import { ThermalTrendChart } from '../ThermalTrendChart'
+
+// Capture the public chart boundary: assert the data and formatters we hand to
+// Recharts without depending on ResizeObserver/layout or its SVG internals.
+const chart = vi.hoisted(() => ({
+  data: [] as Array<Record<string, number | null>>,
+  axes: [] as Array<{ domain?: unknown, tickFormatter?: (value: number) => string }>,
+  tooltip: null as { formatter: (value: number | null, name: string) => string[], labelFormatter: (value: number) => string } | null,
+}))
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => children,
+  LineChart: ({ data, children }: { data: typeof chart.data, children: ReactNode }) => {
+    chart.data = data
+    return children
+  },
+  XAxis: (props: (typeof chart.axes)[number]) => {
+    chart.axes.push(props)
+    return null
+  },
+  YAxis: (props: (typeof chart.axes)[number]) => {
+    chart.axes.push(props)
+    return null
+  },
+  Tooltip: (props: NonNullable<typeof chart.tooltip>) => {
+    chart.tooltip = props
+    return null
+  },
+  Line: () => null,
+  CartesianGrid: () => null,
+  Legend: () => null,
+}))
+
+beforeEach(() => {
+  chart.data = []
+  chart.axes = []
+  chart.tooltip = null
+})
+afterEach(cleanup)
+
+describe('BiometricsTrendChart data', () => {
+  it('sorts without mutating input, retaining nulls and distinct vital series', () => {
+    const rows: VitalSample[] = [
+      { timestamp: new Date(3000), heartRate: 63, hrv: 41, breathingRate: 12.5 },
+      { timestamp: new Date(1000).toISOString(), heartRate: null, hrv: 0, breathingRate: null },
+    ]
+    const original = structuredClone(rows)
+    render(<BiometricsTrendChart rows={rows} />)
+    expect(chart.data).toEqual([
+      { t: 1000, hr: null, hrv: 0, br: null },
+      { t: 3000, hr: 63, hrv: 41, br: 12.5 },
+    ])
+    expect(rows).toEqual(original)
+  })
+
+  it('downsamples a long history in chronological order and always retains the latest sample', () => {
+    const rows = Array.from({ length: 242 }, (_, i) => ({
+      timestamp: new Date(i * 60_000), heartRate: i, hrv: null, breathingRate: null,
+    })).reverse()
+    render(<BiometricsTrendChart rows={rows} />)
+    expect(chart.data).toHaveLength(122)
+    expect(chart.data[0]).toEqual({ t: 0, hr: 0, hrv: null, br: null })
+    expect(chart.data[1]).toEqual({ t: 120_000, hr: 2, hrv: null, br: null })
+    expect(chart.data.at(-1)).toEqual({ t: 241 * 60_000, hr: 241, hrv: null, br: null })
+    expect(chart.data.every((point, i) => i === 0 || Number(point.t) > Number(chart.data[i - 1].t))).toBe(true)
+    expect(rows[0].heartRate).toBe(241)
+  })
+
+  it('formats missing values, whole HR/HRV and fractional breathing independently', () => {
+    render(<BiometricsTrendChart rows={[0, 1000].map(t => ({ timestamp: new Date(t), heartRate: 60, hrv: 40, breathingRate: 12 }))} />)
+    expect(chart.tooltip?.formatter(null, 'HR')).toEqual(['—', 'HR'])
+    expect(chart.tooltip?.formatter(60.6, 'HR')).toEqual(['61', 'HR'])
+    expect(chart.tooltip?.formatter(40.4, 'HRV')).toEqual(['40', 'HRV'])
+    expect(chart.tooltip?.formatter(12.56, 'Breathing')).toEqual(['12.6', 'Breathing'])
+    const time = new Date(1000)
+    expect(chart.tooltip?.labelFormatter(1000)).toBe(time.toLocaleString([], { weekday: 'short', hour: 'numeric', minute: '2-digit' }))
+    expect(chart.axes[0].tickFormatter?.(1000)).toBe(time.toLocaleDateString([], { weekday: 'short' }))
+  })
+})
+
+describe('ThermalTrendChart data', () => {
+  it('bounds all available temperatures, excluding missing readings, with two degrees of padding', () => {
+    const points = [
+      { t: 1000, target: 75, bed: 73.4, water: null },
+      { t: 2000, target: null, bed: null, water: 68.2 },
+    ]
+    render(<ThermalTrendChart side="right" points={points} />)
+    expect(chart.data).toEqual(points)
+    expect(chart.axes[1].domain).toEqual([66, 77])
+    expect(chart.axes[1].tickFormatter?.(68.6)).toBe('69°')
+    expect(chart.axes[0].tickFormatter?.(1000)).toBe(new Date(1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }))
+    expect(chart.tooltip?.formatter(null, 'Bed')).toEqual(['—', 'Bed'])
+    expect(chart.tooltip?.formatter(68.25, 'Water')).toEqual(['68.3°F', 'Water'])
+    expect(chart.tooltip?.labelFormatter(1000)).toBe(new Date(1000).toLocaleTimeString())
+  })
+
+  it('does not render a chart with an infinite domain for an off side without water samples', () => {
+    render(<ThermalTrendChart side="left" points={[1000, 2000].map(t => ({ t, target: null, bed: null, water: null }))} />)
+    expect(chart.axes).toEqual([])
+    expect(chart.data).toEqual([])
+  })
+})

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -39,7 +39,11 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov'],
+      reporter: ['text', 'lcov', 'json-summary'],
+      // Count production files even when no test imports them. Otherwise new,
+      // untested components disappear from the coverage denominator entirely.
+      include: ['src/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}', 'instrumentation.ts', 'proxy.ts'],
+      exclude: ['**/tests/**', '**/*.test.{ts,tsx}', '**/*.d.ts'],
     },
     name: 'unit',
     exclude: ['.claude/worktrees/**', '.codex/**', '.ygg/worktrees/**', 'node_modules/**', '.next/**'],


### PR DESCRIPTION
The existing Vitest report showed 98.21% statement coverage while omitting 113 unimported `src` files and counting test helpers. Python coverage also counted test code. Make both denominators explicit and add 168 behavioral test cases for the highest-risk gaps found during a repository-wide coverage audit.

- Add 48 TypeScript cases for automation biometrics freshness/query/conversion rules, temperature-dial commands and drag lifecycle, power-button optimistic/linked failure behavior, and diagnostic chart data/formatting.
- Add 120 Python cases for RAW CBOR framing and truncation, calibration trigger files, sensor baseline algorithms, and vital-validation boundaries.
- Include unimported application files in Vitest coverage, exclude test helpers, export JSON summaries, and enable Python branch coverage with test modules excluded.
- Record the audit, per-area coverage, reproduction commands, and remaining gaps in `docs/testing/coverage-audit-2026-09-06.md`.

Validation: 3,828 Vitest tests passed (one pre-existing skip), 353 Python tests passed across all six CI scopes, TypeScript typecheck passed, and changed-file ESLint passed. Biometrics signal reading, RAW framing, and both diagnostic charts now have 100% line/branch coverage; the dial and power button have 100% line coverage. Shared Python calibration coverage rises from 19% to 80% (statements + branches).

The corrected overall TypeScript report is 64.44% statements / 53.09% branches / 65.49% lines. This drop reflects the expanded denominator, not removed tests or a runtime regression. The audit documents the substantial remaining UI and Python lifecycle coverage backlog; it does not claim complete application coverage.

CodeRabbit follow-up: fixed calibration trigger FIFO ordering. Both reads and deletions now compare numeric timestamp/PID/counter suffixes, so counter 9 precedes 10, including existing unpadded queued files. Strengthened tests fail against the original lexical ordering and pass with the fix; 194 common-module tests pass. Mixed legacy, padded and unpadded filenames are also covered.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update test/dev-coverage-audit
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/test/dev-coverage-audit/scripts/install \
  | sudo bash -s -- --branch test/dev-coverage-audit
```

🎯 **Pin to this exact build** ([run 34047208411](https://github.com/sleepypod/core/actions/runs/34047208411) · `329a19c`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/329a19ca41826b55de709d6771deec83f2234745/scripts/install \
  | sudo bash -s -- \
      --branch test/dev-coverage-audit \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/34047208411/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/34047208411/artifacts/9993481568) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Calibration trigger requests are now processed in the correct chronological order, including requests created at the same time and older-format filenames.

- **Tests**
  - Expanded automated coverage for calibration, signal reading, biometrics, temperature controls, power controls, trend charts, and data validation.
  - Improved coverage reporting to include production code and branch coverage while excluding test artifacts.

- **Documentation**
  - Added a detailed test coverage audit with results, inventories, and follow-up priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->