### PR TITLE
fix(deploy): support explicit GitHub forks for branch builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Cloned the repo on your computer? Build locally and deploy to an installed Pod:
 ```bash
 ./scripts/deploy POD_IP              # current checkout
 ./scripts/deploy POD_IP fix/my-fix   # branch from your clone's origin
+./scripts/deploy --repo Kovbo/core POD_IP fix/pod3-frozen-heartbeat  # fork branch
 ```
 
 See the [deployment guide](docs/DEPLOYMENT.md) for SSH requirements and fork/PR validation.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -82,10 +82,25 @@ firewall helpers. No GitHub release is required. For first installation, use
 
 ### Validating a fork's PR
 
-Check out the PR in your local clone and run `./scripts/deploy POD_IP`. This
-works even when the fork has not published a branch release. Alternatively,
-enable Actions in the fork and push the branch so its Branch Release workflow
-publishes `sleepypod-core.tar.gz` under `<branch-with-slashes-replaced>-latest`.
+From an up-to-date `sleepypod/core` clone, explicitly select the fork and branch:
+
+```bash
+./scripts/deploy --repo Kovbo/core POD_IP fix/pod3-frozen-heartbeat
+# Equivalent repository selection via the updater's existing environment variable:
+SLEEPYPOD_GITHUB_REPO=Kovbo/core ./scripts/deploy POD_IP fix/pod3-frozen-heartbeat
+```
+
+The fork branch is fetched into a temporary worktree; `origin`, the current
+branch, and local edits stay unchanged. `--repo` takes precedence over the
+environment variable, and either repository selector requires a branch. With
+no selector, branch deployments use your clone's `origin` (which can itself be
+a fork). With neither a selector nor a branch, the current checkout is built.
+
+This works even if the fork's branch predates the new CLI: the local clone's
+updater is uploaded alongside the build. No fork release is required.
+Alternatively, enable Actions in the fork and push the branch so its Branch
+Release workflow publishes `sleepypod-core.tar.gz` under
+`<branch-with-slashes-replaced>-latest`.
 Then run on the Pod:
 
 ```bash

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,22 +2,49 @@
 set -euo pipefail
 
 # Build a clone on macOS/Linux and deploy to an already-installed Pod.
-# An optional branch is fetched from origin into an isolated checkout.
+# An optional branch is fetched from origin or an explicit fork into an isolated checkout.
 usage() {
   cat <<'HELP'
-Usage: ./scripts/deploy POD_IP [branch]
+Usage: ./scripts/deploy [--repo OWNER/REPO] POD_IP [branch]
 
 Build the current checkout (including local edits), or a branch from origin,
 then transfer a pre-built archive over SSH and update the Pod with rollback.
+Use --repo OWNER/REPO to fetch a branch from a GitHub fork without changing
+origin. SLEEPYPOD_GITHUB_REPO sets the same default; --repo takes precedence.
+An explicit repository requires a branch.
 Requires Node.js, the project's pinned pnpm, and root SSH key access.
 The Pod still needs WAN access for production/native dependencies.
 SSH_PORT defaults to 8822; TMPDIR on the Pod defaults to /persistent.
 HELP
 }
-case "${1:-}" in -h|--help) usage; exit 0 ;; esac
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then usage >&2; exit 1; fi
-POD_IP="$1"
-BRANCH="${2:-}"
+GITHUB_REPO="${SLEEPYPOD_GITHUB_REPO:-}"
+POSITIONAL=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --repo)
+      if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+        echo "Error: --repo requires OWNER/REPO." >&2
+        exit 1
+      fi
+      GITHUB_REPO="$2"
+      shift 2
+      ;;
+    -*) echo "Error: Unknown option $1" >&2; usage >&2; exit 1 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+if [ "${#POSITIONAL[@]}" -lt 1 ] || [ "${#POSITIONAL[@]}" -gt 2 ]; then usage >&2; exit 1; fi
+POD_IP="${POSITIONAL[0]}"
+BRANCH="${POSITIONAL[1]:-}"
+FETCH_REPO=origin
+if [ -n "$GITHUB_REPO" ]; then
+  if [[ ! "$GITHUB_REPO" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]] || [ -z "$BRANCH" ]; then
+    echo "Error: An explicit repository requires OWNER/REPO and a branch." >&2
+    exit 1
+  fi
+  FETCH_REPO="https://github.com/$GITHUB_REPO.git"
+fi
 SSH_PORT="${SSH_PORT:-8822}"
 if [[ ! "$POD_IP" =~ ^[a-zA-Z0-9][a-zA-Z0-9.:-]*$ ]] || [[ ! "$SSH_PORT" =~ ^[0-9]+$ ]]; then
   echo "Error: Provide a Pod hostname/IP and a numeric SSH_PORT." >&2
@@ -54,7 +81,8 @@ echo "Target: root@$POD_IP:$SSH_PORT"
 if [ -n "$BRANCH" ]; then
   # Fetch only the chosen ref; do not switch branches or pull into user edits.
   git check-ref-format "refs/heads/$BRANCH"
-  git -C "$PROJECT_DIR" fetch origin "refs/heads/$BRANCH"
+  echo "Fetching $BRANCH from $FETCH_REPO..."
+  git -C "$PROJECT_DIR" fetch "$FETCH_REPO" "refs/heads/$BRANCH"
   BUILD_DIR="$LOCAL_STAGE/checkout"
   git -C "$PROJECT_DIR" worktree add --detach "$BUILD_DIR" FETCH_HEAD
 fi

--- a/tests/updateDeploy.test.ts
+++ b/tests/updateDeploy.test.ts
@@ -194,7 +194,7 @@ describe('sp-update staged deployment', () => {
   })
 })
 
-function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) {
+function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false, repository: 'origin' | 'flag' | 'env' | 'override' = 'origin') {
   const dir = temp()
   const project = join(dir, 'project')
   const bin = join(dir, 'bin')
@@ -215,7 +215,20 @@ function deploy(fail: 'build' | 'transfer' | 'apply' | '' = '', branch = false) 
     git(['init', '-b', 'main'])
     git(['add', '.'])
     git(['-c', 'core.hooksPath=/dev/null', '-c', 'user.name=Test', '-c', 'user.email=test@example.test', 'commit', '-m', 'fixture'])
-    git(['branch', 'fix/test'])
+    if (repository === 'origin') {
+      git(['branch', 'fix/test'])
+    }
+    else {
+      const fork = join(dir, 'fork')
+      git(['clone', '--quiet', project, fork])
+      git(['-C', fork, 'checkout', '-b', 'fix/test'])
+      put(join(fork, 'source.ts'), 'fork-only source')
+      git(['-C', fork, 'add', 'source.ts'])
+      git(['-C', fork, '-c', 'core.hooksPath=/dev/null', '-c', 'user.name=Test', '-c', 'user.email=test@example.test', 'commit', '-m', 'fork change'])
+      // Exercise real Git fetching, redirecting only the fixture's GitHub URL
+      // to a local fork. The fork-only branch is absent from origin.
+      git(['config', `url.${fork}.insteadOf`, 'https://github.com/Kovbo/core.git'])
+    }
     git(['remote', 'add', 'origin', project])
     put(join(project, 'source.ts'), 'uncommitted local edits')
   }
@@ -251,14 +264,41 @@ case "$cmd" in
   *) exit 90 ;;
 esac
 `)
-  const result = spawnSync('bash', [join(project, 'scripts/deploy'), 'pod.local', ...(branch ? ['fix/test'] : [])], { encoding: 'utf8',
-    env: { ...testEnv, PATH: `${bin}:${process.env.PATH}`, TEST_LOG: log, TEST_FAIL: fail,
+  const result = spawnSync('bash', [join(project, 'scripts/deploy'), 'pod.local', ...(branch ? ['fix/test'] : []), ...(['flag', 'override'].includes(repository) ? ['--repo', 'Kovbo/core'] : [])], { encoding: 'utf8',
+    env: { ...testEnv, SLEEPYPOD_GITHUB_REPO: repository === 'env' ? 'Kovbo/core' : repository === 'override' ? 'unused/wrong-repo' : '', PATH: `${bin}:${process.env.PATH}`, TEST_LOG: log, TEST_FAIL: fail,
       TEST_REMOTE: join(dir, 'sleepypod-deploy.abcdef'), TEST_CAPTURE: join(dir, 'captured.tar.gz') },
   })
   return { result, log: existsSync(log) ? readFileSync(log, 'utf8') : '', dir, project }
 }
 
 describe('local deploy', () => {
+  it.each(['flag', 'env', 'override'] as const)('fetches a fork-only branch using %s without changing origin or local edits', (repository) => {
+    const { result, project, dir } = deploy('', true, repository)
+    expect(result.status, result.stderr).toBe(0)
+    expect(readFileSync(join(project, 'source.ts'), 'utf8')).toBe('uncommitted local edits')
+    const git = (args: string[]) => spawnSync('git', ['-C', project, ...args], { encoding: 'utf8', env: testEnv })
+    expect(git(['remote', 'get-url', 'origin']).stdout.trim()).toBe(project)
+    expect(git(['branch', '--show-current']).stdout.trim()).toBe('main')
+    expect(git(['show-ref', '--verify', 'refs/heads/fix/test']).status).not.toBe(0)
+    expect(git(['worktree', 'list', '--porcelain']).stdout.match(/^worktree /gm)).toHaveLength(1)
+    const archived = spawnSync('tar', ['xOf', join(dir, 'captured.tar.gz'), './source.ts'], { encoding: 'utf8' })
+    expect(archived.stdout).toBe('fork-only source')
+  })
+  it.each([
+    ['--repo'],
+    ['--repo', 'Kovbo/core', 'pod.local'],
+    ['--repo', 'https://github.com/Kovbo/core', 'pod.local', 'fix/test'],
+  ])('rejects incomplete or invalid repository arguments before SSH: %j', (...args) => {
+    const dir = temp()
+    put(join(dir, 'ssh'), '#!/bin/bash\necho UNEXPECTED_SSH >&2\nexit 99\n')
+    const result = spawnSync('bash', [join(repo, 'scripts/deploy'), ...args], {
+      encoding: 'utf8', env: { ...testEnv, SLEEPYPOD_GITHUB_REPO: '', PATH: `${dir}:${process.env.PATH}` },
+    })
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('OWNER/REPO')
+    expect(result.stderr).not.toContain('UNEXPECTED_SSH')
+  })
+
   it('builds an origin branch in isolation and preserves the current checkout and edits', () => {
     const { result, project, dir } = deploy('', true)
     expect(result.status, result.stderr).toBe(0)


### PR DESCRIPTION
Deploying `fix/pod3-frozen-heartbeat` from an upstream clone fails because that branch exists in `Kovbo/core`, while the local deploy script fetches only from `origin`.

Add `./scripts/deploy --repo Kovbo/core POD_IP fix/pod3-frozen-heartbeat` to fetch the fork branch into the existing temporary worktree without changing remotes, the current branch, or local edits. `SLEEPYPOD_GITHUB_REPO` selects the same repository; `--repo` takes precedence. Explicit repositories require a branch. With no selector, existing origin/current-checkout behavior is preserved.

Validation: 30 targeted deployment/firewall tests, including real Git fixtures where the branch exists only in a separate fork, environment selection, flag precedence, and invalid arguments rejected before SSH. Also ran the CLI against the actual `Kovbo/core` fork with SSH/install stubs: it fetched `f46b3892e577d89a7eb32f1e108422c44aa69c5c` and verified the heartbeat staging change before stopping at dependency installation. Bash syntax and ShellCheck pass. No additional Pod deployment is needed for this source-selection change; the archive/update path is unchanged from the live-tested PR #703.
