### PR TITLE
fix(deploy): require prebuilt updates and stage local builds over SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,20 @@ After install, these are available system-wide:
 sp-status         # systemctl status sleepypod.service
 sp-restart        # restart the service
 sp-logs           # journalctl -u sleepypod.service -f
-sp-update         # pull latest, rebuild, migrate, restart (with automatic rollback)
+sp-update         # install latest pre-built release, migrate, restart (with rollback)
 sp-maintenance    # one-shot manual prime / reboot / status
 sp-uninstall      # stop services, remove systemd units, optionally wipe data
 ```
+
+Cloned the repo on your computer? Build locally and deploy to an installed Pod:
+
+```bash
+./scripts/deploy POD_IP              # current checkout
+./scripts/deploy POD_IP fix/my-fix   # branch from your clone's origin
+```
+
+See the [deployment guide](docs/DEPLOYMENT.md) for SSH requirements and fork/PR validation.
+
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,7 +26,7 @@ flowchart TB
     end
 
     subgraph trigger["Trigger Sources"]
-        mac["Mac CLI<br/>scripts/deploy"]
+        mac["Local CLI<br/>scripts/deploy"]
         web["Web UI"]
         ios["iOS App"]
     end
@@ -35,7 +35,7 @@ flowchart TB
     repo -->|"push / tag"| build_ci
     build_ci --> release
 
-    mac -->|"1. build locally<br/>2. tar+ssh over LAN"| install
+    mac -->|"1. build locally<br/>2. archive over SSH"| spupdate
     web -->|"tRPC"| spupdate
     ios -->|"tRPC"| spupdate
 
@@ -49,25 +49,48 @@ flowchart TB
 
 ## Three Deployment Paths
 
-### Path 1: Mac Deploy (Development)
+### Path 1: Local Deploy (macOS / Linux)
 
-Builds locally (fast, full RAM), pushes built artifacts to the pod. No WAN needed on the pod.
+From a clone on your computer, build and transfer to an **already-installed** Pod:
 
 ```bash
-./scripts/deploy                           # current branch -> 192.168.1.88
-./scripts/deploy 192.168.1.50              # current branch -> different pod
-./scripts/deploy 192.168.1.88 feat/alarms  # specific branch
+./scripts/deploy 192.168.1.50              # current checkout, including local edits
+./scripts/deploy 192.168.1.50 fix/my-fix   # branch fetched from this clone's origin
+SSH_PORT=8822 ./scripts/deploy pod.local
 ```
 
-**How it works:**
-1. Checks out the requested branch locally (if specified)
-2. Runs `pnpm build` on the Mac
-3. Cleans stale files on the pod (preserves `node_modules`, `.env`)
-4. Tars source + `.next` build, pipes over SSH
-5. Runs `scripts/install --local --no-ssh` on the pod
-6. Install script: installs prod deps (with prebuilt native modules), restarts service (DB migrations run automatically on startup via `instrumentation.ts`)
+Use the Node.js major in `.node-version` and the pnpm version pinned in
+`package.json`. The script installs locked dependencies, builds locally, and
+checks the bundle before uploading. An optional branch builds in a temporary
+Git worktree; your current branch and edits are preserved.
 
-**Requirements:** SSH access to pod on port 8822 with key auth.
+It uploads a complete archive before invoking `sp-update --archive` on the Pod.
+Git metadata, `.env*`, databases, caches, and local `node_modules` are excluded.
+The updater preserves the Pod's `.env`, backs up the installed code/database,
+installs production dependencies for the Pod's architecture, and restarts the
+service. Build-time public environment variables can still be embedded in the
+Next.js output; build with the intended deployment configuration.
+
+**Requirements:** root SSH key access (default port 8822), an existing SleepyPod
+installation, and WAN access on the Pod for production/native dependencies.
+The updater temporarily opens/restores a blocked WAN using the existing
+firewall helpers. No GitHub release is required. For first installation, use
+`scripts/install` instead.
+
+### Validating a fork's PR
+
+Check out the PR in your local clone and run `./scripts/deploy POD_IP`. This
+works even when the fork has not published a branch release. Alternatively,
+enable Actions in the fork and push the branch so its Branch Release workflow
+publishes `sleepypod-core.tar.gz` under `<branch-with-slashes-replaced>-latest`.
+Then run on the Pod:
+
+```bash
+sudo env SLEEPYPOD_GITHUB_REPO=OWNER/core sp-update fix/my-fix
+```
+
+A Git push alone does not upload a locally built `.next`; use the deployment
+script or let CI build and publish the release.
 
 ### Path 2: CI Release (Production)
 
@@ -88,7 +111,8 @@ The pod self-updates by downloading from GitHub. Triggered via the `system.trigg
 ```bash
 # From SSH on the pod:
 sp-update              # latest release (pre-built)
-sp-update feat/alarms  # specific branch (source only, needs build)
+sp-update feat/alarms  # pre-built feat-alarms-latest release
+sp-update --archive /persistent/sleepypod-core.tar.gz  # uploaded pre-built archive
 
 # From web UI or iOS app (tRPC):
 # system.triggerUpdate({ branch: "main" })
@@ -96,14 +120,25 @@ sp-update feat/alarms  # specific branch (source only, needs build)
 ```
 
 **How it works:**
-1. Opens iptables (temporarily allows WAN)
-2. Tries to download latest CI release tarball (includes `.next` — no build needed)
-3. Falls back to GitHub source tarball if no release or if requesting a non-main branch
-4. Installs prod dependencies (prebuild-install fetches linux-arm64 native modules)
-5. Closes iptables (re-blocks WAN)
-6. Restarts service (DB migrations run automatically on startup via `instrumentation.ts`)
+1. Resolves `main`/`latest` to the latest stable release, `dev` to `dev-latest`, and other branches to `<slug>-latest`.
+2. Downloads and validates the pre-built archive before replacing installed files.
+3. Backs up the installed code and database, then installs the new code and production dependencies.
+4. Restores the firewall and starts the service (database migrations run at startup).
 
-**If the update fails:** iptables are restored and the service restarts with existing code. Database is restored from backup.
+There is no source-tarball fallback or on-Pod Next.js build. Missing releases,
+API errors, failed downloads, and incomplete builds fail with actionable errors.
+For a local archive, bundle validation happens before stopping the service.
+When WAN is blocked, the service stops before opening the firewall to avoid
+racing its firewall self-heal; preparation failures restart it with existing code.
+
+`TMPDIR` defaults to `/persistent` for staging and rollback backups. It can be
+overridden with an existing writable directory. The updater requires the
+archive's pinned pnpm version and reports how to correct a mismatch.
+
+**If the update fails:** the updater attempts to restore the firewall and,
+after replacement has begun, the backed-up code and database. A failed update's
+code backup remains at `$TMPDIR/sleepypod-rollback.*` for recovery. Dependency
+changes in `node_modules` and module/systemd changes are not rolled back.
 
 ## Why Build Off-Device
 
@@ -117,7 +152,7 @@ The `.next` output is platform-independent JavaScript — only `better-sqlite3` 
 The pod runs "Eight Layer" (Yocto kirkstone) — a minimal embedded Linux with no package manager. Instead of git, we use GitHub's tarball API and release assets. No commit history is needed on a deployment target.
 
 ### No rsync on the pod
-The deploy script uses `tar | ssh` — creates a tar archive locally, pipes over SSH, extracts on the pod. Stale files are cleaned before extraction (mimics `rsync --delete`).
+The deploy script creates a tar archive locally and transfers it over SSH. The updater stages and validates it before replacing the installed application.
 
 ### prebuild-install for native modules
 `better-sqlite3` ships with `prebuild-install`, which downloads precompiled binaries for `linux-arm64`. No C compiler needed on the pod.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,7 +61,8 @@ SSH_PORT=8822 ./scripts/deploy pod.local
 
 Use the Node.js major in `.node-version` and the pnpm version pinned in
 `package.json`. The script installs locked dependencies, builds locally, and
-checks the bundle before uploading. An optional branch builds in a temporary
+checks the bundle before uploading. Build workers use in-memory databases to
+avoid modifying local data or contending over SQLite files. An optional branch builds in a temporary
 Git worktree; your current branch and edits are preserved.
 
 It uploads a complete archive before invoking `sp-update --archive` on the Pod.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,6 +67,8 @@ Git worktree; your current branch and edits are preserved.
 
 It uploads a complete archive before invoking `sp-update --archive` on the Pod.
 Git metadata, `.env*`, databases, caches, and local `node_modules` are excluded.
+The standalone server and its compiled configuration are retained; native
+modules resolve from the production dependencies installed on the Pod.
 The updater preserves the Pod's `.env`, backs up the installed code/database,
 installs production dependencies for the Pod's architecture, and restarts the
 service. Build-time public environment variables can still be embedded in the

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -56,6 +56,10 @@ if [ ! -d "$INSTALL_DIR" ] || ! command -v systemctl >/dev/null; then
   echo "Error: sp-update runs on an installed Pod. On your computer use ./scripts/deploy POD_IP [branch]." >&2
   exit 1
 fi
+# Existing installations may point at a release via a symlink. find does
+# not descend through a command-line symlink by default; resolve it so stale
+# .next/standalone files are removed rather than silently booting old code.
+INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"
 export TMPDIR="${TMPDIR:-/persistent}"
 
 echo "=== SleepyPod Update ==="

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -249,11 +249,13 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # Pre-flight: disk space
-DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
-if [ "$DISK_AVAIL" -lt 300 ]; then
-  echo "Error: Need 300MB free, only ${DISK_AVAIL}MB available" >&2
-  exit 1
-fi
+for space_dir in "$INSTALL_DIR" "$TMPDIR"; do
+  DISK_AVAIL=$(df -m "$space_dir" | awk 'NR==2{print $4}')
+  if [ "$DISK_AVAIL" -lt 300 ]; then
+    echo "Error: Need 300MB free in $space_dir, only ${DISK_AVAIL}MB available" >&2
+    exit 1
+  fi
+done
 
 # Local archive validation happens before stopping services. GitHub downloads need
 # WAN access, so stop first only when the firewall needs to be opened: the

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -190,7 +190,7 @@ cleanup() {
         ! -name 'node_modules' \
         ! -name '.env' \
         -exec rm -rf {} +
-      cp -r "$BACKUP_DIR/." "$INSTALL_DIR/"
+      cp -a "$BACKUP_DIR/." "$INSTALL_DIR/"
       # Intentionally NOT restoring sp-* tools to /usr/local/bin/.
       # They were already swapped in atomically (see install(1) below)
       # before the failure; restoring the pre-update copies can re-pin a
@@ -322,7 +322,7 @@ fi
 
 # Validate staged artifacts before touching the installed application. Exclude
 # workstation dependencies and environment files even for hand-made archives.
-for required in .next/BUILD_ID .next/required-server-files.json package.json pnpm-lock.yaml; do
+for required in .next/BUILD_ID .next/required-server-files.json .next/standalone/server.js package.json pnpm-lock.yaml; do
   if [ ! -s "$WORK_DIR/$required" ]; then
     echo "Error: Pre-built archive is missing $required. Build on your computer with ./scripts/deploy POD_IP, or publish a complete CI release." >&2
     exit 1

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -13,7 +13,7 @@ export PATH="/usr/local/bin:$PATH"
 #   sp-update feat/alarms  # update to a specific branch
 #
 # Handles iptables toggle automatically (opens WAN, downloads, closes WAN).
-# No git required — uses GitHub's tarball API.
+# No git required. Requires a pre-built release or a local deployment archive.
 
 INSTALL_DIR="/home/dac/sleepypod-core"
 # DATA_DIR pointer is written by scripts/install (storage-aware picker).
@@ -24,11 +24,47 @@ else
   DATA_DIR="/persistent/sleepypod-data"
 fi
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
-BRANCH="${1:-main}"
+BRANCH=main
+ARCHIVE=""
+usage() {
+  cat <<'EOF'
+Usage: sp-update [branch]
+       sp-update --archive /path/to/sleepypod-core.tar.gz
+
+Downloads a pre-built GitHub release; never builds Next.js on the Pod.
+For a cloned repo on your computer, run: ./scripts/deploy POD_IP [branch]
+SLEEPYPOD_GITHUB_REPO selects the release repository (default: sleepypod/core).
+TMPDIR selects temporary storage (default: /persistent).
+EOF
+}
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --archive)
+    if [ "$#" -ne 2 ] || [ ! -f "$2" ]; then
+      echo "Error: --archive requires an existing tar.gz file." >&2
+      exit 1
+    fi
+    ARCHIVE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+    ;;
+  -*) usage >&2; exit 1 ;;
+  *)
+    if [ "$#" -gt 1 ]; then usage >&2; exit 1; fi
+    BRANCH="${1:-main}"
+    ;;
+esac
+if [ ! -d "$INSTALL_DIR" ] || ! command -v systemctl >/dev/null; then
+  echo "Error: sp-update runs on an installed Pod. On your computer use ./scripts/deploy POD_IP [branch]." >&2
+  exit 1
+fi
+export TMPDIR="${TMPDIR:-/persistent}"
 
 echo "=== SleepyPod Update ==="
-echo "Branch: $BRANCH"
-echo "Repo:   $GITHUB_REPO"
+if [ -n "$ARCHIVE" ]; then
+  echo "Archive: $ARCHIVE"
+else
+  echo "Branch: $BRANCH"
+  echo "Repo:   $GITHUB_REPO"
+fi
 echo ""
 
 # Source shared iptables helpers (with inline fallback for transitional installs)
@@ -128,6 +164,9 @@ reload_iptables_helpers() {
 
 # Cleanup — re-block WAN, rollback code, and restart service on failure
 ROLLBACK_READY=false
+SERVICE_STOPPED=false
+WORK_DIR=""
+BACKUP_DIR=""
 cleanup() {
   local exit_code=$?
   if [ "$WAN_WAS_BLOCKED" = true ]; then
@@ -190,12 +229,20 @@ cleanup() {
       echo "Database restored from $DB_BACKUP."
     fi
     systemctl start sleepypod.service 2>/dev/null || true
-  elif [ "$exit_code" -ne 0 ]; then
+  elif [ "$exit_code" -ne 0 ] && [ "$SERVICE_STOPPED" = true ]; then
     echo "Update failed before rollback point, starting service with existing code..." >&2
     systemctl start sleepypod.service 2>/dev/null || true
   fi
+  [ -z "$WORK_DIR" ] || rm -rf "$WORK_DIR"
+  # Keep a failed update's backup for manual recovery.
+  if [ "$exit_code" -eq 0 ] && [ -n "$BACKUP_DIR" ]; then
+    rm -rf "$BACKUP_DIR"
+  fi
+  return "$exit_code"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Pre-flight: disk space
 DISK_AVAIL=$(df -m "$INSTALL_DIR" | awk 'NR==2{print $4}')
@@ -204,119 +251,123 @@ if [ "$DISK_AVAIL" -lt 300 ]; then
   exit 1
 fi
 
-# Stop the service before temporarily flushing the firewall. Its startup and
-# health checks repair required LAN rules; leaving it running during the open
-# WAN window races those repairs against an empty chain (the observed
-# "Index of insertion too big" failure).
-systemctl stop sleepypod.service
-
-# Open WAN if blocked
-if wan_is_blocked; then
-  # Ensure /etc/hosts telemetry block is in place before opening WAN
-  if ! grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
-    echo "Installing /etc/hosts telemetry block before opening WAN..."
-    "$INSTALL_DIR/scripts/internet-control" hosts-block 2>/dev/null || true
+# Local archive validation happens before stopping services. GitHub downloads need
+# WAN access, so stop first only when the firewall needs to be opened: the
+# service's firewall self-heal otherwise races unblock_wan.
+WORK_DIR=$(mktemp -d "$TMPDIR/sleepypod-update.XXXXXX")
+open_update_wan() {
+  if wan_is_blocked; then
+    if [ "$SERVICE_STOPPED" = false ]; then
+      systemctl stop sleepypod.service
+      SERVICE_STOPPED=true
+    fi
+    if ! grep -q "# BEGIN sleepypod-telemetry-block" /etc/hosts 2>/dev/null; then
+      "$INSTALL_DIR/scripts/internet-control" hosts-block 2>/dev/null || true
+    fi
+    WAN_WAS_BLOCKED=true
+    unblock_wan
   fi
-  WAN_WAS_BLOCKED=true
-  unblock_wan
+}
+
+if [ -n "$ARCHIVE" ]; then
+  echo "Using local build: $ARCHIVE"
+  tar xzf "$ARCHIVE" -C "$WORK_DIR"
+else
+  open_update_wan
+  if [ "$BRANCH" = main ] || [ "$BRANCH" = latest ]; then
+    RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+  else
+    RELEASE_TAG="${BRANCH//\//-}-latest"
+    RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}"
+  fi
+  echo "Checking for pre-built release: $RELEASE_API"
+  if ! HTTP_STATUS=$(curl -sS -L --connect-timeout 10 --max-time 60 \
+      -o "$WORK_DIR/release.json" -w '%{http_code}' "$RELEASE_API"); then
+    echo "Error: Could not contact GitHub. Check the Pod's network and retry." >&2
+    exit 1
+  fi
+  case "$HTTP_STATUS" in
+    200) ;;
+    404)
+      echo "Error: No accessible pre-built release for '$BRANCH' in '$GITHUB_REPO'." >&2
+      echo "Enable GitHub Actions in the fork and push the branch to publish its Branch Release." >&2
+      echo "Or, from a cloned repo on your computer: ./scripts/deploy POD_IP" >&2
+      echo "Installed files have not been replaced; source-only builds are not supported on the Pod." >&2
+      exit 1 ;;
+    *)
+      echo "Error: GitHub release lookup returned HTTP $HTTP_STATUS (check API access/rate limits)." >&2
+      exit 1 ;;
+  esac
+  RELEASE_URL=$(node -e '
+    const fs = require("fs");
+    const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const asset = release.assets?.find(a => a.name === "sleepypod-core.tar.gz");
+    if (asset && /^https:\/\//.test(asset.browser_download_url)) process.stdout.write(asset.browser_download_url);
+  ' "$WORK_DIR/release.json")
+  rm -f "$WORK_DIR/release.json"
+  if [ -z "$RELEASE_URL" ]; then
+    echo "Error: Release has no sleepypod-core.tar.gz asset. Build/publish the release, or use ./scripts/deploy POD_IP from your computer." >&2
+    exit 1
+  fi
+  echo "Downloading pre-built release..."
+  if ! curl -fSL --connect-timeout 10 --max-time 600 "$RELEASE_URL" | tar xz -C "$WORK_DIR"; then
+    echo "Error: Release download/extraction failed. Installed files have not been replaced; retry the update." >&2
+    exit 1
+  fi
 fi
 
-# Check connectivity
-if ! curl -sf --max-time 10 https://github.com > /dev/null 2>&1; then
-  echo "Error: Cannot reach GitHub. Check network." >&2
+# Validate staged artifacts before touching the installed application. Exclude
+# workstation dependencies and environment files even for hand-made archives.
+for required in .next/BUILD_ID .next/required-server-files.json package.json pnpm-lock.yaml; do
+  if [ ! -s "$WORK_DIR/$required" ]; then
+    echo "Error: Pre-built archive is missing $required. Build on your computer with ./scripts/deploy POD_IP, or publish a complete CI release." >&2
+    exit 1
+  fi
+done
+find "$WORK_DIR" -name node_modules -prune -exec rm -rf {} +
+find "$WORK_DIR" -maxdepth 1 -name '.env*' -exec rm -rf {} +
+
+# Check the target project's package-manager version before replacing files.
+# An unpinned global install can silently ignore native-dependency settings.
+PNPM_VERSION=$(node -p 'require(process.argv[1]).packageManager' "$WORK_DIR/package.json")
+if [[ ! "$PNPM_VERSION" =~ ^pnpm@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Archive must pin packageManager to pnpm@x.y.z." >&2
+  exit 1
+fi
+# pnpm may manage its own pinned version, which can require WAN even for a
+# local archive. Production dependencies also still need registry access.
+open_update_wan
+ACTUAL_PNPM=$(cd "$WORK_DIR" && pnpm --version)
+if [ "$ACTUAL_PNPM" != "${PNPM_VERSION#pnpm@}" ]; then
+  echo "Error: Expected $PNPM_VERSION, found pnpm $ACTUAL_PNPM. Install the pinned version (npm install -g $PNPM_VERSION), then retry." >&2
   exit 1
 fi
 
-# Backup current code for rollback (everything except node_modules)
-BACKUP_DIR="/tmp/sleepypod-rollback"
-rm -rf "$BACKUP_DIR"
-mkdir -p "$BACKUP_DIR"
-tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . 2>/dev/null | tar xf - -C "$BACKUP_DIR" || true
+if [ "$SERVICE_STOPPED" = false ]; then
+  systemctl stop sleepypod.service
+  SERVICE_STOPPED=true
+fi
 
-# Backup database (service is stopped, so WAL/SHM are consistent)
-# Timestamped name so two rapid updates don't clobber the previous backup.
-# Matches scripts/install's naming; sp-maintenance prunes to 3 most recent.
+# Fail closed if the backup cannot be completed. Keep it off the Pod's /tmp
+# tmpfs by honoring TMPDIR for both staging and rollback storage.
+BACKUP_DIR=$(mktemp -d "$TMPDIR/sleepypod-rollback.XXXXXX")
+tar cf - -C "$INSTALL_DIR" --exclude='node_modules' . | tar xf - -C "$BACKUP_DIR"
+
 BACKUP_TS=$(date +%s)
 DB_BACKUP="$DATA_DIR/sleepypod.db.bak.$BACKUP_TS"
 if [ -f "$DATA_DIR/sleepypod.db" ]; then
   cp "$DATA_DIR/sleepypod.db" "$DB_BACKUP"
-  [ -f "$DATA_DIR/sleepypod.db-wal" ] && cp "$DATA_DIR/sleepypod.db-wal" "$DATA_DIR/sleepypod.db-wal.bak.$BACKUP_TS"
-  [ -f "$DATA_DIR/sleepypod.db-shm" ] && cp "$DATA_DIR/sleepypod.db-shm" "$DATA_DIR/sleepypod.db-shm.bak.$BACKUP_TS"
+  [ ! -f "$DATA_DIR/sleepypod.db-wal" ] || cp "$DATA_DIR/sleepypod.db-wal" "$DATA_DIR/sleepypod.db-wal.bak.$BACKUP_TS"
+  [ ! -f "$DATA_DIR/sleepypod.db-shm" ] || cp "$DATA_DIR/sleepypod.db-shm" "$DATA_DIR/sleepypod.db-shm.bak.$BACKUP_TS"
   echo "Database backed up to $DB_BACKUP."
 fi
 
-# Download code — try CI release first (includes pre-built .next), fall back to source tarball
-WORK_DIR=$(mktemp -d)
-HAS_BUILD=false
-
-# Resolve the release endpoint. Mirrors scripts/install so OTA updates use
-# the same CI-built tarballs as fresh installs:
-#   main / latest      → releases/latest (semantic-release vX.Y.Z asset)
-#   dev                → releases/tags/dev-latest      (built by dev-release.yml)
-#   <other branch>     → releases/tags/<slug>-latest   (built by branch-release.yml)
-# Slugging matches branch-release.yml: `feat/foo` → `feat-foo-latest`.
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "latest" ]; then
-  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-  echo "Checking for CI release (latest stable)..."
-elif [ "$BRANCH" = "dev" ]; then
-  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/dev-latest"
-  echo "Checking for CI release (tag: dev-latest)..."
-else
-  RELEASE_TAG="${BRANCH//\//-}-latest"
-  RELEASE_API="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${RELEASE_TAG}"
-  echo "Checking for CI release (tag: $RELEASE_TAG)..."
-fi
-RELEASE_URL=$(curl -sf "$RELEASE_API" \
-  | grep -om1 '"browser_download_url": *"[^"]*sleepypod-core\.tar\.gz"' \
-  | grep -o 'https://[^"]*' || true)
-
-if [ -n "$RELEASE_URL" ]; then
-  echo "Downloading CI release..."
-  if curl -fSL "$RELEASE_URL" | tar xz -C "$WORK_DIR"; then
-    HAS_BUILD=true
-    echo "CI release downloaded (pre-built)."
-  else
-    # CI download failed mid-stream (e.g. curl truncation). Partial
-    # files would otherwise contaminate WORK_DIR — the source-tarball
-    # fallback below extracts into the same dir, and `ls "$WORK_DIR"
-    # | head -1` would then pick up stale CI-release contents instead
-    # of the freshly-extracted source subdir. Mirrors scripts/install.
-    find "$WORK_DIR" -mindepth 1 -delete 2>/dev/null || true
-  fi
-fi
-
-if [ "$HAS_BUILD" = false ]; then
-  # A failed CI-release download can leave partial extraction in WORK_DIR;
-  # drop and recreate so the source-tarball structure check is reliable.
-  rm -rf "$WORK_DIR"
-  WORK_DIR=$(mktemp -d)
-  # Fall back to source tarball (no .next — would need build on pod)
-  # "latest" is not a real branch — use main for the source tarball
-  SOURCE_BRANCH="$BRANCH"
-  [ "$SOURCE_BRANCH" = "latest" ] && SOURCE_BRANCH="main"
-  echo "Downloading $SOURCE_BRANCH from GitHub..."
-  TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${SOURCE_BRANCH}.tar.gz"
-  if ! curl -fSL "$TARBALL_URL" | tar xz -C "$WORK_DIR"; then
-    echo "Error: Failed to download branch '$BRANCH'" >&2
-    exit 1
-  fi
-  # Source tarball extracts to a subdirectory (e.g., core-main/)
-  SUBDIR=$(ls "$WORK_DIR" | head -1)
-  if [ -z "$SUBDIR" ] || [ ! -d "$WORK_DIR/$SUBDIR" ]; then
-    echo "Error: Unexpected tarball structure in $WORK_DIR" >&2
-    exit 1
-  fi
-  # Move contents up so WORK_DIR is the root
-  mv "$WORK_DIR/$SUBDIR"/* "$WORK_DIR/$SUBDIR"/.[!.]* "$WORK_DIR/" 2>/dev/null || true
-  rmdir "$WORK_DIR/$SUBDIR" 2>/dev/null || true
-fi
-
 # Clean old files (preserve node_modules, .env)
+ROLLBACK_READY=true
 find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 \
   ! -name 'node_modules' \
   ! -name '.env' \
   -exec rm -rf {} +
-ROLLBACK_READY=true
 
 # Move new code into place
 cp -r "$WORK_DIR/." "$INSTALL_DIR/"
@@ -333,29 +384,12 @@ if [ -f "$INSTALL_DIR/scripts/lib/relocation-helpers" ]; then
   ensure_persistent_node_modules "$INSTALL_DIR"
 fi
 
-# Install production dependencies
-pnpm install --frozen-lockfile --prod
+# Native dependencies must be installed for the Pod, never copied from a Mac.
+CI=true pnpm install --frozen-lockfile --prod
 
-# Build only if no pre-built .next exists
-if [ ! -d "$INSTALL_DIR/.next" ]; then
-  echo "No pre-built .next found, building..."
-  # CI=true so pnpm doesn't prompt for TTY confirmation when prod-only
-  # node_modules need to be replaced with the full dev set.
-  CI=true pnpm install --frozen-lockfile
-  SP_BRANCH="$BRANCH" pnpm build
-else
-  # Regenerate .git-info with the correct branch for pre-built releases
+# Preserve the commit/branch metadata produced by the actual build.
+if [ ! -s .git-info ]; then
   SP_BRANCH="$BRANCH" node scripts/generate-git-info.mjs 2>/dev/null || true
-fi
-
-# Validate the build actually produced a startable .next bundle. next start
-# refuses to boot without BUILD_ID and silently crashloops via systemd
-# Restart=on-failure, so without this check sp-update would print "Update
-# complete!" while the service is dying every 10 seconds.
-if [ ! -f "$INSTALL_DIR/.next/BUILD_ID" ]; then
-  echo "Error: build did not produce $INSTALL_DIR/.next/BUILD_ID — refusing to start service" >&2
-  echo "Inspect the build output above; common causes: pnpm build script swallowed an error, OOM/SIGTERM during turbopack, or pre-built tarball missing the file." >&2
-  exit 1
 fi
 
 # Sync biometrics modules

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -75,18 +75,23 @@ if [ -n "$BRANCH" ]; then
 else
   DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: pnpm build
 fi
-for required in .next/BUILD_ID .next/required-server-files.json; do
+for required in .next/BUILD_ID .next/required-server-files.json .next/standalone/server.js; do
   if [ ! -s "$required" ]; then
     echo "Error: Build did not produce $required; Pod files have not been changed." >&2
     exit 1
   fi
 done
 
+# The standalone server changes cwd; keep its version endpoint tied to this
+# build even when output-file tracing does not include the root metadata.
+if [ -s .git-info ]; then cp -f .git-info .next/standalone/.git-info; fi
+
 # Flags shared by BSD tar (macOS) and GNU tar (Linux). Never ship local
 # credentials, Git worktrees, or workstation-native modules (including those
-# traced into .next/standalone). The Pod uses next start with its own modules.
+# traced into .next/standalone). Keep the standalone server: it embeds the
+# compiled config and avoids loading build-only plugins at runtime.
 COPYFILE_DISABLE=1 tar czf "$LOCAL_STAGE/sleepypod-core.tar.gz" \
-  --exclude='node_modules' --exclude='.next/standalone' --exclude='.next/cache' \
+  --exclude='node_modules' --exclude='.next/cache' \
   --exclude='.git' --exclude='.env*' --exclude='*.db' --exclude='*.db-*' \
   --exclude='.DS_Store' --exclude='test-results' --exclude='coverage' \
   --exclude='.serena' --exclude='.claude' --exclude='.codex' --exclude='.ygg' \

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -68,10 +68,12 @@ fi
 pnpm install --frozen-lockfile
 # Remove stale output so a failed/incomplete build cannot deploy an old bundle.
 rm -rf .next
+# Route collection imports the database modules in parallel workers. Give
+# each worker an in-memory database rather than locking/altering local data.
 if [ -n "$BRANCH" ]; then
-  SP_BRANCH="$BRANCH" pnpm build
+  DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: SP_BRANCH="$BRANCH" pnpm build
 else
-  pnpm build
+  DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: pnpm build
 fi
 for required in .next/BUILD_ID .next/required-server-files.json; do
   if [ ! -s "$required" ]; then

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -46,7 +46,8 @@ trap 'exit 143' TERM
 
 echo "=== SleepyPod Deploy ==="
 echo "Target: root@$POD_IP:$SSH_PORT"
-"${SSH[@]}" 'test -d /home/dac/sleepypod-core && command -v node >/dev/null && command -v pnpm >/dev/null' || {
+# shellcheck disable=SC2016 # Use the Pod binaries in non-login SSH sessions.
+"${SSH[@]}" 'export PATH=/usr/local/bin:$PATH; test -d /home/dac/sleepypod-core && command -v node >/dev/null && command -v pnpm >/dev/null' || {
   echo "Error: SSH failed or SleepyPod is not installed. Install SleepyPod on the Pod first." >&2
   exit 1
 }

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,103 +1,107 @@
 #!/bin/bash
 set -euo pipefail
 
-# deploy — build locally, push built artifacts to a Pod
-#
-# Usage:
-#   ./scripts/deploy [POD_IP] [branch]
-#
-# Examples:
-#   ./scripts/deploy                           # deploy current branch to 192.168.1.88
-#   ./scripts/deploy 192.168.1.50              # current branch -> different pod
-#   ./scripts/deploy 192.168.1.88 main         # pull and deploy main
-#   ./scripts/deploy 192.168.1.88 feat/alarms  # pull and deploy a feature branch
-#
-# What it does:
-#   1. Optionally checks out and pulls the specified branch
-#   2. Builds the Next.js app locally (fast, full RAM) with output: 'standalone'
-#   3. Syncs standalone build to the pod via tar+ssh
-#   4. Runs the install script on the pod (prod deps only, no build)
-#
-# Requirements:
-#   - SSH access to the pod on port 8822 with key auth
-#   - The pod must be on your local network
-#   - Node.js and pnpm installed locally
+# Build a clone on macOS/Linux and deploy to an already-installed Pod.
+# An optional branch is fetched from origin into an isolated checkout.
+usage() {
+  cat <<'HELP'
+Usage: ./scripts/deploy POD_IP [branch]
 
-SSH_PORT=8822
-SSH_USER=root
-REMOTE_DIR="/home/dac/sleepypod-core"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-DEFAULT_POD_IP="192.168.1.88"
-
-POD_IP="${1:-$DEFAULT_POD_IP}"
+Build the current checkout (including local edits), or a branch from origin,
+then transfer a pre-built archive over SSH and update the Pod with rollback.
+Requires Node.js, the project's pinned pnpm, and root SSH key access.
+The Pod still needs WAN access for production/native dependencies.
+SSH_PORT defaults to 8822; TMPDIR on the Pod defaults to /persistent.
+HELP
+}
+case "${1:-}" in -h|--help) usage; exit 0 ;; esac
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then usage >&2; exit 1; fi
+POD_IP="$1"
 BRANCH="${2:-}"
-
-echo "=== SleepyPod Deploy ==="
-echo "Target: ${SSH_USER}@${POD_IP}:${SSH_PORT}"
-echo "Source: $PROJECT_DIR"
-echo ""
-
-# Check SSH connectivity
-echo "Checking SSH connectivity..."
-if ! ssh -p "$SSH_PORT" -o ConnectTimeout=5 -o BatchMode=yes "$SSH_USER@$POD_IP" "echo ok" >/dev/null 2>&1; then
-  echo "Error: Cannot SSH to $SSH_USER@$POD_IP:$SSH_PORT" >&2
-  echo "Ensure SSH is configured and your key is authorized." >&2
+SSH_PORT="${SSH_PORT:-8822}"
+if [[ ! "$POD_IP" =~ ^[a-zA-Z0-9][a-zA-Z0-9.:-]*$ ]] || [[ ! "$SSH_PORT" =~ ^[0-9]+$ ]]; then
+  echo "Error: Provide a Pod hostname/IP and a numeric SSH_PORT." >&2
   exit 1
 fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+SSH=(ssh -p "$SSH_PORT" -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30 "root@$POD_IP")
+LOCAL_STAGE=$(mktemp -d "${TMPDIR:-/tmp}/sleepypod-deploy.XXXXXX")
+REMOTE_STAGE=""
+BUILD_DIR="$PROJECT_DIR"
+cleanup() {
+  local status=$?
+  if [ -n "$REMOTE_STAGE" ]; then
+    "${SSH[@]}" "rm -rf '$REMOTE_STAGE'" || true
+  fi
+  if [ "$BUILD_DIR" != "$PROJECT_DIR" ]; then
+    git -C "$PROJECT_DIR" worktree remove --force "$BUILD_DIR" || true
+  fi
+  rm -rf "$LOCAL_STAGE"
+  return "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Optionally switch branch and pull
+echo "=== SleepyPod Deploy ==="
+echo "Target: root@$POD_IP:$SSH_PORT"
+"${SSH[@]}" 'test -d /home/dac/sleepypod-core && command -v node >/dev/null && command -v pnpm >/dev/null' || {
+  echo "Error: SSH failed or SleepyPod is not installed. Install SleepyPod on the Pod first." >&2
+  exit 1
+}
 if [ -n "$BRANCH" ]; then
-  echo "Checking out branch: $BRANCH"
-  cd "$PROJECT_DIR"
-  git fetch origin
-  git checkout "$BRANCH"
-  git pull origin "$BRANCH"
-  echo ""
+  # Fetch only the chosen ref; do not switch branches or pull into user edits.
+  git check-ref-format "refs/heads/$BRANCH"
+  git -C "$PROJECT_DIR" fetch origin "refs/heads/$BRANCH"
+  BUILD_DIR="$LOCAL_STAGE/checkout"
+  git -C "$PROJECT_DIR" worktree add --detach "$BUILD_DIR" FETCH_HEAD
 fi
+cd "$BUILD_DIR"
+EXPECTED_PNPM=$(node -p 'require("./package.json").packageManager')
+ACTUAL_PNPM=$(pnpm --version)
+if [ "pnpm@$ACTUAL_PNPM" != "$EXPECTED_PNPM" ]; then
+  echo "Error: Expected $EXPECTED_PNPM, found pnpm@$ACTUAL_PNPM. Install the pinned pnpm version first." >&2
+  exit 1
+fi
+pnpm install --frozen-lockfile
+# Remove stale output so a failed/incomplete build cannot deploy an old bundle.
+rm -rf .next
+if [ -n "$BRANCH" ]; then
+  SP_BRANCH="$BRANCH" pnpm build
+else
+  pnpm build
+fi
+for required in .next/BUILD_ID .next/required-server-files.json; do
+  if [ ! -s "$required" ]; then
+    echo "Error: Build did not produce $required; Pod files have not been changed." >&2
+    exit 1
+  fi
+done
 
-# Build locally (migrations must be generated and committed beforehand)
-echo "Building locally..."
-cd "$PROJECT_DIR"
-pnpm build
-echo "Build complete."
-echo ""
+# Flags shared by BSD tar (macOS) and GNU tar (Linux). Never ship local
+# credentials, Git worktrees, or workstation-native modules (including those
+# traced into .next/standalone). The Pod uses next start with its own modules.
+COPYFILE_DISABLE=1 tar czf "$LOCAL_STAGE/sleepypod-core.tar.gz" \
+  --exclude='node_modules' --exclude='.next/standalone' --exclude='.next/cache' \
+  --exclude='.git' --exclude='.env*' --exclude='*.db' --exclude='*.db-*' \
+  --exclude='.DS_Store' --exclude='test-results' --exclude='coverage' \
+  --exclude='.serena' --exclude='.claude' --exclude='.codex' --exclude='.ygg' \
+  -C "$BUILD_DIR" .
 
-# Sync to pod via tar+ssh
-echo "Syncing to pod..."
-SSH_CMD="ssh -p $SSH_PORT -o ServerAliveInterval=30 $SSH_USER@$POD_IP"
-
-# Clean old files on pod (preserve node_modules, .env, persistent data)
-$SSH_CMD "mkdir -p '$REMOTE_DIR' && \
-  find '$REMOTE_DIR' -mindepth 1 -maxdepth 1 \
-    ! -name 'node_modules' \
-    ! -name '.env' \
-    -exec rm -rf {} +"
-
-# Tar source + build, pipe over SSH, extract on pod
-# Includes .next (pre-built) but excludes node_modules (installed on pod for native modules)
-COPYFILE_DISABLE=1 tar cf - --no-mac-metadata \
-  --exclude='node_modules' \
-  --exclude='*.db' \
-  --exclude='*.db-shm' \
-  --exclude='*.db-wal' \
-  --exclude='*.db-journal' \
-  --exclude='.DS_Store' \
-  --exclude='test-results' \
-  --exclude='.serena' \
-  --exclude='.claude' \
-  --exclude='docs' \
-  -C "$PROJECT_DIR" . \
-  | $SSH_CMD "tar xf - -C '$REMOTE_DIR' 2>/dev/null"
-
-echo "Files synced."
-echo ""
-
-# Run install on pod (local mode, pre-built — no build step needed)
-echo "Running install on pod..."
-ssh -p "$SSH_PORT" -o ServerAliveInterval=30 "$SSH_USER@$POD_IP" \
-  "bash $REMOTE_DIR/scripts/install --local --no-ssh"
-
-echo ""
-echo "=== Deploy complete ==="
-echo "Web UI: http://$POD_IP:3000/"
+# Upload completely before invoking the updater. Use the deploy script's own
+# updater, so this also works on Pods/target branches with an older sp-update.
+# shellcheck disable=SC2016 # Expanded by the remote shell.
+REMOTE_STAGE=$("${SSH[@]}" 'mktemp -d "${TMPDIR:-/persistent}/sleepypod-deploy.XXXXXX"')
+# Remote paths are interpolated into SSH shell commands; accept only a simple
+# absolute mktemp path and never execute unexpected login-banner output.
+if [[ ! "$REMOTE_STAGE" =~ ^/[a-zA-Z0-9/_.-]+/sleepypod-deploy\.[a-zA-Z0-9]+$ ]]; then
+  echo "Error: Unexpected remote staging path: $REMOTE_STAGE" >&2
+  REMOTE_STAGE=""
+  exit 1
+fi
+"${SSH[@]}" "cat > '$REMOTE_STAGE/sleepypod-core.tar.gz'" < "$LOCAL_STAGE/sleepypod-core.tar.gz"
+"${SSH[@]}" "cat > '$REMOTE_STAGE/sp-update'" < "$SCRIPT_DIR/bin/sp-update"
+echo "Build uploaded. Applying update on the Pod..."
+"${SSH[@]}" "bash '$REMOTE_STAGE/sp-update' --archive '$REMOTE_STAGE/sleepypod-core.tar.gz'"
+echo "Deploy complete. Web UI: http://$POD_IP:3000/"

--- a/tests/iptablesHelpers.contract.test.ts
+++ b/tests/iptablesHelpers.contract.test.ts
@@ -59,8 +59,8 @@ restore_wan
 
   it('stops the service before opening WAN and reloads the installed helper before restore', () => {
     const mainFlow = updateScript.indexOf('# Pre-flight: disk space')
-    const stopCommand = updateScript.indexOf('\nsystemctl stop sleepypod.service\n', mainFlow)
-    const unblockCommand = updateScript.indexOf('\n  unblock_wan\n', mainFlow)
+    const stopCommand = updateScript.indexOf('systemctl stop sleepypod.service', mainFlow)
+    const unblockCommand = updateScript.indexOf('    unblock_wan\n', mainFlow)
     expect(mainFlow).toBeGreaterThan(-1)
     expect(stopCommand).toBeGreaterThan(mainFlow)
     expect(stopCommand).toBeLessThan(unblockCommand)

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -1,0 +1,257 @@
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, cpSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repo = process.cwd()
+// Git hooks export GIT_DIR/GIT_INDEX_FILE/etc. Clear them for every fixture
+// subprocess so a pre-push test cannot operate on the invoking repository.
+const testEnv = {
+  ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))),
+  NODE_ENV: process.env.NODE_ENV,
+}
+const scratch: string[] = []
+function temp() {
+  const dir = mkdtempSync(join(tmpdir(), 'sleepypod-update-test-'))
+  scratch.push(dir)
+  return dir
+}
+function put(path: string, content: string) {
+  mkdirSync(resolve(path, '..'), { recursive: true })
+  writeFileSync(path, content, { mode: 0o755 })
+}
+afterEach(() => {
+  for (const dir of scratch.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+const helper = `
+SAVED_IPTABLES=""
+WAN_WAS_BLOCKED=false
+wan_is_blocked() { [ "$TEST_WAN_BLOCKED" = 1 ]; }
+unblock_wan() { echo unblock >> "$TEST_LOG"; }
+restore_wan() { echo restore >> "$TEST_LOG"; }
+`
+function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean } = {}) {
+  const dir = temp()
+  const app = join(dir, 'app')
+  const bundle = join(dir, 'bundle')
+  const bin = join(dir, 'bin')
+  const log = join(dir, 'log')
+  mkdirSync(join(dir, 'data'))
+  mkdirSync(join(dir, 'stage'))
+  put(join(app, 'old.txt'), 'old code')
+  put(join(app, '.env'), 'POD_SECRET=keep')
+  put(join(app, 'scripts/lib/iptables-helpers'), helper)
+  put(join(bundle, 'scripts/lib/iptables-helpers'), helper)
+  put(join(bundle, 'package.json'), '{"packageManager":"pnpm@10.34.5"}')
+  put(join(bundle, 'pnpm-lock.yaml'), 'lockfileVersion: 9')
+  put(join(bundle, '.next/required-server-files.json'), '{}')
+  if (!options.invalid) put(join(bundle, '.next/BUILD_ID'), 'new-build')
+  put(join(bundle, '.git-info'), '{"branch":"fix/test","commitHash":"abc1234"}')
+  put(join(bundle, '.env'), 'LOCAL_SECRET=do-not-copy')
+  put(join(bundle, 'node_modules/foreign.node'), 'wrong architecture')
+  const archive = join(dir, 'bundle.tar.gz')
+  expect(spawnSync('tar', ['czf', archive, '-C', bundle, '.']).status).toBe(0)
+  let script = readFileSync(join(repo, 'scripts/bin/sp-update'), 'utf8')
+  script = script.replace('export PATH="/usr/local/bin:$PATH"', '')
+    .replaceAll('/home/dac/sleepypod-core', app)
+    .replaceAll('/persistent/sleepypod-data', join(dir, 'data'))
+    .replaceAll('/etc/sleepypod/data-dir', join(dir, 'data-dir'))
+    .replaceAll('/etc/systemd/system', join(dir, 'systemd'))
+    .replaceAll('/etc/hosts', join(dir, 'hosts'))
+  put(join(dir, 'hosts'), '# BEGIN sleepypod-telemetry-block')
+  put(join(dir, 'update'), script)
+  put(join(bin, 'systemctl'), '#!/bin/bash\necho "systemctl $*" >> "$TEST_LOG"\n')
+  put(join(bin, 'sleep'), '#!/bin/bash\nexit 0\n')
+  put(join(bin, 'pnpm'), `#!/bin/bash
+if [ "$1" = --version ]; then echo "$TEST_PNPM_VERSION"; exit; fi
+echo "pnpm $*" >> "$TEST_LOG"
+exit "$TEST_PNPM_FAIL"
+`)
+  put(join(bin, 'curl'), `#!/bin/bash
+echo "curl $*" >> "$TEST_LOG"
+if [[ "$*" == *api.github.com* ]]; then
+  while [ "$1" != -o ]; do shift; done
+  printf '%s' "$TEST_RELEASE" > "$2"
+  printf '%s' "$TEST_HTTP_STATUS"
+else
+  if [ "$TEST_DOWNLOAD_FAIL" = 1 ]; then head -c 20 "$TEST_ARCHIVE"; exit 1; fi
+  cat "$TEST_ARCHIVE"
+fi
+`)
+  const tar = spawnSync('which', ['tar'], { encoding: 'utf8' }).stdout.trim()
+  put(join(bin, 'tar'), `#!/bin/bash
+if [ "$TEST_BACKUP_FAIL" = 1 ] && [ "$1" = cf ]; then exit 1; fi
+exec '${tar}' "$@"
+`)
+  const result = spawnSync('bash', [join(dir, 'update'), ...(options.archive ? ['--archive', archive] : ['fix/test'])], {
+    encoding: 'utf8',
+    env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TMPDIR: join(dir, 'stage'), TEST_LOG: log,
+      TEST_WAN_BLOCKED: options.blocked ? '1' : '0', TEST_PNPM_FAIL: options.pnpmFail ? '1' : '0',
+      TEST_PNPM_VERSION: options.version ?? '10.34.5', TEST_DOWNLOAD_FAIL: options.downloadFail ? '1' : '0',
+      TEST_BACKUP_FAIL: options.backupFail ? '1' : '0', TEST_HTTP_STATUS: options.status ?? '200', TEST_ARCHIVE: archive,
+      TEST_RELEASE: JSON.stringify({ assets: options.noAsset ? [] : [{ name: 'sleepypod-core.tar.gz', browser_download_url: 'https://example.test/bundle' }] }) },
+  })
+  return { result, app, dir, log: existsSync(log) ? readFileSync(log, 'utf8') : '' }
+}
+
+describe('sp-update staged deployment', () => {
+  it.each(['404', '403', '500'])('rejects HTTP %s without touching installed files or dependencies', (status) => {
+    const { result, app, log } = updater({ status, blocked: true })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain(status === '404' ? 'No accessible pre-built release' : `HTTP ${status}`)
+    expect(readFileSync(join(app, 'old.txt'), 'utf8')).toBe('old code')
+    expect(log).not.toContain('pnpm install')
+    expect(log.indexOf('systemctl stop')).toBeLessThan(log.indexOf('unblock'))
+    expect(log.indexOf('restore')).toBeLessThan(log.indexOf('systemctl start'))
+    expect(log).not.toContain('archive/refs/heads')
+  })
+  it('rejects a release without an asset', () => {
+    const { result, app } = updater({ noAsset: true })
+    expect(result.stderr).toContain('Release has no sleepypod-core.tar.gz asset')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+  })
+  it('rejects interrupted downloads and keeps the installed app', () => {
+    const { result, app, log } = updater({ downloadFail: true })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('download/extraction failed')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).not.toContain('pnpm install')
+  })
+  it('rejects an incomplete local build before stopping services or opening WAN', () => {
+    const { result, app, log } = updater({ archive: true, invalid: true, blocked: true })
+    expect(result.stderr).toContain('missing .next/BUILD_ID')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).toBe('')
+  })
+  it('reports pnpm mismatch before replacing the app', () => {
+    const { result, app, log } = updater({ archive: true, version: '11.0.0' })
+    expect(result.stderr).toContain('Expected pnpm@10.34.5')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).not.toContain('pnpm install')
+  })
+  it('does not replace files if the backup fails', () => {
+    const { result, app, log } = updater({ archive: true, backupFail: true })
+    expect(result.status).not.toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).toContain('systemctl start')
+    expect(log).not.toContain('pnpm install')
+  })
+  it.each([true, false])('installs only production deps and preserves Pod env/build metadata (archive=%s)', (archive) => {
+    const { result, app, log } = updater({ archive })
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.env'), 'utf8')).toBe('POD_SECRET=keep')
+    expect(readFileSync(join(app, '.git-info'), 'utf8')).toContain('abc1234')
+    expect(existsSync(join(app, 'node_modules/foreign.node'))).toBe(false)
+    expect(log).toContain('pnpm install --frozen-lockfile --prod')
+    expect(log).not.toContain('pnpm build')
+    if (archive) expect(log).not.toContain('curl')
+  })
+  it('restores installed code and restarts after a dependency failure', () => {
+    const { result, app, log } = updater({ archive: true, pnpmFail: true, blocked: true })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('rolling back')
+    expect(readFileSync(join(app, 'old.txt'), 'utf8')).toBe('old code')
+    expect(log).toContain('restore')
+    expect(log).toContain('systemctl start sleepypod.service')
+  })
+})
+
+function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) {
+  const dir = temp()
+  const project = join(dir, 'project')
+  const bin = join(dir, 'bin')
+  const log = join(dir, 'log')
+  mkdirSync(join(project, 'scripts'), { recursive: true })
+  cpSync(join(repo, 'scripts/deploy'), join(project, 'scripts/deploy'))
+  put(join(project, 'scripts/bin/sp-update'), '# updater to upload')
+  put(join(project, 'package.json'), '{"packageManager":"pnpm@10.34.5"}')
+  put(join(project, '.env'), 'local-secret')
+  if (!branch) put(join(project, '.git/config'), 'credential')
+  put(join(project, 'node_modules/native.node'), 'wrong-arch')
+  put(join(project, 'source.ts'), 'source')
+  if (branch) {
+    const git = (args: string[]) => {
+      const result = spawnSync('git', ['-C', project, ...args], { encoding: 'utf8', env: testEnv })
+      expect(result.status, result.stderr).toBe(0)
+    }
+    git(['init', '-b', 'main'])
+    git(['add', '.'])
+    git(['-c', 'core.hooksPath=/dev/null', '-c', 'user.name=Test', '-c', 'user.email=test@example.test', 'commit', '-m', 'fixture'])
+    git(['branch', 'fix/test'])
+    git(['remote', 'add', 'origin', project])
+    put(join(project, 'source.ts'), 'uncommitted local edits')
+  }
+  put(join(bin, 'pnpm'), `#!/bin/bash
+if [ "$1" = --version ]; then echo 10.34.5; exit; fi
+echo "pnpm $*" >> "$TEST_LOG"
+if [ "$1" = build ]; then
+  [ "$TEST_FAIL" != build ] || exit 1
+  mkdir -p .next/standalone/node_modules .next/cache
+  echo build > .next/BUILD_ID
+  echo '{}' > .next/required-server-files.json
+  echo native > .next/standalone/node_modules/native.node
+  echo cache > .next/cache/item
+fi
+`)
+  put(join(bin, 'ssh'), `#!/bin/bash
+cmd="\${!#}"
+echo "ssh $cmd" >> "$TEST_LOG"
+case "$cmd" in
+  'test -d '*) exit 0 ;;
+  *mktemp*) mkdir -p "$TEST_REMOTE"; echo "$TEST_REMOTE" ;;
+  'cat > '*)
+    bash -c "$cmd"
+    if [[ "$cmd" == *tar.gz* ]]; then
+      cp "$TEST_REMOTE/sleepypod-core.tar.gz" "$TEST_CAPTURE"
+      [ "$TEST_FAIL" != transfer ] || exit 1
+    fi ;;
+  'bash '*) [ "$TEST_FAIL" != apply ] ;;
+  'rm -rf '*) bash -c "$cmd" ;;
+  *) exit 90 ;;
+esac
+`)
+  const result = spawnSync('bash', [join(project, 'scripts/deploy'), 'pod.local', ...(branch ? ['fix/test'] : [])], { encoding: 'utf8',
+    env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TEST_LOG: log, TEST_FAIL: fail,
+      TEST_REMOTE: join(dir, 'sleepypod-deploy.abcdef'), TEST_CAPTURE: join(dir, 'captured.tar.gz') },
+  })
+  return { result, log: readFileSync(log, 'utf8'), dir, project }
+}
+
+describe('local deploy', () => {
+  it('builds an origin branch in isolation and preserves the current checkout and edits', () => {
+    const { result, project, dir } = deploy('', true)
+    expect(result.status, result.stderr).toBe(0)
+    expect(readFileSync(join(project, 'source.ts'), 'utf8')).toBe('uncommitted local edits')
+    const git = (args: string[]) => spawnSync('git', ['-C', project, ...args], { encoding: 'utf8', env: testEnv }).stdout
+    expect(git(['branch', '--show-current']).trim()).toBe('main')
+    expect(git(['worktree', 'list', '--porcelain']).match(/^worktree /gm)).toHaveLength(1)
+    const archived = spawnSync('tar', ['xOf', join(dir, 'captured.tar.gz'), './source.ts'], { encoding: 'utf8' })
+    expect(archived.stdout).toBe('source')
+  })
+
+  it('stages an archive without secrets/native modules before applying with the bundled updater', () => {
+    const { result, log, dir } = deploy()
+    expect(result.status, result.stderr).toBe(0)
+    const archive = spawnSync('tar', ['tzf', join(dir, 'captured.tar.gz')], { encoding: 'utf8' }).stdout
+    expect(archive).toContain('./.next/BUILD_ID')
+    expect(archive).toContain('./source.ts')
+    for (const excluded of ['.env', '.git/', 'node_modules', '.next/cache', '.next/standalone']) expect(archive).not.toContain(excluded)
+    expect(log).toContain('--archive')
+    expect(log.indexOf('cat >')).toBeLessThan(log.indexOf('ssh bash'))
+    expect(log).not.toContain('find /home/dac')
+  })
+  it.each(['build', 'transfer'] as const)('does not invoke the updater on %s failure', (fail) => {
+    const { result, log } = deploy(fail)
+    expect(result.status).not.toBe(0)
+    expect(log).not.toContain('ssh bash')
+  })
+  it('propagates update failure without printing success', () => {
+    const { result } = deploy('apply')
+    expect(result.status).not.toBe(0)
+    expect(result.stdout).not.toContain('Deploy complete')
+  })
+})

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -50,6 +50,7 @@ function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: bool
   put(join(bundle, 'package.json'), '{"packageManager":"pnpm@10.34.5"}')
   put(join(bundle, 'pnpm-lock.yaml'), 'lockfileVersion: 9')
   put(join(bundle, '.next/required-server-files.json'), '{}')
+  put(join(bundle, '.next/standalone/server.js'), 'new standalone server')
   if (!options.invalid) put(join(bundle, '.next/BUILD_ID'), 'new-build')
   put(join(bundle, '.git-info'), '{"branch":"fix/test","commitHash":"abc1234"}')
   put(join(bundle, '.env'), 'LOCAL_SECRET=do-not-copy')
@@ -103,7 +104,7 @@ describe('sp-update staged deployment', () => {
   it('cleans a symlinked installation so stale standalone code cannot shadow the new build', () => {
     const { result, app } = updater({ archive: true, symlinkInstall: true })
     expect(result.status, result.stderr).toBe(0)
-    expect(existsSync(join(app, '.next/standalone/server.js'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
     expect(existsSync(join(app, 'old.txt'))).toBe(false)
     expect(readFileSync(join(app, '.next/BUILD_ID'), 'utf8')).toBe('new-build')
   })
@@ -205,6 +206,8 @@ if [ "$1" = build ]; then
   mkdir -p .next/standalone/node_modules .next/cache
   echo build > .next/BUILD_ID
   echo '{}' > .next/required-server-files.json
+  echo standalone > .next/standalone/server.js
+  echo '{"commitHash":"new-build"}' > .git-info
   echo native > .next/standalone/node_modules/native.node
   echo cache > .next/cache/item
 fi
@@ -250,8 +253,10 @@ describe('local deploy', () => {
     expect(result.status, result.stderr).toBe(0)
     const archive = spawnSync('tar', ['tzf', join(dir, 'captured.tar.gz')], { encoding: 'utf8' }).stdout
     expect(archive).toContain('./.next/BUILD_ID')
+    expect(archive).toContain('./.next/standalone/server.js')
+    expect(archive).toContain('./.next/standalone/.git-info')
     expect(archive).toContain('./source.ts')
-    for (const excluded of ['.env', '.git/', 'node_modules', '.next/cache', '.next/standalone']) expect(archive).not.toContain(excluded)
+    for (const excluded of ['.env', '.git/', 'node_modules', '.next/cache']) expect(archive).not.toContain(excluded)
     expect(log).toContain('export PATH=/usr/local/bin:$PATH; test -d /home/dac/sleepypod-core')
     expect(log).toContain('--archive')
     expect(log.indexOf('cat >')).toBeLessThan(log.indexOf('ssh bash'))

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -189,6 +189,7 @@ function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) 
 if [ "$1" = --version ]; then echo 10.34.5; exit; fi
 echo "pnpm $*" >> "$TEST_LOG"
 if [ "$1" = build ]; then
+  [ "$DATABASE_URL" = :memory: ] && [ "$BIOMETRICS_DATABASE_URL" = :memory: ] || exit 91
   [ "$TEST_FAIL" != build ] || exit 1
   mkdir -p .next/standalone/node_modules .next/cache
   echo build > .next/BUILD_ID

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -32,7 +32,7 @@ wan_is_blocked() { [ "$TEST_WAN_BLOCKED" = 1 ]; }
 unblock_wan() { echo unblock >> "$TEST_LOG"; }
 restore_wan() { echo restore >> "$TEST_LOG"; }
 `
-function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean, symlinkInstall?: boolean } = {}) {
+function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean, symlinkInstall?: boolean, lowTempSpace?: boolean } = {}) {
   const dir = temp()
   const app = join(dir, 'app')
   const bundle = join(dir, 'bundle')
@@ -58,15 +58,27 @@ function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: bool
   const archive = join(dir, 'bundle.tar.gz')
   expect(spawnSync('tar', ['czf', archive, '-C', bundle, '.']).status).toBe(0)
   let script = readFileSync(join(repo, 'scripts/bin/sp-update'), 'utf8')
-  script = script.replace('export PATH="/usr/local/bin:$PATH"', '')
-    .replaceAll('/home/dac/sleepypod-core', installPath)
-    .replaceAll('/persistent/sleepypod-data', join(dir, 'data'))
-    .replaceAll('/etc/sleepypod/data-dir', join(dir, 'data-dir'))
-    .replaceAll('/etc/systemd/system', join(dir, 'systemd'))
-    .replaceAll('/etc/hosts', join(dir, 'hosts'))
+  const rewrites: [string, string][] = [
+    ['export PATH="/usr/local/bin:$PATH"', ''],
+    ['/home/dac/sleepypod-core', installPath],
+    ['/persistent/sleepypod-data', join(dir, 'data')],
+    ['/etc/sleepypod/data-dir', join(dir, 'data-dir')],
+    ['/etc/systemd/system', join(dir, 'systemd')],
+    ['/etc/hosts', join(dir, 'hosts')],
+  ]
+  for (const [from, to] of rewrites) {
+    expect(script).toContain(from)
+    script = script.replaceAll(from, to)
+  }
   put(join(dir, 'hosts'), '# BEGIN sleepypod-telemetry-block')
   put(join(dir, 'update'), script)
   put(join(bin, 'systemctl'), '#!/bin/bash\necho "systemctl $*" >> "$TEST_LOG"\n')
+  put(join(bin, 'df'), `#!/bin/bash
+available=900
+if [ "$2" = "$TMPDIR" ]; then available=$TEST_TEMP_SPACE; fi
+echo 'Filesystem Size Used Available Use% Mounted'
+echo "fixture 1000 100 $available 10% /"
+`)
   put(join(bin, 'sleep'), '#!/bin/bash\nexit 0\n')
   put(join(bin, 'pnpm'), `#!/bin/bash
 if [ "$1" = --version ]; then echo "$TEST_PNPM_VERSION"; exit; fi
@@ -76,7 +88,8 @@ exit "$TEST_PNPM_FAIL"
   put(join(bin, 'curl'), `#!/bin/bash
 echo "curl $*" >> "$TEST_LOG"
 if [[ "$*" == *api.github.com* ]]; then
-  while [ "$1" != -o ]; do shift; done
+  while [ "$#" -gt 0 ] && [ "$1" != -o ]; do shift; done
+  if [ "$#" -lt 2 ]; then echo "curl stub: missing -o" >&2; exit 2; fi
   printf '%s' "$TEST_RELEASE" > "$2"
   printf '%s' "$TEST_HTTP_STATUS"
 else
@@ -94,13 +107,21 @@ exec '${tar}' "$@"
     env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TMPDIR: join(dir, 'stage'), TEST_LOG: log,
       TEST_WAN_BLOCKED: options.blocked ? '1' : '0', TEST_PNPM_FAIL: options.pnpmFail ? '1' : '0',
       TEST_PNPM_VERSION: options.version ?? '10.34.5', TEST_DOWNLOAD_FAIL: options.downloadFail ? '1' : '0',
-      TEST_BACKUP_FAIL: options.backupFail ? '1' : '0', TEST_HTTP_STATUS: options.status ?? '200', TEST_ARCHIVE: archive,
+      TEST_BACKUP_FAIL: options.backupFail ? '1' : '0', TEST_TEMP_SPACE: options.lowTempSpace ? '100' : '900', TEST_HTTP_STATUS: options.status ?? '200', TEST_ARCHIVE: archive,
       TEST_RELEASE: JSON.stringify({ assets: options.noAsset ? [] : [{ name: 'sleepypod-core.tar.gz', browser_download_url: 'https://example.test/bundle' }] }) },
   })
   return { result, app, dir, log: existsSync(log) ? readFileSync(log, 'utf8') : '' }
 }
 
 describe('sp-update staged deployment', () => {
+  it('checks temporary storage before stopping the service or opening WAN', () => {
+    const { result, app, log } = updater({ archive: true, blocked: true, lowTempSpace: true })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('only 100MB available')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).toBe('')
+  })
+
   it('cleans a symlinked installation so stale standalone code cannot shadow the new build', () => {
     const { result, app } = updater({ archive: true, symlinkInstall: true })
     expect(result.status, result.stderr).toBe(0)
@@ -115,6 +136,7 @@ describe('sp-update staged deployment', () => {
     expect(result.stderr).toContain(status === '404' ? 'No accessible pre-built release' : `HTTP ${status}`)
     expect(readFileSync(join(app, 'old.txt'), 'utf8')).toBe('old code')
     expect(log).not.toContain('pnpm install')
+    for (const marker of ['systemctl stop', 'unblock', 'restore', 'systemctl start']) expect(log).toContain(marker)
     expect(log.indexOf('systemctl stop')).toBeLessThan(log.indexOf('unblock'))
     expect(log.indexOf('restore')).toBeLessThan(log.indexOf('systemctl start'))
     expect(log).not.toContain('archive/refs/heads')
@@ -233,7 +255,7 @@ esac
     env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TEST_LOG: log, TEST_FAIL: fail,
       TEST_REMOTE: join(dir, 'sleepypod-deploy.abcdef'), TEST_CAPTURE: join(dir, 'captured.tar.gz') },
   })
-  return { result, log: readFileSync(log, 'utf8'), dir, project }
+  return { result, log: existsSync(log) ? readFileSync(log, 'utf8') : '', dir, project }
 }
 
 describe('local deploy', () => {
@@ -259,6 +281,7 @@ describe('local deploy', () => {
     for (const excluded of ['.env', '.git/', 'node_modules', '.next/cache']) expect(archive).not.toContain(excluded)
     expect(log).toContain('export PATH=/usr/local/bin:$PATH; test -d /home/dac/sleepypod-core')
     expect(log).toContain('--archive')
+    for (const marker of ['cat >', 'ssh bash']) expect(log).toContain(marker)
     expect(log.indexOf('cat >')).toBeLessThan(log.indexOf('ssh bash'))
     expect(log).not.toContain('find /home/dac')
   })

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, cpSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, cpSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -32,7 +32,7 @@ wan_is_blocked() { [ "$TEST_WAN_BLOCKED" = 1 ]; }
 unblock_wan() { echo unblock >> "$TEST_LOG"; }
 restore_wan() { echo restore >> "$TEST_LOG"; }
 `
-function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean } = {}) {
+function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean, symlinkInstall?: boolean } = {}) {
   const dir = temp()
   const app = join(dir, 'app')
   const bundle = join(dir, 'bundle')
@@ -41,6 +41,9 @@ function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: bool
   mkdirSync(join(dir, 'data'))
   mkdirSync(join(dir, 'stage'))
   put(join(app, 'old.txt'), 'old code')
+  put(join(app, '.next/standalone/server.js'), 'old standalone server')
+  const installPath = options.symlinkInstall ? join(dir, 'install-link') : app
+  if (options.symlinkInstall) symlinkSync(app, installPath)
   put(join(app, '.env'), 'POD_SECRET=keep')
   put(join(app, 'scripts/lib/iptables-helpers'), helper)
   put(join(bundle, 'scripts/lib/iptables-helpers'), helper)
@@ -55,7 +58,7 @@ function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: bool
   expect(spawnSync('tar', ['czf', archive, '-C', bundle, '.']).status).toBe(0)
   let script = readFileSync(join(repo, 'scripts/bin/sp-update'), 'utf8')
   script = script.replace('export PATH="/usr/local/bin:$PATH"', '')
-    .replaceAll('/home/dac/sleepypod-core', app)
+    .replaceAll('/home/dac/sleepypod-core', installPath)
     .replaceAll('/persistent/sleepypod-data', join(dir, 'data'))
     .replaceAll('/etc/sleepypod/data-dir', join(dir, 'data-dir'))
     .replaceAll('/etc/systemd/system', join(dir, 'systemd'))
@@ -97,6 +100,14 @@ exec '${tar}' "$@"
 }
 
 describe('sp-update staged deployment', () => {
+  it('cleans a symlinked installation so stale standalone code cannot shadow the new build', () => {
+    const { result, app } = updater({ archive: true, symlinkInstall: true })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, '.next/standalone/server.js'))).toBe(false)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/BUILD_ID'), 'utf8')).toBe('new-build')
+  })
+
   it.each(['404', '403', '500'])('rejects HTTP %s without touching installed files or dependencies', (status) => {
     const { result, app, log } = updater({ status, blocked: true })
     expect(result.status).not.toBe(0)

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -201,7 +201,7 @@ fi
 cmd="\${!#}"
 echo "ssh $cmd" >> "$TEST_LOG"
 case "$cmd" in
-  'test -d '*) exit 0 ;;
+  'export PATH=/usr/local/bin:'*) exit 0 ;;
   *mktemp*) mkdir -p "$TEST_REMOTE"; echo "$TEST_REMOTE" ;;
   'cat > '*)
     bash -c "$cmd"
@@ -240,6 +240,7 @@ describe('local deploy', () => {
     expect(archive).toContain('./.next/BUILD_ID')
     expect(archive).toContain('./source.ts')
     for (const excluded of ['.env', '.git/', 'node_modules', '.next/cache', '.next/standalone']) expect(archive).not.toContain(excluded)
+    expect(log).toContain('export PATH=/usr/local/bin:$PATH; test -d /home/dac/sleepypod-core')
     expect(log).toContain('--archive')
     expect(log.indexOf('cat >')).toBeLessThan(log.indexOf('ssh bash'))
     expect(log).not.toContain('find /home/dac')


### PR DESCRIPTION
A branch without a GitHub release previously made `sp-update` replace the installed app and attempt a full dependency install and Next.js build on the Pod. Updates now require a validated prebuilt bundle and report missing releases, API errors, and failed downloads without falling back to source. Staging and rollback use persistent storage, backups must succeed, and symlinked installation paths are resolved before stale files are removed.

From a clone on macOS or Linux, `./scripts/deploy POD_IP [branch]` installs locked dependencies, builds locally with isolated in-memory databases, and uploads a complete archive before invoking `sp-update --archive`. Optional origin branches build in a temporary worktree without changing the user's checkout. The archive retains the standalone runtime and build metadata while excluding environment files, Git metadata, and workstation node_modules. The Pod installs production dependencies for its own architecture.

Validation:
- Deployed commit `9544003` to Pod 88 through the local build/upload/update path. The running version API reports that exact commit; UI, version API, and OpenAPI return HTTP 200. Firmware connection, sensor frames, and 329 scheduled jobs initialized, with zero service restarts after startup. The Pod's `.env` checksum is unchanged.
- Live testing exercised code/database rollback after a failed start and exposed the SSH PATH, build-worker SQLite contention, symlink cleanup, and standalone-runtime issues fixed in this PR.
- 24 targeted deployment/firewall tests pass, along with TypeScript, ESLint, both Drizzle schema checks, Bash syntax, and ShellCheck at warning severity. GitHub CI builds and unit tests pass. ESLint has one existing warning in stryker.config.mjs.
- CodeRabbit reviewed the initial commit; all five findings were addressed. Its follow-up review of the latest changes was rate-limited for 45 minutes.

Limits: the Pod still needs WAN access for production/native dependencies. Rollback restores code/database but does not restore node_modules or module/systemd changes. First-time installations continue to use scripts/install.
