### PR TITLE
feat(deploy): support installing and deploying from CI workflow artifacts

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -82,18 +82,25 @@ firewall helpers. No GitHub release is required. For first installation, use
 
 ### Validating a fork's PR
 
-Check out the PR in your local clone and run `./scripts/deploy POD_IP`. This
-works even when the fork has not published a branch release. Alternatively,
-enable Actions in the fork and push the branch so its Branch Release workflow
-publishes `sleepypod-core.tar.gz` under `<branch-with-slashes-replaced>-latest`.
-Then run on the Pod:
+When testing a pull request submitted from a contributor's fork, no local build or fork GitHub release is necessary. Each pull request run in GitHub Actions builds and uploads a CI artifact (`sleepypod-core`).
 
+**Option A: Deploy from your computer over SSH (no local Node/build required):**
 ```bash
-sudo env SLEEPYPOD_GITHUB_REPO=OWNER/core sp-update fix/my-fix
+./scripts/deploy POD_IP https://github.com/sleepypod/core/actions/runs/RUN_ID
+# Or with explicit artifact URL:
+./scripts/deploy POD_IP --artifact-url https://nightly.link/sleepypod/core/actions/runs/RUN_ID/sleepypod-core.zip
 ```
 
-A Git push alone does not upload a locally built `.next`; use the deployment
-script or let CI build and publish the release.
+**Option B: Update directly on the Pod:**
+```bash
+sp-update https://github.com/sleepypod/core/actions/runs/RUN_ID
+# Or with an explicit artifact link / nightly.link:
+sp-update --artifact-url https://nightly.link/sleepypod/core/actions/runs/RUN_ID/sleepypod-core.zip
+```
+
+GitHub Actions run URLs (including `/artifacts/ID` and `/job/ID` links) are automatically routed through `nightly.link` so downloads succeed anonymously without requiring GitHub web authentication.
+
+Alternatively, you can check out the PR in your local clone and run `./scripts/deploy POD_IP` to build and deploy locally.
 
 ### Path 2: CI Release (Production)
 

--- a/scripts/bin/sp-update
+++ b/scripts/bin/sp-update
@@ -26,12 +26,14 @@ fi
 GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-sleepypod/core}"
 BRANCH=main
 ARCHIVE=""
+ARTIFACT_URL=""
 usage() {
   cat <<'EOF'
-Usage: sp-update [branch]
+Usage: sp-update [branch | artifact_url]
+       sp-update --artifact-url <url>
        sp-update --archive /path/to/sleepypod-core.tar.gz
 
-Downloads a pre-built GitHub release; never builds Next.js on the Pod.
+Downloads a pre-built GitHub release or CI artifact; never builds Next.js on the Pod.
 For a cloned repo on your computer, run: ./scripts/deploy POD_IP [branch]
 SLEEPYPOD_GITHUB_REPO selects the release repository (default: sleepypod/core).
 TMPDIR selects temporary storage (default: /persistent).
@@ -46,12 +48,37 @@ case "${1:-}" in
     fi
     ARCHIVE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
     ;;
+  --artifact-url)
+    if [ "$#" -ne 2 ] || [ -z "$2" ]; then
+      echo "Error: --artifact-url requires a URL." >&2
+      exit 1
+    fi
+    ARTIFACT_URL="$2"
+    ;;
+  --artifact-url=*)
+    ARTIFACT_URL="${1#--artifact-url=}"
+    if [ -z "$ARTIFACT_URL" ] || [ "$#" -gt 1 ]; then
+      echo "Error: --artifact-url requires a URL." >&2
+      exit 1
+    fi
+    ;;
   -*) usage >&2; exit 1 ;;
   *)
     if [ "$#" -gt 1 ]; then usage >&2; exit 1; fi
-    BRANCH="${1:-main}"
+    if [[ "${1:-}" =~ ^https?:// ]]; then
+      ARTIFACT_URL="$1"
+    else
+      BRANCH="${1:-main}"
+    fi
     ;;
 esac
+
+if [ -n "$ARTIFACT_URL" ]; then
+  if [[ "$ARTIFACT_URL" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
+    ARTIFACT_URL="https://nightly.link/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/actions/runs/${BASH_REMATCH[3]}/sleepypod-core.zip"
+  fi
+fi
+
 if [ ! -d "$INSTALL_DIR" ] || ! command -v systemctl >/dev/null; then
   echo "Error: sp-update runs on an installed Pod. On your computer use ./scripts/deploy POD_IP [branch]." >&2
   exit 1
@@ -65,6 +92,8 @@ export TMPDIR="${TMPDIR:-/persistent}"
 echo "=== SleepyPod Update ==="
 if [ -n "$ARCHIVE" ]; then
   echo "Archive: $ARCHIVE"
+elif [ -n "$ARTIFACT_URL" ]; then
+  echo "Artifact: $ARTIFACT_URL"
 else
   echo "Branch: $BRANCH"
   echo "Repo:   $GITHUB_REPO"
@@ -278,6 +307,54 @@ open_update_wan() {
 if [ -n "$ARCHIVE" ]; then
   echo "Using local build: $ARCHIVE"
   tar xzf "$ARCHIVE" -C "$WORK_DIR"
+elif [ -n "$ARTIFACT_URL" ]; then
+  open_update_wan
+  echo "Downloading CI artifact: $ARTIFACT_URL"
+  if ! curl -fSL --connect-timeout 10 --max-time 600 -o "$WORK_DIR/artifact.download" "$ARTIFACT_URL"; then
+    echo "Error: Artifact download failed. Installed files have not been replaced; retry the update." >&2
+    exit 1
+  fi
+  MAGIC=$(head -c 2 "$WORK_DIR/artifact.download" 2>/dev/null || true)
+  if [ "$MAGIC" = "PK" ]; then
+    echo "Unpacking zip artifact..."
+    UNZIP_DIR="$WORK_DIR/unpacked"
+    mkdir -p "$UNZIP_DIR"
+    if command -v unzip >/dev/null 2>&1; then
+      if ! unzip -qo "$WORK_DIR/artifact.download" -d "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact." >&2
+        exit 1
+      fi
+    elif command -v python3 >/dev/null 2>&1; then
+      if ! python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$WORK_DIR/artifact.download" "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact with python3." >&2
+        exit 1
+      fi
+    elif command -v uv >/dev/null 2>&1; then
+      if ! uv run python -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$WORK_DIR/artifact.download" "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact with uv." >&2
+        exit 1
+      fi
+    else
+      echo "Error: Neither unzip, python3, nor uv is available to extract zip artifact." >&2
+      exit 1
+    fi
+    if [ ! -f "$UNZIP_DIR/sleepypod-core.tar.gz" ]; then
+      echo "Error: Artifact zip did not contain sleepypod-core.tar.gz." >&2
+      exit 1
+    fi
+    if ! tar xzf "$UNZIP_DIR/sleepypod-core.tar.gz" -C "$WORK_DIR"; then
+      echo "Error: Failed to extract sleepypod-core.tar.gz from artifact." >&2
+      exit 1
+    fi
+    rm -rf "$UNZIP_DIR" "$WORK_DIR/artifact.download"
+  else
+    echo "Extracting tarball artifact..."
+    if ! tar xzf "$WORK_DIR/artifact.download" -C "$WORK_DIR"; then
+      echo "Error: Artifact extraction failed. Installed files have not been replaced; retry the update." >&2
+      exit 1
+    fi
+    rm -f "$WORK_DIR/artifact.download"
+  fi
 else
   open_update_wan
   if [ "$BRANCH" = main ] || [ "$BRANCH" = latest ]; then

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -5,24 +5,93 @@ set -euo pipefail
 # An optional branch is fetched from origin into an isolated checkout.
 usage() {
   cat <<'HELP'
-Usage: ./scripts/deploy POD_IP [branch]
+Usage: ./scripts/deploy POD_IP [branch | artifact_url]
+       ./scripts/deploy POD_IP --artifact-url <url>
 
-Build the current checkout (including local edits), or a branch from origin,
-then transfer a pre-built archive over SSH and update the Pod with rollback.
-Requires Node.js, the project's pinned pnpm, and root SSH key access.
-The Pod still needs WAN access for production/native dependencies.
+Build the current checkout (including local edits), a branch from origin,
+or deploy a pre-built CI workflow artifact archive, then transfer over SSH
+and update the Pod with rollback.
+When building locally, requires Node.js and the project's pinned pnpm.
+Requires root SSH key access. The Pod still needs WAN access for
+production/native dependencies.
 SSH_PORT defaults to 8822; TMPDIR on the Pod defaults to /persistent.
 HELP
 }
-case "${1:-}" in -h|--help) usage; exit 0 ;; esac
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then usage >&2; exit 1; fi
-POD_IP="$1"
-BRANCH="${2:-}"
+
+POD_IP=""
+BRANCH=""
+ARTIFACT_URL=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --artifact-url)
+      if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --artifact-url requires a URL." >&2
+        exit 1
+      fi
+      if [ -n "$BRANCH" ] || [ -n "$ARTIFACT_URL" ]; then
+        usage >&2
+        exit 1
+      fi
+      ARTIFACT_URL="$2"
+      shift 2
+      ;;
+    --artifact-url=*)
+      ARTIFACT_URL_VAL="${1#--artifact-url=}"
+      if [ -z "$ARTIFACT_URL_VAL" ]; then
+        echo "Error: --artifact-url requires a URL." >&2
+        exit 1
+      fi
+      if [ -n "$BRANCH" ] || [ -n "$ARTIFACT_URL" ]; then
+        usage >&2
+        exit 1
+      fi
+      ARTIFACT_URL="$ARTIFACT_URL_VAL"
+      shift
+      ;;
+    -*)
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [ -z "$POD_IP" ] && [[ ! "$1" =~ ^https?:// ]]; then
+        POD_IP="$1"
+      elif [ -z "$BRANCH" ] && [ -z "$ARTIFACT_URL" ]; then
+        if [[ "$1" =~ ^https?:// ]]; then
+          ARTIFACT_URL="$1"
+        else
+          BRANCH="$1"
+        fi
+      else
+        usage >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$POD_IP" ]; then
+  usage >&2
+  exit 1
+fi
+
 SSH_PORT="${SSH_PORT:-8822}"
 if [[ ! "$POD_IP" =~ ^[a-zA-Z0-9][a-zA-Z0-9.:-]*$ ]] || [[ ! "$SSH_PORT" =~ ^[0-9]+$ ]]; then
   echo "Error: Provide a Pod hostname/IP and a numeric SSH_PORT." >&2
   exit 1
 fi
+
+if [ -n "$ARTIFACT_URL" ]; then
+  if [[ "$ARTIFACT_URL" =~ ^https://github\.com/([^/]+)/([^/]+)/actions/runs/([0-9]+) ]]; then
+    ARTIFACT_URL="https://nightly.link/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/actions/runs/${BASH_REMATCH[3]}/sleepypod-core.zip"
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 SSH=(ssh -p "$SSH_PORT" -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30 "root@$POD_IP")
@@ -46,56 +115,103 @@ trap 'exit 143' TERM
 
 echo "=== SleepyPod Deploy ==="
 echo "Target: root@$POD_IP:$SSH_PORT"
+if [ -n "$ARTIFACT_URL" ]; then
+  echo "Artifact: $ARTIFACT_URL"
+elif [ -n "$BRANCH" ]; then
+  echo "Branch: $BRANCH"
+fi
+
 # shellcheck disable=SC2016 # Use the Pod binaries in non-login SSH sessions.
 "${SSH[@]}" 'export PATH=/usr/local/bin:$PATH; test -d /home/dac/sleepypod-core && command -v node >/dev/null && command -v pnpm >/dev/null' || {
   echo "Error: SSH failed or SleepyPod is not installed. Install SleepyPod on the Pod first." >&2
   exit 1
 }
-if [ -n "$BRANCH" ]; then
-  # Fetch only the chosen ref; do not switch branches or pull into user edits.
-  git check-ref-format "refs/heads/$BRANCH"
-  git -C "$PROJECT_DIR" fetch origin "refs/heads/$BRANCH"
-  BUILD_DIR="$LOCAL_STAGE/checkout"
-  git -C "$PROJECT_DIR" worktree add --detach "$BUILD_DIR" FETCH_HEAD
-fi
-cd "$BUILD_DIR"
-EXPECTED_PNPM=$(node -p 'require("./package.json").packageManager')
-ACTUAL_PNPM=$(pnpm --version)
-if [ "pnpm@$ACTUAL_PNPM" != "$EXPECTED_PNPM" ]; then
-  echo "Error: Expected $EXPECTED_PNPM, found pnpm@$ACTUAL_PNPM. Install the pinned pnpm version first." >&2
-  exit 1
-fi
-pnpm install --frozen-lockfile
-# Remove stale output so a failed/incomplete build cannot deploy an old bundle.
-rm -rf .next
-# Route collection imports the database modules in parallel workers. Give
-# each worker an in-memory database rather than locking/altering local data.
-if [ -n "$BRANCH" ]; then
-  DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: SP_BRANCH="$BRANCH" pnpm build
-else
-  DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: pnpm build
-fi
-for required in .next/BUILD_ID .next/required-server-files.json .next/standalone/server.js; do
-  if [ ! -s "$required" ]; then
-    echo "Error: Build did not produce $required; Pod files have not been changed." >&2
+
+if [ -n "$ARTIFACT_URL" ]; then
+  echo "Downloading CI artifact: $ARTIFACT_URL"
+  if ! curl -fSL --connect-timeout 10 --max-time 600 -o "$LOCAL_STAGE/artifact.download" "$ARTIFACT_URL"; then
+    echo "Error: Artifact download failed." >&2
     exit 1
   fi
-done
+  MAGIC=$(head -c 2 "$LOCAL_STAGE/artifact.download" 2>/dev/null || true)
+  if [ "$MAGIC" = "PK" ]; then
+    echo "Unpacking zip artifact..."
+    UNZIP_DIR="$LOCAL_STAGE/unpacked"
+    mkdir -p "$UNZIP_DIR"
+    if command -v unzip >/dev/null 2>&1; then
+      if ! unzip -qo "$LOCAL_STAGE/artifact.download" -d "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact." >&2
+        exit 1
+      fi
+    elif command -v python3 >/dev/null 2>&1; then
+      if ! python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$LOCAL_STAGE/artifact.download" "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact with python3." >&2
+        exit 1
+      fi
+    elif command -v uv >/dev/null 2>&1; then
+      if ! uv run python -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$LOCAL_STAGE/artifact.download" "$UNZIP_DIR"; then
+        echo "Error: Failed to unzip artifact with uv." >&2
+        exit 1
+      fi
+    else
+      echo "Error: Neither unzip, python3, nor uv is available to extract zip artifact." >&2
+      exit 1
+    fi
+    if [ ! -f "$UNZIP_DIR/sleepypod-core.tar.gz" ]; then
+      echo "Error: Artifact zip did not contain sleepypod-core.tar.gz." >&2
+      exit 1
+    fi
+    mv -f "$UNZIP_DIR/sleepypod-core.tar.gz" "$LOCAL_STAGE/sleepypod-core.tar.gz"
+  else
+    mv -f "$LOCAL_STAGE/artifact.download" "$LOCAL_STAGE/sleepypod-core.tar.gz"
+  fi
+else
+  if [ -n "$BRANCH" ]; then
+    # Fetch only the chosen ref; do not switch branches or pull into user edits.
+    git check-ref-format "refs/heads/$BRANCH"
+    git -C "$PROJECT_DIR" fetch origin "refs/heads/$BRANCH"
+    BUILD_DIR="$LOCAL_STAGE/checkout"
+    git -C "$PROJECT_DIR" worktree add --detach "$BUILD_DIR" FETCH_HEAD
+  fi
+  cd "$BUILD_DIR"
+  EXPECTED_PNPM=$(node -p 'require("./package.json").packageManager')
+  ACTUAL_PNPM=$(pnpm --version)
+  if [ "pnpm@$ACTUAL_PNPM" != "$EXPECTED_PNPM" ]; then
+    echo "Error: Expected $EXPECTED_PNPM, found pnpm@$ACTUAL_PNPM. Install the pinned pnpm version first." >&2
+    exit 1
+  fi
+  pnpm install --frozen-lockfile
+  # Remove stale output so a failed/incomplete build cannot deploy an old bundle.
+  rm -rf .next
+  # Route collection imports the database modules in parallel workers. Give
+  # each worker an in-memory database rather than locking/altering local data.
+  if [ -n "$BRANCH" ]; then
+    DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: SP_BRANCH="$BRANCH" pnpm build
+  else
+    DATABASE_URL=:memory: BIOMETRICS_DATABASE_URL=:memory: pnpm build
+  fi
+  for required in .next/BUILD_ID .next/required-server-files.json .next/standalone/server.js; do
+    if [ ! -s "$required" ]; then
+      echo "Error: Build did not produce $required; Pod files have not been changed." >&2
+      exit 1
+    fi
+  done
 
-# The standalone server changes cwd; keep its version endpoint tied to this
-# build even when output-file tracing does not include the root metadata.
-if [ -s .git-info ]; then cp -f .git-info .next/standalone/.git-info; fi
+  # The standalone server changes cwd; keep its version endpoint tied to this
+  # build even when output-file tracing does not include the root metadata.
+  if [ -s .git-info ]; then cp -f .git-info .next/standalone/.git-info; fi
 
-# Flags shared by BSD tar (macOS) and GNU tar (Linux). Never ship local
-# credentials, Git worktrees, or workstation-native modules (including those
-# traced into .next/standalone). Keep the standalone server: it embeds the
-# compiled config and avoids loading build-only plugins at runtime.
-COPYFILE_DISABLE=1 tar czf "$LOCAL_STAGE/sleepypod-core.tar.gz" \
-  --exclude='node_modules' --exclude='.next/cache' \
-  --exclude='.git' --exclude='.env*' --exclude='*.db' --exclude='*.db-*' \
-  --exclude='.DS_Store' --exclude='test-results' --exclude='coverage' \
-  --exclude='.serena' --exclude='.claude' --exclude='.codex' --exclude='.ygg' \
-  -C "$BUILD_DIR" .
+  # Flags shared by BSD tar (macOS) and GNU tar (Linux). Never ship local
+  # credentials, Git worktrees, or workstation-native modules (including those
+  # traced into .next/standalone). Keep the standalone server: it embeds the
+  # compiled config and avoids loading build-only plugins at runtime.
+  COPYFILE_DISABLE=1 tar czf "$LOCAL_STAGE/sleepypod-core.tar.gz" \
+    --exclude='node_modules' --exclude='.next/cache' \
+    --exclude='.git' --exclude='.env*' --exclude='*.db' --exclude='*.db-*' \
+    --exclude='.DS_Store' --exclude='test-results' --exclude='coverage' \
+    --exclude='.serena' --exclude='.claude' --exclude='.codex' --exclude='.ygg' \
+    -C "$BUILD_DIR" .
+fi
 
 # Upload completely before invoking the updater. Use the deploy script's own
 # updater, so this also works on Pods/target branches with an older sp-update.

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -32,7 +32,7 @@ wan_is_blocked() { [ "$TEST_WAN_BLOCKED" = 1 ]; }
 unblock_wan() { echo unblock >> "$TEST_LOG"; }
 restore_wan() { echo restore >> "$TEST_LOG"; }
 `
-function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean, symlinkInstall?: boolean, lowTempSpace?: boolean } = {}) {
+function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: boolean, status?: string, blocked?: boolean, pnpmFail?: boolean, version?: string, downloadFail?: boolean, backupFail?: boolean, symlinkInstall?: boolean, lowTempSpace?: boolean, args?: string[], artifactZip?: boolean } = {}) {
   const dir = temp()
   const app = join(dir, 'app')
   const bundle = join(dir, 'bundle')
@@ -57,6 +57,15 @@ function updater(options: { invalid?: boolean, noAsset?: boolean, archive?: bool
   put(join(bundle, 'node_modules/foreign.node'), 'wrong architecture')
   const archive = join(dir, 'bundle.tar.gz')
   expect(spawnSync('tar', ['czf', archive, '-C', bundle, '.']).status).toBe(0)
+  const zipArchive = join(dir, 'artifact.zip')
+  if (options.artifactZip) {
+    const zipScript = 'import zipfile, sys; z = zipfile.ZipFile(sys.argv[1], "w"); z.write(sys.argv[2], "sleepypod-core.tar.gz"); z.close()'
+    let res = spawnSync('uv', ['run', 'python', '-c', zipScript, zipArchive, archive])
+    if (res.status !== 0) {
+      res = spawnSync('python3', ['-c', zipScript, zipArchive, archive])
+    }
+    expect(res.status).toBe(0)
+  }
   let script = readFileSync(join(repo, 'scripts/bin/sp-update'), 'utf8')
   const rewrites: [string, string][] = [
     ['export PATH="/usr/local/bin:$PATH"', ''],
@@ -93,8 +102,23 @@ if [[ "$*" == *api.github.com* ]]; then
   printf '%s' "$TEST_RELEASE" > "$2"
   printf '%s' "$TEST_HTTP_STATUS"
 else
-  if [ "$TEST_DOWNLOAD_FAIL" = 1 ]; then head -c 20 "$TEST_ARCHIVE"; exit 1; fi
-  cat "$TEST_ARCHIVE"
+  out=""
+  prev=""
+  for arg in "$@"; do
+    if [ "$prev" = "-o" ]; then
+      out="$arg"
+      break
+    fi
+    prev="$arg"
+  done
+  src="\${TEST_DOWNLOAD_FILE:-$TEST_ARCHIVE}"
+  if [ -n "$out" ]; then
+    if [ "$TEST_DOWNLOAD_FAIL" = 1 ]; then head -c 20 "$src" > "$out"; exit 1; fi
+    cat "$src" > "$out"
+  else
+    if [ "$TEST_DOWNLOAD_FAIL" = 1 ]; then head -c 20 "$src"; exit 1; fi
+    cat "$src"
+  fi
 fi
 `)
   const tar = spawnSync('which', ['tar'], { encoding: 'utf8' }).stdout.trim()
@@ -102,12 +126,14 @@ fi
 if [ "$TEST_BACKUP_FAIL" = 1 ] && [ "$1" = cf ]; then exit 1; fi
 exec '${tar}' "$@"
 `)
-  const result = spawnSync('bash', [join(dir, 'update'), ...(options.archive ? ['--archive', archive] : ['fix/test'])], {
+  const invocationArgs = options.args ?? (options.archive ? ['--archive', archive] : ['fix/test'])
+  const result = spawnSync('bash', [join(dir, 'update'), ...invocationArgs], {
     encoding: 'utf8',
     env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TMPDIR: join(dir, 'stage'), TEST_LOG: log,
       TEST_WAN_BLOCKED: options.blocked ? '1' : '0', TEST_PNPM_FAIL: options.pnpmFail ? '1' : '0',
       TEST_PNPM_VERSION: options.version ?? '10.34.5', TEST_DOWNLOAD_FAIL: options.downloadFail ? '1' : '0',
       TEST_BACKUP_FAIL: options.backupFail ? '1' : '0', TEST_TEMP_SPACE: options.lowTempSpace ? '100' : '900', TEST_HTTP_STATUS: options.status ?? '200', TEST_ARCHIVE: archive,
+      TEST_DOWNLOAD_FILE: options.artifactZip ? zipArchive : archive,
       TEST_RELEASE: JSON.stringify({ assets: options.noAsset ? [] : [{ name: 'sleepypod-core.tar.gz', browser_download_url: 'https://example.test/bundle' }] }) },
   })
   return { result, app, dir, log: existsSync(log) ? readFileSync(log, 'utf8') : '' }
@@ -192,9 +218,95 @@ describe('sp-update staged deployment', () => {
     expect(log).toContain('restore')
     expect(log).toContain('systemctl start sleepypod.service')
   })
+
+  it('updates from CI artifact zip via --artifact-url', () => {
+    const { result, app, log } = updater({
+      args: ['--artifact-url', 'https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip'],
+      artifactZip: true,
+      blocked: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
+    expect(existsSync(join(app, 'artifact.download'))).toBe(false)
+    expect(existsSync(join(app, 'sleepypod-core.tar.gz'))).toBe(false)
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+    expect(log).toContain('pnpm install --frozen-lockfile --prod')
+  })
+
+  it('normalizes GitHub Actions run artifact URL to nightly.link and completes update', () => {
+    const { result, app, log } = updater({
+      args: ['https://github.com/sleepypod/core/actions/runs/34162726850/artifacts/10033170463'],
+      artifactZip: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+    expect(log).not.toContain('https://github.com/sleepypod/core/actions/runs')
+  })
+
+  it('normalizes GitHub Actions run URL without artifact id to nightly.link and completes update', () => {
+    const { result, app, log } = updater({
+      args: ['https://github.com/sleepypod/core/actions/runs/34162726850'],
+      artifactZip: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+    expect(log).not.toContain('https://github.com/sleepypod/core/actions/runs')
+  })
+
+  it('supports --artifact-url= syntax and extracts tarball artifact if not zip', () => {
+    const { result, app, log } = updater({
+      args: ['--artifact-url=https://example.com/custom/sleepypod-core.tar.gz'],
+      artifactZip: false,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
+    expect(existsSync(join(app, 'artifact.download'))).toBe(false)
+    expect(log).toContain('https://example.com/custom/sleepypod-core.tar.gz')
+  })
+
+  it('normalizes GitHub Actions /job/ URL to nightly.link and completes update', () => {
+    const { result, app, log } = updater({
+      args: ['https://github.com/sleepypod/core/actions/runs/34162726850/job/101867811936?pr=691'],
+      artifactZip: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(existsSync(join(app, 'old.txt'))).toBe(false)
+    expect(readFileSync(join(app, '.next/standalone/server.js'), 'utf8')).toBe('new standalone server')
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+  })
+
+  it('rejects failed artifact download and keeps the installed app', () => {
+    const { result, app, log } = updater({
+      args: ['--artifact-url', 'https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip'],
+      downloadFail: true,
+      blocked: true,
+    })
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('Artifact download failed')
+    expect(existsSync(join(app, 'old.txt'))).toBe(true)
+    expect(log).not.toContain('pnpm install')
+  })
 })
 
-function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) {
+function deploy(options: {
+  fail?: 'build' | 'transfer' | 'apply' | ''
+  branch?: boolean
+  args?: string[]
+  artifactZip?: boolean
+} | 'build' | 'transfer' | 'apply' | '' = '', branchParam = false) {
+  const fail = typeof options === 'object' ? (options.fail ?? '') : options
+  const branch = typeof options === 'object' ? (options.branch ?? false) : branchParam
+  const artifactZip = typeof options === 'object' ? (options.artifactZip ?? false) : false
+  const invocationArgs = typeof options === 'object' && options.args
+    ? (options.args[0] === 'pod.local' ? options.args : ['pod.local', ...options.args])
+    : ['pod.local', ...(branch ? ['fix/test'] : [])]
+
   const dir = temp()
   const project = join(dir, 'project')
   const bin = join(dir, 'bin')
@@ -214,11 +326,44 @@ function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) 
     }
     git(['init', '-b', 'main'])
     git(['add', '.'])
-    git(['-c', 'core.hooksPath=/dev/null', '-c', 'user.name=Test', '-c', 'user.email=test@example.test', 'commit', '-m', 'fixture'])
+    git(['-c', 'core.hooksPath=/dev/null', '-c', 'commit.gpgsign=false', '-c', 'user.name=Test', '-c', 'user.email=test@example.test', 'commit', '-m', 'fixture'])
     git(['branch', 'fix/test'])
     git(['remote', 'add', 'origin', project])
     put(join(project, 'source.ts'), 'uncommitted local edits')
   }
+  const bundle = join(dir, 'bundle')
+  put(join(bundle, 'source.ts'), 'artifact-source')
+  put(join(bundle, '.next/BUILD_ID'), 'artifact-build')
+  put(join(bundle, '.next/standalone/server.js'), 'artifact standalone server')
+  const archive = join(dir, 'bundle.tar.gz')
+  expect(spawnSync('tar', ['czf', archive, '-C', bundle, '.']).status).toBe(0)
+  const zipArchive = join(dir, 'artifact.zip')
+  if (artifactZip) {
+    const zipScript = 'import zipfile, sys; z = zipfile.ZipFile(sys.argv[1], "w"); z.write(sys.argv[2], "sleepypod-core.tar.gz"); z.close()'
+    let res = spawnSync('uv', ['run', 'python', '-c', zipScript, zipArchive, archive])
+    if (res.status !== 0) {
+      res = spawnSync('python3', ['-c', zipScript, zipArchive, archive])
+    }
+    expect(res.status).toBe(0)
+  }
+  put(join(bin, 'curl'), `#!/bin/bash
+echo "curl $*" >> "$TEST_LOG"
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    out="$arg"
+    break
+  fi
+  prev="$arg"
+done
+src="\${TEST_DOWNLOAD_FILE:-$TEST_ARCHIVE}"
+if [ -n "$out" ]; then
+  cat "$src" > "$out"
+else
+  cat "$src"
+fi
+`)
   put(join(bin, 'pnpm'), `#!/bin/bash
 if [ "$1" = --version ]; then echo 10.34.5; exit; fi
 echo "pnpm $*" >> "$TEST_LOG"
@@ -251,9 +396,10 @@ case "$cmd" in
   *) exit 90 ;;
 esac
 `)
-  const result = spawnSync('bash', [join(project, 'scripts/deploy'), 'pod.local', ...(branch ? ['fix/test'] : [])], { encoding: 'utf8',
+  const result = spawnSync('bash', [join(project, 'scripts/deploy'), ...invocationArgs], { encoding: 'utf8',
     env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TEST_LOG: log, TEST_FAIL: fail,
-      TEST_REMOTE: join(dir, 'sleepypod-deploy.abcdef'), TEST_CAPTURE: join(dir, 'captured.tar.gz') },
+      TEST_REMOTE: join(dir, 'sleepypod-deploy.abcdef'), TEST_CAPTURE: join(dir, 'captured.tar.gz'),
+      TEST_ARCHIVE: archive, TEST_DOWNLOAD_FILE: artifactZip ? zipArchive : archive },
   })
   return { result, log: existsSync(log) ? readFileSync(log, 'utf8') : '', dir, project }
 }
@@ -294,5 +440,50 @@ describe('local deploy', () => {
     const { result } = deploy('apply')
     expect(result.status).not.toBe(0)
     expect(result.stdout).not.toContain('Deploy complete')
+  })
+
+  it('downloads GitHub Actions artifact, normalizes to nightly.link, and deploys without building', () => {
+    const { result, log, dir } = deploy({
+      args: ['https://github.com/sleepypod/core/actions/runs/34162726850/artifacts/10033170463'],
+      artifactZip: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('Deploy complete')
+    expect(log).toContain('curl -fSL --connect-timeout 10 --max-time 600 -o')
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+    expect(log).not.toContain('https://github.com/sleepypod/core/actions/runs')
+    expect(log).not.toContain('pnpm build')
+    expect(log).not.toContain('pnpm install')
+    expect(log).toContain('--archive')
+    const archived = spawnSync('tar', ['xOf', join(dir, 'captured.tar.gz'), './source.ts'], { encoding: 'utf8' })
+    expect(archived.stdout).toBe('artifact-source')
+  })
+
+  it('deploys from CI artifact zip via --artifact-url', () => {
+    const { result, log, dir } = deploy({
+      args: ['--artifact-url', 'https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip'],
+      artifactZip: true,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('Deploy complete')
+    expect(log).toContain('https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip')
+    expect(log).not.toContain('pnpm build')
+    expect(log).toContain('--archive')
+    const archived = spawnSync('tar', ['xOf', join(dir, 'captured.tar.gz'), './source.ts'], { encoding: 'utf8' })
+    expect(archived.stdout).toBe('artifact-source')
+  })
+
+  it('supports --artifact-url= syntax and direct tarball artifact', () => {
+    const { result, log, dir } = deploy({
+      args: ['--artifact-url=https://example.com/custom/sleepypod-core.tar.gz'],
+      artifactZip: false,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('Deploy complete')
+    expect(log).toContain('https://example.com/custom/sleepypod-core.tar.gz')
+    expect(log).not.toContain('pnpm build')
+    expect(log).toContain('--archive')
+    const archived = spawnSync('tar', ['xOf', join(dir, 'captured.tar.gz'), './source.ts'], { encoding: 'utf8' })
+    expect(archived.stdout).toBe('artifact-source')
   })
 })


### PR DESCRIPTION
### Summary

Adds support for installing and deploying pre-built CI workflow artifacts (`sleepypod-core.zip` containing `sleepypod-core.tar.gz`) across `scripts/deploy` and `scripts/bin/sp-update`. This allows developers to deploy directly from pull request CI runs without requiring a local Node.js toolchain or running `pnpm build`.

Key changes:
- **`scripts/deploy`**: Supports `./scripts/deploy POD_IP <artifact_url>` and `--artifact-url <url>`. Downloads the artifact locally, extracts the inner tarball, stages it over SSH, and triggers the Pod updater without executing `pnpm build` or creating a local Git worktree.
- **`scripts/bin/sp-update`**: Supports `sp-update <artifact_url>` and `--artifact-url <url>` on the Pod. Extracts the zip payload in an isolated temporary directory (`$WORK_DIR/unpacked`) using `unzip -qo` (with `python3` / `uv run python` fallback), validates `sleepypod-core.tar.gz`, and stages it through the standard upgrade and rollback pipeline.
- **URL Normalization**: GitHub Actions run URLs (e.g., `https://github.com/sleepypod/core/actions/runs/34162726850/...`) are automatically normalized to `nightly.link` for unauthenticated curl downloads.
- **Documentation**: Updated `docs/DEPLOYMENT.md` with CI artifact deployment instructions for both workstation deploy and direct on-pod update.

---

### Verification

#### Automated Tests
- Full test suite in `tests/updateDeploy.test.ts` (27/27 passing):
  - Normalization of GitHub Actions run URLs (with or without artifact/job IDs)
  - Direct zip and tarball download and staging
  - Verification that local `pnpm build` and git worktree creation are skipped when artifact URL is provided
  - Error handling for invalid/failing downloads

```bash
pnpm vitest run tests/updateDeploy.test.ts
# ✓ tests/updateDeploy.test.ts (27 tests)
```

#### Physical Pod Verification
Verified end-to-end against a physical Pod (`192.168.1.183`) deploying CI run artifact #10033170463:

```text
➜  core git:(fix/sp-update-ci-artifact) ✗ ./scripts/deploy 192.168.1.183 https://github.com/sleepypod/core/actions/runs/34162726850/artifacts/10033170463
=== SleepyPod Deploy ===
Target: root@192.168.1.183:8822
Artifact: https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip
Downloading CI artifact: https://nightly.link/sleepypod/core/actions/runs/34162726850/sleepypod-core.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  185M  100  185M    0     0  39.7M      0  0:00:04  0:00:04 --:--:-- 51.3M
Unpacking zip artifact...
Build uploaded. Applying update on the Pod...
=== SleepyPod Update ===
Archive: /persistent/sleepypod-deploy.TcRl0
Backing up current installation...
Cleaning old backups (keeping latest 3)...
Staging new build...
Migrating database...
Rebuilding Python virtual environment...
Restarting sleepypod service...
Waiting for service to become active...
Checking health endpoint...
Update successful!
```
