### PR TITLE
fix: restore journal access on minimal Yocto installs

### DIFF
--- a/scripts/bin/sp-maintenance
+++ b/scripts/bin/sp-maintenance
@@ -92,6 +92,13 @@ case "${1:-}" in
   *) echo "Usage: sp-maintenance [--startup|--housekeeping]" >&2; exit 2 ;;
 esac
 
+# Repair journal membership before systemd launches the unprivileged app.
+# Missing helpers are tolerated when rolling back to an older source bundle.
+if [ -f "$INSTALL_DIR/scripts/lib/service-group-helpers" ]; then
+  source "$INSTALL_DIR/scripts/lib/service-group-helpers"
+  repair_sleepypod_journal_access || echo "WARNING: journal access repair failed" >&2
+fi
+
 # 5. Self-heal /persistent/deviceinfo perms so next-server can unlink
 # stale dac.sock on startup. Older installs created the dir with mkdir's
 # default umask (root:root 0755), which denies write to the sleepypod user

--- a/scripts/install
+++ b/scripts/install
@@ -1341,13 +1341,14 @@ mkdir -p /etc/iptables
 # without it the log viewer fails with "No journal files were opened due
 # to insufficient permissions" on pods where the journal isn't
 # world-readable.
+source "$INSTALL_DIR/scripts/lib/service-group-helpers"
 SUPP_GROUPS=()
-if getent group dac &>/dev/null; then
+if sleepypod_group_exists dac; then
   SUPP_GROUPS+=(dac)
 fi
-if getent group systemd-journal &>/dev/null; then
+if sleepypod_group_exists systemd-journal; then
   SUPP_GROUPS+=(systemd-journal)
-elif getent group adm &>/dev/null; then
+elif sleepypod_group_exists adm; then
   SUPP_GROUPS+=(adm)
 fi
 SUPP_GROUPS_LINE=""

--- a/scripts/lib/service-group-helpers
+++ b/scripts/lib/service-group-helpers
@@ -1,0 +1,49 @@
+# Group lookup for minimal Yocto images, which do not ship getent.
+# Keep NSS lookup where available, then fall back to the local group database.
+sleepypod_group_exists() {
+  if command -v getent >/dev/null 2>&1 && getent group "$1" >/dev/null 2>&1; then
+    return 0
+  fi
+  local name password remainder
+  while IFS=: read -r name password remainder; do
+    [ "$name" != "$1" ] || return 0
+  done < "${SLEEPYPOD_GROUP_FILE:-/etc/group}"
+  return 1
+}
+
+sleepypod_journal_group() {
+  if sleepypod_group_exists systemd-journal; then
+    printf '%s\n' systemd-journal
+  elif sleepypod_group_exists adm; then
+    printf '%s\n' adm
+  fi
+}
+
+# ExecStartPre runs as root. Updating account membership here takes effect when
+# systemd subsequently starts the app as sleepypod, including the first OTA run
+# by an older sp-update (which installs the new sp-maintenance before restart).
+# Avoid daemon-reload/restart inside ExecStartPre and preserve all other groups.
+repair_sleepypod_journal_access() {
+  local journal_group current_groups usermod_bin candidate
+  journal_group=$(sleepypod_journal_group)
+  [ -n "$journal_group" ] || return 0
+  current_groups=$(id -nG sleepypod) || return 1
+  case " $current_groups " in
+    *" $journal_group "*) return 0 ;;
+  esac
+  usermod_bin=$(command -v usermod || true)
+  if [ -z "$usermod_bin" ]; then
+    # The service PATH excludes sbin on Yocto.
+    for candidate in /usr/sbin/usermod /sbin/usermod; do
+      if [ -x "$candidate" ]; then
+        usermod_bin=$candidate
+        break
+      fi
+    done
+  fi
+  if [ -z "$usermod_bin" ]; then
+    echo "WARNING: usermod missing; cannot grant journal access to sleepypod" >&2
+    return 1
+  fi
+  "$usermod_bin" -a -G "$journal_group" sleepypod
+}

--- a/scripts/tests/serviceGroups.test.ts
+++ b/scripts/tests/serviceGroups.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const helper = resolve('scripts/lib/service-group-helpers')
+let root: string
+let groupFile: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'sleepypod-groups-'))
+  groupFile = join(root, 'group')
+  writeFileSync(groupFile, 'dac:x:1000:sleepypod\nsystemd-journal:x:992:\nadm:x:4:\n')
+})
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+function run(script: string) {
+  return spawnSync('/bin/bash', ['-c', `set -euo pipefail; source "$HELPER"; ${script}`], {
+    encoding: 'utf8',
+    env: { ...process.env, HELPER: helper, SLEEPYPOD_GROUP_FILE: groupFile, TEST_ROOT: root },
+  })
+}
+
+describe('service groups on minimal Yocto images', () => {
+  it('finds exact local groups without getent or any external commands', () => {
+    const result = run('PATH=/nonexistent; sleepypod_group_exists dac; ! sleepypod_group_exists da; sleepypod_journal_group')
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('systemd-journal')
+  })
+  it('falls back to adm and tolerates images with neither journal group', () => {
+    writeFileSync(groupFile, 'adm:x:4:\n')
+    expect(run('PATH=/nonexistent; sleepypod_journal_group').stdout.trim()).toBe('adm')
+    writeFileSync(groupFile, 'dac:x:1000:sleepypod\n')
+    const result = run('PATH=/nonexistent; repair_sleepypod_journal_access')
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('')
+  })
+  it('retains NSS lookup and falls back when getent fails', () => {
+    writeFileSync(groupFile, 'adm:x:4:\n')
+    expect(run('getent() { return 0; }; sleepypod_journal_group').stdout.trim()).toBe('systemd-journal')
+    expect(run('getent() { return 2; }; sleepypod_journal_group').stdout.trim()).toBe('adm')
+  })
+  it('appends membership once, preserving dac and custom groups', () => {
+    const result = run(`
+      getent() { return 127; }
+      id() { printf '%s\\n' "sleepypod dac custom \${ADDED_GROUP:-}"; }
+      usermod() { printf '%s\\n' "$*" >> "$TEST_ROOT/calls"; ADDED_GROUP=$3; }
+      repair_sleepypod_journal_access
+      repair_sleepypod_journal_access
+    `)
+    expect(result.status).toBe(0)
+    expect(readFileSync(join(root, 'calls'), 'utf8')).toBe('-a -G systemd-journal sleepypod\n')
+  })
+  it('reports membership repair failure to the best-effort startup caller', () => {
+    const result = run('getent() { return 127; }; id() { echo "sleepypod dac"; }; usermod() { return 1; }; repair_sleepypod_journal_access')
+    expect(result.status).toBe(1)
+  })
+})


### PR DESCRIPTION
Pods whose Yocto image lacks `getent` silently skip the installer's supplementary-group checks. `system.getLogs` then returns HTTP 500 because the sleepypod user cannot read the system journal.

Use NSS lookup when available, with an exact-name `/etc/group` fallback for fresh installs. During startup maintenance, append missing journal membership with `usermod -a -G`, preserving dac and custom groups. This also repairs existing pods on their first OTA update: older updaters install the new maintenance script before starting core. Missing journal groups are tolerated; repair failures warn without blocking app startup.

Validation:
- Five regression tests cover missing getent, exact matching, NSS fallback, adm/absent groups, idempotency, and failure propagation.
- Bash syntax checks pass.
- A transient systemd service on a real Yocto pod confirmed that root ExecStartPre can repair membership before the unprivileged ExecStart reads the journal.
- The targeted journal-access repair on that pod restored system.getLogs; all 59 iOS unit/live API tests passed, including logs.

The runtime repair used a service drop-in and core restart. No firmware or branch deployment was performed.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update fix/yocto-journal-access
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/fix/yocto-journal-access/scripts/install \
  | sudo bash -s -- --branch fix/yocto-journal-access
```

🎯 **Pin to this exact build** ([run 34023319214](https://github.com/sleepypod/core/actions/runs/34023319214) · `7da7efe`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/7da7efece7ebb82358c5b8a7a45e9346e2fd518c/scripts/install \
  | sudo bash -s -- \
      --branch fix/yocto-journal-access \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/34023319214/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/34023319214/artifacts/9986250569) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->
