### PR TITLE
feat(streaming): expose LPS diagnostic subscriptions

### DIFF
--- a/docs/hardware/lps-diagnostics.md
+++ b/docs/hardware/lps-diagnostics.md
@@ -56,9 +56,10 @@ The 210-second sequence comprises empty (30 s), left occupied (60 s), empty
 
 ## Remaining evidence
 
-The existing JSONL capture and phase metadata are sufficient for the next step;
-no further physical experiment is requested. Verify the sample bytes, compare
-LPS and piezo side responses and timing, and plot unload recovery before adding
+Field JSONL data remains pending. When the capture is available, use it with the
+phase metadata to verify the sample bytes, compare LPS and piezo side responses
+and timing, and plot unload recovery. No further physical experiment is requested.
+Complete this analysis before adding
 sample interpretation or biometric consumers. Do not globally swap channels,
 label channels as disconnected, or assume the format is exclusive to Pod 4
 based on this single-device report.

--- a/docs/hardware/lps-diagnostics.md
+++ b/docs/hardware/lps-diagnostics.md
@@ -1,0 +1,64 @@
+# LPS diagnostic stream
+
+`lps` is a recognized WebSocket sensor type, available through an explicit
+subscription and `useSensorFrame('lps')`. It has no occupancy, calibration,
+biometric, or persistence consumer. Recognition removes the generic unknown-type
+warning; it does not imply physiological validation.
+
+```json
+{"type":"subscribe","sensors":["lps","piezo-dual"]}
+```
+
+Both RAW and NATS sources use the shared dispatcher. NATS field validation is
+still pending; the LPS reports below are from RAW firmware.
+
+## Reported schema
+
+Trinity reports Pod 4 model prefix `20500-0004-G09`, firmware 1.4.2,
+Eight Layer 4.0.2, running core `dev` at `dd5c425`. Only the capture README
+and summary were available for this implementation, not the JSONL records.
+Tests use synthetic payloads matching the reported schema.
+
+Each frame has `type: "lps"`, `ts` in Unix seconds, `temp` with numeric
+`left1`, `left2`, `right1`, `right2`, and `pres` containing `adc: 1`,
+`freq: 200`, and four equally named byte channels. Each channel contains
+800 bytes: 200 little-endian int32 samples, one second at the reported rate.
+The stream runs alongside `piezo-dual`, not in its place. The acronym,
+measurement units, and underlying sensor hardware remain unconfirmed.
+
+LPS preserves its nested payload. On the Node WebSocket stream byte buffers
+serialize as `{"type":"Buffer","data":[...bytes]}`. In contrast, `piezo-dual`
+is already converted to numeric sample arrays before WebSocket transmission;
+its WebSocket payload is not the original firmware byte representation.
+
+## Reported occupancy sequence
+
+The 210-second sequence comprises empty (30 s), left occupied (60 s), empty
+(30 s), right occupied (60 s), empty (30 s), with both sides off throughout.
+"Left" means the sleeper's left while lying face-up.
+
+- `right1` responds most strongly to physical left occupancy; `left1` responds
+  most strongly to physical right occupancy. Preserve firmware names until the
+  paired piezo capture establishes whether this is a shared convention.
+- `left2` and `right2` stay around 32767 with zero IQR, independent of load.
+  This supports inactivity in the trial, not proof of unpopulated hardware.
+- All temperature fields remain zero. Units and validity are unknown; do not
+  present these as measured temperatures.
+- Empty phases after occupancy remain elevated. Settling, sensor recovery, or
+  filtering may contribute; the initial empty phase is a reference, not a
+  calibrated physical zero.
+- `0x7fffffff` occurs at sample indices 20–29 in all four channels of two
+  frames: eight affected channel buffers out of 840, two frames out of 210.
+  The synchronized ten-sample burst spans 50 ms at 200 Hz. Treat this as a
+  candidate missing-data marker in future analysis, preserving time positions.
+  Diagnostic transport deliberately preserves the original bytes, including
+  these values, rather than deleting samples or replacing them with zero.
+
+## Remaining evidence
+
+The existing JSONL capture and phase metadata are sufficient for the next step;
+no further physical experiment is requested. Verify the sample bytes, compare
+LPS and piezo side responses and timing, and plot unload recovery before adding
+sample interpretation or biometric consumers. Do not globally swap channels,
+label channels as disconnected, or assume the format is exclusive to Pod 4
+based on this single-device report.

--- a/src/hooks/tests/useSensorStream.test.ts
+++ b/src/hooks/tests/useSensorStream.test.ts
@@ -264,6 +264,24 @@ describe('useSensorStream', () => {
 })
 
 describe('useSensorFrame', () => {
+  it('exposes lps diagnostic payloads without normalizing bytes or temperatures', async () => {
+    const stream = renderHook(() => useSensorStream({ sensors: ['lps'] }))
+    await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))
+    const ws = wsMock.sockets[0] as FakeWS
+    act(() => ws.triggerOpen())
+    const frame = renderHook(() => useSensorFrame('lps'))
+    const bytes = { type: 'Buffer', data: [255, 255, 255, 127] }
+    const payload = {
+      type: 'lps', ts: 123,
+      temp: { left1: 0, left2: 0, right1: 0, right2: 0 },
+      pres: { adc: 1, freq: 200, left1: bytes, left2: bytes, right1: bytes, right2: bytes },
+    }
+    act(() => ws.triggerMessage(payload))
+    await waitFor(() => expect(frame.result.current).toEqual(payload))
+    frame.unmount()
+    stream.unmount()
+  })
+
   it('returns the latest frame for a specific sensor only', async () => {
     const stream = renderHook(() => useSensorStream())
     await waitFor(() => expect(wsMock.sockets.length).toBeGreaterThan(0))

--- a/src/hooks/useSensorStream.ts
+++ b/src/hooks/useSensorStream.ts
@@ -11,7 +11,7 @@ import type { SideStatus } from '@/src/hardware/types'
 export const ALL_SENSOR_TYPES = [
   'piezo-dual', 'capSense', 'capSense2',
   'bedTemp', 'bedTemp2', 'frzTemp', 'frzTherm', 'frzHealth', 'log',
-  'deviceStatus', 'gesture',
+  'deviceStatus', 'gesture', 'lps',
 ] as const
 
 export type SensorType = typeof ALL_SENSOR_TYPES[number]
@@ -25,6 +25,21 @@ export interface PiezoDualFrame {
   right1: number[]
   left2?: number[]
   right2?: number[]
+}
+
+/**
+ * LPS diagnostic frame. Channel bytes remain in their JSON Buffer envelope,
+ * unlike piezo-dual's decoded sample arrays. Units and physical side mapping
+ * are unconfirmed; preserve sentinel samples and temperature placeholders.
+ */
+export interface LpsFrame {
+  type: 'lps'
+  ts: number
+  temp: Record<'left1' | 'left2' | 'right1' | 'right2', number>
+  pres: {
+    adc: number
+    freq: number
+  } & Record<'left1' | 'left2' | 'right1' | 'right2', { type: 'Buffer', data: number[] }>
 }
 
 /** Capacitive presence sensor frame (~2 Hz). */
@@ -152,6 +167,7 @@ export interface DeviceStatusFrame {
 /** Union of all sensor frame types. */
 export type SensorFrame
   = | PiezoDualFrame
+    | LpsFrame
     | CapSenseFrame
     | CapSense2Frame
     | BedTempFrame

--- a/src/streaming/piezoStream.ts
+++ b/src/streaming/piezoStream.ts
@@ -365,11 +365,11 @@ async function findLatestRawAsync(dir: string): Promise<string | null> {
 // Sensor types
 // ---------------------------------------------------------------------------
 
-/** All sensor record types the firmware emits. */
+/** Recognized stream types; subscription support does not imply ingestion. */
 const ALL_SENSOR_TYPES = [
   'piezo-dual', 'capSense', 'capSense2',
   'bedTemp', 'bedTemp2', 'frzTemp', 'frzTherm', 'frzHealth', 'log',
-  'deviceStatus', 'gesture',
+  'deviceStatus', 'gesture', 'lps',
 ] as const
 
 /** Valid sensor type string. Used for subscription filtering. */
@@ -833,6 +833,8 @@ function dispatchSensorFrame(frame: Record<string, unknown>): void {
   recordFirstSensorFrame()
   const frameType = frame.type as string
 
+  // lps is recognized for diagnostic subscriptions only. Preserve its nested
+  // payload and channel labels; no biometric consumer is wired for it.
   // New / out-of-scope firmware types (blanketReadings, …) pass through to
   // subscribers but are not ingested — log the first sight of each, once.
   if (!(ALL_SENSOR_TYPES as readonly string[]).includes(frameType)

--- a/src/streaming/tests/piezoStream.test.ts
+++ b/src/streaming/tests/piezoStream.test.ts
@@ -739,6 +739,41 @@ describe('piezoStream — server lifecycle and protocol', () => {
     await client.close()
   })
 
+  it('supports lps-only diagnostic subscriptions and preserves channel bytes', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    __test__.warnedUnknownTypes.delete('lps')
+    const client = await connectClient(startAndPort())
+    try {
+      client.ws.send(JSON.stringify({ type: 'subscribe', sensors: ['lps'] }))
+      const ack = await client.waitFor(m => m.type === 'subscribed')
+      expect(ack.sensors).toEqual(['lps'])
+      // Synthetic schema fixture, not a field capture. Include the reported
+      // 10-sample sentinel gap and distinct channels to catch swaps/conversion.
+      const channel = (value: number) => {
+        const bytes = Buffer.alloc(800)
+        for (let i = 0; i < 200; i++) bytes.writeInt32LE(i >= 20 && i < 30 ? 0x7fffffff : value, i * 4)
+        return bytes
+      }
+      const frame = {
+        type: 'lps', ts: 123,
+        temp: { left1: 0, left2: 0, right1: 0, right2: 0 },
+        pres: { adc: 1, freq: 200, left1: channel(453), left2: channel(32767), right1: channel(256), right2: channel(32768) },
+      }
+      const encoded = Buffer.from(new Encoder({ useRecords: false }).encode(frame))
+      const before = getLatestCapSenseSnapshot()
+      __test__.dispatchSensorFrame({ type: 'piezo-dual', ts: 123, freq: 500, left1: [], right1: [] })
+      for (const decoded of decodeSensorFrames(encoded)) __test__.dispatchSensorFrame(decoded)
+      const received = await client.waitFor(m => m.type === 'lps')
+      expect(received).toEqual(JSON.parse(JSON.stringify(frame)))
+      expect(getLatestCapSenseSnapshot()).toBe(before)
+      expect(warn.mock.calls.filter(args => args[1] === 'lps')).toEqual([])
+      expect(client.messages.some(m => m.type === 'piezo-dual')).toBe(false)
+    }
+    finally {
+      await client.close()
+    }
+  })
+
   it('subscribe with an empty sensors array → subscribes to all types', async () => {
     const logSpy = vi.spyOn(console, 'log')
     const port = startAndPort()


### PR DESCRIPTION
LPS frames on Pod 4 currently produce an unknown-type warning and cannot be requested through an explicit sensor subscription. Recognize `lps` on the server and in the typed client hook, preserving the nested byte payload, channel names, temperature placeholders, and sentinel values.

This adds diagnostic access only; no hardware controls, biometric ingestion, calibration, or database behavior changes. Document the reported occupancy trial and outstanding questions. Field JSONL data remains pending; regression fixtures are synthetic.

Validation: 1,703 related tests, TypeScript, ESLint, and both Drizzle schema checks passed. Branch Release and Build & Package succeeded for 77f255b.

<!-- sleepypod:install-start -->
<!-- 🛑 AUTO-GENERATED — sleepypod-bot owns this block.
     Hello fellow agent / curious human! Anything between the
     sleepypod:install-start and sleepypod:install-end markers
     gets overwritten on the next CI run. Want to change what's
     here? Edit .github/workflows/build.yml instead. 💤 -->
<details open>
<summary>🛏️ <strong>Beam this PR onto a sleepypod</strong> ✨</summary>

Pick the snippet that matches your pod. **Already-installed pods can't use the curl bootstraps below** — sleepypod's egress firewall DROPs github.com, and the script that knows how to unblock WAN is the very file curl is trying to fetch. Use `sp-update` instead; it's on disk and opens WAN as its first step.

🔄 **Already on a sleepypod** (most common — review a PR on a running pod):
```bash
sudo sp-update feat/trinity-lps
```

🚀 **Fresh pod / first install** — bootstraps from GitHub, rebuilds every push:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/feat/trinity-lps/scripts/install \
  | sudo bash -s -- --branch feat/trinity-lps
```

🎯 **Pin to this exact build** ([run 34166313032](https://github.com/sleepypod/core/actions/runs/34166313032) · `296ad50`) — fresh-pod path, locked to one CI artifact for reproducible review:
```bash
curl -fsSL https://raw.githubusercontent.com/sleepypod/core/296ad507f1b81d85eba484cacdc7ef6eedbadb77/scripts/install \
  | sudo bash -s -- \
      --branch feat/trinity-lps \
      --artifact-url 'https://nightly.link/sleepypod/core/actions/runs/34166313032/sleepypod-core.zip'
```

🧊 Artifact: [`sleepypod-core`](https://github.com/sleepypod/core/actions/runs/34166313032/artifacts/10034280217) · self-destructs in 30 days 💥
</details>

<!-- sleepypod:install-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for subscribing to the LPS diagnostic sensor stream.
  - LPS frames are available through sensor-frame access with their raw channel data, byte buffers, and temperature values preserved.
  - LPS diagnostic subscriptions retain channel labels and support round-trip delivery without affecting other sensor data.

- **Documentation**
  - Added documentation covering LPS frame fields, observed occupancy sequences, and current diagnostic limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
